### PR TITLE
Validate API keys and improve HTTP client patterns

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,11 +2,13 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/dosu-ai/dosu-cli/internal/config"
@@ -234,6 +236,27 @@ type APIKeyResponse struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
 	KeyPrefix string `json:"key_prefix"`
+}
+
+// ValidateAPIKey checks if an API key is valid against the current backend.
+// Returns true if valid, false if invalid. On network errors, assumes valid (optimistic).
+func (c *Client) ValidateAPIKey(apiKey string, deploymentID string) bool {
+	endpoint := fmt.Sprintf("%s/v1/mcp/deployments/%s", c.baseURL, url.PathEscape(deploymentID))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return true // assume valid on error
+	}
+	req.Header.Set("X-Dosu-API-Key", apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return true // network error — assume valid, will fail later with a clearer message
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	return resp.StatusCode != 401 && resp.StatusCode != 403
 }
 
 // CreateAPIKey mints a new API key for the given deployment.

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -260,10 +260,13 @@ func stepSelectDeployment(apiClient *client.Client, org *client.Org) (*client.De
 
 // stepMintAPIKey creates a new API key or reuses an existing one.
 func stepMintAPIKey(apiClient *client.Client, cfg *config.Config) (string, error) {
-	// Reuse existing key if available
+	// Reuse existing key if valid against current backend
 	if cfg.APIKey != "" {
-		PrintSuccess("API key: " + dimStyle.Render("using existing"))
-		return cfg.APIKey, nil
+		if apiClient.ValidateAPIKey(cfg.APIKey, cfg.DeploymentID) {
+			PrintSuccess("API key: " + dimStyle.Render("using existing"))
+			return cfg.APIKey, nil
+		}
+		PrintWarning("Existing API key is invalid, creating a new one...")
 	}
 
 	var apiKeyResp *client.APIKeyResponse


### PR DESCRIPTION
Adds API key validation during setup to ensure existing keys work with the current deployment. Also improves HTTP client patterns: uses context.WithTimeout instead of creating temporary clients, properly drains response bodies, and URL-escapes deployment IDs.

Improves reliability when switching deployments or when keys have expired.

**Changes:**
- Add ValidateAPIKey method to verify keys against the backend
- Validate existing keys before reusing them during setup  
- Use context.WithTimeout for cleaner timeout handling
- Drain response body before closing
- URL-escape deploymentID in request path
- Add user warning when existing key is invalid