### PR TITLE
fix(ci): use supported node for semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24.10.0"
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
This updates the release job to use Node 24.10.0 instead of Node 20. The change fixes semantic-release startup on GitHub Actions, which now requires ^22.14.0 or >=24.10.0. No other files are changed in this branch.