### PR TITLE
fix(release): specify current tag to prevent GoReleaser tag conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
   update-homebrew:
     needs: goreleaser


### PR DESCRIPTION
When multiple tags point to the same commit (e.g. v0.1.4-alpha and v0.1.4), GoReleaser defaults to selecting a tag via sorting, which may not be the one that triggered the workflow. This fix explicitly sets GORELEASER_CURRENT_TAG to the triggering tag.

This prevents 'already_exists' asset errors and enables the alpha → stable promotion workflow, where the same commit can have both an alpha tag and later a stable tag.