### PR TITLE
Add layered .env file structure for environment config

### DIFF
--- a/.env
+++ b/.env
@@ -1,13 +1,2 @@
-# ===========================================
-# Dosu CLI — Base Environment (all environments)
-# ===========================================
-# Override per-environment in .env.development / .env.production
-# Override locally in .env.local or .env.{development,production}.local
-#
-# Load priority (low → high):
-#   .env → .env.{NODE_ENV} → .env.local → .env.{NODE_ENV}.local
-
-# Build info (set by CI, safe to leave empty for local dev)
-# DOSU_VERSION=
-# DOSU_COMMIT=
-# DOSU_DATE=
+# Dosu CLI — Base (all environments)
+# Load priority: .env → .env.{NODE_ENV} → .env.local → .env.{NODE_ENV}.local

--- a/.env
+++ b/.env
@@ -1,0 +1,13 @@
+# ===========================================
+# Dosu CLI — Base Environment (all environments)
+# ===========================================
+# Override per-environment in .env.development / .env.production
+# Override locally in .env.local or .env.{development,production}.local
+#
+# Load priority (low → high):
+#   .env → .env.{NODE_ENV} → .env.local → .env.{NODE_ENV}.local
+
+# Build info (set by CI, safe to leave empty for local dev)
+# DOSU_VERSION=
+# DOSU_COMMIT=
+# DOSU_DATE=

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,11 @@
+# ===========================================
+# Dosu CLI — Development Environment
+# ===========================================
+# Loaded when NODE_ENV=development (or via `bun run dev:local`)
+# Personal overrides go in .env.development.local (git-ignored)
+
+DOSU_DEV=true
+
+DOSU_WEB_APP_URL=http://localhost:3001
+DOSU_BACKEND_URL=http://localhost:7001
+SUPABASE_URL=http://localhost:54321

--- a/.env.development
+++ b/.env.development
@@ -1,11 +1,4 @@
-# ===========================================
-# Dosu CLI — Development Environment
-# ===========================================
-# Loaded when NODE_ENV=development (or via `bun run dev:local`)
-# Personal overrides go in .env.development.local (git-ignored)
-
 DOSU_DEV=true
-
 DOSU_WEB_APP_URL=http://localhost:3001
 DOSU_BACKEND_URL=http://localhost:7001
 SUPABASE_URL=http://localhost:54321

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# ===========================================
+# Dosu CLI — Environment Variables Reference
+# ===========================================
+#
+# File hierarchy (Bun loads automatically, low → high priority):
+#
+#   .env                       ← base defaults (tracked)
+#   .env.development           ← dev defaults (tracked)
+#   .env.production            ← prod defaults (tracked)
+#   .env.local                 ← personal overrides (git-ignored)
+#   .env.development.local     ← personal dev overrides (git-ignored)
+#   .env.production.local      ← personal prod overrides (git-ignored)
+#
+# To override locally, copy this file:
+#   cp .env.example .env.development.local   # for local dev
+#   cp .env.example .env.production.local    # for local prod testing
+
+# ---------- Runtime Mode ----------
+
+# Set to "true" to use development endpoints
+# DOSU_DEV=true
+
+# ---------- Service URLs ----------
+
+# DOSU_WEB_APP_URL=http://localhost:3001
+# DOSU_BACKEND_URL=http://localhost:7001
+# SUPABASE_URL=http://localhost:54321
+# SUPABASE_ANON_KEY=
+
+# ---------- Build Info (set by CI) ----------
+
+# DOSU_VERSION=
+# DOSU_COMMIT=
+# DOSU_DATE=

--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,7 @@
-# ===========================================
-# Dosu CLI — Environment Variables Reference
-# ===========================================
-#
-# File hierarchy (Bun loads automatically, low → high priority):
-#
-#   .env                       ← base defaults (tracked)
-#   .env.development           ← dev defaults (tracked)
-#   .env.production            ← prod defaults (tracked)
-#   .env.local                 ← personal overrides (git-ignored)
-#   .env.development.local     ← personal dev overrides (git-ignored)
-#   .env.production.local      ← personal prod overrides (git-ignored)
-#
-# To override locally, copy this file:
-#   cp .env.example .env.development.local   # for local dev
-#   cp .env.example .env.production.local    # for local prod testing
+# Dosu CLI — Personal overrides template
+# Copy to .env.development.local or .env.production.local
 
-# ---------- Runtime Mode ----------
-
-# Set to "true" to use development endpoints
-# DOSU_DEV=true
-
-# ---------- Service URLs ----------
-
-# DOSU_WEB_APP_URL=http://localhost:3001
-# DOSU_BACKEND_URL=http://localhost:7001
-# SUPABASE_URL=http://localhost:54321
+# DOSU_WEB_APP_URL=
+# DOSU_BACKEND_URL=
+# SUPABASE_URL=
 # SUPABASE_ANON_KEY=
-
-# ---------- Build Info (set by CI) ----------
-
-# DOSU_VERSION=
-# DOSU_COMMIT=
-# DOSU_DATE=

--- a/.env.production
+++ b/.env.production
@@ -1,11 +1,4 @@
-# ===========================================
-# Dosu CLI — Production Environment
-# ===========================================
-# Loaded when NODE_ENV=production
-# Personal overrides go in .env.production.local (git-ignored)
-
 DOSU_DEV=false
-
 DOSU_WEB_APP_URL=https://app.dosu.dev
 DOSU_BACKEND_URL=https://api.dosu.dev
 SUPABASE_URL=https://wldmetsoicvieidlsqrb.supabase.co

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,11 @@
+# ===========================================
+# Dosu CLI — Production Environment
+# ===========================================
+# Loaded when NODE_ENV=production
+# Personal overrides go in .env.production.local (git-ignored)
+
+DOSU_DEV=false
+
+DOSU_WEB_APP_URL=https://app.dosu.dev
+DOSU_BACKEND_URL=https://api.dosu.dev
+SUPABASE_URL=https://wldmetsoicvieidlsqrb.supabase.co

--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,10 @@ dist/
 bun.lock
 *.bun-build
 
-# Environment
-.env
+# Environment — only .local files are ignored (contain personal overrides)
+# .env, .env.development, .env.production are tracked in git
 .env.local
-.env.*
+.env.*.local
 
 # Editor/IDE
 # .idea/


### PR DESCRIPTION
## Summary
- Add `.env`, `.env.development`, `.env.production` with environment-specific defaults (tracked in git)
- Add `.env.example` documenting all supported variables and Bun's load priority
- Update `.gitignore` to only ignore `.env.local` / `.env.*.local` (personal overrides), while tracking shared env files

## Test plan
- [x] Verified Bun correctly loads `.env.development` with `NODE_ENV=development`
- [x] Verified Bun correctly loads `.env.production` with `NODE_ENV=production`
- [x] Verified `.local` files override shared env values at highest priority
- [x] Existing `constants.test.ts` tests pass (10/10)