### PR TITLE
Add coverage thresholds to vitest config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,8 @@ coverage:
       default:
         target: 80%
         threshold: 1%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { CallbackServer, TokenResponse } from "./server";
+
+const {
+  mockOpenDefault,
+  mockClose,
+  mockStartCallbackServer,
+  mockGetWebAppURL,
+} = vi.hoisted(() => ({
+  mockOpenDefault: vi.fn().mockResolvedValue(undefined),
+  mockClose: vi.fn(),
+  mockStartCallbackServer: vi.fn(),
+  mockGetWebAppURL: vi.fn(() => "https://app.dosu.dev"),
+}));
+
+vi.mock("open", () => ({
+  default: mockOpenDefault,
+}));
+
+vi.mock("./server", () => ({
+  startCallbackServer: mockStartCallbackServer,
+}));
+
+vi.mock("../config/constants", () => ({
+  getWebAppURL: mockGetWebAppURL,
+}));
+
+import { startOAuthFlow } from "./flow";
+
+function createMockServer(): CallbackServer {
+  return {
+    port: 12345,
+    close: mockClose,
+  };
+}
+
+describe("startOAuthFlow", () => {
+  let mockServer: CallbackServer;
+  let resolveToken: (token: TokenResponse) => void;
+  let rejectToken: (err: Error) => void;
+
+  beforeEach(() => {
+    mockOpenDefault.mockClear().mockResolvedValue(undefined);
+    mockClose.mockClear();
+    mockGetWebAppURL.mockClear().mockReturnValue("https://app.dosu.dev");
+
+    mockServer = createMockServer();
+
+    const tokenPromise = new Promise<TokenResponse>((resolve, reject) => {
+      resolveToken = resolve;
+      rejectToken = reject;
+    });
+
+    mockStartCallbackServer.mockClear().mockResolvedValue({
+      server: mockServer,
+      tokenPromise,
+    });
+  });
+
+  it("resolves with the token when tokenPromise resolves", async () => {
+    const expectedToken: TokenResponse = {
+      access_token: "test-access-token",
+      refresh_token: "test-refresh-token",
+      expires_in: 3600,
+    };
+
+    const flowPromise = startOAuthFlow();
+
+    // Let the async setup run
+    await new Promise((r) => setTimeout(r, 10));
+
+    resolveToken(expectedToken);
+
+    const result = await flowPromise;
+    expect(result).toEqual(expectedToken);
+  });
+
+  it("closes the server after successful completion", async () => {
+    const token: TokenResponse = {
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_in: 3600,
+    };
+
+    const flowPromise = startOAuthFlow();
+    await new Promise((r) => setTimeout(r, 10));
+
+    resolveToken(token);
+    await flowPromise;
+
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes the server when tokenPromise rejects", async () => {
+    const flowPromise = startOAuthFlow();
+    await new Promise((r) => setTimeout(r, 10));
+
+    rejectToken(new Error("something went wrong"));
+
+    const error = await flowPromise.catch((e: Error) => e);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("something went wrong");
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it("rejects when abort signal is triggered", async () => {
+    const controller = new AbortController();
+
+    const flowPromise = startOAuthFlow(controller.signal);
+    await new Promise((r) => setTimeout(r, 10));
+
+    controller.abort();
+
+    const error = await flowPromise.catch((e: Error) => e);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("authentication cancelled");
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it("opens the browser with the correct auth URL", async () => {
+    const flowPromise = startOAuthFlow();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockOpenDefault).toHaveBeenCalledOnce();
+    const calledURL = mockOpenDefault.mock.calls[0]![0] as string;
+    expect(calledURL).toBe(
+      "https://app.dosu.dev/cli-login?callback=http%3A%2F%2Flocalhost%3A12345%2Fcallback",
+    );
+
+    resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
+    await flowPromise;
+  });
+
+  it("uses the configured web app URL for building the auth URL", async () => {
+    mockGetWebAppURL.mockReturnValue("http://localhost:3001");
+
+    const flowPromise = startOAuthFlow();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockOpenDefault).toHaveBeenCalledOnce();
+    const calledURL = mockOpenDefault.mock.calls[0]![0] as string;
+    expect(calledURL).toContain("http://localhost:3001/cli-login?");
+
+    resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
+    await flowPromise;
+  });
+});

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -1,0 +1,438 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createProgram } from "./cli";
+import type { Config } from "../config/config";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockLoadConfig = vi.fn<() => Config>();
+const mockSaveConfig = vi.fn<(cfg: Config) => void>();
+const mockIsAuthenticated = vi.fn<(cfg: Config) => boolean>();
+const mockIsTokenExpired = vi.fn<(cfg: Config) => boolean>();
+const mockGetConfigPath = vi.fn<() => string>();
+
+vi.mock("../config/config", () => ({
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...(args as [])),
+  saveConfig: (...args: unknown[]) => mockSaveConfig(...(args as [Config])),
+  isAuthenticated: (...args: unknown[]) => mockIsAuthenticated(...(args as [Config])),
+  isTokenExpired: (...args: unknown[]) => mockIsTokenExpired(...(args as [Config])),
+  getConfigPath: (...args: unknown[]) => mockGetConfigPath(...(args as [])),
+}));
+
+const mockInstall = vi.fn();
+
+const fakeProvider = (overrides: Partial<{
+  id: string;
+  name: string;
+  supportsLocal: boolean;
+}> = {}) => ({
+  id: vi.fn().mockReturnValue(overrides.id ?? "cursor"),
+  name: vi.fn().mockReturnValue(overrides.name ?? "Cursor"),
+  supportsLocal: vi.fn().mockReturnValue(overrides.supportsLocal ?? true),
+  install: mockInstall,
+  remove: vi.fn(),
+});
+
+const mockGetProvider = vi.fn();
+const mockAllProviders = vi.fn();
+
+vi.mock("../mcp/providers", () => ({
+  getProvider: (...args: unknown[]) => mockGetProvider(...args),
+  allProviders: (...args: unknown[]) => mockAllProviders(...args),
+}));
+
+const mockStartOAuthFlow = vi.fn();
+vi.mock("../auth/flow", () => ({
+  startOAuthFlow: (...args: unknown[]) => mockStartOAuthFlow(...args),
+}));
+
+const mockRunTUI = vi.fn();
+vi.mock("../tui/tui", () => ({
+  runTUI: (...args: unknown[]) => mockRunTUI(...args),
+}));
+
+const mockRunSetup = vi.fn();
+vi.mock("../setup/flow", () => ({
+  runSetup: (...args: unknown[]) => mockRunSetup(...args),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function authenticatedConfig(): Config {
+  return {
+    access_token: "tok_abc",
+    refresh_token: "ref_abc",
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    deployment_id: "dep_123",
+    deployment_name: "My App",
+    api_key: "key_abc",
+  };
+}
+
+function unauthenticatedConfig(): Config {
+  return {
+    access_token: "",
+    refresh_token: "",
+    expires_at: 0,
+  };
+}
+
+/** Parse a command through Commander, catching Commander's own exit calls. */
+async function run(...args: string[]) {
+  const program = createProgram();
+  program.exitOverride();
+  // Commander wraps action errors in CommanderError; we want the original.
+  await program.parseAsync(["node", "dosu", ...args]);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("CLI actions", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockGetConfigPath.mockReturnValue("/home/user/.config/dosu-cli/config.json");
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  // ── default (no subcommand) ──────────────────────────────────────────────
+
+  describe("default action (no subcommand)", () => {
+    it("launches the TUI", async () => {
+      mockRunTUI.mockResolvedValue(undefined);
+      await run();
+      expect(mockRunTUI).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── login ────────────────────────────────────────────────────────────────
+
+  describe("login", () => {
+    it("prints already-logged-in message when authenticated", async () => {
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(false);
+
+      await run("login");
+
+      expect(logSpy).toHaveBeenCalledWith("You are already logged in.");
+      expect(logSpy).toHaveBeenCalledWith("Run 'dosu logout' first to re-authenticate.");
+      expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+    });
+
+    it("runs OAuth flow and saves token when not authenticated", async () => {
+      const cfg = unauthenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(false);
+      mockIsTokenExpired.mockReturnValue(false);
+      mockStartOAuthFlow.mockResolvedValue({
+        access_token: "new_tok",
+        refresh_token: "new_ref",
+        expires_in: 3600,
+      });
+
+      await run("login");
+
+      expect(logSpy).toHaveBeenCalledWith("Opening browser for authentication...");
+      expect(mockStartOAuthFlow).toHaveBeenCalledOnce();
+      expect(mockSaveConfig).toHaveBeenCalledOnce();
+      const saved = mockSaveConfig.mock.calls[0][0];
+      expect(saved.access_token).toBe("new_tok");
+      expect(saved.refresh_token).toBe("new_ref");
+      expect(saved.expires_at).toBeGreaterThan(0);
+      expect(logSpy).toHaveBeenCalledWith("Successfully authenticated!");
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Credentials saved to"),
+      );
+    });
+
+    it("runs OAuth flow when token is expired", async () => {
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(true);
+      mockStartOAuthFlow.mockResolvedValue({
+        access_token: "refreshed",
+        refresh_token: "ref2",
+        expires_in: 7200,
+      });
+
+      await run("login");
+
+      expect(mockStartOAuthFlow).toHaveBeenCalledOnce();
+      expect(mockSaveConfig).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── logout ───────────────────────────────────────────────────────────────
+
+  describe("logout", () => {
+    it("clears credentials and saves config when authenticated", async () => {
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+
+      await run("logout");
+
+      expect(mockSaveConfig).toHaveBeenCalledOnce();
+      const saved = mockSaveConfig.mock.calls[0][0];
+      expect(saved.access_token).toBe("");
+      expect(saved.refresh_token).toBe("");
+      expect(saved.expires_at).toBe(0);
+      expect(saved.deployment_id).toBeUndefined();
+      expect(saved.deployment_name).toBeUndefined();
+      expect(saved.api_key).toBeUndefined();
+      expect(logSpy).toHaveBeenCalledWith("Successfully logged out.");
+    });
+
+    it("prints not-logged-in message when not authenticated", async () => {
+      mockLoadConfig.mockReturnValue(unauthenticatedConfig());
+      mockIsAuthenticated.mockReturnValue(false);
+
+      await run("logout");
+
+      expect(logSpy).toHaveBeenCalledWith("You are not logged in.");
+      expect(mockSaveConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── status ───────────────────────────────────────────────────────────────
+
+  describe("status", () => {
+    it("shows not-logged-in when unauthenticated", async () => {
+      mockLoadConfig.mockReturnValue(unauthenticatedConfig());
+      mockIsAuthenticated.mockReturnValue(false);
+
+      await run("status");
+
+      expect(logSpy).toHaveBeenCalledWith("Status: Not logged in");
+      expect(logSpy).toHaveBeenCalledWith("Run 'dosu login' to authenticate.");
+    });
+
+    it("shows logged in with deployment info", async () => {
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(false);
+
+      await run("status");
+
+      expect(logSpy).toHaveBeenCalledWith("Status: Logged in");
+      expect(logSpy).toHaveBeenCalledWith("Deployment: My App");
+      expect(logSpy).toHaveBeenCalledWith("Deployment ID: dep_123");
+    });
+
+    it("shows token-expired status", async () => {
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(true);
+
+      await run("status");
+
+      expect(logSpy).toHaveBeenCalledWith("Status: Token expired");
+      expect(logSpy).toHaveBeenCalledWith("Run 'dosu login' to re-authenticate.");
+    });
+
+    it("shows no deployment when none selected", async () => {
+      const cfg = authenticatedConfig();
+      cfg.deployment_id = undefined;
+      cfg.deployment_name = undefined;
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(false);
+
+      await run("status");
+
+      expect(logSpy).toHaveBeenCalledWith("Deployment: None selected");
+      expect(logSpy).toHaveBeenCalledWith(
+        "Run 'dosu' to open the TUI and select a deployment.",
+      );
+    });
+  });
+
+  // ── mcp list ─────────────────────────────────────────────────────────────
+
+  describe("mcp list", () => {
+    it("prints all providers", async () => {
+      const providers = [
+        fakeProvider({ id: "cursor", name: "Cursor", supportsLocal: true }),
+        fakeProvider({ id: "claude", name: "Claude Code", supportsLocal: true }),
+        fakeProvider({ id: "manual", name: "Manual", supportsLocal: true }),
+      ];
+      // Override the id check for "manual" — the list action uses p.id() === "manual"
+      providers[2].id.mockReturnValue("manual");
+      // Make the third one not support local to exercise all branches
+      providers[1].supportsLocal.mockReturnValue(false);
+
+      mockAllProviders.mockReturnValue(providers);
+
+      await run("mcp", "list");
+
+      expect(logSpy).toHaveBeenCalledWith("Available AI tools:\n");
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("cursor"),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("claude"),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("manual"),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        "\nUse 'dosu mcp add <tool>' to add Dosu MCP to a tool.",
+      );
+    });
+  });
+
+  // ── mcp add ──────────────────────────────────────────────────────────────
+
+  describe("mcp add", () => {
+    it("installs a valid tool", async () => {
+      const provider = fakeProvider({ id: "cursor", name: "Cursor", supportsLocal: true });
+      mockGetProvider.mockReturnValue(provider);
+
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(false);
+
+      await run("mcp", "add", "cursor");
+
+      expect(mockGetProvider).toHaveBeenCalledWith("cursor");
+      expect(mockInstall).toHaveBeenCalledWith(cfg, false);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Successfully added Dosu MCP to Cursor"),
+      );
+    });
+
+    it("throws error for unknown tool", async () => {
+      mockGetProvider.mockImplementation(() => {
+        throw new Error("unknown tool: nope");
+      });
+
+      await expect(run("mcp", "add", "nope")).rejects.toThrow(
+        "unknown tool 'nope'",
+      );
+    });
+
+    it("throws error when not authenticated", async () => {
+      const provider = fakeProvider();
+      mockGetProvider.mockReturnValue(provider);
+      mockLoadConfig.mockReturnValue(unauthenticatedConfig());
+      mockIsAuthenticated.mockReturnValue(false);
+
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow(
+        "not logged in",
+      );
+    });
+
+    it("throws error when token is expired", async () => {
+      const provider = fakeProvider();
+      mockGetProvider.mockReturnValue(provider);
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(true);
+
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow(
+        "session expired",
+      );
+    });
+
+    it("throws error when no deployment selected", async () => {
+      const provider = fakeProvider();
+      mockGetProvider.mockReturnValue(provider);
+      const cfg = authenticatedConfig();
+      cfg.deployment_id = undefined;
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(false);
+
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow(
+        "no deployment selected",
+      );
+    });
+
+    it("calls install without global flag for manual tool", async () => {
+      const provider = fakeProvider({ id: "manual", name: "Manual" });
+      mockGetProvider.mockReturnValue(provider);
+
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(false);
+
+      await run("mcp", "add", "manual");
+
+      expect(mockInstall).toHaveBeenCalledWith(cfg, false);
+      // Should return early — no "Successfully added" message for manual
+      expect(logSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Successfully added"),
+      );
+    });
+
+    it("auto-sets global when provider does not support local", async () => {
+      const provider = fakeProvider({
+        id: "zed",
+        name: "Zed",
+        supportsLocal: false,
+      });
+      mockGetProvider.mockReturnValue(provider);
+
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(false);
+
+      await run("mcp", "add", "zed");
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("only supports global installation"),
+      );
+      expect(mockInstall).toHaveBeenCalledWith(cfg, true);
+    });
+
+    it("installs globally when --global flag is passed", async () => {
+      const provider = fakeProvider({ id: "cursor", name: "Cursor", supportsLocal: true });
+      mockGetProvider.mockReturnValue(provider);
+
+      const cfg = authenticatedConfig();
+      mockLoadConfig.mockReturnValue(cfg);
+      mockIsAuthenticated.mockReturnValue(true);
+      mockIsTokenExpired.mockReturnValue(false);
+
+      await run("mcp", "add", "cursor", "--global");
+
+      expect(mockInstall).toHaveBeenCalledWith(cfg, true);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("global (all projects)"),
+      );
+    });
+  });
+
+  // ── setup ────────────────────────────────────────────────────────────────
+
+  describe("setup", () => {
+    it("runs setup flow", async () => {
+      mockRunSetup.mockResolvedValue(undefined);
+
+      await run("setup");
+
+      expect(mockRunSetup).toHaveBeenCalledWith({ deploymentID: undefined });
+    });
+
+    it("passes --deployment option to setup flow", async () => {
+      mockRunSetup.mockResolvedValue(undefined);
+
+      await run("setup", "--deployment", "dep_456");
+
+      expect(mockRunSetup).toHaveBeenCalledWith({ deploymentID: "dep_456" });
+    });
+  });
+});

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -1,44 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createProgram } from "./cli";
+import { loadConfig, saveConfig } from "../config/config";
 import type { Config } from "../config/config";
+import { allProviders } from "../mcp/providers";
 
-// ── Mocks ────────────────────────────────────────────────────────────────────
-
-const mockLoadConfig = vi.fn<() => Config>();
-const mockSaveConfig = vi.fn<(cfg: Config) => void>();
-const mockIsAuthenticated = vi.fn<(cfg: Config) => boolean>();
-const mockIsTokenExpired = vi.fn<(cfg: Config) => boolean>();
-const mockGetConfigPath = vi.fn<() => string>();
-
-vi.mock("../config/config", () => ({
-  loadConfig: (...args: unknown[]) => mockLoadConfig(...(args as [])),
-  saveConfig: (...args: unknown[]) => mockSaveConfig(...(args as [Config])),
-  isAuthenticated: (...args: unknown[]) => mockIsAuthenticated(...(args as [Config])),
-  isTokenExpired: (...args: unknown[]) => mockIsTokenExpired(...(args as [Config])),
-  getConfigPath: (...args: unknown[]) => mockGetConfigPath(...(args as [])),
-}));
-
-const mockInstall = vi.fn();
-
-const fakeProvider = (overrides: Partial<{
-  id: string;
-  name: string;
-  supportsLocal: boolean;
-}> = {}) => ({
-  id: vi.fn().mockReturnValue(overrides.id ?? "cursor"),
-  name: vi.fn().mockReturnValue(overrides.name ?? "Cursor"),
-  supportsLocal: vi.fn().mockReturnValue(overrides.supportsLocal ?? true),
-  install: mockInstall,
-  remove: vi.fn(),
-});
-
-const mockGetProvider = vi.fn();
-const mockAllProviders = vi.fn();
-
-vi.mock("../mcp/providers", () => ({
-  getProvider: (...args: unknown[]) => mockGetProvider(...args),
-  allProviders: (...args: unknown[]) => mockAllProviders(...args),
-}));
+// ── Mocks (true external boundaries only) ───────────────────────────────────
 
 const mockStartOAuthFlow = vi.fn();
 vi.mock("../auth/flow", () => ({
@@ -55,7 +24,34 @@ vi.mock("../setup/flow", () => ({
   runSetup: (...args: unknown[]) => mockRunSetup(...args),
 }));
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Temp dir + env management ───────────────────────────────────────────────
+
+let tempDir: string;
+let origXDG: string | undefined;
+let origHome: string | undefined;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-cli-test-"));
+  origXDG = process.env.XDG_CONFIG_HOME;
+  origHome = process.env.HOME;
+  process.env.XDG_CONFIG_HOME = tempDir;
+  process.env.HOME = tempDir;
+
+  vi.clearAllMocks();
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
+  else delete process.env.XDG_CONFIG_HOME;
+  if (origHome !== undefined) process.env.HOME = origHome;
+  else delete process.env.HOME;
+  rmSync(tempDir, { recursive: true, force: true });
+  logSpy.mockRestore();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
 function authenticatedConfig(): Config {
   return {
@@ -68,38 +64,20 @@ function authenticatedConfig(): Config {
   };
 }
 
-function unauthenticatedConfig(): Config {
-  return {
-    access_token: "",
-    refresh_token: "",
-    expires_at: 0,
-  };
-}
-
-/** Parse a command through Commander, catching Commander's own exit calls. */
 async function run(...args: string[]) {
   const program = createProgram();
   program.exitOverride();
-  // Commander wraps action errors in CommanderError; we want the original.
   await program.parseAsync(["node", "dosu", ...args]);
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────────
+function allLogOutput(): string {
+  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
 
 describe("CLI actions", () => {
-  let logSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    mockGetConfigPath.mockReturnValue("/home/user/.config/dosu-cli/config.json");
-  });
-
-  afterEach(() => {
-    logSpy.mockRestore();
-  });
-
-  // ── default (no subcommand) ──────────────────────────────────────────────
+  // ── default (no subcommand) ─────────────────────────────────────────────
 
   describe("default action (no subcommand)", () => {
     it("launches the TUI", async () => {
@@ -109,27 +87,23 @@ describe("CLI actions", () => {
     });
   });
 
-  // ── login ────────────────────────────────────────────────────────────────
+  // ── login ───────────────────────────────────────────────────────────────
 
   describe("login", () => {
-    it("prints already-logged-in message when authenticated", async () => {
-      const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(false);
+    it("prints already-logged-in when config has valid token", async () => {
+      saveConfig(authenticatedConfig());
 
       await run("login");
 
       expect(logSpy).toHaveBeenCalledWith("You are already logged in.");
-      expect(logSpy).toHaveBeenCalledWith("Run 'dosu logout' first to re-authenticate.");
+      expect(logSpy).toHaveBeenCalledWith(
+        "Run 'dosu logout' first to re-authenticate.",
+      );
       expect(mockStartOAuthFlow).not.toHaveBeenCalled();
     });
 
-    it("runs OAuth flow and saves token when not authenticated", async () => {
-      const cfg = unauthenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(false);
-      mockIsTokenExpired.mockReturnValue(false);
+    it("runs OAuth flow and writes token to real config file", async () => {
+      // Start with empty config (no file on disk)
       mockStartOAuthFlow.mockResolvedValue({
         access_token: "new_tok",
         refresh_token: "new_ref",
@@ -138,87 +112,73 @@ describe("CLI actions", () => {
 
       await run("login");
 
-      expect(logSpy).toHaveBeenCalledWith("Opening browser for authentication...");
-      expect(mockStartOAuthFlow).toHaveBeenCalledOnce();
-      expect(mockSaveConfig).toHaveBeenCalledOnce();
-      const saved = mockSaveConfig.mock.calls[0][0];
-      expect(saved.access_token).toBe("new_tok");
-      expect(saved.refresh_token).toBe("new_ref");
-      expect(saved.expires_at).toBeGreaterThan(0);
-      expect(logSpy).toHaveBeenCalledWith("Successfully authenticated!");
       expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Credentials saved to"),
+        "Opening browser for authentication...",
       );
+      expect(mockStartOAuthFlow).toHaveBeenCalledOnce();
+      expect(logSpy).toHaveBeenCalledWith("Successfully authenticated!");
+
+      // Verify the real config file was written
+      const cfg = loadConfig();
+      expect(cfg.access_token).toBe("new_tok");
+      expect(cfg.refresh_token).toBe("new_ref");
+      expect(cfg.expires_at).toBeGreaterThan(0);
     });
 
     it("runs OAuth flow when token is expired", async () => {
       const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(true);
+      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000; // expired
+      saveConfig(cfg);
+
       mockStartOAuthFlow.mockResolvedValue({
-        access_token: "refreshed",
-        refresh_token: "ref2",
+        access_token: "refreshed_tok",
+        refresh_token: "refreshed_ref",
         expires_in: 7200,
       });
 
       await run("login");
 
       expect(mockStartOAuthFlow).toHaveBeenCalledOnce();
-      expect(mockSaveConfig).toHaveBeenCalledOnce();
+
+      const updated = loadConfig();
+      expect(updated.access_token).toBe("refreshed_tok");
+      expect(updated.refresh_token).toBe("refreshed_ref");
     });
   });
 
-  // ── logout ───────────────────────────────────────────────────────────────
+  // ── logout ──────────────────────────────────────────────────────────────
 
   describe("logout", () => {
-    it("clears credentials and saves config when authenticated", async () => {
-      const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
+    it("clears credentials in real config file", async () => {
+      saveConfig(authenticatedConfig());
 
       await run("logout");
 
-      expect(mockSaveConfig).toHaveBeenCalledOnce();
-      const saved = mockSaveConfig.mock.calls[0][0];
-      expect(saved.access_token).toBe("");
-      expect(saved.refresh_token).toBe("");
-      expect(saved.expires_at).toBe(0);
-      expect(saved.deployment_id).toBeUndefined();
-      expect(saved.deployment_name).toBeUndefined();
-      expect(saved.api_key).toBeUndefined();
       expect(logSpy).toHaveBeenCalledWith("Successfully logged out.");
+
+      // Read back the real config file and verify credentials are cleared
+      const cfg = loadConfig();
+      expect(cfg.access_token).toBe("");
+      expect(cfg.refresh_token).toBe("");
+      expect(cfg.expires_at).toBe(0);
+      expect(cfg.deployment_id).toBeUndefined();
+      expect(cfg.deployment_name).toBeUndefined();
+      expect(cfg.api_key).toBeUndefined();
     });
 
-    it("prints not-logged-in message when not authenticated", async () => {
-      mockLoadConfig.mockReturnValue(unauthenticatedConfig());
-      mockIsAuthenticated.mockReturnValue(false);
-
+    it("prints not-logged-in when config has no credentials", async () => {
+      // No config file on disk = empty config
       await run("logout");
 
       expect(logSpy).toHaveBeenCalledWith("You are not logged in.");
-      expect(mockSaveConfig).not.toHaveBeenCalled();
     });
   });
 
-  // ── status ───────────────────────────────────────────────────────────────
+  // ── status ──────────────────────────────────────────────────────────────
 
   describe("status", () => {
-    it("shows not-logged-in when unauthenticated", async () => {
-      mockLoadConfig.mockReturnValue(unauthenticatedConfig());
-      mockIsAuthenticated.mockReturnValue(false);
-
-      await run("status");
-
-      expect(logSpy).toHaveBeenCalledWith("Status: Not logged in");
-      expect(logSpy).toHaveBeenCalledWith("Run 'dosu login' to authenticate.");
-    });
-
-    it("shows logged in with deployment info", async () => {
-      const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(false);
+    it("shows deployment info from real config", async () => {
+      saveConfig(authenticatedConfig());
 
       await run("status");
 
@@ -227,25 +187,33 @@ describe("CLI actions", () => {
       expect(logSpy).toHaveBeenCalledWith("Deployment ID: dep_123");
     });
 
+    it("shows not-logged-in with empty config", async () => {
+      await run("status");
+
+      expect(logSpy).toHaveBeenCalledWith("Status: Not logged in");
+      expect(logSpy).toHaveBeenCalledWith(
+        "Run 'dosu login' to authenticate.",
+      );
+    });
+
     it("shows token-expired status", async () => {
       const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(true);
+      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
+      saveConfig(cfg);
 
       await run("status");
 
       expect(logSpy).toHaveBeenCalledWith("Status: Token expired");
-      expect(logSpy).toHaveBeenCalledWith("Run 'dosu login' to re-authenticate.");
+      expect(logSpy).toHaveBeenCalledWith(
+        "Run 'dosu login' to re-authenticate.",
+      );
     });
 
     it("shows no deployment when none selected", async () => {
       const cfg = authenticatedConfig();
       cfg.deployment_id = undefined;
       cfg.deployment_name = undefined;
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(false);
+      saveConfig(cfg);
 
       await run("status");
 
@@ -256,89 +224,73 @@ describe("CLI actions", () => {
     });
   });
 
-  // ── mcp list ─────────────────────────────────────────────────────────────
+  // ── mcp list ────────────────────────────────────────────────────────────
 
   describe("mcp list", () => {
-    it("prints all providers", async () => {
-      const providers = [
-        fakeProvider({ id: "cursor", name: "Cursor", supportsLocal: true }),
-        fakeProvider({ id: "claude", name: "Claude Code", supportsLocal: true }),
-        fakeProvider({ id: "manual", name: "Manual", supportsLocal: true }),
-      ];
-      // Override the id check for "manual" — the list action uses p.id() === "manual"
-      providers[2].id.mockReturnValue("manual");
-      // Make the third one not support local to exercise all branches
-      providers[1].supportsLocal.mockReturnValue(false);
-
-      mockAllProviders.mockReturnValue(providers);
-
+    it("prints all real provider names", async () => {
       await run("mcp", "list");
 
-      expect(logSpy).toHaveBeenCalledWith("Available AI tools:\n");
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("cursor"),
-      );
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("claude"),
-      );
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("manual"),
-      );
-      expect(logSpy).toHaveBeenCalledWith(
-        "\nUse 'dosu mcp add <tool>' to add Dosu MCP to a tool.",
+      const output = allLogOutput();
+      expect(output).toContain("Available AI tools:");
+
+      // Verify all real providers appear in the output
+      const providers = allProviders();
+      for (const p of providers) {
+        expect(output).toContain(p.id());
+      }
+
+      expect(output).toContain(
+        "Use 'dosu mcp add <tool>' to add Dosu MCP to a tool.",
       );
     });
   });
 
-  // ── mcp add ──────────────────────────────────────────────────────────────
+  // ── mcp add ─────────────────────────────────────────────────────────────
 
   describe("mcp add", () => {
-    it("installs a valid tool", async () => {
-      const provider = fakeProvider({ id: "cursor", name: "Cursor", supportsLocal: true });
-      mockGetProvider.mockReturnValue(provider);
-
+    it("creates real cursor config file with --global", async () => {
       const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(false);
+      saveConfig(cfg);
 
-      await run("mcp", "add", "cursor");
+      await run("mcp", "add", "cursor", "--global");
 
-      expect(mockGetProvider).toHaveBeenCalledWith("cursor");
-      expect(mockInstall).toHaveBeenCalledWith(cfg, false);
+      // Verify real file was created on disk
+      const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+      const cursorConfig = JSON.parse(
+        readFileSync(cursorConfigPath, "utf-8"),
+      );
+      expect(cursorConfig.mcpServers).toBeDefined();
+      expect(cursorConfig.mcpServers.dosu).toBeDefined();
+      expect(cursorConfig.mcpServers.dosu.url).toContain("dep_123");
+      expect(cursorConfig.mcpServers.dosu.headers).toBeDefined();
+      expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe(
+        "key_abc",
+      );
+
       expect(logSpy).toHaveBeenCalledWith(
         expect.stringContaining("Successfully added Dosu MCP to Cursor"),
       );
     });
 
     it("throws error for unknown tool", async () => {
-      mockGetProvider.mockImplementation(() => {
-        throw new Error("unknown tool: nope");
-      });
+      saveConfig(authenticatedConfig());
 
-      await expect(run("mcp", "add", "nope")).rejects.toThrow(
-        "unknown tool 'nope'",
+      await expect(run("mcp", "add", "nonexistent")).rejects.toThrow(
+        "unknown tool 'nonexistent'",
       );
     });
 
-    it("throws error when not authenticated", async () => {
-      const provider = fakeProvider();
-      mockGetProvider.mockReturnValue(provider);
-      mockLoadConfig.mockReturnValue(unauthenticatedConfig());
-      mockIsAuthenticated.mockReturnValue(false);
-
+    it("throws error when not logged in", async () => {
+      // No config on disk = empty/unauthenticated
       await expect(run("mcp", "add", "cursor")).rejects.toThrow(
         "not logged in",
       );
     });
 
     it("throws error when token is expired", async () => {
-      const provider = fakeProvider();
-      mockGetProvider.mockReturnValue(provider);
       const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(true);
+      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
+      saveConfig(cfg);
 
       await expect(run("mcp", "add", "cursor")).rejects.toThrow(
         "session expired",
@@ -346,77 +298,50 @@ describe("CLI actions", () => {
     });
 
     it("throws error when no deployment selected", async () => {
-      const provider = fakeProvider();
-      mockGetProvider.mockReturnValue(provider);
       const cfg = authenticatedConfig();
       cfg.deployment_id = undefined;
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(false);
+      saveConfig(cfg);
 
       await expect(run("mcp", "add", "cursor")).rejects.toThrow(
         "no deployment selected",
       );
     });
 
-    it("calls install without global flag for manual tool", async () => {
-      const provider = fakeProvider({ id: "manual", name: "Manual" });
-      mockGetProvider.mockReturnValue(provider);
-
-      const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(false);
+    it("logs manual config details without writing files", async () => {
+      saveConfig(authenticatedConfig());
 
       await run("mcp", "add", "manual");
 
-      expect(mockInstall).toHaveBeenCalledWith(cfg, false);
-      // Should return early — no "Successfully added" message for manual
-      expect(logSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("Successfully added"),
-      );
+      const output = allLogOutput();
+      expect(output).toContain("dep_123");
+      expect(output).toContain("key_abc");
+      // Manual provider returns early, no "Successfully added" message
+      expect(output).not.toContain("Successfully added");
     });
 
     it("auto-sets global when provider does not support local", async () => {
-      const provider = fakeProvider({
-        id: "zed",
-        name: "Zed",
-        supportsLocal: false,
-      });
-      mockGetProvider.mockReturnValue(provider);
+      saveConfig(authenticatedConfig());
 
-      const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(false);
+      // Windsurf only supports global installation
+      await run("mcp", "add", "windsurf");
 
-      await run("mcp", "add", "zed");
-
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("only supports global installation"),
-      );
-      expect(mockInstall).toHaveBeenCalledWith(cfg, true);
+      const output = allLogOutput();
+      expect(output).toContain("only supports global installation");
+      expect(output).toContain("Successfully added Dosu MCP to Windsurf");
     });
 
     it("installs globally when --global flag is passed", async () => {
-      const provider = fakeProvider({ id: "cursor", name: "Cursor", supportsLocal: true });
-      mockGetProvider.mockReturnValue(provider);
-
-      const cfg = authenticatedConfig();
-      mockLoadConfig.mockReturnValue(cfg);
-      mockIsAuthenticated.mockReturnValue(true);
-      mockIsTokenExpired.mockReturnValue(false);
+      saveConfig(authenticatedConfig());
 
       await run("mcp", "add", "cursor", "--global");
 
-      expect(mockInstall).toHaveBeenCalledWith(cfg, true);
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("global (all projects)"),
-      );
+      const output = allLogOutput();
+      expect(output).toContain("global (all projects)");
+      expect(output).toContain("Successfully added Dosu MCP to Cursor");
     });
   });
 
-  // ── setup ────────────────────────────────────────────────────────────────
+  // ── setup ───────────────────────────────────────────────────────────────
 
   describe("setup", () => {
     it("runs setup flow", async () => {
@@ -424,7 +349,9 @@ describe("CLI actions", () => {
 
       await run("setup");
 
-      expect(mockRunSetup).toHaveBeenCalledWith({ deploymentID: undefined });
+      expect(mockRunSetup).toHaveBeenCalledWith({
+        deploymentID: undefined,
+      });
     });
 
     it("passes --deployment option to setup flow", async () => {
@@ -432,7 +359,9 @@ describe("CLI actions", () => {
 
       await run("setup", "--deployment", "dep_456");
 
-      expect(mockRunSetup).toHaveBeenCalledWith({ deploymentID: "dep_456" });
+      expect(mockRunSetup).toHaveBeenCalledWith({
+        deploymentID: "dep_456",
+      });
     });
   });
 });

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -227,7 +227,7 @@ describe("CLI actions", () => {
   // ── mcp list ────────────────────────────────────────────────────────────
 
   describe("mcp list", () => {
-    it("prints all real provider names", async () => {
+    it("prints all real provider names with correct scope labels", async () => {
       await run("mcp", "list");
 
       const output = allLogOutput();
@@ -237,6 +237,24 @@ describe("CLI actions", () => {
       const providers = allProviders();
       for (const p of providers) {
         expect(output).toContain(p.id());
+        expect(output).toContain(p.name());
+      }
+
+      // Verify scope labels are present for providers
+      for (const p of providers) {
+        if (p.id() === "manual") {
+          // Manual provider should have NO scope label
+          // Check that the line with "manual" does not include "(global only)" or "(local + global)"
+          const lines = output.split("\n");
+          const manualLine = lines.find((l: string) => l.includes("manual"));
+          expect(manualLine).toBeDefined();
+          expect(manualLine).not.toContain("(global only)");
+          expect(manualLine).not.toContain("(local + global)");
+        } else if (!p.supportsLocal()) {
+          expect(output).toContain("(global only)");
+        } else {
+          expect(output).toContain("(local + global)");
+        }
       }
 
       expect(output).toContain(

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -79,6 +79,42 @@ describe("Client", () => {
       const client = new Client(makeConfig());
       await expect(client.get("/test")).rejects.toBeInstanceOf(SessionExpiredError);
     });
+
+    it("pre-emptively refreshes token when locally expired before making request", async () => {
+      // Refresh response
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "refreshed-token",
+          refresh_token: "refreshed-refresh",
+          expires_in: 7200,
+        }),
+      );
+      // Actual request after refresh
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const cfg = makeConfig({
+        expires_at: Math.floor(Date.now() / 1000) - 100, // already expired
+      });
+      const client = new Client(cfg);
+      const resp = await client.get("/test");
+
+      expect(resp.status).toBe(200);
+      // Should have made 2 calls: refresh + actual request
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // First call should be to the refresh endpoint
+      expect(mockFetch.mock.calls[0][0]).toContain("/auth/v1/token");
+      // Config should be updated with new tokens
+      expect(cfg.access_token).toBe("refreshed-token");
+      expect(cfg.refresh_token).toBe("refreshed-refresh");
+    });
+
+    it("throws when refresh_token is missing and token is expired", async () => {
+      const client = new Client(makeConfig({
+        refresh_token: "",
+        expires_at: Math.floor(Date.now() / 1000) - 100,
+      }));
+      await expect(client.get("/test")).rejects.toThrow("no refresh token available");
+    });
   });
 
   describe("HTTP methods", () => {

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -98,9 +98,48 @@ describe("config", () => {
     expect(cleared.api_key).toBeUndefined();
   });
 
-  it("emptyConfig returns default values", () => {
+  it("emptyConfig returns exact default shape", () => {
     const cfg = emptyConfig();
-    expect(cfg.access_token).toBe("");
-    expect(cfg.expires_at).toBe(0);
+    expect(cfg).toEqual({
+      access_token: "",
+      refresh_token: "",
+      expires_at: 0,
+    });
+    // Ensure optional fields are not present
+    expect(cfg.deployment_id).toBeUndefined();
+    expect(cfg.deployment_name).toBeUndefined();
+    expect(cfg.api_key).toBeUndefined();
+  });
+
+  it("loadConfig returns emptyConfig on corrupt JSON file", () => {
+    const { writeFileSync } = require("node:fs");
+    const path = getConfigPath();
+    writeFileSync(path, "NOT VALID JSON {{{{");
+    const cfg = loadConfig();
+    expect(cfg).toEqual({
+      access_token: "",
+      refresh_token: "",
+      expires_at: 0,
+    });
+  });
+
+  it("clearConfig returns exact empty shape with undefined optional fields", () => {
+    const cfg: Config = {
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: 999,
+      deployment_id: "dep",
+      deployment_name: "name",
+      api_key: "key",
+    };
+    const cleared = clearConfig(cfg);
+    expect(cleared).toEqual({
+      access_token: "",
+      refresh_token: "",
+      expires_at: 0,
+      deployment_id: undefined,
+      deployment_name: undefined,
+      api_key: undefined,
+    });
   });
 });

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -254,6 +254,7 @@ describe("CodexProvider", () => {
     expect(existsSync(configPath)).toBe(true);
     const content = readFileSync(configPath, "utf-8");
     expect(content).toContain("[mcp_servers.dosu]");
+    expect(content).toContain('type = "http"');
     expect(content).toContain("dep-123");
     expect(content).toContain("X-Dosu-API-Key");
     expect(content).toContain("key-abc");

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -610,7 +610,7 @@ describe("ManualProvider", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    provider.install(makeCfg());
+    provider.install(makeCfg(), false);
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("dep-123");
@@ -626,7 +626,7 @@ describe("ManualProvider", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    provider.remove();
+    provider.remove(false);
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("remove");

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -1,0 +1,996 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Config } from "../../config/config";
+import { loadJSONConfig } from "../config-helpers";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCfg(overrides: Partial<Config> = {}): Config {
+  return {
+    access_token: "at",
+    refresh_token: "rt",
+    expires_at: Date.now() + 3600_000,
+    deployment_id: "dep-123",
+    deployment_name: "my-deploy",
+    api_key: "key-abc",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Base provider (createJSONProvider)
+// ---------------------------------------------------------------------------
+
+describe("createJSONProvider (base)", () => {
+  let tempDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-base-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install creates JSON config with dosu entry", async () => {
+    const { createJSONProvider } = await import("./base");
+    const globalPath = join(tempDir, "test-config.json");
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: false,
+      priorityValue: 1,
+      paths: [],
+      globalPath,
+      topKey: "mcpServers",
+    });
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(globalPath);
+    expect(cfg.mcpServers).toBeDefined();
+    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.type).toBe("http");
+    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+    expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("install throws when deployment_id is missing", async () => {
+    const { createJSONProvider } = await import("./base");
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: false,
+      priorityValue: 1,
+      paths: [],
+      globalPath: join(tempDir, "nope.json"),
+      topKey: "mcpServers",
+    });
+
+    expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
+      "deployment ID is required",
+    );
+  });
+
+  it("local install throws when localConfigPath is not provided", async () => {
+    const { createJSONProvider } = await import("./base");
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: false,
+      priorityValue: 1,
+      paths: [],
+      globalPath: join(tempDir, "g.json"),
+      topKey: "mcpServers",
+    });
+
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support local installation",
+    );
+  });
+
+  it("local install writes to localConfigPath when provided", async () => {
+    const { createJSONProvider } = await import("./base");
+    const localPath = join(tempDir, "local", "mcp.json");
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: true,
+      priorityValue: 1,
+      paths: [],
+      globalPath: join(tempDir, "g.json"),
+      topKey: "mcpServers",
+      localConfigPath: () => localPath,
+    });
+
+    provider.install(makeCfg(), false);
+
+    const cfg = loadJSONConfig(localPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+  });
+
+  it("global remove deletes dosu entry from JSON config", async () => {
+    const { createJSONProvider } = await import("./base");
+    const globalPath = join(tempDir, "remove.json");
+    writeFileSync(
+      globalPath,
+      JSON.stringify({
+        mcpServers: { dosu: { url: "old" }, other: { url: "keep" } },
+      }),
+    );
+
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: false,
+      priorityValue: 1,
+      paths: [],
+      globalPath,
+      topKey: "mcpServers",
+    });
+
+    provider.remove(true);
+
+    const cfg = loadJSONConfig(globalPath);
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+    expect(cfg.mcpServers.other).toEqual({ url: "keep" });
+  });
+
+  it("local remove throws when localConfigPath is not provided", async () => {
+    const { createJSONProvider } = await import("./base");
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: false,
+      priorityValue: 1,
+      paths: [],
+      globalPath: join(tempDir, "g.json"),
+      topKey: "mcpServers",
+    });
+
+    expect(() => provider.remove(false)).toThrow("does not support local removal");
+  });
+
+  it("local remove deletes dosu entry when localConfigPath is provided", async () => {
+    const { createJSONProvider } = await import("./base");
+    const localPath = join(tempDir, "local-rm", "mcp.json");
+    mkdirSync(join(tempDir, "local-rm"), { recursive: true });
+    writeFileSync(
+      localPath,
+      JSON.stringify({ mcpServers: { dosu: { url: "x" } } }),
+    );
+
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: true,
+      priorityValue: 1,
+      paths: [],
+      globalPath: join(tempDir, "g.json"),
+      topKey: "mcpServers",
+      localConfigPath: () => localPath,
+    });
+
+    provider.remove(false);
+
+    const cfg = loadJSONConfig(localPath);
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+
+  it("install with custom buildServer uses that shape", async () => {
+    const { createJSONProvider } = await import("./base");
+    const globalPath = join(tempDir, "custom.json");
+
+    const provider = createJSONProvider({
+      providerName: "Custom",
+      providerID: "custom",
+      local: false,
+      priorityValue: 1,
+      paths: [],
+      globalPath,
+      topKey: "servers",
+      buildServer: (cfg) => ({
+        myUrl: `custom-${cfg.deployment_id}`,
+      }),
+    });
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(globalPath);
+    expect(cfg.servers.dosu).toEqual({ myUrl: "custom-dep-123" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Codex provider (TOML-based)
+// ---------------------------------------------------------------------------
+
+describe("CodexProvider", () => {
+  let tempDir: string;
+  let origCodexHome: string | undefined;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-codex-test-"));
+    origCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = join(tempDir, "codex-home");
+    origCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    if (origCodexHome !== undefined) {
+      process.env.CODEX_HOME = origCodexHome;
+    } else {
+      delete process.env.CODEX_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes TOML config with dosu section", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    provider.install(makeCfg(), true);
+
+    const configPath = join(tempDir, "codex-home", "config.toml");
+    expect(existsSync(configPath)).toBe(true);
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).toContain("[mcp_servers.dosu]");
+    expect(content).toContain("dep-123");
+    expect(content).toContain("X-Dosu-API-Key");
+    expect(content).toContain("key-abc");
+  });
+
+  it("local install writes TOML config to .codex/config.toml in cwd", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    provider.install(makeCfg(), false);
+
+    const configPath = join(tempDir, ".codex", "config.toml");
+    expect(existsSync(configPath)).toBe(true);
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).toContain("[mcp_servers.dosu]");
+  });
+
+  it("install throws when deployment_id is missing", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), true),
+    ).toThrow("deployment ID is required");
+  });
+
+  it("install replaces existing dosu section", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    // First install
+    provider.install(makeCfg({ deployment_id: "old-dep", api_key: "old-key" }), true);
+
+    // Second install should replace
+    provider.install(makeCfg({ deployment_id: "new-dep", api_key: "new-key" }), true);
+
+    const configPath = join(tempDir, "codex-home", "config.toml");
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).toContain("new-dep");
+    expect(content).not.toContain("old-dep");
+    // Should only have one dosu section
+    const matches = content.match(/\[mcp_servers\.dosu\]/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  it("install preserves other TOML content", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    const configPath = join(tempDir, "codex-home", "config.toml");
+    mkdirSync(join(tempDir, "codex-home"), { recursive: true });
+    writeFileSync(configPath, '[other_section]\nkey = "value"\n');
+
+    provider.install(makeCfg(), true);
+
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).toContain('[other_section]');
+    expect(content).toContain('key = "value"');
+    expect(content).toContain("[mcp_servers.dosu]");
+  });
+
+  it("global remove deletes dosu section from TOML", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const configPath = join(tempDir, "codex-home", "config.toml");
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).not.toContain("[mcp_servers.dosu]");
+  });
+
+  it("local remove deletes dosu section from local TOML", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    provider.install(makeCfg(), false);
+    provider.remove(false);
+
+    const configPath = join(tempDir, ".codex", "config.toml");
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).not.toContain("[mcp_servers.dosu]");
+  });
+
+  it("remove does nothing when config file does not exist", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    // Should not throw
+    provider.remove(true);
+  });
+
+  it("isConfigured returns true when dosu section exists", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    provider.install(makeCfg(), true);
+    expect(provider.isConfigured()).toBe(true);
+  });
+
+  it("isConfigured returns false when config does not exist", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    expect(provider.isConfigured()).toBe(false);
+  });
+
+  it("getConfigPath uses CODEX_HOME for global path", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    expect(provider.globalConfigPath()).toBe(
+      join(tempDir, "codex-home", "config.toml"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Copilot provider
+// ---------------------------------------------------------------------------
+
+describe("CopilotProvider", () => {
+  let tempDir: string;
+  let origXdgConfig: string | undefined;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-copilot-test-"));
+    origXdgConfig = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = join(tempDir, "xdg-config");
+    origCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    if (origXdgConfig !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXdgConfig;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes to XDG_CONFIG_HOME/mcp-config.json with mcpServers key", async () => {
+    const { CopilotProvider } = await import("./copilot");
+    const provider = CopilotProvider();
+
+    provider.install(makeCfg(), true);
+
+    const configPath = join(tempDir, "xdg-config", "mcp-config.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers).toBeDefined();
+    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.type).toBe("http");
+    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+    expect(cfg.mcpServers.dosu.tools).toEqual(["*"]);
+    expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("local install writes to cwd/.vscode/mcp.json with servers key", async () => {
+    const { CopilotProvider } = await import("./copilot");
+    const provider = CopilotProvider();
+
+    provider.install(makeCfg(), false);
+
+    const configPath = join(tempDir, ".vscode", "mcp.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.servers).toBeDefined();
+    expect(cfg.servers.dosu).toBeDefined();
+    expect(cfg.servers.dosu.type).toBe("http");
+    expect(cfg.servers.dosu.url).toContain("dep-123");
+    // local config should not have tools key
+    expect(cfg.servers.dosu.tools).toBeUndefined();
+  });
+
+  it("install throws when deployment_id is missing", async () => {
+    const { CopilotProvider } = await import("./copilot");
+    const provider = CopilotProvider();
+
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), true),
+    ).toThrow("deployment ID is required");
+  });
+
+  it("global remove deletes dosu entry from mcpServers", async () => {
+    const { CopilotProvider } = await import("./copilot");
+    const provider = CopilotProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const configPath = join(tempDir, "xdg-config", "mcp-config.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+
+  it("local remove deletes dosu entry from servers", async () => {
+    const { CopilotProvider } = await import("./copilot");
+    const provider = CopilotProvider();
+
+    provider.install(makeCfg(), false);
+    provider.remove(false);
+
+    const configPath = join(tempDir, ".vscode", "mcp.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.servers.dosu).toBeUndefined();
+  });
+
+  it("install preserves existing entries", async () => {
+    const { CopilotProvider } = await import("./copilot");
+    const provider = CopilotProvider();
+
+    const configPath = join(tempDir, "xdg-config", "mcp-config.json");
+    mkdirSync(join(tempDir, "xdg-config"), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { other: { url: "http://other" } } }),
+    );
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.other).toEqual({ url: "http://other" });
+    expect(cfg.mcpServers.dosu).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. MCPorter provider
+// ---------------------------------------------------------------------------
+
+describe("MCPorterProvider", () => {
+  let tempDir: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-mcporter-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    origCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    process.env.HOME = origHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes to ~/.mcporter/mcporter.json with mcpServers key", async () => {
+    const { MCPorterProvider } = await import("./mcporter");
+    const provider = MCPorterProvider();
+
+    provider.install(makeCfg(), true);
+
+    const configPath = join(tempDir, ".mcporter", "mcporter.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers).toBeDefined();
+    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+    expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("global install uses .jsonc path if it exists", async () => {
+    const jsoncPath = join(tempDir, ".mcporter", "mcporter.jsonc");
+    mkdirSync(join(tempDir, ".mcporter"), { recursive: true });
+    writeFileSync(jsoncPath, JSON.stringify({ mcpServers: {} }));
+
+    const { MCPorterProvider } = await import("./mcporter");
+    const provider = MCPorterProvider();
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(jsoncPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+  });
+
+  it("global install prefers .json over .jsonc when .json exists", async () => {
+    const jsonPath = join(tempDir, ".mcporter", "mcporter.json");
+    const jsoncPath = join(tempDir, ".mcporter", "mcporter.jsonc");
+    mkdirSync(join(tempDir, ".mcporter"), { recursive: true });
+    writeFileSync(jsonPath, JSON.stringify({ mcpServers: {} }));
+    writeFileSync(jsoncPath, JSON.stringify({ mcpServers: {} }));
+
+    const { MCPorterProvider } = await import("./mcporter");
+    const provider = MCPorterProvider();
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(jsonPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+  });
+
+  it("local install writes to cwd/config/mcporter.json", async () => {
+    const { MCPorterProvider } = await import("./mcporter");
+    const provider = MCPorterProvider();
+
+    provider.install(makeCfg(), false);
+
+    const configPath = join(tempDir, "config", "mcporter.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+  });
+
+  it("install throws when deployment_id is missing", async () => {
+    const { MCPorterProvider } = await import("./mcporter");
+    const provider = MCPorterProvider();
+
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), true),
+    ).toThrow("deployment ID is required");
+  });
+
+  it("global remove deletes dosu entry", async () => {
+    const { MCPorterProvider } = await import("./mcporter");
+    const provider = MCPorterProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const configPath = join(tempDir, ".mcporter", "mcporter.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+
+  it("local remove deletes dosu entry", async () => {
+    const { MCPorterProvider } = await import("./mcporter");
+    const provider = MCPorterProvider();
+
+    provider.install(makeCfg(), false);
+    provider.remove(false);
+
+    const configPath = join(tempDir, "config", "mcporter.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Manual provider
+// ---------------------------------------------------------------------------
+
+describe("ManualProvider", () => {
+  it("install logs MCP config to console", async () => {
+    const { ManualProvider } = await import("./manual");
+    const provider = ManualProvider();
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    provider.install(makeCfg());
+
+    const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(allOutput).toContain("dep-123");
+    expect(allOutput).toContain("key-abc");
+    expect(allOutput).toContain("X-Dosu-API-Key");
+
+    logSpy.mockRestore();
+  });
+
+  it("remove logs removal instructions", async () => {
+    const { ManualProvider } = await import("./manual");
+    const provider = ManualProvider();
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    provider.remove();
+
+    const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(allOutput).toContain("remove");
+
+    logSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Claude Desktop provider
+// ---------------------------------------------------------------------------
+
+describe("ClaudeDesktopProvider", () => {
+  it("install throws with stdio-only error", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    expect(() => provider.install(makeCfg(), true)).toThrow(
+      "this tool only supports local (stdio) servers",
+    );
+  });
+
+  it("remove throws with stdio-only error", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    expect(() => provider.remove(true)).toThrow(
+      "this tool only supports local (stdio) servers",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. createJSONProvider-based providers: Cursor, OpenCode, ClineCli,
+//    Antigravity, Zed
+//    (Cline is excluded because it depends on appSupportDir which is
+//    platform-specific and hard to override via env)
+// ---------------------------------------------------------------------------
+
+describe("CursorProvider", () => {
+  let tempDir: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-cursor-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    origCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    process.env.HOME = origHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes to ~/.cursor/mcp.json with mcpServers key", async () => {
+    const { CursorProvider } = await import("./cursor");
+    const provider = CursorProvider();
+
+    provider.install(makeCfg(), true);
+
+    const configPath = join(tempDir, ".cursor", "mcp.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+    expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+    // Cursor does not include type in buildServer
+    expect(cfg.mcpServers.dosu.type).toBeUndefined();
+  });
+
+  it("local install writes to cwd/.cursor/mcp.json", async () => {
+    const { CursorProvider } = await import("./cursor");
+    const provider = CursorProvider();
+
+    provider.install(makeCfg(), false);
+
+    const configPath = join(tempDir, ".cursor", "mcp.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+  });
+
+  it("remove deletes dosu entry", async () => {
+    const { CursorProvider } = await import("./cursor");
+    const provider = CursorProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const configPath = join(tempDir, ".cursor", "mcp.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+});
+
+describe("OpenCodeProvider", () => {
+  let tempDir: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-opencode-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    origCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    process.env.HOME = origHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes to ~/.config/opencode/opencode.json with mcp key", async () => {
+    const { OpenCodeProvider } = await import("./opencode");
+    const provider = OpenCodeProvider();
+
+    provider.install(makeCfg(), true);
+
+    const configPath = join(tempDir, ".config", "opencode", "opencode.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcp.dosu).toBeDefined();
+    expect(cfg.mcp.dosu.type).toBe("remote");
+    expect(cfg.mcp.dosu.enabled).toBe(true);
+    expect(cfg.mcp.dosu.url).toContain("dep-123");
+  });
+
+  it("local install writes to cwd/opencode.json", async () => {
+    const { OpenCodeProvider } = await import("./opencode");
+    const provider = OpenCodeProvider();
+
+    provider.install(makeCfg(), false);
+
+    const configPath = join(tempDir, "opencode.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcp.dosu).toBeDefined();
+  });
+
+  it("remove deletes dosu entry", async () => {
+    const { OpenCodeProvider } = await import("./opencode");
+    const provider = OpenCodeProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const configPath = join(tempDir, ".config", "opencode", "opencode.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcp.dosu).toBeUndefined();
+  });
+});
+
+describe("ClineCliProvider", () => {
+  let tempDir: string;
+  let origClineDir: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-clinecli-test-"));
+    origClineDir = process.env.CLINE_DIR;
+    process.env.CLINE_DIR = join(tempDir, "cline-home");
+  });
+
+  afterEach(() => {
+    if (origClineDir !== undefined) {
+      process.env.CLINE_DIR = origClineDir;
+    } else {
+      delete process.env.CLINE_DIR;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes to CLINE_DIR/data/settings/cline_mcp_settings.json", async () => {
+    const { ClineCliProvider } = await import("./cline-cli");
+    const provider = ClineCliProvider();
+
+    provider.install(makeCfg(), true);
+
+    const configPath = join(
+      tempDir,
+      "cline-home",
+      "data",
+      "settings",
+      "cline_mcp_settings.json",
+    );
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.type).toBe("streamableHttp");
+    expect(cfg.mcpServers.dosu.disabled).toBe(false);
+    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+  });
+
+  it("install throws when deployment_id is missing", async () => {
+    const { ClineCliProvider } = await import("./cline-cli");
+    const provider = ClineCliProvider();
+
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), true),
+    ).toThrow("deployment ID is required");
+  });
+
+  it("remove deletes dosu entry", async () => {
+    const { ClineCliProvider } = await import("./cline-cli");
+    const provider = ClineCliProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const configPath = join(
+      tempDir,
+      "cline-home",
+      "data",
+      "settings",
+      "cline_mcp_settings.json",
+    );
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+
+  it("local install throws because ClineCli does not support local", async () => {
+    const { ClineCliProvider } = await import("./cline-cli");
+    const provider = ClineCliProvider();
+
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support local installation",
+    );
+  });
+});
+
+describe("AntigravityProvider", () => {
+  let tempDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-antigravity-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes to ~/.gemini/antigravity/mcp_config.json with mcpServers key", async () => {
+    const { AntigravityProvider } = await import("./antigravity");
+    const provider = AntigravityProvider();
+
+    provider.install(makeCfg(), true);
+
+    const configPath = join(
+      tempDir,
+      ".gemini",
+      "antigravity",
+      "mcp_config.json",
+    );
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+    // Antigravity uses serverUrl instead of url
+    expect(cfg.mcpServers.dosu.serverUrl).toContain("dep-123");
+    expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("local install throws because Antigravity does not support local", async () => {
+    const { AntigravityProvider } = await import("./antigravity");
+    const provider = AntigravityProvider();
+
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support local installation",
+    );
+  });
+
+  it("remove deletes dosu entry", async () => {
+    const { AntigravityProvider } = await import("./antigravity");
+    const provider = AntigravityProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const configPath = join(
+      tempDir,
+      ".gemini",
+      "antigravity",
+      "mcp_config.json",
+    );
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+});
+
+describe("ZedProvider", () => {
+  let tempDir: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-zed-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    origCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    process.env.HOME = origHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes to settings.json with context_servers key", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+
+    provider.install(makeCfg(), true);
+
+    const globalCfgPath = provider.globalConfigPath();
+    expect(existsSync(globalCfgPath)).toBe(true);
+    const cfg = loadJSONConfig(globalCfgPath);
+    expect(cfg.context_servers.dosu).toBeDefined();
+    expect(cfg.context_servers.dosu.source).toBe("custom");
+    expect(cfg.context_servers.dosu.type).toBe("http");
+    expect(cfg.context_servers.dosu.url).toContain("dep-123");
+  });
+
+  it("local install writes to cwd/.zed/settings.json", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+
+    provider.install(makeCfg(), false);
+
+    const configPath = join(tempDir, ".zed", "settings.json");
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.context_servers.dosu).toBeDefined();
+  });
+
+  it("remove deletes dosu entry globally", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const globalCfgPath = provider.globalConfigPath();
+    const cfg = loadJSONConfig(globalCfgPath);
+    expect(cfg.context_servers.dosu).toBeUndefined();
+  });
+
+  it("local remove deletes dosu entry from local config", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+
+    provider.install(makeCfg(), false);
+    provider.remove(false);
+
+    const configPath = join(tempDir, ".zed", "settings.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.context_servers.dosu).toBeUndefined();
+  });
+});

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  mkdirSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-// Mock dependencies before importing the module under test
+// Only mock true boundaries: terminal UI, auth (browser), and HTTP client
 vi.mock("@clack/prompts", () => ({
   intro: vi.fn(),
   outro: vi.fn(),
@@ -21,9 +30,8 @@ vi.mock("@clack/prompts", () => ({
   },
 }));
 
-vi.mock("../config/config", () => ({
-  loadConfig: vi.fn(),
-  saveConfig: vi.fn(),
+vi.mock("../auth/flow", () => ({
+  startOAuthFlow: vi.fn(),
 }));
 
 vi.mock("../client/client", () => {
@@ -39,808 +47,882 @@ vi.mock("../client/client", () => {
   };
 });
 
-vi.mock("../mcp/providers", () => ({
-  allSetupProviders: vi.fn(),
-}));
-
-vi.mock("../auth/flow", () => ({
-  startOAuthFlow: vi.fn(),
-}));
-
-vi.mock("./styles", () => ({
-  info: (s: string) => s,
-  dim: (s: string) => s,
-}));
-
 import * as p from "@clack/prompts";
-import { loadConfig, saveConfig } from "../config/config";
-import { Client, SessionExpiredError } from "../client/client";
-import { allSetupProviders } from "../mcp/providers";
+import type { Config } from "../config/config";
+import { loadConfig, saveConfig, getConfigPath } from "../config/config";
+import { CursorProvider } from "../mcp/providers/cursor";
+import { OpenCodeProvider } from "../mcp/providers/opencode";
+import { ClaudeDesktopProvider } from "../mcp/providers/claude-desktop";
+import { loadJSONConfig } from "../mcp/config-helpers";
+import {
+  isStdioOnly,
+  stepDetectTools,
+  stepConfigureTools,
+  stepShowSummary,
+  runSetup,
+  type ToolSelection,
+  type ConfigResult,
+} from "./flow";
+import { Client } from "../client/client";
 import { startOAuthFlow } from "../auth/flow";
-import { runSetup } from "./flow";
+import * as providersModule from "../mcp/providers";
 
-const mockLoadConfig = vi.mocked(loadConfig);
-const mockSaveConfig = vi.mocked(saveConfig);
-const mockClient = vi.mocked(Client);
-const mockAllSetupProviders = vi.mocked(allSetupProviders);
-const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
-const mockConfirm = vi.mocked(p.confirm);
-const mockSelect = vi.mocked(p.select);
-const mockMultiselect = vi.mocked(p.multiselect);
-const mockIsCancel = vi.mocked(p.isCancel);
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
 
-function makeCfg(overrides: Record<string, unknown> = {}) {
+let tempDir: string;
+let origHome: string | undefined;
+let origXdg: string | undefined;
+
+function setupTempEnv() {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-flow-test-"));
+  origHome = process.env.HOME;
+  origXdg = process.env.XDG_CONFIG_HOME;
+  process.env.HOME = tempDir;
+  process.env.XDG_CONFIG_HOME = tempDir;
+}
+
+function teardownTempEnv() {
+  process.env.HOME = origHome;
+  if (origXdg !== undefined) {
+    process.env.XDG_CONFIG_HOME = origXdg;
+  } else {
+    delete process.env.XDG_CONFIG_HOME;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+function makeCfg(overrides: Partial<Config> = {}): Config {
   return {
-    access_token: "",
-    refresh_token: "",
-    expires_at: 0,
-    deployment_id: undefined as string | undefined,
-    deployment_name: undefined as string | undefined,
-    api_key: undefined as string | undefined,
+    access_token: "tok",
+    refresh_token: "ref",
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    deployment_id: "dep-123",
+    deployment_name: "TestDeploy",
+    api_key: "key-abc",
     ...overrides,
   };
 }
 
-function makeProvider(id: string, name: string, opts: {
-  isInstalled?: boolean;
-  isConfigured?: boolean;
-  isStdio?: boolean;
-  installError?: Error;
-  removeError?: Error;
-} = {}) {
-  return {
-    id: () => id,
-    name: () => name,
-    detectPaths: () => ["/mock/path"],
-    isInstalled: () => opts.isInstalled ?? true,
-    isConfigured: () => opts.isConfigured ?? false,
-    globalConfigPath: () => `/mock/${id}/config.json`,
-    priority: () => 1,
-    supportsLocal: () => true,
-    install: opts.installError
-      ? vi.fn().mockImplementation(() => { throw opts.installError; })
-      : vi.fn(),
-    remove: opts.removeError
-      ? vi.fn().mockImplementation(() => { throw opts.removeError; })
-      : vi.fn(),
-  };
-}
+// ---------------------------------------------------------------------------
+// 1. isStdioOnly — pure function, real providers
+// ---------------------------------------------------------------------------
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockIsCancel.mockReturnValue(false);
+describe("isStdioOnly", () => {
+  it("returns true for ClaudeDesktopProvider", () => {
+    const provider = ClaudeDesktopProvider();
+    expect(isStdioOnly(provider)).toBe(true);
+  });
+
+  it("returns false for CursorProvider", () => {
+    const provider = CursorProvider();
+    expect(isStdioOnly(provider)).toBe(false);
+  });
+
+  it("returns false for OpenCodeProvider", () => {
+    const provider = OpenCodeProvider();
+    expect(isStdioOnly(provider)).toBe(false);
+  });
 });
 
-describe("runSetup", () => {
-  // ---- stepAuthenticate tests ----
+// ---------------------------------------------------------------------------
+// 2. stepDetectTools — real providers, temp HOME
+// ---------------------------------------------------------------------------
 
-  describe("stepAuthenticate", () => {
-    it("uses existing valid token without prompting login", async () => {
-      const cfg = makeCfg({ access_token: "valid-tok", refresh_token: "ref" });
-      mockLoadConfig.mockReturnValue(cfg);
+describe("stepDetectTools", () => {
+  beforeEach(() => {
+    setupTempEnv();
+    vi.clearAllMocks();
+  });
+  afterEach(teardownTempEnv);
 
-      const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 200 });
-      const mockGetOrgs = vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]);
-      const mockGetDeployments = vi.fn().mockResolvedValue([
-        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
-      ]);
-      const mockValidateAPIKey = vi.fn().mockResolvedValue(true);
+  it("returns providers whose detect paths exist, excluding stdio-only", () => {
+    // Create Cursor detect path so it's "installed"
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
 
-      mockClient.mockImplementation(() => ({
-        doRequestRaw: mockDoRequestRaw,
-        getOrgs: mockGetOrgs,
-        getDeployments: mockGetDeployments,
-        validateAPIKey: mockValidateAPIKey,
-        refreshToken: vi.fn(),
-      }) as any);
-
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      // Should not have prompted for login
-      expect(mockConfirm).not.toHaveBeenCalled();
-      expect(mockStartOAuthFlow).not.toHaveBeenCalled();
-      // Should have verified the session
-      expect(mockDoRequestRaw).toHaveBeenCalledWith("GET", "/v1/mcp/deployments");
+    // Mock allSetupProviders to return real providers built in our temp env
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => {
+      return [CursorProvider(), ClaudeDesktopProvider()];
     });
 
-    it("prompts for OAuth when no token exists", async () => {
-      const cfg = makeCfg();
-      mockLoadConfig.mockReturnValue(cfg);
-
-      // User confirms login
-      mockConfirm.mockResolvedValue(true);
-
-      mockStartOAuthFlow.mockResolvedValue({
-        access_token: "new-tok",
-        refresh_token: "new-ref",
-        expires_in: 3600,
-      } as any);
-
-      const mockGetOrgs = vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]);
-      const mockGetDeployments = vi.fn().mockResolvedValue([
-        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
-      ]);
-      const mockValidateAPIKey = vi.fn().mockResolvedValue(false);
-      const mockCreateAPIKey = vi.fn().mockResolvedValue({ api_key: "new-key" });
-
-      mockClient.mockImplementation(() => ({
-        getOrgs: mockGetOrgs,
-        getDeployments: mockGetDeployments,
-        validateAPIKey: mockValidateAPIKey,
-        createAPIKey: mockCreateAPIKey,
-      }) as any);
-
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      expect(mockStartOAuthFlow).toHaveBeenCalled();
-      expect(mockSaveConfig).toHaveBeenCalled();
-      // Config should have the new token
-      const savedCfg = mockSaveConfig.mock.calls[0][0];
-      expect(savedCfg.access_token).toBe("new-tok");
-      expect(savedCfg.refresh_token).toBe("new-ref");
-    });
-
-    it("returns early when user declines login", async () => {
-      const cfg = makeCfg();
-      mockLoadConfig.mockReturnValue(cfg);
-
-      mockConfirm.mockResolvedValue(false);
-
-      await runSetup();
-
-      expect(mockStartOAuthFlow).not.toHaveBeenCalled();
-      expect(p.log.success).not.toHaveBeenCalled();
-    });
-
-    it("returns early when user cancels login confirm", async () => {
-      const cfg = makeCfg();
-      mockLoadConfig.mockReturnValue(cfg);
-
-      const cancelSymbol = Symbol("cancel");
-      mockConfirm.mockResolvedValue(cancelSymbol as any);
-      mockIsCancel.mockImplementation((val) => val === cancelSymbol);
-
-      await runSetup();
-
-      expect(mockStartOAuthFlow).not.toHaveBeenCalled();
-    });
-
-    it("shows error when OAuth fails", async () => {
-      const cfg = makeCfg();
-      mockLoadConfig.mockReturnValue(cfg);
-
-      mockConfirm.mockResolvedValue(true);
-      mockStartOAuthFlow.mockRejectedValue(new Error("OAuth timeout"));
-
-      await runSetup();
-
-      expect(p.log.error).toHaveBeenCalledWith(
-        expect.stringContaining("OAuth timeout"),
-      );
-    });
-
-    it("refreshes token when session returns 401", async () => {
-      const cfg = makeCfg({ access_token: "expired-tok", refresh_token: "ref" });
-      mockLoadConfig.mockReturnValue(cfg);
-
-      const mockDoRequestRaw = vi.fn()
-        .mockResolvedValueOnce({ status: 401 })   // first check fails
-        .mockResolvedValueOnce({ status: 200 });   // after refresh succeeds
-      const mockRefreshToken = vi.fn().mockResolvedValue(undefined);
-      const mockGetOrgs = vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]);
-      const mockGetDeployments = vi.fn().mockResolvedValue([
-        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
-      ]);
-      const mockValidateAPIKey = vi.fn().mockResolvedValue(true);
-
-      mockClient.mockImplementation(() => ({
-        doRequestRaw: mockDoRequestRaw,
-        refreshToken: mockRefreshToken,
-        getOrgs: mockGetOrgs,
-        getDeployments: mockGetDeployments,
-        validateAPIKey: mockValidateAPIKey,
-      }) as any);
-
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      expect(mockRefreshToken).toHaveBeenCalled();
-      expect(mockConfirm).not.toHaveBeenCalled(); // No login prompt needed
-    });
+    const detected = stepDetectTools();
+    expect(detected.length).toBe(1);
+    expect(detected[0].id()).toBe("cursor");
   });
 
-  // ---- stepSelectOrg tests ----
-
-  describe("stepSelectOrg", () => {
-    function setupAuthenticated(cfg = makeCfg({ access_token: "tok" })) {
-      mockLoadConfig.mockReturnValue(cfg);
-      const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 200 });
-      const clientMethods = {
-        doRequestRaw: mockDoRequestRaw,
-        refreshToken: vi.fn(),
-        getOrgs: vi.fn(),
-        getDeployments: vi.fn(),
-        validateAPIKey: vi.fn(),
-        createAPIKey: vi.fn(),
-      };
-      mockClient.mockImplementation(() => clientMethods as any);
-      return clientMethods;
-    }
-
-    it("auto-selects single org", async () => {
-      const client = setupAuthenticated();
-      client.getOrgs.mockResolvedValue([{ org_id: "o1", name: "MyOrg" }]);
-      client.getDeployments.mockResolvedValue([
-        { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "MyOrg" },
-      ]);
-      client.validateAPIKey.mockResolvedValue(true);
-
-      const cfg = mockLoadConfig();
-      cfg.api_key = "existing-key";
-      mockLoadConfig.mockReturnValue(cfg);
-
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      // Should log success with org name (auto-selected)
-      expect(p.log.success).toHaveBeenCalledWith(
-        expect.stringContaining("MyOrg"),
-      );
-      // Should NOT have shown org selection prompt
-      expect(mockSelect).not.toHaveBeenCalled();
+  it("returns empty array when no providers are installed", () => {
+    // Don't create any detect paths
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => {
+      return [CursorProvider(), OpenCodeProvider()];
     });
 
-    it("prompts selection with multiple orgs", async () => {
-      const client = setupAuthenticated();
-      client.getOrgs.mockResolvedValue([
+    const detected = stepDetectTools();
+    expect(detected.length).toBe(0);
+  });
+
+  it("returns multiple providers when all are installed", () => {
+    // Create detect paths for both Cursor and OpenCode
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    mkdirSync(join(tempDir, ".config", "opencode"), { recursive: true });
+
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => {
+      return [CursorProvider(), OpenCodeProvider()];
+    });
+
+    const detected = stepDetectTools();
+    expect(detected.length).toBe(2);
+    const ids = detected.map((p) => p.id());
+    expect(ids).toContain("cursor");
+    expect(ids).toContain("opencode");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. stepConfigureTools — real providers, real filesystem
+// ---------------------------------------------------------------------------
+
+describe("stepConfigureTools", () => {
+  beforeEach(() => {
+    setupTempEnv();
+    vi.clearAllMocks();
+  });
+  afterEach(teardownTempEnv);
+
+  it("installs a provider and writes real JSON config to disk", () => {
+    const cfg = makeCfg();
+    const cursor = CursorProvider();
+    const selection: ToolSelection = {
+      toInstall: [cursor],
+      toRemove: [],
+      skipped: [],
+    };
+
+    const results = stepConfigureTools(cfg, selection);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("install");
+    expect(results[0].error).toBeUndefined();
+
+    // Verify the file was actually written to disk
+    const configPath = cursor.globalConfigPath();
+    expect(existsSync(configPath)).toBe(true);
+
+    const written = loadJSONConfig(configPath);
+    expect(written.mcpServers).toBeDefined();
+    expect(written.mcpServers.dosu).toBeDefined();
+    expect(written.mcpServers.dosu.url).toContain("dep-123");
+    expect(written.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("removes a provider and deletes the dosu entry from disk", () => {
+    const cfg = makeCfg();
+    const cursor = CursorProvider();
+
+    // First install so there's something to remove
+    cursor.install(cfg, true);
+    const configPath = cursor.globalConfigPath();
+    let written = loadJSONConfig(configPath);
+    expect(written.mcpServers.dosu).toBeDefined();
+
+    const selection: ToolSelection = {
+      toInstall: [],
+      toRemove: [cursor],
+      skipped: [],
+    };
+
+    const results = stepConfigureTools(cfg, selection);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("remove");
+    expect(results[0].error).toBeUndefined();
+
+    // Verify the dosu entry was removed from disk
+    written = loadJSONConfig(configPath);
+    expect(written.mcpServers.dosu).toBeUndefined();
+  });
+
+  it("records skipped providers without touching disk", () => {
+    const cursor = CursorProvider();
+    const cfg = makeCfg();
+    const selection: ToolSelection = {
+      toInstall: [],
+      toRemove: [],
+      skipped: [cursor],
+    };
+
+    const results = stepConfigureTools(cfg, selection);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("skip");
+    expect(results[0].error).toBeUndefined();
+    // No file should have been created
+    expect(existsSync(cursor.globalConfigPath())).toBe(false);
+  });
+
+  it("handles install errors and records them in results", () => {
+    const claudeDesktop = ClaudeDesktopProvider();
+    const cfg = makeCfg();
+    // ClaudeDesktopProvider.install() always throws
+    const selection: ToolSelection = {
+      toInstall: [claudeDesktop],
+      toRemove: [],
+      skipped: [],
+    };
+
+    const results = stepConfigureTools(cfg, selection);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("install");
+    expect(results[0].error).toBeDefined();
+    expect(results[0].error!.message).toContain("stdio");
+    // p.log.error should have been called
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Claude Desktop"),
+    );
+  });
+
+  it("handles mixed install, remove, and skip in one call", () => {
+    const cfg = makeCfg();
+    const cursor = CursorProvider();
+    const opencode = OpenCodeProvider();
+
+    // Pre-install opencode so we can remove it
+    opencode.install(cfg, true);
+
+    const cursorForSkip = CursorProvider();
+    // Pre-install cursor so the skip entry refers to an installed provider
+    cursorForSkip.install(cfg, true);
+
+    // Fresh providers for this call
+    const freshCursor = CursorProvider();
+    const freshOpencode = OpenCodeProvider();
+    const anotherCursor = CursorProvider();
+
+    const selection: ToolSelection = {
+      toInstall: [freshCursor],
+      toRemove: [freshOpencode],
+      skipped: [anotherCursor],
+    };
+
+    const results = stepConfigureTools(cfg, selection);
+
+    expect(results).toHaveLength(3);
+
+    const installResult = results.find((r) => r.action === "install");
+    const removeResult = results.find((r) => r.action === "remove");
+    const skipResult = results.find((r) => r.action === "skip");
+
+    expect(installResult).toBeDefined();
+    expect(installResult!.error).toBeUndefined();
+    expect(removeResult).toBeDefined();
+    expect(removeResult!.error).toBeUndefined();
+    expect(skipResult).toBeDefined();
+
+    // Verify cursor config was written
+    const cursorConfig = loadJSONConfig(freshCursor.globalConfigPath());
+    expect(cursorConfig.mcpServers.dosu).toBeDefined();
+
+    // Verify opencode dosu entry was removed
+    const opencodeConfig = loadJSONConfig(freshOpencode.globalConfigPath());
+    expect(opencodeConfig.mcp.dosu).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. stepShowSummary — real providers, mocked clack log
+// ---------------------------------------------------------------------------
+
+describe("stepShowSummary", () => {
+  beforeEach(() => {
+    setupTempEnv();
+    vi.clearAllMocks();
+  });
+  afterEach(teardownTempEnv);
+
+  it("logs configured tools count and paths for installs", () => {
+    const cursor = CursorProvider();
+    const results: ConfigResult[] = [
+      { provider: cursor, action: "install" },
+    ];
+
+    stepShowSummary(results);
+
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Configured 1 tool"),
+    );
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Cursor"),
+    );
+    expect(p.log.message).toHaveBeenCalledWith(
+      expect.stringContaining("Try it out"),
+    );
+  });
+
+  it("logs removed tools count for removals", () => {
+    const cursor = CursorProvider();
+    const results: ConfigResult[] = [
+      { provider: cursor, action: "remove" },
+    ];
+
+    stepShowSummary(results);
+
+    expect(p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Removed from 1 tool"),
+    );
+    // No "Try it out" when only removals
+    expect(p.log.message).not.toHaveBeenCalled();
+  });
+
+  it("shows 'all configured' when only skipped results", () => {
+    const cursor = CursorProvider();
+    const results: ConfigResult[] = [
+      { provider: cursor, action: "skip" },
+    ];
+
+    stepShowSummary(results);
+
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("All tools already configured"),
+    );
+    // Skipped still gets the "Try it out" message
+    expect(p.log.message).toHaveBeenCalledWith(
+      expect.stringContaining("Try it out"),
+    );
+  });
+
+  it("shows both install and remove summaries for mixed results", () => {
+    const cursor = CursorProvider();
+    const opencode = OpenCodeProvider();
+    const results: ConfigResult[] = [
+      { provider: cursor, action: "install" },
+      { provider: opencode, action: "remove" },
+    ];
+
+    stepShowSummary(results);
+
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Configured 1 tool"),
+    );
+    expect(p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Removed from 1 tool"),
+    );
+  });
+
+  it("does not count errored results in install summary", () => {
+    const cursor = CursorProvider();
+    const opencode = OpenCodeProvider();
+    const results: ConfigResult[] = [
+      { provider: cursor, action: "install" },
+      { provider: opencode, action: "install", error: new Error("failed") },
+    ];
+
+    stepShowSummary(results);
+
+    // Only 1 successful install
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Configured 1 tool"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. runSetup integration — thin tests for interactive routing
+//    Mocks: @clack/prompts, Client, auth/flow
+//    Real: config (temp dir), styles
+// ---------------------------------------------------------------------------
+
+describe("runSetup integration", () => {
+  const mockClient = vi.mocked(Client);
+  const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
+
+  beforeEach(() => {
+    setupTempEnv();
+    vi.clearAllMocks();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+  });
+  afterEach(teardownTempEnv);
+
+  function setupAuthenticatedClient(overrides: Record<string, any> = {}) {
+    const clientMethods = {
+      doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+      refreshToken: vi.fn(),
+      getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+      getDeployments: vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+      ]),
+      validateAPIKey: vi.fn().mockResolvedValue(true),
+      createAPIKey: vi.fn().mockResolvedValue({ api_key: "new-key" }),
+      ...overrides,
+    };
+    mockClient.mockImplementation(() => clientMethods as any);
+    return clientMethods;
+  }
+
+  it("returns early when user declines login", async () => {
+    // No token in config (fresh state via temp dir)
+    vi.mocked(p.confirm).mockResolvedValue(false);
+
+    await runSetup();
+
+    expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+    expect(p.log.success).not.toHaveBeenCalled();
+  });
+
+  it("returns early when user cancels login prompt", async () => {
+    const cancelSymbol = Symbol("cancel");
+    vi.mocked(p.confirm).mockResolvedValue(cancelSymbol as any);
+    vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
+
+    await runSetup();
+
+    expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it("completes full flow with existing token and no tools", async () => {
+    // Save a real config with token
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+
+    // Mock allSetupProviders to return nothing
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // Should warn about no tools
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("No supported AI tools detected"),
+    );
+
+    // Config should have been saved with deployment info
+    const savedCfg = loadConfig();
+    expect(savedCfg.deployment_id).toBe("d1");
+    expect(savedCfg.deployment_name).toBe("Deploy1");
+  });
+
+  it("completes full flow with tool install via real filesystem", async () => {
+    // Save a real config with token
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+
+    // Create Cursor detect path
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+
+    // User selects cursor in multiselect
+    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+
+    await runSetup();
+
+    // Verify the config was actually written to disk
+    const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+    expect(existsSync(cursorConfigPath)).toBe(true);
+    const cursorConfig = loadJSONConfig(cursorConfigPath);
+    expect(cursorConfig.mcpServers.dosu).toBeDefined();
+    expect(cursorConfig.mcpServers.dosu.url).toContain("d1");
+
+    // Verify summary was shown
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Configured 1 tool"),
+    );
+  });
+
+  it("runs OAuth flow and saves tokens to real config", async () => {
+    // No pre-existing config (fresh temp dir), so needs login
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    mockStartOAuthFlow.mockResolvedValue({
+      access_token: "oauth-tok",
+      refresh_token: "oauth-ref",
+      expires_in: 7200,
+    } as any);
+
+    const clientMethods = setupAuthenticatedClient();
+    clientMethods.createAPIKey.mockResolvedValue({ api_key: "minted-key" });
+
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // Real config on disk should have OAuth tokens
+    const savedCfg = loadConfig();
+    expect(savedCfg.access_token).toBe("oauth-tok");
+    expect(savedCfg.refresh_token).toBe("oauth-ref");
+  });
+
+  it("uses deploymentID option to resolve deployment directly", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    const clientMethods = setupAuthenticatedClient();
+    clientMethods.getDeployments.mockResolvedValue([
+      { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+      { deployment_id: "d2", name: "Deploy2", org_id: "o1", org_name: "Org1" },
+    ]);
+
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup({ deploymentID: "d2" });
+
+    // Should have skipped org selection
+    expect(p.select).not.toHaveBeenCalled();
+
+    // Config on disk should have d2
+    const savedCfg = loadConfig();
+    expect(savedCfg.deployment_id).toBe("d2");
+    expect(savedCfg.deployment_name).toBe("Deploy2");
+  });
+
+  it("creates new API key when existing one is invalid", async () => {
+    const cfg = makeCfg({ api_key: "bad-key" });
+    saveConfig(cfg);
+
+    const clientMethods = setupAuthenticatedClient({
+      validateAPIKey: vi.fn().mockResolvedValue(false),
+      createAPIKey: vi.fn().mockResolvedValue({ api_key: "fresh-key" }),
+    });
+
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("invalid"),
+    );
+
+    // Config on disk should have fresh key
+    const savedCfg = loadConfig();
+    expect(savedCfg.api_key).toBe("fresh-key");
+  });
+
+  it("shows error when OAuth fails", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    mockStartOAuthFlow.mockRejectedValue(new Error("browser timeout"));
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("browser timeout"),
+    );
+  });
+
+  it("auto-selects single org without prompting", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // Should not have shown org select since there's only one org
+    expect(p.select).not.toHaveBeenCalled();
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Org1"),
+    );
+  });
+
+  it("prompts when multiple orgs exist", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient({
+      getOrgs: vi.fn().mockResolvedValue([
         { org_id: "o1", name: "Org1" },
         { org_id: "o2", name: "Org2" },
-      ]);
-      client.getDeployments.mockResolvedValue([
+      ]),
+    });
+    vi.mocked(p.select).mockResolvedValueOnce("o1");
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select an organization" }),
+    );
+  });
+
+  it("returns early when no orgs found", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient({
+      getOrgs: vi.fn().mockResolvedValue([]),
+    });
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      "No organizations found for your account",
+    );
+  });
+
+  it("handles SessionExpiredError during org fetch", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    const { SessionExpiredError } = await import("../client/client");
+    setupAuthenticatedClient({
+      getOrgs: vi.fn().mockRejectedValue(new SessionExpiredError()),
+    });
+
+    await runSetup();
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Session expired"),
+    );
+  });
+
+  it("handles org fetch error", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient({
+      getOrgs: vi.fn().mockRejectedValue(new Error("network fail")),
+    });
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("network fail"),
+    );
+  });
+
+  it("prompts when multiple deployments exist for org", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient({
+      getDeployments: vi.fn().mockResolvedValue([
         { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
-      ]);
-      client.validateAPIKey.mockResolvedValue(true);
+        { deployment_id: "d2", name: "D2", org_id: "o1", org_name: "Org1" },
+      ]),
+    });
+    vi.mocked(p.select).mockResolvedValueOnce("d2");
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
-      const cfg = mockLoadConfig();
-      cfg.api_key = "existing-key";
-      mockLoadConfig.mockReturnValue(cfg);
+    await runSetup();
 
-      mockSelect.mockResolvedValueOnce("o1");
-      mockAllSetupProviders.mockReturnValue([]);
+    expect(p.select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select a deployment" }),
+    );
+    const saved = loadConfig();
+    expect(saved.deployment_id).toBe("d2");
+  });
 
-      await runSetup();
+  it("returns early when no deployments for org", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
 
-      expect(mockSelect).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: "Select an organization",
-        }),
-      );
+    setupAuthenticatedClient({
+      getDeployments: vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "D1", org_id: "other", org_name: "Other" },
+      ]),
     });
 
-    it("returns null on SessionExpiredError", async () => {
-      const client = setupAuthenticated();
-      client.getOrgs.mockRejectedValue(new SessionExpiredError());
-      mockAllSetupProviders.mockReturnValue([]);
+    await runSetup();
 
-      await runSetup();
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("No deployments found"),
+    );
+  });
 
-      expect(p.log.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Session expired"),
-      );
+  it("handles deployment fetch error", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient({
+      getDeployments: vi.fn().mockRejectedValue(new Error("timeout")),
     });
 
-    it("returns null when no orgs found", async () => {
-      const client = setupAuthenticated();
-      client.getOrgs.mockResolvedValue([]);
+    await runSetup();
 
-      await runSetup();
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("timeout"),
+    );
+  });
 
-      expect(p.log.error).toHaveBeenCalledWith(
-        "No organizations found for your account",
-      );
+  it("handles API key creation failure", async () => {
+    const cfg = makeCfg({ api_key: undefined });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient({
+      validateAPIKey: vi.fn().mockResolvedValue(false),
+      createAPIKey: vi.fn().mockRejectedValue(new Error("rate limited")),
     });
 
-    it("returns null when user cancels org selection", async () => {
-      const client = setupAuthenticated();
-      client.getOrgs.mockResolvedValue([
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("rate limited"),
+    );
+  });
+
+  it("refreshes token when initial check returns 401", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    const mockRefreshToken = vi.fn().mockResolvedValue(undefined);
+    setupAuthenticatedClient({
+      doRequestRaw: vi.fn()
+        .mockResolvedValueOnce({ status: 401 })
+        .mockResolvedValueOnce({ status: 200 }),
+      refreshToken: mockRefreshToken,
+    });
+
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockRefreshToken).toHaveBeenCalled();
+  });
+
+  it("falls through to login when refresh fails", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient({
+      doRequestRaw: vi.fn().mockResolvedValue({ status: 401 }),
+      refreshToken: vi.fn().mockRejectedValue(new Error("refresh failed")),
+    });
+
+    // User declines login
+    vi.mocked(p.confirm).mockResolvedValue(false);
+
+    await runSetup();
+
+    expect(p.log.warn).toHaveBeenCalledWith("Session expired.");
+  });
+
+  it("returns early when user cancels tool selection", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+
+    const cancelSymbol = Symbol("cancel");
+    vi.mocked(p.multiselect).mockResolvedValue(cancelSymbol as any);
+    vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
+
+    await runSetup();
+
+    // Should not have configured anything
+    expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
+  });
+
+  it("handles user cancelling org selection", async () => {
+    // Start with no deployment in config
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient({
+      getOrgs: vi.fn().mockResolvedValue([
         { org_id: "o1", name: "Org1" },
         { org_id: "o2", name: "Org2" },
-      ]);
-
-      const cancelSymbol = Symbol("cancel");
-      mockSelect.mockResolvedValueOnce(cancelSymbol as any);
-      mockIsCancel.mockImplementation((val) => val === cancelSymbol);
-
-      await runSetup();
-
-      // Should have returned early -- no deployment selection
-      expect(p.log.error).not.toHaveBeenCalled();
+      ]),
     });
+
+    const cancelSymbol = Symbol("cancel");
+    vi.mocked(p.select).mockResolvedValueOnce(cancelSymbol as any);
+    vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
+
+    await runSetup();
+
+    // Should return early without saving deployment
+    const saved = loadConfig();
+    expect(saved.deployment_id).toBeUndefined();
   });
 
-  // ---- stepResolveDeployment tests ----
+  it("handles user cancelling deployment selection", async () => {
+    // Start with no deployment in config
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
+    saveConfig(cfg);
 
-  describe("stepResolveDeployment (via deploymentID option)", () => {
-    function setupAuthenticated() {
-      const cfg = makeCfg({ access_token: "tok" });
-      mockLoadConfig.mockReturnValue(cfg);
-      const clientMethods = {
-        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
-        refreshToken: vi.fn(),
-        getOrgs: vi.fn(),
-        getDeployments: vi.fn(),
-        validateAPIKey: vi.fn(),
-        createAPIKey: vi.fn(),
-      };
-      mockClient.mockImplementation(() => clientMethods as any);
-      return clientMethods;
-    }
-
-    it("resolves deployment by ID when found", async () => {
-      const client = setupAuthenticated();
-      client.getDeployments.mockResolvedValue([
-        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
-        { deployment_id: "d2", name: "Deploy2", org_id: "o1", org_name: "Org1" },
-      ]);
-      client.validateAPIKey.mockResolvedValue(true);
-
-      const cfg = mockLoadConfig();
-      cfg.api_key = "existing-key";
-      mockLoadConfig.mockReturnValue(cfg);
-
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup({ deploymentID: "d2" });
-
-      expect(p.log.success).toHaveBeenCalledWith(
-        expect.stringContaining("Deploy2"),
-      );
-      // Verify config was saved with deployment info
-      expect(mockSaveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          deployment_id: "d2",
-          deployment_name: "Deploy2",
-        }),
-      );
+    setupAuthenticatedClient({
+      getDeployments: vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
+        { deployment_id: "d2", name: "D2", org_id: "o1", org_name: "Org1" },
+      ]),
     });
 
-    it("shows error when deployment ID not found", async () => {
-      const client = setupAuthenticated();
-      client.getDeployments.mockResolvedValue([
-        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
-      ]);
+    const cancelSymbol = Symbol("cancel");
+    vi.mocked(p.select).mockResolvedValueOnce(cancelSymbol as any);
+    vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
 
-      await runSetup({ deploymentID: "nonexistent" });
+    await runSetup();
 
-      expect(p.log.error).toHaveBeenCalledWith("Deployment nonexistent not found");
-    });
-
-    it("shows error when getDeployments fails", async () => {
-      const client = setupAuthenticated();
-      client.getDeployments.mockRejectedValue(new Error("network issue"));
-
-      await runSetup({ deploymentID: "d1" });
-
-      expect(p.log.error).toHaveBeenCalledWith(
-        expect.stringContaining("network issue"),
-      );
-    });
+    const saved = loadConfig();
+    expect(saved.deployment_id).toBeUndefined();
   });
 
-  // ---- stepSelectDeployment tests ----
+  it("shows deployment not found error", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
 
-  describe("stepSelectDeployment", () => {
-    function setupWithOrg() {
-      const cfg = makeCfg({ access_token: "tok" });
-      mockLoadConfig.mockReturnValue(cfg);
-      const clientMethods = {
-        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
-        refreshToken: vi.fn(),
-        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
-        getDeployments: vi.fn(),
-        validateAPIKey: vi.fn(),
-        createAPIKey: vi.fn(),
-      };
-      mockClient.mockImplementation(() => clientMethods as any);
-      return clientMethods;
-    }
-
-    it("auto-selects single deployment", async () => {
-      const client = setupWithOrg();
-      client.getDeployments.mockResolvedValue([
-        { deployment_id: "d1", name: "OnlyDeploy", org_id: "o1", org_name: "Org1" },
-      ]);
-      client.validateAPIKey.mockResolvedValue(true);
-
-      const cfg = mockLoadConfig();
-      cfg.api_key = "key";
-      mockLoadConfig.mockReturnValue(cfg);
-
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      expect(p.log.success).toHaveBeenCalledWith(
-        expect.stringContaining("OnlyDeploy"),
-      );
+    setupAuthenticatedClient({
+      getDeployments: vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
+      ]),
     });
 
-    it("prompts when multiple deployments for org", async () => {
-      const client = setupWithOrg();
-      client.getDeployments.mockResolvedValue([
-        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
-        { deployment_id: "d2", name: "Deploy2", org_id: "o1", org_name: "Org1" },
-      ]);
-      client.validateAPIKey.mockResolvedValue(true);
+    await runSetup({ deploymentID: "nonexistent" });
 
-      const cfg = mockLoadConfig();
-      cfg.api_key = "key";
-      mockLoadConfig.mockReturnValue(cfg);
-
-      mockSelect.mockResolvedValueOnce("d1");
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      expect(mockSelect).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: "Select a deployment",
-        }),
-      );
-    });
-
-    it("returns null when no deployments for org", async () => {
-      const client = setupWithOrg();
-      client.getDeployments.mockResolvedValue([
-        { deployment_id: "d1", name: "Deploy1", org_id: "other-org", org_name: "Other" },
-      ]);
-
-      await runSetup();
-
-      expect(p.log.error).toHaveBeenCalledWith(
-        expect.stringContaining("No deployments found"),
-      );
-    });
+    expect(p.log.error).toHaveBeenCalledWith("Deployment nonexistent not found");
   });
 
-  // ---- stepMintAPIKey tests ----
+  it("handles resolve deployment fetch error", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
 
-  describe("stepMintAPIKey", () => {
-    function setupThroughDeployment() {
-      const cfg = makeCfg({ access_token: "tok" });
-      mockLoadConfig.mockReturnValue(cfg);
-      const clientMethods = {
-        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
-        refreshToken: vi.fn(),
-        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
-        getDeployments: vi.fn().mockResolvedValue([
-          { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
-        ]),
-        validateAPIKey: vi.fn(),
-        createAPIKey: vi.fn(),
-      };
-      mockClient.mockImplementation(() => clientMethods as any);
-      return { clientMethods, cfg };
-    }
-
-    it("uses existing valid API key", async () => {
-      const { clientMethods } = setupThroughDeployment();
-      clientMethods.validateAPIKey.mockResolvedValue(true);
-
-      const cfg = mockLoadConfig();
-      cfg.api_key = "existing-key";
-      mockLoadConfig.mockReturnValue(cfg);
-
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      expect(clientMethods.validateAPIKey).toHaveBeenCalledWith("existing-key", "d1");
-      expect(clientMethods.createAPIKey).not.toHaveBeenCalled();
-      expect(p.log.success).toHaveBeenCalledWith(
-        expect.stringContaining("using existing"),
-      );
+    setupAuthenticatedClient({
+      getDeployments: vi.fn().mockRejectedValue(new Error("gone")),
     });
 
-    it("creates new key when existing key is invalid", async () => {
-      const { clientMethods } = setupThroughDeployment();
-      clientMethods.validateAPIKey.mockResolvedValue(false);
-      clientMethods.createAPIKey.mockResolvedValue({ api_key: "brand-new-key" });
+    await runSetup({ deploymentID: "d1" });
 
-      const cfg = mockLoadConfig();
-      cfg.api_key = "bad-key";
-      mockLoadConfig.mockReturnValue(cfg);
-
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      expect(p.log.warn).toHaveBeenCalledWith(
-        expect.stringContaining("invalid"),
-      );
-      expect(clientMethods.createAPIKey).toHaveBeenCalledWith("d1", "dosu-cli");
-      expect(p.log.success).toHaveBeenCalledWith(
-        expect.stringContaining("created"),
-      );
-    });
-
-    it("creates new key when no existing key", async () => {
-      const { clientMethods } = setupThroughDeployment();
-      clientMethods.createAPIKey.mockResolvedValue({ api_key: "new-key" });
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      expect(clientMethods.createAPIKey).toHaveBeenCalledWith("d1", "dosu-cli");
-    });
-
-    it("returns null when key creation fails", async () => {
-      const { clientMethods } = setupThroughDeployment();
-      clientMethods.createAPIKey.mockRejectedValue(new Error("rate limited"));
-      mockAllSetupProviders.mockReturnValue([]);
-
-      await runSetup();
-
-      expect(p.log.error).toHaveBeenCalledWith(
-        expect.stringContaining("rate limited"),
-      );
-    });
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("gone"),
+    );
   });
 
-  // ---- stepDetectTools tests ----
+  it("handles session verification failure (network error)", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
 
-  describe("stepDetectTools", () => {
-    function setupThroughAPIKey() {
-      const cfg = makeCfg({ access_token: "tok", api_key: "key" });
-      mockLoadConfig.mockReturnValue(cfg);
-      const clientMethods = {
-        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
-        refreshToken: vi.fn(),
-        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
-        getDeployments: vi.fn().mockResolvedValue([
-          { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
-        ]),
-        validateAPIKey: vi.fn().mockResolvedValue(true),
-        createAPIKey: vi.fn(),
-      };
-      mockClient.mockImplementation(() => clientMethods as any);
-      return clientMethods;
-    }
-
-    it("filters out non-installed and stdio-only providers", async () => {
-      setupThroughAPIKey();
-
-      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true });
-      const vscodeProvider = makeProvider("vscode", "VS Code", { isInstalled: false });
-      const claudeDesktop = makeProvider("claude-desktop", "Claude Desktop", { isInstalled: true });
-
-      mockAllSetupProviders.mockReturnValue([cursorProvider, vscodeProvider, claudeDesktop]);
-
-      // Only cursor should remain after filtering (vscode not installed, claude-desktop is stdio-only)
-      // The multiselect will be shown for cursor only
-      mockMultiselect.mockResolvedValue(["cursor"]);
-
-      await runSetup();
-
-      // Cursor was selected for install
-      expect(cursorProvider.install).toHaveBeenCalled();
-      // VS Code was not installed, so never offered
-      expect(vscodeProvider.install).not.toHaveBeenCalled();
-      // Claude Desktop filtered as stdio-only
-      expect(claudeDesktop.install).not.toHaveBeenCalled();
+    setupAuthenticatedClient({
+      doRequestRaw: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
     });
 
-    it("shows warning when no tools detected", async () => {
-      setupThroughAPIKey();
-      mockAllSetupProviders.mockReturnValue([]);
+    // Falls through to login prompt
+    vi.mocked(p.confirm).mockResolvedValue(false);
 
-      await runSetup();
+    await runSetup();
 
-      expect(p.log.warn).toHaveBeenCalledWith(
-        expect.stringContaining("No supported AI tools detected"),
-      );
-    });
+    // Should have asked to login
+    expect(p.confirm).toHaveBeenCalled();
   });
 
-  // ---- stepConfigureTools tests ----
+  it("handles refresh succeeding but second verify failing", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
 
-  describe("stepConfigureTools", () => {
-    function setupThroughAPIKey() {
-      const cfg = makeCfg({ access_token: "tok", api_key: "key" });
-      mockLoadConfig.mockReturnValue(cfg);
-      const clientMethods = {
-        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
-        refreshToken: vi.fn(),
-        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
-        getDeployments: vi.fn().mockResolvedValue([
-          { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
-        ]),
-        validateAPIKey: vi.fn().mockResolvedValue(true),
-        createAPIKey: vi.fn(),
-      };
-      mockClient.mockImplementation(() => clientMethods as any);
-      return clientMethods;
-    }
-
-    it("installs selected unconfigured providers", async () => {
-      setupThroughAPIKey();
-
-      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: false });
-      mockAllSetupProviders.mockReturnValue([cursorProvider]);
-
-      // User selects cursor for install
-      mockMultiselect.mockResolvedValue(["cursor"]);
-
-      await runSetup();
-
-      expect(cursorProvider.install).toHaveBeenCalled();
-      expect(p.log.success).toHaveBeenCalledWith(
-        expect.stringContaining("Configured 1 tool"),
-      );
+    setupAuthenticatedClient({
+      doRequestRaw: vi.fn()
+        .mockResolvedValueOnce({ status: 403 })    // initial check fails
+        .mockResolvedValueOnce({ status: 500 }),    // after refresh, still fails
+      refreshToken: vi.fn().mockResolvedValue(undefined),
     });
 
-    it("removes deselected configured providers", async () => {
-      setupThroughAPIKey();
+    vi.mocked(p.confirm).mockResolvedValue(false);
 
-      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: true });
-      mockAllSetupProviders.mockReturnValue([cursorProvider]);
+    await runSetup();
 
-      // User deselects cursor (it was previously configured)
-      mockMultiselect.mockResolvedValue([]);
-
-      await runSetup();
-
-      expect(cursorProvider.remove).toHaveBeenCalled();
-      expect(p.log.info).toHaveBeenCalledWith(
-        expect.stringContaining("Removed from 1 tool"),
-      );
-    });
-
-    it("skips already-configured providers that remain selected", async () => {
-      setupThroughAPIKey();
-
-      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: true });
-      mockAllSetupProviders.mockReturnValue([cursorProvider]);
-
-      // User keeps cursor selected (already configured)
-      mockMultiselect.mockResolvedValue(["cursor"]);
-
-      await runSetup();
-
-      expect(cursorProvider.install).not.toHaveBeenCalled();
-      expect(cursorProvider.remove).not.toHaveBeenCalled();
-      expect(p.log.success).toHaveBeenCalledWith(
-        expect.stringContaining("All tools already configured"),
-      );
-    });
-
-    it("handles install errors gracefully", async () => {
-      setupThroughAPIKey();
-
-      const failProvider = makeProvider("cursor", "Cursor", {
-        isInstalled: true,
-        isConfigured: false,
-        installError: new Error("permission denied"),
-      });
-      mockAllSetupProviders.mockReturnValue([failProvider]);
-
-      mockMultiselect.mockResolvedValue(["cursor"]);
-
-      await runSetup();
-
-      expect(p.log.error).toHaveBeenCalledWith(
-        expect.stringContaining("permission denied"),
-      );
-    });
-
-    it("handles remove errors gracefully", async () => {
-      setupThroughAPIKey();
-
-      const failProvider = makeProvider("cursor", "Cursor", {
-        isInstalled: true,
-        isConfigured: true,
-        removeError: new Error("config locked"),
-      });
-      mockAllSetupProviders.mockReturnValue([failProvider]);
-
-      // Deselect to trigger remove
-      mockMultiselect.mockResolvedValue([]);
-
-      await runSetup();
-
-      expect(p.log.error).toHaveBeenCalledWith(
-        expect.stringContaining("config locked"),
-      );
-    });
-
-    it("returns null when user cancels tool selection", async () => {
-      setupThroughAPIKey();
-
-      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true });
-      mockAllSetupProviders.mockReturnValue([cursorProvider]);
-
-      const cancelSymbol = Symbol("cancel");
-      mockMultiselect.mockResolvedValue(cancelSymbol as any);
-      mockIsCancel.mockImplementation((val) => val === cancelSymbol);
-
-      await runSetup();
-
-      expect(cursorProvider.install).not.toHaveBeenCalled();
-    });
-  });
-
-  // ---- stepShowSummary tests ----
-
-  describe("stepShowSummary", () => {
-    function setupThroughAPIKey() {
-      const cfg = makeCfg({ access_token: "tok", api_key: "key" });
-      mockLoadConfig.mockReturnValue(cfg);
-      const clientMethods = {
-        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
-        refreshToken: vi.fn(),
-        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
-        getDeployments: vi.fn().mockResolvedValue([
-          { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
-        ]),
-        validateAPIKey: vi.fn().mockResolvedValue(true),
-        createAPIKey: vi.fn(),
-      };
-      mockClient.mockImplementation(() => clientMethods as any);
-      return clientMethods;
-    }
-
-    it("shows try-it-out message when tools are installed", async () => {
-      setupThroughAPIKey();
-
-      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: false });
-      mockAllSetupProviders.mockReturnValue([cursorProvider]);
-      mockMultiselect.mockResolvedValue(["cursor"]);
-
-      await runSetup();
-
-      expect(p.log.message).toHaveBeenCalledWith(
-        expect.stringContaining("Try it out"),
-      );
-    });
-
-    it("shows try-it-out message when tools are skipped (already configured)", async () => {
-      setupThroughAPIKey();
-
-      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: true });
-      mockAllSetupProviders.mockReturnValue([cursorProvider]);
-      mockMultiselect.mockResolvedValue(["cursor"]);
-
-      await runSetup();
-
-      expect(p.log.message).toHaveBeenCalledWith(
-        expect.stringContaining("Try it out"),
-      );
-    });
-
-    it("mixed install and remove shows both summaries", async () => {
-      setupThroughAPIKey();
-
-      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: false });
-      const vscodeProvider = makeProvider("vscode", "VS Code", { isInstalled: true, isConfigured: true });
-      mockAllSetupProviders.mockReturnValue([cursorProvider, vscodeProvider]);
-
-      // Select cursor (new install), deselect vscode (remove)
-      mockMultiselect.mockResolvedValue(["cursor"]);
-
-      await runSetup();
-
-      expect(p.log.success).toHaveBeenCalledWith(
-        expect.stringContaining("Configured 1 tool"),
-      );
-      expect(p.log.info).toHaveBeenCalledWith(
-        expect.stringContaining("Removed from 1 tool"),
-      );
-    });
+    expect(p.log.warn).toHaveBeenCalledWith("Session expired.");
   });
 });

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -424,6 +424,53 @@ describe("stepShowSummary", () => {
       expect.stringContaining("Configured 1 tool"),
     );
   });
+
+  it("does not show 'Try it out' when only removals and no skips", () => {
+    const cursor = CursorProvider();
+    const opencode = OpenCodeProvider();
+    const results: ConfigResult[] = [
+      { provider: cursor, action: "remove" },
+      { provider: opencode, action: "remove" },
+    ];
+
+    stepShowSummary(results);
+
+    expect(p.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("Removed from 2 tool"),
+    );
+    expect(p.log.message).not.toHaveBeenCalled();
+  });
+
+  it("does not show 'all configured' when installs and skips are mixed", () => {
+    const cursor = CursorProvider();
+    const opencode = OpenCodeProvider();
+    const results: ConfigResult[] = [
+      { provider: cursor, action: "install" },
+      { provider: opencode, action: "skip" },
+    ];
+
+    stepShowSummary(results);
+
+    // Should show install summary, NOT "all configured"
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining("Configured 1 tool"),
+    );
+    expect(p.log.success).not.toHaveBeenCalledWith(
+      expect.stringContaining("All tools already configured"),
+    );
+    // Should still show "Try it out"
+    expect(p.log.message).toHaveBeenCalledWith(
+      expect.stringContaining("Try it out"),
+    );
+  });
+
+  it("does not show 'Try it out' or 'all configured' when results are empty", () => {
+    stepShowSummary([]);
+
+    expect(p.log.success).not.toHaveBeenCalled();
+    expect(p.log.info).not.toHaveBeenCalled();
+    expect(p.log.message).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1,0 +1,846 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the module under test
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  confirm: vi.fn(),
+  select: vi.fn(),
+  multiselect: vi.fn(),
+  isCancel: vi.fn(),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  log: {
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock("../config/config", () => ({
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+vi.mock("../client/client", () => {
+  const SessionExpiredError = class extends Error {
+    constructor() {
+      super("session expired");
+      this.name = "SessionExpiredError";
+    }
+  };
+  return {
+    Client: vi.fn(),
+    SessionExpiredError,
+  };
+});
+
+vi.mock("../mcp/providers", () => ({
+  allSetupProviders: vi.fn(),
+}));
+
+vi.mock("../auth/flow", () => ({
+  startOAuthFlow: vi.fn(),
+}));
+
+vi.mock("./styles", () => ({
+  info: (s: string) => s,
+  dim: (s: string) => s,
+}));
+
+import * as p from "@clack/prompts";
+import { loadConfig, saveConfig } from "../config/config";
+import { Client, SessionExpiredError } from "../client/client";
+import { allSetupProviders } from "../mcp/providers";
+import { startOAuthFlow } from "../auth/flow";
+import { runSetup } from "./flow";
+
+const mockLoadConfig = vi.mocked(loadConfig);
+const mockSaveConfig = vi.mocked(saveConfig);
+const mockClient = vi.mocked(Client);
+const mockAllSetupProviders = vi.mocked(allSetupProviders);
+const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
+const mockConfirm = vi.mocked(p.confirm);
+const mockSelect = vi.mocked(p.select);
+const mockMultiselect = vi.mocked(p.multiselect);
+const mockIsCancel = vi.mocked(p.isCancel);
+
+function makeCfg(overrides: Record<string, unknown> = {}) {
+  return {
+    access_token: "",
+    refresh_token: "",
+    expires_at: 0,
+    deployment_id: undefined as string | undefined,
+    deployment_name: undefined as string | undefined,
+    api_key: undefined as string | undefined,
+    ...overrides,
+  };
+}
+
+function makeProvider(id: string, name: string, opts: {
+  isInstalled?: boolean;
+  isConfigured?: boolean;
+  isStdio?: boolean;
+  installError?: Error;
+  removeError?: Error;
+} = {}) {
+  return {
+    id: () => id,
+    name: () => name,
+    detectPaths: () => ["/mock/path"],
+    isInstalled: () => opts.isInstalled ?? true,
+    isConfigured: () => opts.isConfigured ?? false,
+    globalConfigPath: () => `/mock/${id}/config.json`,
+    priority: () => 1,
+    supportsLocal: () => true,
+    install: opts.installError
+      ? vi.fn().mockImplementation(() => { throw opts.installError; })
+      : vi.fn(),
+    remove: opts.removeError
+      ? vi.fn().mockImplementation(() => { throw opts.removeError; })
+      : vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsCancel.mockReturnValue(false);
+});
+
+describe("runSetup", () => {
+  // ---- stepAuthenticate tests ----
+
+  describe("stepAuthenticate", () => {
+    it("uses existing valid token without prompting login", async () => {
+      const cfg = makeCfg({ access_token: "valid-tok", refresh_token: "ref" });
+      mockLoadConfig.mockReturnValue(cfg);
+
+      const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 200 });
+      const mockGetOrgs = vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]);
+      const mockGetDeployments = vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+      ]);
+      const mockValidateAPIKey = vi.fn().mockResolvedValue(true);
+
+      mockClient.mockImplementation(() => ({
+        doRequestRaw: mockDoRequestRaw,
+        getOrgs: mockGetOrgs,
+        getDeployments: mockGetDeployments,
+        validateAPIKey: mockValidateAPIKey,
+        refreshToken: vi.fn(),
+      }) as any);
+
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      // Should not have prompted for login
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+      // Should have verified the session
+      expect(mockDoRequestRaw).toHaveBeenCalledWith("GET", "/v1/mcp/deployments");
+    });
+
+    it("prompts for OAuth when no token exists", async () => {
+      const cfg = makeCfg();
+      mockLoadConfig.mockReturnValue(cfg);
+
+      // User confirms login
+      mockConfirm.mockResolvedValue(true);
+
+      mockStartOAuthFlow.mockResolvedValue({
+        access_token: "new-tok",
+        refresh_token: "new-ref",
+        expires_in: 3600,
+      } as any);
+
+      const mockGetOrgs = vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]);
+      const mockGetDeployments = vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+      ]);
+      const mockValidateAPIKey = vi.fn().mockResolvedValue(false);
+      const mockCreateAPIKey = vi.fn().mockResolvedValue({ api_key: "new-key" });
+
+      mockClient.mockImplementation(() => ({
+        getOrgs: mockGetOrgs,
+        getDeployments: mockGetDeployments,
+        validateAPIKey: mockValidateAPIKey,
+        createAPIKey: mockCreateAPIKey,
+      }) as any);
+
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(mockStartOAuthFlow).toHaveBeenCalled();
+      expect(mockSaveConfig).toHaveBeenCalled();
+      // Config should have the new token
+      const savedCfg = mockSaveConfig.mock.calls[0][0];
+      expect(savedCfg.access_token).toBe("new-tok");
+      expect(savedCfg.refresh_token).toBe("new-ref");
+    });
+
+    it("returns early when user declines login", async () => {
+      const cfg = makeCfg();
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockConfirm.mockResolvedValue(false);
+
+      await runSetup();
+
+      expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+      expect(p.log.success).not.toHaveBeenCalled();
+    });
+
+    it("returns early when user cancels login confirm", async () => {
+      const cfg = makeCfg();
+      mockLoadConfig.mockReturnValue(cfg);
+
+      const cancelSymbol = Symbol("cancel");
+      mockConfirm.mockResolvedValue(cancelSymbol as any);
+      mockIsCancel.mockImplementation((val) => val === cancelSymbol);
+
+      await runSetup();
+
+      expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+    });
+
+    it("shows error when OAuth fails", async () => {
+      const cfg = makeCfg();
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockConfirm.mockResolvedValue(true);
+      mockStartOAuthFlow.mockRejectedValue(new Error("OAuth timeout"));
+
+      await runSetup();
+
+      expect(p.log.error).toHaveBeenCalledWith(
+        expect.stringContaining("OAuth timeout"),
+      );
+    });
+
+    it("refreshes token when session returns 401", async () => {
+      const cfg = makeCfg({ access_token: "expired-tok", refresh_token: "ref" });
+      mockLoadConfig.mockReturnValue(cfg);
+
+      const mockDoRequestRaw = vi.fn()
+        .mockResolvedValueOnce({ status: 401 })   // first check fails
+        .mockResolvedValueOnce({ status: 200 });   // after refresh succeeds
+      const mockRefreshToken = vi.fn().mockResolvedValue(undefined);
+      const mockGetOrgs = vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]);
+      const mockGetDeployments = vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+      ]);
+      const mockValidateAPIKey = vi.fn().mockResolvedValue(true);
+
+      mockClient.mockImplementation(() => ({
+        doRequestRaw: mockDoRequestRaw,
+        refreshToken: mockRefreshToken,
+        getOrgs: mockGetOrgs,
+        getDeployments: mockGetDeployments,
+        validateAPIKey: mockValidateAPIKey,
+      }) as any);
+
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(mockRefreshToken).toHaveBeenCalled();
+      expect(mockConfirm).not.toHaveBeenCalled(); // No login prompt needed
+    });
+  });
+
+  // ---- stepSelectOrg tests ----
+
+  describe("stepSelectOrg", () => {
+    function setupAuthenticated(cfg = makeCfg({ access_token: "tok" })) {
+      mockLoadConfig.mockReturnValue(cfg);
+      const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 200 });
+      const clientMethods = {
+        doRequestRaw: mockDoRequestRaw,
+        refreshToken: vi.fn(),
+        getOrgs: vi.fn(),
+        getDeployments: vi.fn(),
+        validateAPIKey: vi.fn(),
+        createAPIKey: vi.fn(),
+      };
+      mockClient.mockImplementation(() => clientMethods as any);
+      return clientMethods;
+    }
+
+    it("auto-selects single org", async () => {
+      const client = setupAuthenticated();
+      client.getOrgs.mockResolvedValue([{ org_id: "o1", name: "MyOrg" }]);
+      client.getDeployments.mockResolvedValue([
+        { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "MyOrg" },
+      ]);
+      client.validateAPIKey.mockResolvedValue(true);
+
+      const cfg = mockLoadConfig();
+      cfg.api_key = "existing-key";
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      // Should log success with org name (auto-selected)
+      expect(p.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("MyOrg"),
+      );
+      // Should NOT have shown org selection prompt
+      expect(mockSelect).not.toHaveBeenCalled();
+    });
+
+    it("prompts selection with multiple orgs", async () => {
+      const client = setupAuthenticated();
+      client.getOrgs.mockResolvedValue([
+        { org_id: "o1", name: "Org1" },
+        { org_id: "o2", name: "Org2" },
+      ]);
+      client.getDeployments.mockResolvedValue([
+        { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
+      ]);
+      client.validateAPIKey.mockResolvedValue(true);
+
+      const cfg = mockLoadConfig();
+      cfg.api_key = "existing-key";
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockSelect.mockResolvedValueOnce("o1");
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(mockSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Select an organization",
+        }),
+      );
+    });
+
+    it("returns null on SessionExpiredError", async () => {
+      const client = setupAuthenticated();
+      client.getOrgs.mockRejectedValue(new SessionExpiredError());
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(p.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Session expired"),
+      );
+    });
+
+    it("returns null when no orgs found", async () => {
+      const client = setupAuthenticated();
+      client.getOrgs.mockResolvedValue([]);
+
+      await runSetup();
+
+      expect(p.log.error).toHaveBeenCalledWith(
+        "No organizations found for your account",
+      );
+    });
+
+    it("returns null when user cancels org selection", async () => {
+      const client = setupAuthenticated();
+      client.getOrgs.mockResolvedValue([
+        { org_id: "o1", name: "Org1" },
+        { org_id: "o2", name: "Org2" },
+      ]);
+
+      const cancelSymbol = Symbol("cancel");
+      mockSelect.mockResolvedValueOnce(cancelSymbol as any);
+      mockIsCancel.mockImplementation((val) => val === cancelSymbol);
+
+      await runSetup();
+
+      // Should have returned early -- no deployment selection
+      expect(p.log.error).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- stepResolveDeployment tests ----
+
+  describe("stepResolveDeployment (via deploymentID option)", () => {
+    function setupAuthenticated() {
+      const cfg = makeCfg({ access_token: "tok" });
+      mockLoadConfig.mockReturnValue(cfg);
+      const clientMethods = {
+        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+        refreshToken: vi.fn(),
+        getOrgs: vi.fn(),
+        getDeployments: vi.fn(),
+        validateAPIKey: vi.fn(),
+        createAPIKey: vi.fn(),
+      };
+      mockClient.mockImplementation(() => clientMethods as any);
+      return clientMethods;
+    }
+
+    it("resolves deployment by ID when found", async () => {
+      const client = setupAuthenticated();
+      client.getDeployments.mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+        { deployment_id: "d2", name: "Deploy2", org_id: "o1", org_name: "Org1" },
+      ]);
+      client.validateAPIKey.mockResolvedValue(true);
+
+      const cfg = mockLoadConfig();
+      cfg.api_key = "existing-key";
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup({ deploymentID: "d2" });
+
+      expect(p.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("Deploy2"),
+      );
+      // Verify config was saved with deployment info
+      expect(mockSaveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deployment_id: "d2",
+          deployment_name: "Deploy2",
+        }),
+      );
+    });
+
+    it("shows error when deployment ID not found", async () => {
+      const client = setupAuthenticated();
+      client.getDeployments.mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+      ]);
+
+      await runSetup({ deploymentID: "nonexistent" });
+
+      expect(p.log.error).toHaveBeenCalledWith("Deployment nonexistent not found");
+    });
+
+    it("shows error when getDeployments fails", async () => {
+      const client = setupAuthenticated();
+      client.getDeployments.mockRejectedValue(new Error("network issue"));
+
+      await runSetup({ deploymentID: "d1" });
+
+      expect(p.log.error).toHaveBeenCalledWith(
+        expect.stringContaining("network issue"),
+      );
+    });
+  });
+
+  // ---- stepSelectDeployment tests ----
+
+  describe("stepSelectDeployment", () => {
+    function setupWithOrg() {
+      const cfg = makeCfg({ access_token: "tok" });
+      mockLoadConfig.mockReturnValue(cfg);
+      const clientMethods = {
+        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+        refreshToken: vi.fn(),
+        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+        getDeployments: vi.fn(),
+        validateAPIKey: vi.fn(),
+        createAPIKey: vi.fn(),
+      };
+      mockClient.mockImplementation(() => clientMethods as any);
+      return clientMethods;
+    }
+
+    it("auto-selects single deployment", async () => {
+      const client = setupWithOrg();
+      client.getDeployments.mockResolvedValue([
+        { deployment_id: "d1", name: "OnlyDeploy", org_id: "o1", org_name: "Org1" },
+      ]);
+      client.validateAPIKey.mockResolvedValue(true);
+
+      const cfg = mockLoadConfig();
+      cfg.api_key = "key";
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(p.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("OnlyDeploy"),
+      );
+    });
+
+    it("prompts when multiple deployments for org", async () => {
+      const client = setupWithOrg();
+      client.getDeployments.mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+        { deployment_id: "d2", name: "Deploy2", org_id: "o1", org_name: "Org1" },
+      ]);
+      client.validateAPIKey.mockResolvedValue(true);
+
+      const cfg = mockLoadConfig();
+      cfg.api_key = "key";
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockSelect.mockResolvedValueOnce("d1");
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(mockSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Select a deployment",
+        }),
+      );
+    });
+
+    it("returns null when no deployments for org", async () => {
+      const client = setupWithOrg();
+      client.getDeployments.mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "other-org", org_name: "Other" },
+      ]);
+
+      await runSetup();
+
+      expect(p.log.error).toHaveBeenCalledWith(
+        expect.stringContaining("No deployments found"),
+      );
+    });
+  });
+
+  // ---- stepMintAPIKey tests ----
+
+  describe("stepMintAPIKey", () => {
+    function setupThroughDeployment() {
+      const cfg = makeCfg({ access_token: "tok" });
+      mockLoadConfig.mockReturnValue(cfg);
+      const clientMethods = {
+        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+        refreshToken: vi.fn(),
+        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+        getDeployments: vi.fn().mockResolvedValue([
+          { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+        ]),
+        validateAPIKey: vi.fn(),
+        createAPIKey: vi.fn(),
+      };
+      mockClient.mockImplementation(() => clientMethods as any);
+      return { clientMethods, cfg };
+    }
+
+    it("uses existing valid API key", async () => {
+      const { clientMethods } = setupThroughDeployment();
+      clientMethods.validateAPIKey.mockResolvedValue(true);
+
+      const cfg = mockLoadConfig();
+      cfg.api_key = "existing-key";
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(clientMethods.validateAPIKey).toHaveBeenCalledWith("existing-key", "d1");
+      expect(clientMethods.createAPIKey).not.toHaveBeenCalled();
+      expect(p.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("using existing"),
+      );
+    });
+
+    it("creates new key when existing key is invalid", async () => {
+      const { clientMethods } = setupThroughDeployment();
+      clientMethods.validateAPIKey.mockResolvedValue(false);
+      clientMethods.createAPIKey.mockResolvedValue({ api_key: "brand-new-key" });
+
+      const cfg = mockLoadConfig();
+      cfg.api_key = "bad-key";
+      mockLoadConfig.mockReturnValue(cfg);
+
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(p.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("invalid"),
+      );
+      expect(clientMethods.createAPIKey).toHaveBeenCalledWith("d1", "dosu-cli");
+      expect(p.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("created"),
+      );
+    });
+
+    it("creates new key when no existing key", async () => {
+      const { clientMethods } = setupThroughDeployment();
+      clientMethods.createAPIKey.mockResolvedValue({ api_key: "new-key" });
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(clientMethods.createAPIKey).toHaveBeenCalledWith("d1", "dosu-cli");
+    });
+
+    it("returns null when key creation fails", async () => {
+      const { clientMethods } = setupThroughDeployment();
+      clientMethods.createAPIKey.mockRejectedValue(new Error("rate limited"));
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(p.log.error).toHaveBeenCalledWith(
+        expect.stringContaining("rate limited"),
+      );
+    });
+  });
+
+  // ---- stepDetectTools tests ----
+
+  describe("stepDetectTools", () => {
+    function setupThroughAPIKey() {
+      const cfg = makeCfg({ access_token: "tok", api_key: "key" });
+      mockLoadConfig.mockReturnValue(cfg);
+      const clientMethods = {
+        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+        refreshToken: vi.fn(),
+        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+        getDeployments: vi.fn().mockResolvedValue([
+          { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
+        ]),
+        validateAPIKey: vi.fn().mockResolvedValue(true),
+        createAPIKey: vi.fn(),
+      };
+      mockClient.mockImplementation(() => clientMethods as any);
+      return clientMethods;
+    }
+
+    it("filters out non-installed and stdio-only providers", async () => {
+      setupThroughAPIKey();
+
+      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true });
+      const vscodeProvider = makeProvider("vscode", "VS Code", { isInstalled: false });
+      const claudeDesktop = makeProvider("claude-desktop", "Claude Desktop", { isInstalled: true });
+
+      mockAllSetupProviders.mockReturnValue([cursorProvider, vscodeProvider, claudeDesktop]);
+
+      // Only cursor should remain after filtering (vscode not installed, claude-desktop is stdio-only)
+      // The multiselect will be shown for cursor only
+      mockMultiselect.mockResolvedValue(["cursor"]);
+
+      await runSetup();
+
+      // Cursor was selected for install
+      expect(cursorProvider.install).toHaveBeenCalled();
+      // VS Code was not installed, so never offered
+      expect(vscodeProvider.install).not.toHaveBeenCalled();
+      // Claude Desktop filtered as stdio-only
+      expect(claudeDesktop.install).not.toHaveBeenCalled();
+    });
+
+    it("shows warning when no tools detected", async () => {
+      setupThroughAPIKey();
+      mockAllSetupProviders.mockReturnValue([]);
+
+      await runSetup();
+
+      expect(p.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No supported AI tools detected"),
+      );
+    });
+  });
+
+  // ---- stepConfigureTools tests ----
+
+  describe("stepConfigureTools", () => {
+    function setupThroughAPIKey() {
+      const cfg = makeCfg({ access_token: "tok", api_key: "key" });
+      mockLoadConfig.mockReturnValue(cfg);
+      const clientMethods = {
+        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+        refreshToken: vi.fn(),
+        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+        getDeployments: vi.fn().mockResolvedValue([
+          { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
+        ]),
+        validateAPIKey: vi.fn().mockResolvedValue(true),
+        createAPIKey: vi.fn(),
+      };
+      mockClient.mockImplementation(() => clientMethods as any);
+      return clientMethods;
+    }
+
+    it("installs selected unconfigured providers", async () => {
+      setupThroughAPIKey();
+
+      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: false });
+      mockAllSetupProviders.mockReturnValue([cursorProvider]);
+
+      // User selects cursor for install
+      mockMultiselect.mockResolvedValue(["cursor"]);
+
+      await runSetup();
+
+      expect(cursorProvider.install).toHaveBeenCalled();
+      expect(p.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("Configured 1 tool"),
+      );
+    });
+
+    it("removes deselected configured providers", async () => {
+      setupThroughAPIKey();
+
+      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: true });
+      mockAllSetupProviders.mockReturnValue([cursorProvider]);
+
+      // User deselects cursor (it was previously configured)
+      mockMultiselect.mockResolvedValue([]);
+
+      await runSetup();
+
+      expect(cursorProvider.remove).toHaveBeenCalled();
+      expect(p.log.info).toHaveBeenCalledWith(
+        expect.stringContaining("Removed from 1 tool"),
+      );
+    });
+
+    it("skips already-configured providers that remain selected", async () => {
+      setupThroughAPIKey();
+
+      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: true });
+      mockAllSetupProviders.mockReturnValue([cursorProvider]);
+
+      // User keeps cursor selected (already configured)
+      mockMultiselect.mockResolvedValue(["cursor"]);
+
+      await runSetup();
+
+      expect(cursorProvider.install).not.toHaveBeenCalled();
+      expect(cursorProvider.remove).not.toHaveBeenCalled();
+      expect(p.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("All tools already configured"),
+      );
+    });
+
+    it("handles install errors gracefully", async () => {
+      setupThroughAPIKey();
+
+      const failProvider = makeProvider("cursor", "Cursor", {
+        isInstalled: true,
+        isConfigured: false,
+        installError: new Error("permission denied"),
+      });
+      mockAllSetupProviders.mockReturnValue([failProvider]);
+
+      mockMultiselect.mockResolvedValue(["cursor"]);
+
+      await runSetup();
+
+      expect(p.log.error).toHaveBeenCalledWith(
+        expect.stringContaining("permission denied"),
+      );
+    });
+
+    it("handles remove errors gracefully", async () => {
+      setupThroughAPIKey();
+
+      const failProvider = makeProvider("cursor", "Cursor", {
+        isInstalled: true,
+        isConfigured: true,
+        removeError: new Error("config locked"),
+      });
+      mockAllSetupProviders.mockReturnValue([failProvider]);
+
+      // Deselect to trigger remove
+      mockMultiselect.mockResolvedValue([]);
+
+      await runSetup();
+
+      expect(p.log.error).toHaveBeenCalledWith(
+        expect.stringContaining("config locked"),
+      );
+    });
+
+    it("returns null when user cancels tool selection", async () => {
+      setupThroughAPIKey();
+
+      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true });
+      mockAllSetupProviders.mockReturnValue([cursorProvider]);
+
+      const cancelSymbol = Symbol("cancel");
+      mockMultiselect.mockResolvedValue(cancelSymbol as any);
+      mockIsCancel.mockImplementation((val) => val === cancelSymbol);
+
+      await runSetup();
+
+      expect(cursorProvider.install).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- stepShowSummary tests ----
+
+  describe("stepShowSummary", () => {
+    function setupThroughAPIKey() {
+      const cfg = makeCfg({ access_token: "tok", api_key: "key" });
+      mockLoadConfig.mockReturnValue(cfg);
+      const clientMethods = {
+        doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+        refreshToken: vi.fn(),
+        getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+        getDeployments: vi.fn().mockResolvedValue([
+          { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
+        ]),
+        validateAPIKey: vi.fn().mockResolvedValue(true),
+        createAPIKey: vi.fn(),
+      };
+      mockClient.mockImplementation(() => clientMethods as any);
+      return clientMethods;
+    }
+
+    it("shows try-it-out message when tools are installed", async () => {
+      setupThroughAPIKey();
+
+      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: false });
+      mockAllSetupProviders.mockReturnValue([cursorProvider]);
+      mockMultiselect.mockResolvedValue(["cursor"]);
+
+      await runSetup();
+
+      expect(p.log.message).toHaveBeenCalledWith(
+        expect.stringContaining("Try it out"),
+      );
+    });
+
+    it("shows try-it-out message when tools are skipped (already configured)", async () => {
+      setupThroughAPIKey();
+
+      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: true });
+      mockAllSetupProviders.mockReturnValue([cursorProvider]);
+      mockMultiselect.mockResolvedValue(["cursor"]);
+
+      await runSetup();
+
+      expect(p.log.message).toHaveBeenCalledWith(
+        expect.stringContaining("Try it out"),
+      );
+    });
+
+    it("mixed install and remove shows both summaries", async () => {
+      setupThroughAPIKey();
+
+      const cursorProvider = makeProvider("cursor", "Cursor", { isInstalled: true, isConfigured: false });
+      const vscodeProvider = makeProvider("vscode", "VS Code", { isInstalled: true, isConfigured: true });
+      mockAllSetupProviders.mockReturnValue([cursorProvider, vscodeProvider]);
+
+      // Select cursor (new install), deselect vscode (remove)
+      mockMultiselect.mockResolvedValue(["cursor"]);
+
+      await runSetup();
+
+      expect(p.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("Configured 1 tool"),
+      );
+      expect(p.log.info).toHaveBeenCalledWith(
+        expect.stringContaining("Removed from 1 tool"),
+      );
+    });
+  });
+});

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -15,15 +15,15 @@ export interface SetupOptions {
   deploymentID?: string;
 }
 
-type ConfigAction = "install" | "remove" | "skip";
+export type ConfigAction = "install" | "remove" | "skip";
 
-interface ConfigResult {
+export interface ConfigResult {
   provider: SetupProvider;
   action: ConfigAction;
   error?: Error;
 }
 
-interface ToolSelection {
+export interface ToolSelection {
   toInstall: SetupProvider[];
   toRemove: SetupProvider[];
   skipped: SetupProvider[];
@@ -222,11 +222,11 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
   }
 }
 
-function isStdioOnly(p: SetupProvider): boolean {
+export function isStdioOnly(p: SetupProvider): boolean {
   return p.id() === "claude-desktop";
 }
 
-function stepDetectTools(): SetupProvider[] {
+export function stepDetectTools(): SetupProvider[] {
   return allSetupProviders().filter((p) => p.isInstalled() && !isStdioOnly(p));
 }
 
@@ -270,7 +270,7 @@ async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection
   return result;
 }
 
-function stepConfigureTools(cfg: Config, selection: ToolSelection): ConfigResult[] {
+export function stepConfigureTools(cfg: Config, selection: ToolSelection): ConfigResult[] {
   const results: ConfigResult[] = [];
 
   for (const provider of selection.toInstall) {
@@ -300,7 +300,7 @@ function stepConfigureTools(cfg: Config, selection: ToolSelection): ConfigResult
   return results;
 }
 
-function stepShowSummary(results: ConfigResult[]): void {
+export function stepShowSummary(results: ConfigResult[]): void {
   const installed = results.filter((r) => r.action === "install" && !r.error);
   const removed = results.filter((r) => r.action === "remove" && !r.error);
   const skipped = results.filter((r) => r.action === "skip");

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,12 +1,508 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// The TUI is interactive and can't be easily unit tested without mocking
-// the entire @clack/prompts library. We test that the module exports correctly
-// and that the logo constant exists.
+// Mock dependencies before importing the module under test
+vi.mock("@clack/prompts", () => ({
+  select: vi.fn(),
+  isCancel: vi.fn(),
+  outro: vi.fn(),
+  log: {
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
 
-describe("TUI", () => {
-  it("exports runTUI function", async () => {
-    const mod = await import("./tui");
-    expect(typeof mod.runTUI).toBe("function");
+vi.mock("../config/config", () => ({
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+  isAuthenticated: vi.fn(),
+}));
+
+vi.mock("../client/client", () => ({
+  Client: vi.fn(),
+}));
+
+vi.mock("../setup/flow", () => ({
+  runSetup: vi.fn(),
+}));
+
+vi.mock("../mcp/providers", () => ({
+  allProviders: vi.fn(),
+}));
+
+vi.mock("picocolors", () => ({
+  default: {
+    magenta: (s: string) => s,
+    dim: (s: string) => s,
+  },
+}));
+
+import * as p from "@clack/prompts";
+import { loadConfig, saveConfig, isAuthenticated } from "../config/config";
+import { Client } from "../client/client";
+import { runSetup } from "../setup/flow";
+import { runTUI } from "./tui";
+
+const mockSelect = vi.mocked(p.select);
+const mockIsCancel = vi.mocked(p.isCancel);
+const mockOutro = vi.mocked(p.outro);
+const mockLoadConfig = vi.mocked(loadConfig);
+const mockSaveConfig = vi.mocked(saveConfig);
+const mockIsAuthenticated = vi.mocked(isAuthenticated);
+const mockRunSetup = vi.mocked(runSetup);
+
+function makeCfg(overrides: Record<string, unknown> = {}) {
+  return {
+    access_token: "tok",
+    refresh_token: "ref",
+    expires_at: 9999999999,
+    deployment_id: undefined as string | undefined,
+    deployment_name: undefined as string | undefined,
+    api_key: undefined as string | undefined,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Suppress console.log for the logo
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+describe("runTUI", () => {
+  it("calls runSetup when not authenticated", async () => {
+    const cfg = makeCfg({ access_token: "" });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(false);
+    mockRunSetup.mockResolvedValue(undefined);
+
+    await runTUI();
+
+    expect(mockRunSetup).toHaveBeenCalledOnce();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("exits loop and calls outro when user selects exit", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockSelect.mockResolvedValueOnce("exit");
+    mockIsCancel.mockReturnValue(false);
+
+    await runTUI();
+
+    expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
+  });
+
+  it("exits loop when user cancels select", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockSelect.mockResolvedValueOnce(Symbol("cancel") as any);
+    mockIsCancel.mockReturnValue(true);
+
+    await runTUI();
+
+    expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
+  });
+
+  it("calls runSetup when user selects setup action", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+    mockRunSetup.mockResolvedValue(undefined);
+
+    // First call: select "setup", second call: select "exit"
+    mockSelect.mockResolvedValueOnce("setup").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockRunSetup).toHaveBeenCalledOnce();
+    expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
+  });
+
+  it("handleLogout clears credentials and saves config", async () => {
+    const cfg = makeCfg({
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: 9999999999,
+      deployment_id: "dep-1",
+      deployment_name: "My Deploy",
+      api_key: "key-123",
+    });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    // First select "logout", then "exit"
+    mockSelect.mockResolvedValueOnce("logout").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockSaveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        access_token: "",
+        refresh_token: "",
+        expires_at: 0,
+        deployment_id: undefined,
+        deployment_name: undefined,
+        api_key: undefined,
+      }),
+    );
+    expect(p.log.success).toHaveBeenCalledWith("Credentials cleared.");
+  });
+
+  it("handleLogout shows warning when not logged in", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+
+    // isAuthenticated is called at: (1) line 30 initial check, (2) line 42 hint,
+    // (3) line 43 hint, then (4) inside handleLogout at line 175
+    mockIsAuthenticated
+      .mockReturnValueOnce(true)  // enter menu
+      .mockReturnValueOnce(true)  // select hint 1
+      .mockReturnValueOnce(true)  // select hint 2
+      .mockReturnValueOnce(false) // handleLogout check
+      .mockReturnValue(true);     // rest of loop
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect.mockResolvedValueOnce("logout").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("You are not logged in.");
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+  });
+
+  it("handleDeployments shows warning when not authenticated", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+
+    // isAuthenticated is called at: (1) line 30 initial check, (2) line 42 hint,
+    // (3) line 43 hint, then (4) inside handleDeployments at line 86
+    mockIsAuthenticated
+      .mockReturnValueOnce(true)  // enter menu
+      .mockReturnValueOnce(true)  // select hint 1
+      .mockReturnValueOnce(true)  // select hint 2
+      .mockReturnValueOnce(false) // handleDeployments check
+      .mockReturnValue(true);     // rest of loop
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect.mockResolvedValueOnce("deployments").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("Please authenticate first.");
+  });
+
+  it("handleDeployments fetches and allows selection", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    const mockDeployments = [
+      { deployment_id: "d1", name: "Deploy 1", org_name: "Org" },
+      { deployment_id: "d2", name: "Deploy 2", org_name: "Org" },
+    ];
+    const mockGetDeployments = vi.fn().mockResolvedValue(mockDeployments);
+    vi.mocked(Client).mockImplementation(
+      () => ({ getDeployments: mockGetDeployments }) as any,
+    );
+
+    // First select "deployments", then select deployment "d1", then "exit"
+    mockSelect
+      .mockResolvedValueOnce("deployments")
+      .mockResolvedValueOnce("d1")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockGetDeployments).toHaveBeenCalled();
+    expect(mockSaveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deployment_id: "d1",
+        deployment_name: "Deploy 1",
+      }),
+    );
+    expect(p.log.success).toHaveBeenCalledWith("Selected: Deploy 1");
+  });
+
+  it("handleDeployments shows warning when no deployments found", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    const mockGetDeployments = vi.fn().mockResolvedValue([]);
+    vi.mocked(Client).mockImplementation(
+      () => ({ getDeployments: mockGetDeployments }) as any,
+    );
+
+    mockSelect.mockResolvedValueOnce("deployments").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("No deployments found.");
+  });
+
+  it("handleDeployments cancels when user cancels deployment selection", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+
+    const mockDeployments = [
+      { deployment_id: "d1", name: "Deploy 1", org_name: "Org" },
+    ];
+    const mockGetDeployments = vi.fn().mockResolvedValue(mockDeployments);
+    vi.mocked(Client).mockImplementation(
+      () => ({ getDeployments: mockGetDeployments }) as any,
+    );
+
+    const cancelSymbol = Symbol("cancel");
+    mockIsCancel.mockImplementation((val) => val === cancelSymbol);
+
+    // First select "deployments", then cancel the deployment selection, then "exit"
+    mockSelect
+      .mockResolvedValueOnce("deployments")
+      .mockResolvedValueOnce(cancelSymbol as any)
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+    expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
+  });
+
+  it("handleMCPAdd shows warning when no deployment selected", async () => {
+    const cfg = makeCfg({ deployment_id: undefined });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    // Select mcp-add, then exit
+    mockSelect.mockResolvedValueOnce("mcp-add").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("Please select a deployment first.");
+  });
+
+  it("handleMCPRemove shows warning when no deployment selected", async () => {
+    const cfg = makeCfg({ deployment_id: undefined });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect.mockResolvedValueOnce("mcp-remove").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("Please select a deployment first.");
+  });
+
+  it("handleMCPAdd installs the selected provider", async () => {
+    const mockInstall = vi.fn();
+    const mockProvider = {
+      id: () => "cursor",
+      name: () => "Cursor",
+      supportsLocal: () => true,
+      install: mockInstall,
+      remove: vi.fn(),
+    };
+
+    const { allProviders } = await import("../mcp/providers");
+    vi.mocked(allProviders).mockReturnValue([mockProvider]);
+
+    const cfg = makeCfg({ deployment_id: "d1" });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-add")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockInstall).toHaveBeenCalledWith(cfg, true);
+    expect(p.log.success).toHaveBeenCalledWith("Added Dosu MCP to Cursor");
+  });
+
+  it("handleMCPAdd shows error when install fails", async () => {
+    const mockInstall = vi.fn().mockImplementation(() => {
+      throw new Error("write permission denied");
+    });
+    const mockProvider = {
+      id: () => "cursor",
+      name: () => "Cursor",
+      supportsLocal: () => true,
+      install: mockInstall,
+      remove: vi.fn(),
+    };
+
+    const { allProviders } = await import("../mcp/providers");
+    vi.mocked(allProviders).mockReturnValue([mockProvider]);
+
+    const cfg = makeCfg({ deployment_id: "d1" });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-add")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.error).toHaveBeenCalledWith("Failed: write permission denied");
+  });
+
+  it("handleMCPAdd does nothing when user cancels provider selection", async () => {
+    const mockProvider = {
+      id: () => "cursor",
+      name: () => "Cursor",
+      supportsLocal: () => true,
+      install: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    const { allProviders } = await import("../mcp/providers");
+    vi.mocked(allProviders).mockReturnValue([mockProvider]);
+
+    const cfg = makeCfg({ deployment_id: "d1" });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+
+    const cancelSymbol = Symbol("cancel");
+    mockIsCancel.mockImplementation((val) => val === cancelSymbol);
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-add")
+      .mockResolvedValueOnce(cancelSymbol as any)
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("handleMCPRemove removes the selected provider", async () => {
+    const mockRemove = vi.fn();
+    const mockProvider = {
+      id: () => "cursor",
+      name: () => "Cursor",
+      supportsLocal: () => true,
+      install: vi.fn(),
+      remove: mockRemove,
+    };
+
+    const { allProviders } = await import("../mcp/providers");
+    vi.mocked(allProviders).mockReturnValue([mockProvider]);
+
+    const cfg = makeCfg({ deployment_id: "d1" });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-remove")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockRemove).toHaveBeenCalledWith(true);
+    expect(p.log.success).toHaveBeenCalledWith("Removed Dosu MCP from Cursor");
+  });
+
+  it("handleMCPRemove shows error when remove fails", async () => {
+    const mockRemove = vi.fn().mockImplementation(() => {
+      throw new Error("file not found");
+    });
+    const mockProvider = {
+      id: () => "cursor",
+      name: () => "Cursor",
+      supportsLocal: () => true,
+      install: vi.fn(),
+      remove: mockRemove,
+    };
+
+    const { allProviders } = await import("../mcp/providers");
+    vi.mocked(allProviders).mockReturnValue([mockProvider]);
+
+    const cfg = makeCfg({ deployment_id: "d1" });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-remove")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.error).toHaveBeenCalledWith("Failed: file not found");
+  });
+
+  it("handleMCPRemove filters out manual provider", async () => {
+    const manualProvider = {
+      id: () => "manual",
+      name: () => "Manual",
+      supportsLocal: () => false,
+      install: vi.fn(),
+      remove: vi.fn(),
+    };
+    const cursorProvider = {
+      id: () => "cursor",
+      name: () => "Cursor",
+      supportsLocal: () => true,
+      install: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    const { allProviders } = await import("../mcp/providers");
+    vi.mocked(allProviders).mockReturnValue([manualProvider, cursorProvider]);
+
+    const cfg = makeCfg({ deployment_id: "d1" });
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-remove")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    // The select call for mcp-remove should only include cursor, not manual
+    const removeSelectCall = mockSelect.mock.calls[1];
+    const options = (removeSelectCall[0] as any).options;
+    expect(options).toHaveLength(1);
+    expect(options[0].value).toBe("cursor");
+  });
+
+  it("handleDeployments shows error when fetch fails", async () => {
+    const cfg = makeCfg();
+    mockLoadConfig.mockReturnValue(cfg);
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsCancel.mockReturnValue(false);
+
+    const mockGetDeployments = vi.fn().mockRejectedValue(new Error("network error"));
+    vi.mocked(Client).mockImplementation(
+      () => ({ getDeployments: mockGetDeployments }) as any,
+    );
+
+    mockSelect.mockResolvedValueOnce("deployments").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.error).toHaveBeenCalledWith("Failed: network error");
   });
 });

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,6 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-// Mock dependencies before importing the module under test
+// ---------------------------------------------------------------------------
+// Mocks — only true I/O boundaries
+// ---------------------------------------------------------------------------
+
 vi.mock("@clack/prompts", () => ({
   select: vi.fn(),
   isCancel: vi.fn(),
@@ -13,22 +26,12 @@ vi.mock("@clack/prompts", () => ({
   },
 }));
 
-vi.mock("../config/config", () => ({
-  loadConfig: vi.fn(),
-  saveConfig: vi.fn(),
-  isAuthenticated: vi.fn(),
-}));
-
-vi.mock("../client/client", () => ({
-  Client: vi.fn(),
-}));
-
 vi.mock("../setup/flow", () => ({
   runSetup: vi.fn(),
 }));
 
-vi.mock("../mcp/providers", () => ({
-  allProviders: vi.fn(),
+vi.mock("../client/client", () => ({
+  Client: vi.fn(),
 }));
 
 vi.mock("picocolors", () => ({
@@ -38,43 +41,150 @@ vi.mock("picocolors", () => ({
   },
 }));
 
+// ---------------------------------------------------------------------------
+// Imports — config is REAL, not mocked
+// ---------------------------------------------------------------------------
+
 import * as p from "@clack/prompts";
 import { loadConfig, saveConfig, isAuthenticated } from "../config/config";
+import type { Config } from "../config/config";
 import { Client } from "../client/client";
 import { runSetup } from "../setup/flow";
-import { runTUI } from "./tui";
+import { runTUI, handleLogout } from "./tui";
+import { loadJSONConfig } from "../mcp/config-helpers";
 
 const mockSelect = vi.mocked(p.select);
 const mockIsCancel = vi.mocked(p.isCancel);
 const mockOutro = vi.mocked(p.outro);
-const mockLoadConfig = vi.mocked(loadConfig);
-const mockSaveConfig = vi.mocked(saveConfig);
-const mockIsAuthenticated = vi.mocked(isAuthenticated);
 const mockRunSetup = vi.mocked(runSetup);
 
-function makeCfg(overrides: Record<string, unknown> = {}) {
+// ---------------------------------------------------------------------------
+// Temp directory setup — real config on disk
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+let origHome: string | undefined;
+let origXdg: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-tui-test-"));
+  origHome = process.env.HOME;
+  origXdg = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = tempDir;
+  process.env.HOME = tempDir;
+
+  vi.clearAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  if (origXdg !== undefined) {
+    process.env.XDG_CONFIG_HOME = origXdg;
+  } else {
+    delete process.env.XDG_CONFIG_HOME;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCfg(overrides: Partial<Config> = {}): Config {
   return {
     access_token: "tok",
     refresh_token: "ref",
     expires_at: 9999999999,
-    deployment_id: undefined as string | undefined,
-    deployment_name: undefined as string | undefined,
-    api_key: undefined as string | undefined,
+    deployment_id: undefined,
+    deployment_name: undefined,
+    api_key: undefined,
     ...overrides,
   };
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  // Suppress console.log for the logo
-  vi.spyOn(console, "log").mockImplementation(() => {});
+function writeRealConfig(cfg: Config): void {
+  saveConfig(cfg);
+}
+
+function readRealConfig(): Config {
+  return loadConfig();
+}
+
+/** Returns the path to the Cursor global MCP config given current HOME. */
+function cursorMcpPath(): string {
+  return join(tempDir, ".cursor", "mcp.json");
+}
+
+// ---------------------------------------------------------------------------
+// 1. handleLogout — direct, high-fidelity tests
+// ---------------------------------------------------------------------------
+
+describe("handleLogout (direct)", () => {
+  it("clears credentials on disk when authenticated", () => {
+    const cfg = makeCfg({
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: 9999999999,
+      deployment_id: "dep-1",
+      deployment_name: "My Deploy",
+      api_key: "key-123",
+    });
+    writeRealConfig(cfg);
+
+    // handleLogout mutates cfg in place and calls saveConfig
+    handleLogout(cfg);
+
+    // Verify the object was cleared
+    expect(cfg.access_token).toBe("");
+    expect(cfg.refresh_token).toBe("");
+    expect(cfg.expires_at).toBe(0);
+    expect(cfg.deployment_id).toBeUndefined();
+    expect(cfg.deployment_name).toBeUndefined();
+    expect(cfg.api_key).toBeUndefined();
+
+    // Verify the file on disk was actually written with cleared values
+    const ondisk = readRealConfig();
+    expect(ondisk.access_token).toBe("");
+    expect(ondisk.refresh_token).toBe("");
+    expect(ondisk.expires_at).toBe(0);
+    expect(ondisk.deployment_id).toBeUndefined();
+    expect(ondisk.deployment_name).toBeUndefined();
+    expect(ondisk.api_key).toBeUndefined();
+
+    expect(p.log.success).toHaveBeenCalledWith("Credentials cleared.");
+  });
+
+  it("shows warning and does not write when not authenticated", () => {
+    const cfg = makeCfg({ access_token: "" });
+    writeRealConfig(cfg);
+
+    // Grab file mtime before call
+    const configPath = join(tempDir, "dosu-cli", "config.json");
+    const mtimeBefore = existsSync(configPath)
+      ? readFileSync(configPath, "utf-8")
+      : null;
+
+    handleLogout(cfg);
+
+    // File content should be unchanged
+    const mtimeAfter = existsSync(configPath)
+      ? readFileSync(configPath, "utf-8")
+      : null;
+    expect(mtimeAfter).toBe(mtimeBefore);
+
+    expect(p.log.warn).toHaveBeenCalledWith("You are not logged in.");
+    expect(p.log.success).not.toHaveBeenCalled();
+  });
 });
 
+// ---------------------------------------------------------------------------
+// 2. runTUI flow tests — mock prompts, real config
+// ---------------------------------------------------------------------------
+
 describe("runTUI", () => {
-  it("calls runSetup when not authenticated", async () => {
-    const cfg = makeCfg({ access_token: "" });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(false);
+  it("calls runSetup when not authenticated (real config, no file on disk)", async () => {
+    // No config file exists, so loadConfig returns empty → not authenticated
     mockRunSetup.mockResolvedValue(undefined);
 
     await runTUI();
@@ -84,9 +194,7 @@ describe("runTUI", () => {
   });
 
   it("exits loop and calls outro when user selects exit", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
+    writeRealConfig(makeCfg({ access_token: "tok" }));
     mockSelect.mockResolvedValueOnce("exit");
     mockIsCancel.mockReturnValue(false);
 
@@ -96,10 +204,9 @@ describe("runTUI", () => {
   });
 
   it("exits loop when user cancels select", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-    mockSelect.mockResolvedValueOnce(Symbol("cancel") as any);
+    writeRealConfig(makeCfg({ access_token: "tok" }));
+    const cancelSymbol = Symbol("cancel");
+    mockSelect.mockResolvedValueOnce(cancelSymbol as any);
     mockIsCancel.mockReturnValue(true);
 
     await runTUI();
@@ -108,13 +215,10 @@ describe("runTUI", () => {
   });
 
   it("calls runSetup when user selects setup action", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
+    writeRealConfig(makeCfg({ access_token: "tok" }));
     mockIsCancel.mockReturnValue(false);
     mockRunSetup.mockResolvedValue(undefined);
 
-    // First call: select "setup", second call: select "exit"
     mockSelect.mockResolvedValueOnce("setup").mockResolvedValueOnce("exit");
 
     await runTUI();
@@ -123,7 +227,7 @@ describe("runTUI", () => {
     expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
   });
 
-  it("handleLogout clears credentials and saves config", async () => {
+  it("logout action clears real config on disk", async () => {
     const cfg = makeCfg({
       access_token: "tok",
       refresh_token: "ref",
@@ -132,75 +236,23 @@ describe("runTUI", () => {
       deployment_name: "My Deploy",
       api_key: "key-123",
     });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
+    writeRealConfig(cfg);
     mockIsCancel.mockReturnValue(false);
 
-    // First select "logout", then "exit"
     mockSelect.mockResolvedValueOnce("logout").mockResolvedValueOnce("exit");
 
     await runTUI();
 
-    expect(mockSaveConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        access_token: "",
-        refresh_token: "",
-        expires_at: 0,
-        deployment_id: undefined,
-        deployment_name: undefined,
-        api_key: undefined,
-      }),
-    );
+    // Verify real file on disk was cleared
+    const ondisk = readRealConfig();
+    expect(ondisk.access_token).toBe("");
+    expect(ondisk.refresh_token).toBe("");
+    expect(ondisk.expires_at).toBe(0);
     expect(p.log.success).toHaveBeenCalledWith("Credentials cleared.");
   });
 
-  it("handleLogout shows warning when not logged in", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-
-    // isAuthenticated is called at: (1) line 30 initial check, (2) line 42 hint,
-    // (3) line 43 hint, then (4) inside handleLogout at line 175
-    mockIsAuthenticated
-      .mockReturnValueOnce(true)  // enter menu
-      .mockReturnValueOnce(true)  // select hint 1
-      .mockReturnValueOnce(true)  // select hint 2
-      .mockReturnValueOnce(false) // handleLogout check
-      .mockReturnValue(true);     // rest of loop
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect.mockResolvedValueOnce("logout").mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(p.log.warn).toHaveBeenCalledWith("You are not logged in.");
-    expect(mockSaveConfig).not.toHaveBeenCalled();
-  });
-
-  it("handleDeployments shows warning when not authenticated", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-
-    // isAuthenticated is called at: (1) line 30 initial check, (2) line 42 hint,
-    // (3) line 43 hint, then (4) inside handleDeployments at line 86
-    mockIsAuthenticated
-      .mockReturnValueOnce(true)  // enter menu
-      .mockReturnValueOnce(true)  // select hint 1
-      .mockReturnValueOnce(true)  // select hint 2
-      .mockReturnValueOnce(false) // handleDeployments check
-      .mockReturnValue(true);     // rest of loop
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect.mockResolvedValueOnce("deployments").mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(p.log.warn).toHaveBeenCalledWith("Please authenticate first.");
-  });
-
-  it("handleDeployments fetches and allows selection", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
+  it("deployments action saves selected deployment_id to real config", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok" }));
     mockIsCancel.mockReturnValue(false);
 
     const mockDeployments = [
@@ -212,7 +264,6 @@ describe("runTUI", () => {
       () => ({ getDeployments: mockGetDeployments }) as any,
     );
 
-    // First select "deployments", then select deployment "d1", then "exit"
     mockSelect
       .mockResolvedValueOnce("deployments")
       .mockResolvedValueOnce("d1")
@@ -221,19 +272,35 @@ describe("runTUI", () => {
     await runTUI();
 
     expect(mockGetDeployments).toHaveBeenCalled();
-    expect(mockSaveConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        deployment_id: "d1",
-        deployment_name: "Deploy 1",
-      }),
-    );
     expect(p.log.success).toHaveBeenCalledWith("Selected: Deploy 1");
+
+    // Verify real config on disk has the deployment
+    const ondisk = readRealConfig();
+    expect(ondisk.deployment_id).toBe("d1");
+    expect(ondisk.deployment_name).toBe("Deploy 1");
   });
 
-  it("handleDeployments shows warning when no deployments found", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
+  it("deployments shows warning when not authenticated (handles inner check)", async () => {
+    // Write a config that starts authenticated, then becomes unauthenticated
+    // We simulate this by writing the config, then having logout clear it before deployments
+    // Actually, simpler: write config with access_token, select logout then deployments
+    // But the code checks isAuthenticated inside handleDeployments with the same cfg object.
+    // After logout, cfg.access_token is "". So selecting deployments after logout triggers the warn.
+    writeRealConfig(makeCfg({ access_token: "tok" }));
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect
+      .mockResolvedValueOnce("logout")
+      .mockResolvedValueOnce("deployments")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("Please authenticate first.");
+  });
+
+  it("deployments shows warning when no deployments found", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok" }));
     mockIsCancel.mockReturnValue(false);
 
     const mockGetDeployments = vi.fn().mockResolvedValue([]);
@@ -248,10 +315,8 @@ describe("runTUI", () => {
     expect(p.log.warn).toHaveBeenCalledWith("No deployments found.");
   });
 
-  it("handleDeployments cancels when user cancels deployment selection", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
+  it("deployments handles cancel during deployment selection", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok" }));
 
     const mockDeployments = [
       { deployment_id: "d1", name: "Deploy 1", org_name: "Org" },
@@ -264,7 +329,6 @@ describe("runTUI", () => {
     const cancelSymbol = Symbol("cancel");
     mockIsCancel.mockImplementation((val) => val === cancelSymbol);
 
-    // First select "deployments", then cancel the deployment selection, then "exit"
     mockSelect
       .mockResolvedValueOnce("deployments")
       .mockResolvedValueOnce(cancelSymbol as any)
@@ -272,226 +336,14 @@ describe("runTUI", () => {
 
     await runTUI();
 
-    expect(mockSaveConfig).not.toHaveBeenCalled();
+    // Config should not have been updated
+    const ondisk = readRealConfig();
+    expect(ondisk.deployment_id).toBeUndefined();
     expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
   });
 
-  it("handleMCPAdd shows warning when no deployment selected", async () => {
-    const cfg = makeCfg({ deployment_id: undefined });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-    mockIsCancel.mockReturnValue(false);
-
-    // Select mcp-add, then exit
-    mockSelect.mockResolvedValueOnce("mcp-add").mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(p.log.warn).toHaveBeenCalledWith("Please select a deployment first.");
-  });
-
-  it("handleMCPRemove shows warning when no deployment selected", async () => {
-    const cfg = makeCfg({ deployment_id: undefined });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect.mockResolvedValueOnce("mcp-remove").mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(p.log.warn).toHaveBeenCalledWith("Please select a deployment first.");
-  });
-
-  it("handleMCPAdd installs the selected provider", async () => {
-    const mockInstall = vi.fn();
-    const mockProvider = {
-      id: () => "cursor",
-      name: () => "Cursor",
-      supportsLocal: () => true,
-      install: mockInstall,
-      remove: vi.fn(),
-    };
-
-    const { allProviders } = await import("../mcp/providers");
-    vi.mocked(allProviders).mockReturnValue([mockProvider]);
-
-    const cfg = makeCfg({ deployment_id: "d1" });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect
-      .mockResolvedValueOnce("mcp-add")
-      .mockResolvedValueOnce("cursor")
-      .mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(mockInstall).toHaveBeenCalledWith(cfg, true);
-    expect(p.log.success).toHaveBeenCalledWith("Added Dosu MCP to Cursor");
-  });
-
-  it("handleMCPAdd shows error when install fails", async () => {
-    const mockInstall = vi.fn().mockImplementation(() => {
-      throw new Error("write permission denied");
-    });
-    const mockProvider = {
-      id: () => "cursor",
-      name: () => "Cursor",
-      supportsLocal: () => true,
-      install: mockInstall,
-      remove: vi.fn(),
-    };
-
-    const { allProviders } = await import("../mcp/providers");
-    vi.mocked(allProviders).mockReturnValue([mockProvider]);
-
-    const cfg = makeCfg({ deployment_id: "d1" });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect
-      .mockResolvedValueOnce("mcp-add")
-      .mockResolvedValueOnce("cursor")
-      .mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(p.log.error).toHaveBeenCalledWith("Failed: write permission denied");
-  });
-
-  it("handleMCPAdd does nothing when user cancels provider selection", async () => {
-    const mockProvider = {
-      id: () => "cursor",
-      name: () => "Cursor",
-      supportsLocal: () => true,
-      install: vi.fn(),
-      remove: vi.fn(),
-    };
-
-    const { allProviders } = await import("../mcp/providers");
-    vi.mocked(allProviders).mockReturnValue([mockProvider]);
-
-    const cfg = makeCfg({ deployment_id: "d1" });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-
-    const cancelSymbol = Symbol("cancel");
-    mockIsCancel.mockImplementation((val) => val === cancelSymbol);
-
-    mockSelect
-      .mockResolvedValueOnce("mcp-add")
-      .mockResolvedValueOnce(cancelSymbol as any)
-      .mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(mockProvider.install).not.toHaveBeenCalled();
-  });
-
-  it("handleMCPRemove removes the selected provider", async () => {
-    const mockRemove = vi.fn();
-    const mockProvider = {
-      id: () => "cursor",
-      name: () => "Cursor",
-      supportsLocal: () => true,
-      install: vi.fn(),
-      remove: mockRemove,
-    };
-
-    const { allProviders } = await import("../mcp/providers");
-    vi.mocked(allProviders).mockReturnValue([mockProvider]);
-
-    const cfg = makeCfg({ deployment_id: "d1" });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect
-      .mockResolvedValueOnce("mcp-remove")
-      .mockResolvedValueOnce("cursor")
-      .mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(mockRemove).toHaveBeenCalledWith(true);
-    expect(p.log.success).toHaveBeenCalledWith("Removed Dosu MCP from Cursor");
-  });
-
-  it("handleMCPRemove shows error when remove fails", async () => {
-    const mockRemove = vi.fn().mockImplementation(() => {
-      throw new Error("file not found");
-    });
-    const mockProvider = {
-      id: () => "cursor",
-      name: () => "Cursor",
-      supportsLocal: () => true,
-      install: vi.fn(),
-      remove: mockRemove,
-    };
-
-    const { allProviders } = await import("../mcp/providers");
-    vi.mocked(allProviders).mockReturnValue([mockProvider]);
-
-    const cfg = makeCfg({ deployment_id: "d1" });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect
-      .mockResolvedValueOnce("mcp-remove")
-      .mockResolvedValueOnce("cursor")
-      .mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(p.log.error).toHaveBeenCalledWith("Failed: file not found");
-  });
-
-  it("handleMCPRemove filters out manual provider", async () => {
-    const manualProvider = {
-      id: () => "manual",
-      name: () => "Manual",
-      supportsLocal: () => false,
-      install: vi.fn(),
-      remove: vi.fn(),
-    };
-    const cursorProvider = {
-      id: () => "cursor",
-      name: () => "Cursor",
-      supportsLocal: () => true,
-      install: vi.fn(),
-      remove: vi.fn(),
-    };
-
-    const { allProviders } = await import("../mcp/providers");
-    vi.mocked(allProviders).mockReturnValue([manualProvider, cursorProvider]);
-
-    const cfg = makeCfg({ deployment_id: "d1" });
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect
-      .mockResolvedValueOnce("mcp-remove")
-      .mockResolvedValueOnce("cursor")
-      .mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    // The select call for mcp-remove should only include cursor, not manual
-    const removeSelectCall = mockSelect.mock.calls[1];
-    const options = (removeSelectCall[0] as any).options;
-    expect(options).toHaveLength(1);
-    expect(options[0].value).toBe("cursor");
-  });
-
-  it("handleDeployments shows error when fetch fails", async () => {
-    const cfg = makeCfg();
-    mockLoadConfig.mockReturnValue(cfg);
-    mockIsAuthenticated.mockReturnValue(true);
+  it("deployments shows error when fetch fails", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok" }));
     mockIsCancel.mockReturnValue(false);
 
     const mockGetDeployments = vi.fn().mockRejectedValue(new Error("network error"));
@@ -504,5 +356,185 @@ describe("runTUI", () => {
     await runTUI();
 
     expect(p.log.error).toHaveBeenCalledWith("Failed: network error");
+  });
+
+  it("mcp-add shows warning when no deployment selected", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok", deployment_id: undefined }));
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect.mockResolvedValueOnce("mcp-add").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("Please select a deployment first.");
+  });
+
+  it("mcp-remove shows warning when no deployment selected", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok", deployment_id: undefined }));
+    mockIsCancel.mockReturnValue(false);
+
+    mockSelect.mockResolvedValueOnce("mcp-remove").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("Please select a deployment first.");
+  });
+
+  it("mcp-add with real Cursor provider creates JSON config on disk", async () => {
+    writeRealConfig(
+      makeCfg({
+        access_token: "tok",
+        deployment_id: "dep-123",
+        deployment_name: "my-deploy",
+        api_key: "key-abc",
+      }),
+    );
+    mockIsCancel.mockReturnValue(false);
+
+    // Create the ~/.cursor directory so the provider is "installed"
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-add")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.success).toHaveBeenCalledWith("Added Dosu MCP to Cursor");
+
+    // Verify real Cursor MCP config file was created on disk
+    const mcpPath = cursorMcpPath();
+    expect(existsSync(mcpPath)).toBe(true);
+
+    const mcpConfig = loadJSONConfig(mcpPath);
+    expect(mcpConfig.mcpServers).toBeDefined();
+    expect(mcpConfig.mcpServers.dosu).toBeDefined();
+    expect(mcpConfig.mcpServers.dosu.url).toContain("dep-123");
+    expect(mcpConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("mcp-remove with real Cursor provider removes dosu entry from JSON config", async () => {
+    writeRealConfig(
+      makeCfg({
+        access_token: "tok",
+        deployment_id: "dep-123",
+        deployment_name: "my-deploy",
+        api_key: "key-abc",
+      }),
+    );
+    mockIsCancel.mockReturnValue(false);
+
+    // Pre-create a Cursor MCP config with dosu entry and another entry
+    const mcpPath = cursorMcpPath();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    writeFileSync(
+      mcpPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            dosu: { url: "http://old-url", headers: {} },
+            "other-tool": { url: "http://other" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-remove")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.success).toHaveBeenCalledWith("Removed Dosu MCP from Cursor");
+
+    // Verify dosu entry was removed but other-tool remains
+    const mcpConfig = loadJSONConfig(mcpPath);
+    expect(mcpConfig.mcpServers.dosu).toBeUndefined();
+    expect(mcpConfig.mcpServers["other-tool"]).toBeDefined();
+  });
+
+  it("mcp-add does nothing when user cancels provider selection", async () => {
+    writeRealConfig(
+      makeCfg({
+        access_token: "tok",
+        deployment_id: "dep-123",
+        api_key: "key-abc",
+      }),
+    );
+
+    const cancelSymbol = Symbol("cancel");
+    mockIsCancel.mockImplementation((val) => val === cancelSymbol);
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-add")
+      .mockResolvedValueOnce(cancelSymbol as any)
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    // No MCP config file should have been created
+    expect(existsSync(cursorMcpPath())).toBe(false);
+  });
+
+  it("mcp-add shows error when install fails", async () => {
+    // Config without api_key — provider.install requires deployment_id
+    // but let's trigger the error by having no deployment_id on the config object
+    // Actually, the menu guard blocks this. Let's use a provider that throws.
+    // We write a config with deployment_id so the guard passes, but with
+    // a deployment_id that the provider can use. The real provider won't fail
+    // unless something is wrong. We can force it by making the target dir read-only...
+    // Simplest: just use a mock for the providers module for this specific error test.
+    writeRealConfig(
+      makeCfg({
+        access_token: "tok",
+        deployment_id: "dep-123",
+        api_key: "key-abc",
+      }),
+    );
+    mockIsCancel.mockReturnValue(false);
+
+    // Create ~/.cursor as a FILE (not directory) so writing mcp.json inside it fails
+    writeFileSync(join(tempDir, ".cursor"), "not-a-directory");
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-add")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    // The install should fail because .cursor is a file, not a directory
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Failed:"));
+  });
+
+  it("mcp-remove filters out manual provider from options", async () => {
+    writeRealConfig(
+      makeCfg({
+        access_token: "tok",
+        deployment_id: "dep-123",
+        api_key: "key-abc",
+      }),
+    );
+    mockIsCancel.mockReturnValue(false);
+
+    // Create ~/.cursor so cursor provider is "installed"
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-remove")
+      .mockResolvedValueOnce("cursor")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    // Check the options passed to the remove select call (2nd select invocation)
+    const removeSelectCall = mockSelect.mock.calls[1];
+    const options = (removeSelectCall[0] as any).options;
+    const ids = options.map((o: any) => o.value);
+    expect(ids).not.toContain("manual");
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -171,7 +171,7 @@ async function handleMCPRemove(cfg: ReturnType<typeof loadConfig>): Promise<void
   }
 }
 
-function handleLogout(cfg: ReturnType<typeof loadConfig>): void {
+export function handleLogout(cfg: ReturnType<typeof loadConfig>): void {
   if (!isAuthenticated(cfg)) {
     p.log.warn("You are not logged in.");
     return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,11 +10,17 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       reportsDirectory: "coverage",
+      exclude: [
+        "**/index.ts",           // barrel re-export files
+        "src/index.ts",          // CLI entry point
+        "scripts/*",             // build scripts (spawn Bun)
+        "vitest.config.ts",      // config file
+      ],
       thresholds: {
-        statements: 80,
-        branches: 80,
+        statements: 95,
+        branches: 90,
         functions: 80,
-        lines: 80,
+        lines: 95,
       },
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       reportsDirectory: "coverage",
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add vitest coverage thresholds (80% for statements, branches, functions, lines) to match `codecov.yml` target
- Tests now fail locally and in CI when coverage drops below 80%
- Current coverage: **52.09%** statements — needs improvement to meet the threshold

## Current coverage gaps
| Module | Stmts | Notes |
|---|---|---|
| `src/tui` | 4.1% | `tui.ts` nearly uncovered |
| `src/setup` | 17.0% | `flow.ts` nearly uncovered |
| `src/cli` | 33.3% | Large portions uncovered |
| `src/mcp/providers` | 57.5% | Several providers lack tests |

## Test plan
- [ ] Verify Codecov bot posts a coverage comment on this PR
- [ ] Confirm CI correctly reports coverage threshold failures
- [ ] Incrementally add tests to reach 80% target before merging

https://claude.ai/code/session_01PEboGGi39nNQhBHhvFJFuZ