### PR TITLE
fix: remove homebrew configuration in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,20 +66,6 @@ changelog:
     - title: Other Changes
       order: 999
 
-# Homebrew tap
-homebrew_casks:
-  - name: dosu
-    repository:
-      owner: dosu-ai
-      name: homebrew-dosu
-      token: "{{ .Env.HOMEBREW_TOKEN }}"
-    homepage: https://github.com/dosu-ai/dosu-cli
-    description: "Dosu CLI tool"
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-    commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
-
 # Release configuration
 release:
   github:


### PR DESCRIPTION
This PR removes the homebrew configuration in goreleaser. Since [homebrew formula](https://goreleaser.com/customization/homebrew_formulas/) is deprecated since `v2.10` as described in this [blog post](https://goreleaser.com/blog/goreleaser-v2.10/), creating brew file using [homebrew_casks](https://goreleaser.com/customization/homebrew_casks/) means users have to `brew install --cask` to install a CLI which is not the best UX. I will add a script in the `homebrew-dosu` repo which will have to be manually run for each release.