### PR TITLE
Add npm distribution for dosu-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,34 @@ jobs:
           git add Formula/dosu.rb
           git commit -m "Update dosu to ${{ github.ref_name }}"
           git push
+
+  publish-npm:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist
+          gh release download "${{ github.ref_name }}" \
+            --pattern "dosu_*.tar.gz" \
+            --dir dist
+
+      - name: Build and publish npm packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: ./npm/scripts/build-npm.sh "${{ steps.version.outputs.version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ dist/
 # Air hot-reload
 tmp/
 build-errors.log
+
+# npm platform binaries (injected by CI)
+npm/cli-*/bin/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ brew tap dosu-ai/dosu
 brew install dosu
 ```
 
+### npm
+
+```bash
+npx @dosu/cli setup
+```
+
+Or install globally:
+
+```bash
+npm install -g @dosu/cli
+dosu setup
+```
+
 ### Manual Download
 
 Download the appropriate archive from the [Releases](https://github.com/dosu-ai/dosu-cli/releases) page.

--- a/npm/cli-darwin-arm64/package.json
+++ b/npm/cli-darwin-arm64/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dosu/cli-darwin-arm64",
+  "version": "0.0.0",
+  "description": "Dosu CLI binary for macOS ARM64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dosu-ai/dosu-cli.git"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/dosu"
+  ]
+}

--- a/npm/cli-darwin-x64/package.json
+++ b/npm/cli-darwin-x64/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dosu/cli-darwin-x64",
+  "version": "0.0.0",
+  "description": "Dosu CLI binary for macOS x64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dosu-ai/dosu-cli.git"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/dosu"
+  ]
+}

--- a/npm/cli-linux-arm64/package.json
+++ b/npm/cli-linux-arm64/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dosu/cli-linux-arm64",
+  "version": "0.0.0",
+  "description": "Dosu CLI binary for Linux ARM64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dosu-ai/dosu-cli.git"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/dosu"
+  ]
+}

--- a/npm/cli-linux-x64/package.json
+++ b/npm/cli-linux-x64/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dosu/cli-linux-x64",
+  "version": "0.0.0",
+  "description": "Dosu CLI binary for Linux x64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dosu-ai/dosu-cli.git"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/dosu"
+  ]
+}

--- a/npm/cli-win32-x64/package.json
+++ b/npm/cli-win32-x64/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dosu/cli-win32-x64",
+  "version": "0.0.0",
+  "description": "Dosu CLI binary for Windows x64",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dosu-ai/dosu-cli.git"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/dosu.exe"
+  ]
+}

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -1,0 +1,35 @@
+# @dosu/cli
+
+Dosu CLI — Manage MCP servers for AI tools.
+
+## Quick Start
+
+```bash
+npx @dosu/cli setup
+```
+
+## Global Install
+
+```bash
+npm install -g @dosu/cli
+dosu setup
+```
+
+## Supported Platforms
+
+| OS      | Architecture |
+|---------|-------------|
+| macOS   | ARM64 (Apple Silicon) |
+| macOS   | x64 (Intel) |
+| Linux   | ARM64 |
+| Linux   | x64 |
+| Windows | x64 |
+
+## Alternative Installation
+
+If you prefer not to use npm, install via [Homebrew](https://github.com/dosu-ai/dosu-cli#homebrew-recommended) or download directly from [GitHub Releases](https://github.com/dosu-ai/dosu-cli/releases).
+
+## Links
+
+- [GitHub](https://github.com/dosu-ai/dosu-cli)
+- [Discord](https://go.dosu.dev/discord-cli)

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -1,19 +1,32 @@
 # @dosu/cli
 
-Dosu CLI — Manage MCP servers for AI tools.
+## ⚠️ Pre-Release:
+The Dosu CLI is pre-release alpha software and is not fully supported currently. Please check back soon. Join our [Discord](https://go.dosu.dev/discord-cli) so you'll be the first to know when it's launched!
 
-## Quick Start
+## Installation
+
+### npm
 
 ```bash
 npx @dosu/cli setup
 ```
 
-## Global Install
+Or install globally:
 
 ```bash
 npm install -g @dosu/cli
 dosu setup
 ```
+
+### Homebrew
+
+```bash
+brew install dosu-ai/dosu/dosu
+```
+
+### Manual Download
+
+Download the appropriate archive from the [Releases](https://github.com/dosu-ai/dosu-cli/releases) page.
 
 ## Supported Platforms
 
@@ -24,10 +37,6 @@ dosu setup
 | Linux   | ARM64 |
 | Linux   | x64 |
 | Windows | x64 |
-
-## Alternative Installation
-
-If you prefer not to use npm, install via [Homebrew](https://github.com/dosu-ai/dosu-cli#homebrew-recommended) or download directly from [GitHub Releases](https://github.com/dosu-ai/dosu-cli/releases).
 
 ## Links
 

--- a/npm/cli/bin/dosu
+++ b/npm/cli/bin/dosu
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const PLATFORMS = {
+  "darwin arm64": "@dosu/cli-darwin-arm64",
+  "darwin x64": "@dosu/cli-darwin-x64",
+  "linux arm64": "@dosu/cli-linux-arm64",
+  "linux x64": "@dosu/cli-linux-x64",
+  "win32 x64": "@dosu/cli-win32-x64",
+};
+
+function getBinaryPath() {
+  const key = `${process.platform} ${process.arch}`;
+  const pkg = PLATFORMS[key];
+  if (!pkg) {
+    console.error(
+      `Unsupported platform: ${process.platform} ${process.arch}\n` +
+      `Install from https://github.com/dosu-ai/dosu-cli/releases instead.`
+    );
+    process.exit(1);
+  }
+
+  let pkgDir;
+  try {
+    pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
+  } catch {
+    console.error(
+      `Platform package ${pkg} is not installed.\n` +
+      `Try: npm install -g @dosu/cli\n` +
+      `Or download from https://github.com/dosu-ai/dosu-cli/releases`
+    );
+    process.exit(1);
+  }
+
+  const bin = process.platform === "win32" ? "dosu.exe" : "dosu";
+  const p = path.join(pkgDir, "bin", bin);
+  if (!fs.existsSync(p)) {
+    console.error(`Binary not found at ${p}. Try reinstalling @dosu/cli.`);
+    process.exit(1);
+  }
+  return p;
+}
+
+const child = spawn(getBinaryPath(), process.argv.slice(2), {
+  stdio: "inherit",
+  env: process.env,
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 1);
+  }
+});

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dosu/cli",
+  "version": "0.0.0",
+  "description": "Dosu CLI - Manage MCP servers for AI tools",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dosu-ai/dosu-cli.git"
+  },
+  "homepage": "https://github.com/dosu-ai/dosu-cli",
+  "bin": {
+    "dosu": "bin/dosu"
+  },
+  "files": [
+    "bin/dosu",
+    "README.md"
+  ],
+  "optionalDependencies": {
+    "@dosu/cli-darwin-arm64": "0.0.0",
+    "@dosu/cli-darwin-x64": "0.0.0",
+    "@dosu/cli-linux-arm64": "0.0.0",
+    "@dosu/cli-linux-x64": "0.0.0",
+    "@dosu/cli-win32-x64": "0.0.0"
+  },
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/npm/scripts/build-npm.sh
+++ b/npm/scripts/build-npm.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:?Usage: build-npm.sh <version> [--dry-run]}"
+DRY_RUN=""
+if [[ "${2:-}" == "--dry-run" ]]; then
+  DRY_RUN="--dry-run"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NPM_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DIST_DIR="${DIST_DIR:-dist}"
+
+# Determine dist-tag: prerelease versions get "next", stable get "latest"
+if [[ "$VERSION" == *-* ]]; then
+  DIST_TAG="next"
+else
+  DIST_TAG="latest"
+fi
+
+echo "==> Publishing version $VERSION (dist-tag: $DIST_TAG)"
+
+# Extract binaries into platform packages
+# Format: "archive_name|package_dir|binary_name"
+PLATFORMS="
+dosu_Darwin_arm64.tar.gz|cli-darwin-arm64|dosu
+dosu_Darwin_x86_64.tar.gz|cli-darwin-x64|dosu
+dosu_Linux_arm64.tar.gz|cli-linux-arm64|dosu
+dosu_Linux_x86_64.tar.gz|cli-linux-x64|dosu
+dosu_Windows_x86_64.tar.gz|cli-win32-x64|dosu.exe
+"
+
+for entry in $PLATFORMS; do
+  archive="$(echo "$entry" | cut -d'|' -f1)"
+  pkg="$(echo "$entry" | cut -d'|' -f2)"
+  bin_name="$(echo "$entry" | cut -d'|' -f3)"
+
+  pkg_dir="$NPM_DIR/$pkg"
+  bin_dir="$pkg_dir/bin"
+  mkdir -p "$bin_dir"
+
+  archive_path="$DIST_DIR/$archive"
+  if [[ ! -f "$archive_path" ]]; then
+    echo "ERROR: Archive not found: $archive_path"
+    exit 1
+  fi
+
+  echo "  Extracting $archive -> $pkg/bin/$bin_name"
+  tar -xzf "$archive_path" -C "$bin_dir" "$bin_name"
+  chmod +x "$bin_dir/$bin_name"
+done
+
+# Update versions in all package.json files
+echo "==> Updating versions to $VERSION"
+for pkg_dir in "$NPM_DIR"/cli "$NPM_DIR"/cli-*; do
+  if [[ -f "$pkg_dir/package.json" ]]; then
+    jq --arg v "$VERSION" '.version = $v' "$pkg_dir/package.json" > "$pkg_dir/package.json.tmp"
+    mv "$pkg_dir/package.json.tmp" "$pkg_dir/package.json"
+  fi
+done
+
+# Update optionalDependencies versions in main package
+jq --arg v "$VERSION" '
+  .optionalDependencies |= with_entries(.value = $v)
+' "$NPM_DIR/cli/package.json" > "$NPM_DIR/cli/package.json.tmp"
+mv "$NPM_DIR/cli/package.json.tmp" "$NPM_DIR/cli/package.json"
+
+# Publish platform packages first
+echo "==> Publishing platform packages"
+for pkg_dir in "$NPM_DIR"/cli-*; do
+  pkg_name="$(jq -r .name "$pkg_dir/package.json")"
+  echo "  Publishing $pkg_name@$VERSION"
+  npm publish "$pkg_dir" --access public --tag "$DIST_TAG" $DRY_RUN
+done
+
+# Publish main package
+echo "==> Publishing main package"
+npm publish "$NPM_DIR/cli" --access public --tag "$DIST_TAG" $DRY_RUN
+
+echo "==> Done! Published @dosu/cli@$VERSION (tag: $DIST_TAG)"


### PR DESCRIPTION
Implement esbuild-style platform-split npm packages.

**Changes:**
- Main package @dosu/cli with JS shim entry point (spawn-based, supports TUI signal forwarding)
- 5 platform packages for macOS (ARM64/x64), Linux (ARM64/x64), Windows (x64)
- Build script: extracts GoReleaser binaries, stamps versions, publishes in correct order
- CI job: downloads release artifacts and publishes to npm with dist-tags (next for prerelease, latest for stable)
- README updated with npm installation instructions

**Verification:**
All 6 packages published to npm @next tag. Tested with `npx @dosu/cli@next --help` successfully.