### PR TITLE
chore: add homebrew cask configuration for publishing tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,4 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,21 +29,17 @@ builds:
       - -s -w
 
 archives:
-  - format: tar.gz
-    name_template: >-
+  - name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}
-    format_overrides:
-      - goos: windows
-        format: zip
 
 checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,6 +70,19 @@ changelog:
     - title: Other Changes
       order: 999
 
+# Homebrew tap
+homebrew_casks:
+  - name: dosu
+    repository:
+      owner: dosu-ai
+      name: homebrew-dosu
+    homepage: https://github.com/dosu-ai/dosu-cli
+    description: "Dosu CLI tool"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
+
 # Release configuration
 release:
   github:


### PR DESCRIPTION
This PR adds the `homebrew_casks` to the goreleaser configuration file to automate publishing dosu-cli to Homebrew. [homebrew_casks](https://goreleaser.com/customization/homebrew_casks/) was introduced in `v2.10` and the name might be a little misleading but it's what we use to generate and publish a Homebrew Cask into a repository (Tap). There is a [blog post](https://goreleaser.com/blog/goreleaser-v2.10/) explaining this migration to `homebrew_casks` from [brews](https://goreleaser.com/customization/homebrew_formulas/) (deprecated). This PR also fixes deprecated fields I introduced in the previous PR. 

TODO
- We need to add `HOMEBREW_TOKEN` to the repo's env variable with a token that has the repo scope. I didn't think adding my token was a good idea.
- We might want to name our `homebrew-dosu` repo as `homebrew-tap`. Because what comes after the `homebrew-` is taken as the tap name and the user will have to run `brew install dosu-ai/dosu/dosu` which can be a little confusing. If we rename the repo as `homebrew-tap`, it will be `brew install dosu-ai/tap/dosu`. (just a suggestion).

Testing
- Ran `goreleaser check`, this cannot really be tested locally. I could release a test/prerelease version for testing but I didn't think that was needed yet.