### PR TITLE
fix(ci): align workflow node runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -154,7 +157,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24.10.0"
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
This updates the CI workflow to use Node 24.10.0 in the release job and opts GitHub JavaScript actions into Node 24. The change fixes semantic-release startup and keeps the workflow runtime consistent. No other files are changed in this branch.