### PR TITLE
Add code coverage tracking with Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,13 @@ jobs:
       - name: Run typecheck
         run: bunx tsc --noEmit
 
-      - name: Run tests
-        run: bunx vitest run
+      - name: Run tests with coverage
+        run: bunx vitest run --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Verify build compiles
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,10 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     pool: "forks",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "coverage",
+    },
   },
 });


### PR DESCRIPTION
## Summary
This PR adds code coverage measurement and reporting to the project using Vitest's built-in coverage provider and Codecov integration for tracking coverage metrics over time.

## Key Changes
- **Added codecov.yml configuration** - Defines coverage targets (80%) and thresholds (1%) for both project and patch coverage
- **Updated CI workflow** - Modified the test step to generate coverage reports and added a new step to upload coverage data to Codecov
- **Configured Vitest coverage** - Added coverage configuration using the v8 provider with text and lcov reporters, outputting to a `coverage` directory

## Implementation Details
- Coverage is generated during test runs using Vitest's v8 provider, which provides accurate coverage metrics without additional dependencies
- The lcov format enables detailed coverage reports and integration with third-party tools
- Codecov token is securely passed via GitHub secrets for authentication
- Coverage requirements are enforced at both the project level (overall codebase) and patch level (changes in the PR)

https://claude.ai/code/session_014iZrdTa7739Uo4PmnvgWU1