### PR TITLE
feat: add --version flag with build-time version injection

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,11 @@ builds:
         goarch: arm64
     # Strip debug info to reduce binary size
     ldflags:
-      - -s -w -X github.com/dosu-ai/dosu-cli/internal/version.Version={{ .Version }}
+      - >-
+        -s -w
+        -X github.com/dosu-ai/dosu-cli/internal/version.Version={{.Version}}
+        -X github.com/dosu-ai/dosu-cli/internal/version.Commit={{.Commit}}
+        -X github.com/dosu-ai/dosu-cli/internal/version.Date={{.CommitDate}}
 
 archives:
   - name_template: >-

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
         goarch: arm64
     # Strip debug info to reduce binary size
     ldflags:
-      - -s -w
+      - -s -w -X github.com/dosu-ai/dosu-cli/internal/version.Version={{ .Version }}
 
 archives:
   - name_template: >-

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 BINARY_NAME=dosu
 BUILD_DIR=bin
 CMD_DIR=cmd/dosu-cli
-VERSION?=dev
-LDFLAGS=-s -w -X github.com/dosu-ai/dosu-cli/internal/version.Version=$(VERSION)
+VERSION ?= $(shell git describe --tags 2>/dev/null || echo "dev")
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE    ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS  = -s -w -X github.com/dosu-ai/dosu-cli/internal/version.Version=$(VERSION) -X github.com/dosu-ai/dosu-cli/internal/version.Commit=$(COMMIT) -X github.com/dosu-ai/dosu-cli/internal/version.Date=$(DATE)
 
 .PHONY: build run clean format lint test install help
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 BINARY_NAME=dosu
 BUILD_DIR=bin
 CMD_DIR=cmd/dosu-cli
+VERSION?=dev
+LDFLAGS=-s -w -X github.com/dosu-ai/dosu-cli/internal/version.Version=$(VERSION)
 
 .PHONY: build run clean format lint test install help
 
 build:
-	go build -o $(BUILD_DIR)/$(BINARY_NAME) ./$(CMD_DIR)
+	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) ./$(CMD_DIR)
 
 run: build
 	$(BUILD_DIR)/$(BINARY_NAME)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dosu-ai/dosu-cli/internal/tui"
+	"github.com/dosu-ai/dosu-cli/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +25,10 @@ Run without arguments to launch the interactive TUI.`,
 			os.Exit(1)
 		}
 	},
+}
+
+func init() {
+	rootCmd.Version = version.Version
 }
 
 // Execute runs the root command

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is set at build time via ldflags.
+var Version = "dev"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,18 @@
 package version
 
-// Version is set at build time via ldflags.
-var Version = "dev"
+import "runtime/debug"
+
+// Set at build time via ldflags.
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)
+
+func init() {
+	if Version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+			Version = info.Main.Version
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/version` package with `Version`, `Commit`, and `Date` variables (defaults: `dev`, `none`, `unknown`)
- GoReleaser injects release version, commit hash, and commit date via ldflags at build time
- Uses `CommitDate` (not `Date`) for reproducible builds, per GoReleaser recommendation
- Makefile auto-detects version from git tags via `git describe --tags`, also injects commit and date
- Uses Cobra's built-in `rootCmd.Version` to enable the `--version` flag
- Falls back to `debug.ReadBuildInfo()` for users who install via `go install`

## Test plan
- `make build && ./bin/dosu --version` → outputs version from git describe
- `make build VERSION=0.1.5 && ./bin/dosu --version` → outputs `dosu version 0.1.5`
- `go install ./cmd/dosu-cli && dosu --version` → picks up module version from BuildInfo
- GoReleaser release will inject the exact tag version automatically