### PR TITLE
chore: add release.yml and goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.4"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25.4"
+          go-version-file: "go.mod"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ go.work.sum
 # The Dosu-CLI Executable (root only)
 /dosu
 /bin
+
+# GoReleaser artifacts
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,79 @@
+# GoReleaser configuration for dosu-cli
+version: 2
+
+project_name: dosu
+
+before:
+  hooks:
+    # Download dependencies to cache
+    - go mod download
+
+builds:
+  - main: ./cmd/dosu-cli
+    binary: "{{ .ProjectName }}"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    # Exclude uncommon platform combinations
+    ignore:
+      - goos: windows
+        goarch: arm64
+    # Strip debug info to reduce binary size
+    ldflags:
+      - -s -w
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "merge conflict"
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+  groups:
+    - title: "New Features"
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: "Bug Fixes"
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: "Enhancements"
+      regexp: "^.*enhancement[(\\w)]*:+.*$"
+      order: 2
+    - title: Other Changes
+      order: 999
+
+# Release configuration
+release:
+  github:
+    owner: dosu-ai
+    name: dosu-cli
+  draft: false
+  prerelease: auto


### PR DESCRIPTION
This PR adds the `release.yml` and `.goreleaser.yaml` to automate releases with multi-platform binary distribution when a tag is pushed (ex. `git tag -a v0.1.0 -m "First release" && git push origin v0.1.0`)

`.goreleaser.yaml`: GoReleaser configuration with:
- Multi-platform builds (Linux, macOS, Windows)
- Multi-architecture support (amd64, arm64)
- Automated changelog generation
- Archive creation with platform-appropriate formats (tar.gz for Unix, zip for Windows)

`.github/workflows/release.yml`: GitHub Actions workflow that:
- Triggers on version tags (v*)
- Creates GitHub releases with binaries automatically

Tested locally with `goreleaser release --snapshot --clean`. This generates artifacts in `dist/`