### PR TITLE
Redesign auth success page with logo, email, and auto-close

### DIFF
--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -69,4 +69,103 @@ describe("auth callback server", () => {
     const token = await result.tokenPromise;
     expect(token.refresh_token).toBe("");
   });
+
+  it("passes email through when provided", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?access_token=tok123&refresh_token=ref456&expires_in=7200&email=user%40example.com`,
+    );
+    const html = await resp.text();
+    expect(html).toContain("user@example.com");
+    expect(html).toContain("Signed in as");
+
+    const token = await result.tokenPromise;
+    expect(token.email).toBe("user@example.com");
+  });
+
+  it("omits email line when email is not provided", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?access_token=tok123`,
+    );
+    const html = await resp.text();
+    expect(html).not.toContain("Signed in as");
+    expect(html).toContain("Authentication Successful");
+
+    const token = await result.tokenPromise;
+    expect(token.email).toBeUndefined();
+  });
+
+  it("escapes HTML in email to prevent XSS", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?access_token=tok123&email=${encodeURIComponent('<script>alert(1)</script>')}`,
+    );
+    const html = await resp.text();
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("extract page forwards email parameter", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(`http://localhost:${server.port}/callback`);
+    const html = await resp.text();
+    expect(html).toContain("params.get('email')");
+    expect(html).toContain("encodeURIComponent(email)");
+  });
+
+  it("success page includes Dosu logo SVG", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?access_token=tok`,
+    );
+    const html = await resp.text();
+    expect(html).toContain('<svg width="52" height="54"');
+    expect(html).toContain("viewBox");
+  });
+
+  it("success page includes 10s auto-close countdown", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?access_token=tok`,
+    );
+    const html = await resp.text();
+    expect(html).toContain('id="countdown">10</span>');
+    expect(html).toContain("window.close()");
+  });
+
+  it("success page card is clickable to close", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?access_token=tok`,
+    );
+    const html = await resp.text();
+    expect(html).toContain('class="card" onclick="window.close()"');
+    expect(html).toContain("cursor: pointer");
+  });
+
+  it("email is rendered bold in success page", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?access_token=tok&email=test%40dosu.dev`,
+    );
+    const html = await resp.text();
+    expect(html).toContain("<strong>test@dosu.dev</strong>");
+  });
 });

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -89,9 +89,7 @@ describe("auth callback server", () => {
     const result = await startCallbackServer();
     server = result.server;
 
-    const resp = await fetch(
-      `http://localhost:${server.port}/callback?access_token=tok123`,
-    );
+    const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok123`);
     const html = await resp.text();
     expect(html).not.toContain("Signed in as");
     expect(html).toContain("Authentication Successful");
@@ -105,7 +103,7 @@ describe("auth callback server", () => {
     server = result.server;
 
     const resp = await fetch(
-      `http://localhost:${server.port}/callback?access_token=tok123&email=${encodeURIComponent('<script>alert(1)</script>')}`,
+      `http://localhost:${server.port}/callback?access_token=tok123&email=${encodeURIComponent("<script>alert(1)</script>")}`,
     );
     const html = await resp.text();
     expect(html).not.toContain("<script>alert(1)</script>");
@@ -126,9 +124,7 @@ describe("auth callback server", () => {
     const result = await startCallbackServer();
     server = result.server;
 
-    const resp = await fetch(
-      `http://localhost:${server.port}/callback?access_token=tok`,
-    );
+    const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
     const html = await resp.text();
     expect(html).toContain('<svg width="52" height="54"');
     expect(html).toContain("viewBox");
@@ -138,9 +134,7 @@ describe("auth callback server", () => {
     const result = await startCallbackServer();
     server = result.server;
 
-    const resp = await fetch(
-      `http://localhost:${server.port}/callback?access_token=tok`,
-    );
+    const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
     const html = await resp.text();
     expect(html).toContain('id="countdown">10</span>');
     expect(html).toContain("window.close()");
@@ -150,9 +144,7 @@ describe("auth callback server", () => {
     const result = await startCallbackServer();
     server = result.server;
 
-    const resp = await fetch(
-      `http://localhost:${server.port}/callback?access_token=tok`,
-    );
+    const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
     const html = await resp.text();
     expect(html).toContain('class="card" onclick="window.close()"');
     expect(html).toContain("cursor: pointer");

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -6,6 +6,7 @@ export interface TokenResponse {
   access_token: string;
   refresh_token: string;
   expires_in: number;
+  email?: string;
 }
 
 const CALLBACK_HTML_EXTRACT = `<!DOCTYPE html>
@@ -62,17 +63,23 @@ if (hash) {
     const token = params.get('access_token');
     const refresh = params.get('refresh_token');
     const expires = params.get('expires_in');
+    const email = params.get('email');
     if (token) {
         window.location.href = '/callback?access_token=' + encodeURIComponent(token) +
             '&refresh_token=' + encodeURIComponent(refresh) +
-            '&expires_in=' + encodeURIComponent(expires);
+            '&expires_in=' + encodeURIComponent(expires) +
+            (email ? '&email=' + encodeURIComponent(email) : '');
     }
 }
 </script>
 </body>
 </html>`;
 
-const CALLBACK_HTML_SUCCESS = `<!DOCTYPE html>
+function buildSuccessHtml(email?: string): string {
+  const emailLine = email
+    ? `<p class="email">Signed in as <strong>${email.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")}</strong></p>`
+    : "";
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -81,8 +88,9 @@ const CALLBACK_HTML_SUCCESS = `<!DOCTYPE html>
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
     background: #fafafa;
+    color: #171717;
     min-height: 100vh;
     display: flex;
     align-items: center;
@@ -90,48 +98,83 @@ body {
     padding: 20px;
 }
 .container {
-    background: white;
-    border-radius: 12px;
-    padding: 48px 40px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    max-width: 480px;
+    max-width: 420px;
     width: 100%;
     text-align: center;
-    border: 1px solid #e5e7eb;
 }
-.checkmark {
-    width: 64px;
-    height: 64px;
-    border-radius: 50%;
-    background: #10b981;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0 auto 24px;
+.logo {
+    width: 52px;
+    height: 52px;
+    margin: 0 auto 28px;
 }
-.checkmark svg { width: 32px; height: 32px; stroke: white; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; fill: none; }
-h1 { font-size: 24px; font-weight: 600; color: #111827; margin-bottom: 8px; }
-.subtitle { font-size: 15px; color: #6b7280; margin-bottom: 28px; }
-.info { background: #f9fafb; border-radius: 8px; padding: 16px; text-align: left; border: 1px solid #e5e7eb; }
-.info p { font-size: 14px; color: #374151; line-height: 1.5; }
-.info strong { display: block; margin-bottom: 4px; color: #111827; }
-.footer { margin-top: 24px; font-size: 13px; color: #9ca3af; }
+h1 {
+    font-size: 24px;
+    font-weight: 600;
+    color: #171717;
+    letter-spacing: -0.02em;
+    margin-bottom: 8px;
+}
+.subtitle {
+    font-size: 16px;
+    color: #666;
+    margin-bottom: 8px;
+}
+.email {
+    font-size: 14px;
+    color: #999;
+    margin-bottom: 28px;
+}
+.card {
+    background: #fff;
+    border: 1px solid #eaeaea;
+    border-radius: 8px;
+    padding: 16px 20px;
+    font-size: 16px;
+    color: #666;
+    line-height: 1.5;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+}
+.card:hover {
+    background: #f5f5f5;
+    border-color: #ccc;
+}
+.close-hint {
+    margin-top: 20px;
+    font-size: 14px;
+    color: #999;
+}
 </style>
 </head>
 <body>
 <div class="container">
-    <div class="checkmark">
-        <svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
+    <div class="logo">
+        <svg width="52" height="54" viewBox="0 0 86 89" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M5.29236 12.7928L17.7593 6.68188V72.5667L5.29236 84.0618V12.7928Z" fill="#B4BB91"/>
+        <path d="M18.2575 73.1196L59.1329 72.748L51.7011 82.4095L29.0338 86.291L6.23962 85.1554L18.2575 73.1196Z" fill="#778561"/>
+        <path d="M17.4916 3.73633L3.58557 12.7099V83.5792C3.58557 84.7542 4.98563 85.3652 5.84705 84.566L19.6296 71.7801" stroke="black" stroke-width="6.42844" stroke-linecap="round"/>
+        <mask id="path-4-inside-1_355_26707" fill="white">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M40.704 0.518066H17.0439V76.2221H40.704H42.5805H47.8013C68.7064 76.2221 85.6533 59.2752 85.6533 38.3701C85.6533 17.465 68.7063 0.518066 47.8013 0.518066H42.5805H40.704Z"/>
+        </mask>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M40.704 0.518066H17.0439V76.2221H40.704H42.5805H47.8013C68.7064 76.2221 85.6533 59.2752 85.6533 38.3701C85.6533 17.465 68.7063 0.518066 47.8013 0.518066H42.5805H40.704Z" fill="#F3F6F1"/>
+        <path d="M17.0439 0.518066V-6.57919H9.94669V0.518066H17.0439ZM17.0439 76.2221H9.94669V83.3194H17.0439V76.2221ZM17.0439 7.61532H40.704V-6.57919H17.0439V7.61532ZM24.1412 76.2221V0.518066H9.94669V76.2221H24.1412ZM40.704 69.1249H17.0439V83.3194H40.704V69.1249ZM42.5805 69.1249H40.704V83.3194H42.5805V69.1249ZM47.8013 69.1249H42.5805V83.3194H47.8013V69.1249ZM78.556 38.3701C78.556 55.3555 64.7867 69.1249 47.8013 69.1249V83.3194C72.6261 83.3194 92.7505 63.1949 92.7505 38.3701H78.556ZM47.8013 7.61532C64.7866 7.61532 78.556 21.3847 78.556 38.3701H92.7505C92.7505 13.5453 72.626 -6.57919 47.8013 -6.57919V7.61532ZM42.5805 7.61532H47.8013V-6.57919H42.5805V7.61532ZM40.704 7.61532H42.5805V-6.57919H40.704V7.61532Z" fill="black" mask="url(#path-4-inside-1_355_26707)"/>
+        <path d="M68.9215 36.0135C68.9215 36.0135 65.7369 49.4738 51.4231 49.4738C37.1093 49.4738 32.5787 37.3596 32.5787 36.0135" stroke="black" stroke-width="7.69161" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M0.348633 85.4946C0.348633 85.4946 29.4856 85.8309 34.809 85.698C44.8337 85.4477 51.2872 84.402 57.5269 78.9724C62.8129 74.3727 75.1342 59.6836 75.1342 59.6836" stroke="black" stroke-width="6.16482"/>
+        </svg>
     </div>
     <h1>Authentication Successful</h1>
-    <p class="subtitle">You've successfully authenticated the Dosu CLI</p>
-    <div class="info">
-        <p><strong>Next step:</strong> Return to your terminal to continue. You can safely close this window.</p>
-    </div>
-    <div class="footer">Dosu CLI</div>
+    <p class="subtitle">You're all set. The CLI is now authenticated.</p>
+    ${emailLine}
+    <div class="card" onclick="window.close()">Close this tab and return to your terminal.</div>
+    <p class="close-hint">This tab will close automatically in <span id="countdown">10</span>s</p>
 </div>
+<script>
+var s=10,el=document.getElementById('countdown');
+var t=setInterval(function(){if(--s<=0){clearInterval(t);window.close();}el.textContent=s;},1000);
+</script>
 </body>
 </html>`;
+}
 
 export interface CallbackServer {
   port: number;
@@ -166,6 +209,7 @@ export async function startCallbackServer(): Promise<{
     const accessToken = url.searchParams.get("access_token");
     const refreshToken = url.searchParams.get("refresh_token");
     const expiresIn = url.searchParams.get("expires_in");
+    const email = url.searchParams.get("email");
 
     if (!accessToken) {
       res.writeHead(200, { "Content-Type": "text/html" });
@@ -184,10 +228,11 @@ export async function startCallbackServer(): Promise<{
       access_token: accessToken,
       refresh_token: refreshToken ?? "",
       expires_in: expiresInInt,
+      email: email ?? undefined,
     });
 
     res.writeHead(200, { "Content-Type": "text/html" });
-    res.end(CALLBACK_HTML_SUCCESS);
+    res.end(buildSuccessHtml(email ?? undefined));
   });
 
   // Listen on random port and wait for it to be ready


### PR DESCRIPTION
## Summary
- Replaces the green checkmark on the OAuth success page with the Dosu logo (inline SVG)
- Adds optional `email` parameter passthrough from the web app redirect, displayed as "Signed in as **email**"
- Redesigns the page with clean, minimal styling inspired by Vercel (lighter layout, no outer card border, tighter spacing)
- Card is now clickable (with hover effect) to close the tab, plus a 10-second auto-close countdown
- HTML-escapes the email to prevent XSS

## Test plan
- [x] 14 tests passing covering: email passthrough, missing email, XSS escaping, extract page forwarding, logo SVG presence, countdown, clickable card, bold email
- [x] `server.ts` at 100% statement/line coverage