### PR TITLE
Fix process not exiting after setup and on Ctrl+C

### DIFF
--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CallbackServer, TokenResponse } from "./server";
 
 const { mockOpenDefault, mockClose, mockStartCallbackServer, mockGetWebAppURL } = vi.hoisted(
@@ -35,6 +35,10 @@ describe("startOAuthFlow", () => {
   let mockServer: CallbackServer;
   let resolveToken: (token: TokenResponse) => void;
   let rejectToken: (err: Error) => void;
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   beforeEach(() => {
     mockOpenDefault.mockClear().mockResolvedValue(undefined);
@@ -126,6 +130,25 @@ describe("startOAuthFlow", () => {
 
     resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
     await flowPromise;
+  });
+
+  it("clears the timeout timer after successful token receipt", async () => {
+    vi.useFakeTimers();
+
+    const token: TokenResponse = {
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_in: 3600,
+    };
+
+    const flowPromise = startOAuthFlow();
+    await vi.advanceTimersByTimeAsync(10);
+
+    resolveToken(token);
+    await flowPromise;
+
+    // The 5-minute timeout should have been cleared — no lingering timers
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("uses the configured web app URL for building the auth URL", async () => {

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -15,6 +15,8 @@ import { startCallbackServer, type TokenResponse } from "./server";
 export async function startOAuthFlow(signal?: AbortSignal): Promise<TokenResponse> {
   const { server, tokenPromise } = await startCallbackServer();
 
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
   try {
     const callbackURL = `http://localhost:${server.port}/callback`;
     const authURL = buildAuthURL(callbackURL);
@@ -25,7 +27,7 @@ export async function startOAuthFlow(signal?: AbortSignal): Promise<TokenRespons
 
     // Race: token, abort, or timeout
     const timeout = new Promise<never>((_, reject) => {
-      setTimeout(
+      timeoutId = setTimeout(
         () => reject(new Error("authentication timeout - please try again")),
         5 * 60 * 1000,
       );
@@ -39,6 +41,7 @@ export async function startOAuthFlow(signal?: AbortSignal): Promise<TokenRespons
 
     return await Promise.race([tokenPromise, timeout, abort]);
   } finally {
+    clearTimeout(timeoutId);
     server.close();
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./cli/cli", () => ({
+  execute: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("CLI entry point", () => {
+  it("registers a SIGINT handler that calls process.exit(0)", async () => {
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    // Import triggers module-level side effects (SIGINT handler registration)
+    await import("./index");
+
+    // Simulate SIGINT by emitting the event
+    process.emit("SIGINT");
+
+    expect(mockExit).toHaveBeenCalledWith(0);
+    mockExit.mockRestore();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@
 
 import { execute } from "./cli/cli";
 
+// Ensure Ctrl+C always exits immediately, even when @clack/prompts
+// intercepts SIGINT and swallows it as a cancel symbol.
+process.on("SIGINT", () => process.exit(0));
+
 execute().catch((err) => {
   console.error(err.message ?? err);
   process.exit(1);

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@clack/prompts", () => ({
   intro: vi.fn(),
   outro: vi.fn(),
+  cancel: vi.fn(),
   confirm: vi.fn(),
   select: vi.fn(),
   multiselect: vi.fn(),

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@clack/prompts", () => ({
   select: vi.fn(),
   isCancel: vi.fn(),
+  cancel: vi.fn(),
   outro: vi.fn(),
   log: {
     warn: vi.fn(),


### PR DESCRIPTION
## Summary
- **setTimeout leak**: The 5-minute auth timeout in `startOAuthFlow` was never cleared, keeping the Node process alive after setup completed. Added `clearTimeout` in the `finally` block.
- **Ctrl+C requires two presses**: `@clack/prompts` intercepts SIGINT and returns a cancel symbol instead of exiting. Added a global `process.on("SIGINT")` handler in `index.ts` to ensure one Ctrl+C always exits immediately.
- Added tests for both fixes: timer cleanup test with fake timers, and SIGINT handler registration test.

## Test plan
- [x] All 276 tests pass (18 files)
- [ ] Manual: run `dosu setup`, complete auth, verify process exits immediately
- [ ] Manual: run `dosu setup`, press Ctrl+C at any prompt, verify single press exits