### PR TITLE
Fix auth state loss causing repeated login redirects

### DIFF
--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -160,4 +160,17 @@ describe("auth callback server", () => {
     const html = await resp.text();
     expect(html).toContain("<strong>test@dosu.dev</strong>");
   });
+
+  it("treats literal string 'null' in refresh_token as empty", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    // Simulates what happens when browser JS does encodeURIComponent(null)
+    // which produces the literal string "null" in the URL
+    await fetch(`http://localhost:${server.port}/callback?access_token=tok&refresh_token=null`);
+    const token = await result.tokenPromise;
+
+    // Should normalize "null" to empty string, not store literal "null"
+    expect(token.refresh_token).toBe("");
+  });
 });

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -61,8 +61,8 @@ const hash = window.location.hash.substring(1);
 if (hash) {
     const params = new URLSearchParams(hash);
     const token = params.get('access_token');
-    const refresh = params.get('refresh_token');
-    const expires = params.get('expires_in');
+    const refresh = params.get('refresh_token') || '';
+    const expires = params.get('expires_in') || '';
     const email = params.get('email');
     if (token) {
         window.location.href = '/callback?access_token=' + encodeURIComponent(token) +
@@ -226,7 +226,7 @@ export async function startCallbackServer(): Promise<{
 
     resolveToken?.({
       access_token: accessToken,
-      refresh_token: refreshToken ?? "",
+      refresh_token: refreshToken && refreshToken !== "null" ? refreshToken : "",
       expires_in: expiresInInt,
       email: email ?? undefined,
     });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -214,6 +214,26 @@ describe("Client", () => {
     });
   });
 
+  describe("refreshToken", () => {
+    it("sends apikey header to Supabase refresh endpoint", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "new-tok",
+          refresh_token: "new-ref",
+          expires_in: 3600,
+        }),
+      );
+
+      const client = new Client(makeConfig());
+      await client.refreshToken();
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain("/auth/v1/token");
+      expect(options.headers).toHaveProperty("apikey");
+      expect(options.headers.apikey).toBeTruthy();
+    });
+  });
+
   describe("createAPIKey", () => {
     it("returns API key on success", async () => {
       const response = { api_key: "key-123", id: "id-1", name: "cli", key_prefix: "key" };

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -4,7 +4,7 @@
 
 import type { Config } from "../config/config";
 import { isAuthenticated, isTokenExpired, saveConfig } from "../config/config";
-import { getBackendURL, getSupabaseURL } from "../config/constants";
+import { getBackendURL, getSupabaseAnonKey, getSupabaseURL } from "../config/constants";
 
 export class SessionExpiredError extends Error {
   constructor() {
@@ -132,7 +132,10 @@ export class Client {
 
     const resp = await fetch(endpoint, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        apikey: getSupabaseAnonKey(),
+      },
       body: JSON.stringify({ refresh_token: this.config.refresh_token }),
     });
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,6 +11,12 @@ const ProdBackendURL = "https://api.dosu.dev";
 const DevSupabaseURL = "http://localhost:54321";
 const ProdSupabaseURL = "https://wldmetsoicvieidlsqrb.supabase.co";
 
+// Supabase anon keys — public, safe to embed in client code
+const DevSupabaseAnonKey =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const ProdSupabaseAnonKey =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndsbG1ldHNvaWN2aWVpZGxzcXJiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzQ0NjA1NjUsImV4cCI6MjA1MDAzNjU2NX0.15LIxqSMVRnxsvLrk0GPjL1aSYPfOeaeFMdJXqgc5Xs";
+
 function isDev(): boolean {
   return process.env.DOSU_DEV === "true";
 }
@@ -28,4 +34,9 @@ export function getBackendURL(): string {
 export function getSupabaseURL(): string {
   if (process.env.SUPABASE_URL) return process.env.SUPABASE_URL;
   return isDev() ? DevSupabaseURL : ProdSupabaseURL;
+}
+
+export function getSupabaseAnonKey(): string {
+  if (process.env.SUPABASE_ANON_KEY) return process.env.SUPABASE_ANON_KEY;
+  return isDev() ? DevSupabaseAnonKey : ProdSupabaseAnonKey;
 }

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -904,6 +904,29 @@ describe("runSetup integration", () => {
     expect(p.confirm).toHaveBeenCalled();
   });
 
+  it("retries on transient backend error (502) instead of declaring session expired", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    const mockRefreshToken = vi.fn().mockResolvedValue(undefined);
+    setupAuthenticatedClient({
+      doRequestRaw: vi
+        .fn()
+        .mockResolvedValueOnce({ status: 502 }) // transient error
+        .mockResolvedValueOnce({ status: 200 }), // succeeds after refresh
+      refreshToken: mockRefreshToken,
+    });
+
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // Should have tried to refresh instead of immediately declaring "session expired"
+    expect(mockRefreshToken).toHaveBeenCalled();
+    // Should NOT have shown "Session expired" warning
+    expect(p.log.warn).not.toHaveBeenCalledWith("Session expired.");
+  });
+
   it("handles refresh succeeding but second verify failing", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -91,18 +91,16 @@ async function stepAuthenticate(): Promise<Config | null> {
         s.stop("Authenticated");
         return cfg;
       }
-      // Token invalid — try refresh
-      if (resp.status === 401 || resp.status === 403 || resp.status === 500) {
-        try {
-          await apiClient.refreshToken();
-          const resp2 = await apiClient.doRequestRaw("GET", "/v1/mcp/deployments");
-          if (resp2.status === 200) {
-            s.stop("Authenticated");
-            return cfg;
-          }
-        } catch {
-          // refresh failed, fall through to login
+      // Any non-200 status — try refresh before giving up
+      try {
+        await apiClient.refreshToken();
+        const resp2 = await apiClient.doRequestRaw("GET", "/v1/mcp/deployments");
+        if (resp2.status === 200) {
+          s.stop("Authenticated");
+          return cfg;
         }
+      } catch {
+        // refresh failed, fall through to login
       }
       s.stop("Session expired");
       p.log.warn("Session expired.");


### PR DESCRIPTION
## Summary
- **Missing Supabase `apikey` header**: `refreshToken()` called Supabase's `/auth/v1/token` endpoint without the required `apikey` header, causing all token refreshes to silently fail
- **`encodeURIComponent(null)` bug**: OAuth callback HTML encoded a null `refresh_token` as the literal string `"null"`, which was then stored in config and used in subsequent refresh attempts
- **Overly narrow error handling in `stepAuthenticate`**: Only 401/403/500 triggered a refresh attempt; transient errors like 502/503 immediately declared "session expired" and forced re-login

## Test plan
- [x] Added test: `refreshToken` sends `apikey` header to Supabase endpoint
- [x] Added test: literal string `"null"` in `refresh_token` is normalized to empty string
- [x] Added test: transient 502 triggers refresh retry instead of session expired
- [x] All 279 tests pass, lint and typecheck clean