### PR TITLE
feat: add public library commands (add, sync, init)

### DIFF
--- a/scripts/mock-backend.ts
+++ b/scripts/mock-backend.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env bun
+/**
+ * Mock backend for local testing of `dosu add`, `dosu sync`, and related commands.
+ *
+ * Stubs POST /v1/public-libraries. All other requests proxy to production.
+ *
+ * Usage:
+ *   bun run scripts/mock-backend.ts
+ *
+ * Then in another terminal:
+ *   DOSU_BACKEND_URL=http://localhost:7099 bun run dev add facebook/react
+ *   DOSU_BACKEND_URL=http://localhost:7099 bun run dev sync facebook/react
+ */
+
+const PORT = Number(process.env.MOCK_PORT ?? 7099);
+const UPSTREAM = "https://api.dosu.dev";
+
+// In-memory store of added libraries
+const libraries = new Map<string, { repo_slug: string; data_source_id: string }>();
+let counter = 0;
+
+const server = Bun.serve({
+  port: PORT,
+  async fetch(req) {
+    const url = new URL(req.url);
+    const method = req.method;
+
+    // POST /v1/public-libraries
+    if (method === "POST" && url.pathname === "/v1/public-libraries") {
+      const apiKey = req.headers.get("X-Dosu-API-Key");
+      if (!apiKey) {
+        return Response.json({ detail: "Missing API key" }, { status: 401 });
+      }
+
+      const body = (await req.json()) as { repo_slug: string };
+      const existing = libraries.get(body.repo_slug);
+
+      if (existing) {
+        console.log(`[mock] ${body.repo_slug} already exists — sync re-triggered`);
+        return Response.json({
+          status: "already_exists",
+          repo_slug: body.repo_slug,
+          data_source_id: existing.data_source_id,
+          deployment_id: "mock-dep",
+          sync_triggered: true,
+        });
+      }
+
+      counter++;
+      const dsId = `mock-ds-${counter}`;
+      libraries.set(body.repo_slug, { repo_slug: body.repo_slug, data_source_id: dsId });
+      console.log(`[mock] created ${body.repo_slug} (${dsId})`);
+      return Response.json(
+        {
+          status: "created",
+          repo_slug: body.repo_slug,
+          data_source_id: dsId,
+          deployment_id: "mock-dep",
+          sync_triggered: true,
+        },
+        { status: 201 },
+      );
+    }
+
+    // Proxy everything else to production
+    const upstream = `${UPSTREAM}${url.pathname}${url.search}`;
+    const headers = new Headers(req.headers);
+    headers.set("host", new URL(UPSTREAM).host);
+
+    try {
+      const proxyBody = method !== "GET" && method !== "HEAD" ? await req.blob() : undefined;
+      const resp = await fetch(upstream, { method, headers, body: proxyBody });
+      console.log(`[proxy] ${method} ${url.pathname} → ${resp.status}`);
+      return new Response(resp.body, {
+        status: resp.status,
+        headers: resp.headers,
+      });
+    } catch (err) {
+      console.error(`[proxy] error: ${err}`);
+      return Response.json({ error: "proxy error" }, { status: 502 });
+    }
+  },
+});
+
+console.log(`Mock backend running on http://localhost:${server.port}`);
+console.log(`Proxying non-stubbed routes to ${UPSTREAM}`);
+console.log(`\nStubbed endpoints:`);
+console.log(`  POST /v1/public-libraries → create/re-add library`);
+console.log(`\nTest with:`);
+console.log(`  DOSU_BACKEND_URL=http://localhost:${server.port} bun run dev add facebook/react`);

--- a/src/add/flow.test.ts
+++ b/src/add/flow.test.ts
@@ -1,0 +1,312 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock boundaries: terminal UI, GitHub module, fetch
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  isCancel: vi.fn(),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  log: {
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock("./github", () => ({
+  parseRepoSlug: vi.fn(),
+  resolveGitHubToken: vi.fn(),
+  validatePublicRepo: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import * as p from "@clack/prompts";
+import type { Config } from "../config/config";
+import { saveConfig } from "../config/config";
+import { createPublicLibrary, runAdd } from "./flow";
+import { parseRepoSlug, resolveGitHubToken, validatePublicRepo } from "./github";
+
+// ── Temp env ───────────────────────────────────────────────────────────────
+
+let tempDir: string;
+let origXDG: string | undefined;
+let origHome: string | undefined;
+
+function makeCfg(overrides: Partial<Config> = {}): Config {
+  return {
+    access_token: "tok",
+    refresh_token: "ref",
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    deployment_id: "dep-123",
+    deployment_name: "TestDeploy",
+    api_key: "key-abc",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-add-test-"));
+  origXDG = process.env.XDG_CONFIG_HOME;
+  origHome = process.env.HOME;
+  process.env.XDG_CONFIG_HOME = tempDir;
+  process.env.HOME = tempDir;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
+  else delete process.env.XDG_CONFIG_HOME;
+  if (origHome !== undefined) process.env.HOME = origHome;
+  else delete process.env.HOME;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ── runAdd ─────────────────────────────────────────────────────────────────
+
+describe("runAdd", () => {
+  it("fails on invalid slug", async () => {
+    vi.mocked(parseRepoSlug).mockImplementation(() => {
+      throw new Error('invalid repository format: "bad"');
+    });
+
+    await runAdd({ repo: "bad" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("invalid repository format"));
+  });
+
+  it("fails when not authenticated", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    saveConfig(makeCfg({ access_token: "" }));
+
+    await runAdd({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Not logged in"));
+  });
+
+  it("fails when token expired", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    saveConfig(makeCfg({ expires_at: 1 }));
+
+    await runAdd({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Session expired"));
+  });
+
+  it("fails when no API key", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    saveConfig(makeCfg({ api_key: undefined }));
+
+    await runAdd({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No API key"));
+  });
+
+  it("fails when no GitHub token found", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    vi.mocked(resolveGitHubToken).mockReturnValue(null);
+    saveConfig(makeCfg());
+
+    await runAdd({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("GitHub token"));
+  });
+
+  it("fails when repo validation fails", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    vi.mocked(resolveGitHubToken).mockReturnValue("gh_tok");
+    vi.mocked(validatePublicRepo).mockRejectedValue(new Error("not found"));
+    saveConfig(makeCfg());
+
+    await runAdd({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith("not found");
+  });
+
+  it("succeeds for a valid public repo (created)", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "dosu-ai", repo: "dosu" });
+    vi.mocked(resolveGitHubToken).mockReturnValue("gh_tok");
+    vi.mocked(validatePublicRepo).mockResolvedValue({
+      owner: "dosu-ai",
+      repo: "dosu",
+      slug: "dosu-ai/dosu",
+      description: "A cool project",
+      html_url: "https://github.com/dosu-ai/dosu",
+      default_branch: "main",
+      private: false,
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        status: "created",
+        repo_slug: "dosu-ai/dosu",
+        data_source_id: "ds-1",
+        deployment_id: "dep-123",
+        sync_triggered: true,
+      }),
+    });
+
+    saveConfig(makeCfg());
+    await runAdd({ repo: "dosu-ai/dosu" });
+
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("dosu-ai/dosu"));
+    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("ask_public_library"));
+  });
+
+  it("shows already-exists message on re-add", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    vi.mocked(resolveGitHubToken).mockReturnValue("gh_tok");
+    vi.mocked(validatePublicRepo).mockResolvedValue({
+      owner: "o",
+      repo: "r",
+      slug: "o/r",
+      description: "",
+      html_url: "https://github.com/o/r",
+      default_branch: "main",
+      private: false,
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: "already_exists",
+        repo_slug: "o/r",
+        data_source_id: "ds-1",
+        deployment_id: "dep-123",
+        sync_triggered: true,
+      }),
+    });
+
+    saveConfig(makeCfg());
+    await runAdd({ repo: "o/r" });
+
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("o/r"));
+  });
+
+  it("handles backend failure", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    vi.mocked(resolveGitHubToken).mockReturnValue("gh_tok");
+    vi.mocked(validatePublicRepo).mockResolvedValue({
+      owner: "o",
+      repo: "r",
+      slug: "o/r",
+      description: "",
+      html_url: "https://github.com/o/r",
+      default_branch: "main",
+      private: false,
+    });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "internal error",
+    });
+
+    saveConfig(makeCfg());
+    await runAdd({ repo: "o/r" });
+
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("status 500"));
+  });
+
+  it("handles API key auth error", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    vi.mocked(resolveGitHubToken).mockReturnValue("gh_tok");
+    vi.mocked(validatePublicRepo).mockResolvedValue({
+      owner: "o",
+      repo: "r",
+      slug: "o/r",
+      description: "",
+      html_url: "https://github.com/o/r",
+      default_branch: "main",
+      private: false,
+    });
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+
+    saveConfig(makeCfg());
+    await runAdd({ repo: "o/r" });
+
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("API key is invalid"));
+  });
+});
+
+// ── createPublicLibrary ────────────────────────────────────────────────────
+
+describe("createPublicLibrary", () => {
+  it("returns result on 201", async () => {
+    const body = {
+      status: "created",
+      repo_slug: "o/r",
+      data_source_id: "ds-1",
+      deployment_id: "dep-1",
+      sync_triggered: true,
+    };
+    mockFetch.mockResolvedValue({ ok: true, status: 201, json: async () => body });
+
+    const result = await createPublicLibrary("key", "o/r", "tok");
+    expect(result.status).toBe("created");
+    expect(result.repo_slug).toBe("o/r");
+  });
+
+  it("returns result on 200 (already exists)", async () => {
+    const body = {
+      status: "already_exists",
+      repo_slug: "o/r",
+      data_source_id: "ds-1",
+      deployment_id: "dep-1",
+      sync_triggered: true,
+    };
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => body });
+
+    const result = await createPublicLibrary("key", "o/r", "tok");
+    expect(result.status).toBe("already_exists");
+  });
+
+  it("throws on 401", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    await expect(createPublicLibrary("bad", "o/r", "tok")).rejects.toThrow("API key is invalid");
+  });
+
+  it("throws on 403", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 403 });
+    await expect(createPublicLibrary("bad", "o/r", "tok")).rejects.toThrow("API key is invalid");
+  });
+
+  it("throws on other errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "server error",
+    });
+    await expect(createPublicLibrary("key", "o/r", "tok")).rejects.toThrow("status 500");
+  });
+
+  it("sends correct headers and body", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        status: "created",
+        repo_slug: "o/r",
+        data_source_id: "ds-1",
+        deployment_id: "dep-1",
+        sync_triggered: true,
+      }),
+    });
+
+    await createPublicLibrary("my-key", "o/r", "gh-tok");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/public-libraries"),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-Dosu-API-Key": "my-key",
+        }),
+        body: JSON.stringify({ repo_slug: "o/r", github_token: "gh-tok" }),
+      }),
+    );
+  });
+});

--- a/src/add/flow.ts
+++ b/src/add/flow.ts
@@ -1,0 +1,160 @@
+/**
+ * `dosu add <owner/repo>` — add a public GitHub repository as a Dosu public library.
+ */
+
+import * as p from "@clack/prompts";
+import { isAuthenticated, isTokenExpired, loadConfig } from "../config/config";
+import { getBackendURL } from "../config/constants";
+import { dim, info } from "../setup/styles";
+import { parseRepoSlug, resolveGitHubToken, validatePublicRepo } from "./github";
+
+export interface AddOptions {
+  repo: string;
+}
+
+export interface CreateLibraryResult {
+  status: "created" | "already_exists";
+  repo_slug: string;
+  data_source_id: string;
+  deployment_id: string;
+  sync_triggered: boolean;
+}
+
+export async function runAdd(opts: AddOptions): Promise<void> {
+  p.intro("Add public library");
+
+  // Step 1: Parse slug
+  let owner: string;
+  let repo: string;
+  try {
+    ({ owner, repo } = parseRepoSlug(opts.repo));
+  } catch (err: unknown) {
+    p.log.error(err instanceof Error ? err.message : String(err));
+    p.outro("Failed");
+    return;
+  }
+
+  // Step 2: Ensure authenticated with Dosu
+  const cfg = loadConfig();
+  if (!isAuthenticated(cfg)) {
+    p.log.error(`Not logged in. Run ${info("dosu login")} first.`);
+    p.outro("Failed");
+    return;
+  }
+  if (isTokenExpired(cfg)) {
+    p.log.error(`Session expired. Run ${info("dosu login")} to re-authenticate.`);
+    p.outro("Failed");
+    return;
+  }
+  if (!cfg.api_key) {
+    p.log.error(`No API key configured. Run ${info("dosu setup")} first.`);
+    p.outro("Failed");
+    return;
+  }
+
+  // Step 3: Detect GitHub token
+  const s = p.spinner();
+  s.start("Detecting GitHub token...");
+  const ghToken = resolveGitHubToken();
+  if (!ghToken) {
+    s.stop("No GitHub token found");
+    p.log.error(
+      `Could not find a GitHub token. Please set GH_TOKEN or run ${info("gh auth login")}.`,
+    );
+    p.outro("Failed");
+    return;
+  }
+  s.stop("GitHub token detected");
+
+  // Step 4: Validate repo is public
+  s.start(`Validating ${owner}/${repo}...`);
+  let repoInfo: Awaited<ReturnType<typeof validatePublicRepo>>;
+  try {
+    repoInfo = await validatePublicRepo(owner, repo, ghToken);
+  } catch (err: unknown) {
+    s.stop("Validation failed");
+    p.log.error(err instanceof Error ? err.message : String(err));
+    p.outro("Failed");
+    return;
+  }
+  s.stop(`Validated ${repoInfo.slug}`);
+
+  if (repoInfo.description) {
+    p.log.info(dim(repoInfo.description));
+  }
+
+  // Step 5: Create public library via Dosu backend
+  s.start("Adding to Dosu...");
+  let result: CreateLibraryResult;
+  try {
+    result = await createPublicLibrary(cfg.api_key, repoInfo.slug, ghToken);
+  } catch (err: unknown) {
+    s.stop("Failed to add library");
+    p.log.error(err instanceof Error ? err.message : String(err));
+    p.outro("Failed");
+    return;
+  }
+
+  if (result.status === "already_exists") {
+    s.stop("Already exists — sync re-triggered");
+  } else {
+    s.stop("Added to Dosu");
+  }
+
+  // Success
+  p.log.success(`Added ${info(repoInfo.slug)} as a public library`);
+  p.log.message(
+    `Query it with:\n\n` +
+      info(`ask_public_library(question="...", repository_slug="${repoInfo.slug}")`),
+  );
+
+  p.outro("Done!");
+}
+
+/**
+ * Call POST /v1/public-libraries to create (or re-add) a public library.
+ * Uses X-Dosu-API-Key auth.
+ */
+export async function createPublicLibrary(
+  apiKey: string,
+  repoSlug: string,
+  githubToken: string,
+): Promise<CreateLibraryResult> {
+  const url = `${getBackendURL()}/v1/public-libraries`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Dosu-API-Key": apiKey,
+      },
+      body: JSON.stringify({
+        repo_slug: repoSlug,
+        github_token: githubToken,
+      }),
+      signal: controller.signal,
+    });
+
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error("API key is invalid or expired. Run `dosu setup` to configure a new one");
+    }
+
+    if (!resp.ok) {
+      let detail: string;
+      try {
+        detail = (await resp.text()).slice(0, 1024);
+      } catch {
+        detail = "";
+      }
+      throw new Error(`failed to create public library (status ${resp.status}): ${detail}`);
+    }
+
+    return (await resp.json()) as CreateLibraryResult;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/add/github.test.ts
+++ b/src/add/github.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock child_process at the boundary
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from "node:child_process";
+import { parseRepoSlug, resolveGitHubToken, validatePublicRepo } from "./github";
+
+// ── parseRepoSlug ──────────────────────────────────────────────────────────
+
+describe("parseRepoSlug", () => {
+  it("parses valid owner/repo slug", () => {
+    expect(parseRepoSlug("dosu-ai/dosu")).toEqual({ owner: "dosu-ai", repo: "dosu" });
+  });
+
+  it("rejects slug with no slash", () => {
+    expect(() => parseRepoSlug("dosu")).toThrow('invalid repository format: "dosu"');
+  });
+
+  it("rejects slug with too many slashes", () => {
+    expect(() => parseRepoSlug("a/b/c")).toThrow('invalid repository format: "a/b/c"');
+  });
+
+  it("rejects empty owner", () => {
+    expect(() => parseRepoSlug("/repo")).toThrow('invalid repository format: "/repo"');
+  });
+
+  it("rejects empty repo", () => {
+    expect(() => parseRepoSlug("owner/")).toThrow('invalid repository format: "owner/"');
+  });
+
+  it("rejects empty string", () => {
+    expect(() => parseRepoSlug("")).toThrow('invalid repository format: ""');
+  });
+});
+
+// ── resolveGitHubToken ─────────────────────────────────────────────────────
+
+describe("resolveGitHubToken", () => {
+  let origGH: string | undefined;
+  let origGITHUB: string | undefined;
+
+  beforeEach(() => {
+    origGH = process.env.GH_TOKEN;
+    origGITHUB = process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (origGH !== undefined) process.env.GH_TOKEN = origGH;
+    else delete process.env.GH_TOKEN;
+    if (origGITHUB !== undefined) process.env.GITHUB_TOKEN = origGITHUB;
+    else delete process.env.GITHUB_TOKEN;
+  });
+
+  it("returns GH_TOKEN when set", () => {
+    process.env.GH_TOKEN = "gh_tok_123";
+    expect(resolveGitHubToken()).toBe("gh_tok_123");
+  });
+
+  it("returns GITHUB_TOKEN when GH_TOKEN is not set", () => {
+    process.env.GITHUB_TOKEN = "github_tok_456";
+    expect(resolveGitHubToken()).toBe("github_tok_456");
+  });
+
+  it("prefers GH_TOKEN over GITHUB_TOKEN", () => {
+    process.env.GH_TOKEN = "gh_tok_123";
+    process.env.GITHUB_TOKEN = "github_tok_456";
+    expect(resolveGitHubToken()).toBe("gh_tok_123");
+  });
+
+  it("falls back to gh auth token CLI", () => {
+    vi.mocked(execFileSync).mockReturnValue("cli_token_789\n");
+    expect(resolveGitHubToken()).toBe("cli_token_789");
+    expect(execFileSync).toHaveBeenCalledWith("gh", ["auth", "token"], expect.any(Object));
+  });
+
+  it("returns null when no token source available", () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error("gh not found");
+    });
+    expect(resolveGitHubToken()).toBeNull();
+  });
+
+  it("returns null when gh returns empty string", () => {
+    vi.mocked(execFileSync).mockReturnValue("  \n");
+    expect(resolveGitHubToken()).toBeNull();
+  });
+});
+
+// ── validatePublicRepo ─────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("validatePublicRepo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns repo info for a public repo", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        name: "dosu",
+        full_name: "dosu-ai/dosu",
+        description: "A cool project",
+        html_url: "https://github.com/dosu-ai/dosu",
+        default_branch: "main",
+        private: false,
+      }),
+    });
+
+    const info = await validatePublicRepo("dosu-ai", "dosu", "tok_123");
+    expect(info.slug).toBe("dosu-ai/dosu");
+    expect(info.private).toBe(false);
+    expect(info.description).toBe("A cool project");
+  });
+
+  it("throws for a private repo", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        name: "secret",
+        full_name: "dosu-ai/secret",
+        description: null,
+        html_url: "https://github.com/dosu-ai/secret",
+        default_branch: "main",
+        private: true,
+      }),
+    });
+
+    await expect(validatePublicRepo("dosu-ai", "secret", "tok_123")).rejects.toThrow(
+      "private repository",
+    );
+  });
+
+  it("throws for a 404", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+    await expect(validatePublicRepo("dosu-ai", "nope", "tok_123")).rejects.toThrow("not found");
+  });
+
+  it("throws for a 401", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    await expect(validatePublicRepo("dosu-ai", "dosu", "bad_tok")).rejects.toThrow(
+      "invalid or expired",
+    );
+  });
+
+  it("throws for a 403", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 403 });
+    await expect(validatePublicRepo("dosu-ai", "dosu", "bad_tok")).rejects.toThrow(
+      "invalid or expired",
+    );
+  });
+
+  it("throws for other errors", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    await expect(validatePublicRepo("dosu-ai", "dosu", "tok")).rejects.toThrow(
+      "GitHub API error (status 500)",
+    );
+  });
+
+  it("omits Authorization header when no token provided", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        name: "dosu",
+        full_name: "dosu-ai/dosu",
+        description: null,
+        html_url: "https://github.com/dosu-ai/dosu",
+        default_branch: "main",
+        private: false,
+      }),
+    });
+
+    await validatePublicRepo("dosu-ai", "dosu");
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers.Accept).toBe("application/vnd.github+json");
+  });
+
+  it("handles null description", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        name: "dosu",
+        full_name: "dosu-ai/dosu",
+        description: null,
+        html_url: "https://github.com/dosu-ai/dosu",
+        default_branch: "main",
+        private: false,
+      }),
+    });
+
+    const info = await validatePublicRepo("dosu-ai", "dosu", "tok");
+    expect(info.description).toBe("");
+  });
+});

--- a/src/add/github.ts
+++ b/src/add/github.ts
@@ -1,0 +1,121 @@
+/**
+ * GitHub token detection and repository validation.
+ *
+ * Token cascade: GH_TOKEN env var → GITHUB_TOKEN env var → `gh auth token` CLI fallback.
+ */
+
+import { execFileSync } from "node:child_process";
+
+export interface RepoInfo {
+  owner: string;
+  repo: string;
+  slug: string;
+  description: string;
+  html_url: string;
+  default_branch: string;
+  private: boolean;
+}
+
+/**
+ * Parse an "owner/repo" slug into its parts.
+ * Throws if the format is invalid.
+ */
+export function parseRepoSlug(slug: string): { owner: string; repo: string } {
+  const parts = slug.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`invalid repository format: "${slug}". Expected "owner/repo"`);
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
+
+/**
+ * Resolve a GitHub token from the environment or the `gh` CLI.
+ * Returns the token string, or null if none found.
+ */
+export function resolveGitHubToken(): string | null {
+  // 1. GH_TOKEN (GitHub CLI's primary env var)
+  if (process.env.GH_TOKEN) return process.env.GH_TOKEN;
+
+  // 2. GITHUB_TOKEN (CI / Actions)
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+
+  // 3. `gh auth token` CLI fallback
+  try {
+    const token = execFileSync("gh", ["auth", "token"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (token) return token;
+  } catch {
+    // gh not installed or not authenticated — fall through
+  }
+
+  return null;
+}
+
+/**
+ * Validate that a repo exists and is public via the GitHub API.
+ * Returns repo info on success, throws on failure.
+ */
+export async function validatePublicRepo(
+  owner: string,
+  repo: string,
+  token?: string,
+): Promise<RepoInfo> {
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const resp = await fetch(url, { headers, signal: controller.signal });
+
+    if (resp.status === 404) {
+      throw new Error(`repository "${owner}/${repo}" not found`);
+    }
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error(
+        "GitHub token is invalid or expired. Check your GH_TOKEN or run `gh auth login`",
+      );
+    }
+    if (!resp.ok) {
+      throw new Error(`GitHub API error (status ${resp.status})`);
+    }
+
+    const data = (await resp.json()) as {
+      name: string;
+      full_name: string;
+      description: string | null;
+      html_url: string;
+      default_branch: string;
+      private: boolean;
+    };
+
+    if (data.private) {
+      throw new Error(
+        `"${owner}/${repo}" is a private repository. Only public repositories can be added as Dosu public libraries`,
+      );
+    }
+
+    return {
+      owner,
+      repo: data.name,
+      slug: data.full_name,
+      description: data.description ?? "",
+      html_url: data.html_url,
+      default_branch: data.default_branch,
+      private: data.private,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -66,4 +66,25 @@ describe("CLI", () => {
     const globalOpt = addCmd?.options.find((o) => o.long === "--global");
     expect(globalOpt).toBeDefined();
   });
+
+  it("has add command", () => {
+    const program = createProgram();
+    const cmd = program.commands.find((c) => c.name() === "add");
+    expect(cmd).toBeDefined();
+    expect(cmd?.description()).toContain("public GitHub repository");
+  });
+
+  it("has sync command", () => {
+    const program = createProgram();
+    const cmd = program.commands.find((c) => c.name() === "sync");
+    expect(cmd).toBeDefined();
+    expect(cmd?.description()).toContain("indexing");
+  });
+
+  it("has init command", () => {
+    const program = createProgram();
+    const cmd = program.commands.find((c) => c.name() === "init");
+    expect(cmd).toBeDefined();
+    expect(cmd?.description()).toContain("skills");
+  });
 });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -173,6 +173,33 @@ export function createProgram(): Command {
       await runSetup({ deploymentID: opts.deployment });
     });
 
+  // add
+  program
+    .command("add <repo>")
+    .description("Add a public GitHub repository as a Dosu library")
+    .action(async (repo: string) => {
+      const { runAdd } = await import("../add/flow");
+      await runAdd({ repo });
+    });
+
+  // sync
+  program
+    .command("sync [repo]")
+    .description("Re-trigger indexing for a public library")
+    .action(async (repo?: string) => {
+      const { runSync } = await import("../sync/flow");
+      await runSync({ repo });
+    });
+
+  // init
+  program
+    .command("init")
+    .description("Initialize Dosu skills for this project")
+    .action(async () => {
+      const { runInit } = await import("../init/flow");
+      await runInit();
+    });
+
   return program;
 }
 

--- a/src/init/flow.test.ts
+++ b/src/init/flow.test.ts
@@ -1,0 +1,179 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock terminal UI boundary
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: vi.fn(),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  log: {
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+import * as p from "@clack/prompts";
+import { generateSkillContent, runInit, writeAgentsEntry } from "./flow";
+
+// ── Temp dir ───────────────────────────────────────────────────────────────
+
+let tempDir: string;
+let origCwd: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-init-test-"));
+  origCwd = process.cwd();
+  process.chdir(tempDir);
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  process.chdir(origCwd);
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ── generateSkillContent ───────────────────────────────────────────────────
+
+describe("generateSkillContent", () => {
+  it("contains dosu-add instruction", () => {
+    const content = generateSkillContent();
+    expect(content).toContain("/dosu-add");
+    expect(content).toContain("ask_public_library");
+  });
+
+  it("contains dosu-sync instruction", () => {
+    const content = generateSkillContent();
+    expect(content).toContain("/dosu-sync");
+  });
+
+  it("has valid frontmatter", () => {
+    const content = generateSkillContent();
+    expect(content).toMatch(/^---\n/);
+    expect(content).toContain("description:");
+    expect(content).toContain("globs:");
+  });
+});
+
+// ── writeAgentsEntry ───────────────────────────────────────────────────────
+
+describe("writeAgentsEntry", () => {
+  it("creates new AGENTS.md when it does not exist", () => {
+    const agentsPath = join(tempDir, "AGENTS.md");
+    writeAgentsEntry(agentsPath, false);
+
+    const content = readFileSync(agentsPath, "utf-8");
+    expect(content).toContain("# Agents");
+    expect(content).toContain("/dosu-add");
+    expect(content).toContain(".claude/skills/dosu/SKILL.md");
+  });
+
+  it("appends to existing AGENTS.md", () => {
+    const agentsPath = join(tempDir, "AGENTS.md");
+    writeFileSync(agentsPath, "# Agents\n\n## Other\nSomething here.\n");
+
+    writeAgentsEntry(agentsPath, true);
+
+    const content = readFileSync(agentsPath, "utf-8");
+    expect(content).toContain("## Other");
+    expect(content).toContain("## Dosu");
+    expect(content).toContain("/dosu-add");
+  });
+
+  it("does not duplicate if already present", () => {
+    const agentsPath = join(tempDir, "AGENTS.md");
+    writeFileSync(agentsPath, "# Agents\n\nSee .claude/skills/dosu/SKILL.md for details.\n");
+
+    writeAgentsEntry(agentsPath, true);
+
+    const content = readFileSync(agentsPath, "utf-8");
+    // Should appear only once
+    const count = content.split(".claude/skills/dosu/SKILL.md").length - 1;
+    expect(count).toBe(1);
+  });
+});
+
+// ── runInit ────────────────────────────────────────────────────────────────
+
+describe("runInit", () => {
+  it("creates skill file and AGENTS.md", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(true);
+
+    await runInit();
+
+    const skillPath = join(tempDir, ".claude/skills/dosu/SKILL.md");
+    expect(existsSync(skillPath)).toBe(true);
+    expect(readFileSync(skillPath, "utf-8")).toContain("/dosu-add");
+
+    const agentsPath = join(tempDir, "AGENTS.md");
+    expect(existsSync(agentsPath)).toBe(true);
+
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Dosu initialized"));
+  });
+
+  it("skips AGENTS.md when user declines", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(false);
+
+    await runInit();
+
+    const skillPath = join(tempDir, ".claude/skills/dosu/SKILL.md");
+    expect(existsSync(skillPath)).toBe(true);
+
+    const agentsPath = join(tempDir, "AGENTS.md");
+    expect(existsSync(agentsPath)).toBe(false);
+  });
+
+  it("prompts overwrite when skill already exists", async () => {
+    const skillDir = join(tempDir, ".claude/skills/dosu");
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "old content");
+
+    // First confirm = overwrite yes, second confirm = create AGENTS.md
+    vi.mocked(p.confirm).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await runInit();
+
+    const content = readFileSync(join(skillDir, "SKILL.md"), "utf-8");
+    expect(content).toContain("/dosu-add");
+    expect(content).not.toBe("old content");
+  });
+
+  it("aborts when user declines overwrite", async () => {
+    const skillDir = join(tempDir, ".claude/skills/dosu");
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "old content");
+
+    vi.mocked(p.confirm).mockResolvedValue(false);
+
+    await runInit();
+
+    const content = readFileSync(join(skillDir, "SKILL.md"), "utf-8");
+    expect(content).toBe("old content");
+    expect(p.outro).toHaveBeenCalledWith("No changes made");
+  });
+
+  it("handles cancellation on overwrite prompt", async () => {
+    const skillDir = join(tempDir, ".claude/skills/dosu");
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "old content");
+
+    vi.mocked(p.isCancel).mockReturnValue(true);
+    vi.mocked(p.confirm).mockResolvedValue(Symbol("cancel") as never);
+
+    await runInit();
+
+    expect(p.outro).toHaveBeenCalledWith("No changes made");
+  });
+});

--- a/src/init/flow.ts
+++ b/src/init/flow.ts
@@ -1,0 +1,142 @@
+/**
+ * `dosu init` — interactive setup wizard that installs Claude Code skills into a project.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as p from "@clack/prompts";
+import { dim, info } from "../setup/styles";
+
+const SKILL_DIR = ".claude/skills/dosu";
+const SKILL_FILE = "SKILL.md";
+const AGENTS_FILE = "AGENTS.md";
+
+export async function runInit(): Promise<void> {
+  p.intro("Initialize Dosu for this project");
+
+  const cwd = process.cwd();
+  const skillDir = join(cwd, SKILL_DIR);
+  const skillPath = join(skillDir, SKILL_FILE);
+
+  // Check if already initialized
+  if (existsSync(skillPath)) {
+    const overwrite = await p.confirm({
+      message: "Dosu skill already exists. Overwrite?",
+      initialValue: false,
+    });
+
+    if (p.isCancel(overwrite) || !overwrite) {
+      p.outro("No changes made");
+      return;
+    }
+  }
+
+  // Write skill file
+  const s = p.spinner();
+  s.start("Writing skill file...");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(skillPath, generateSkillContent());
+  s.stop(`Created ${dim(join(SKILL_DIR, SKILL_FILE))}`);
+
+  // Optionally update AGENTS.md
+  const agentsPath = join(cwd, AGENTS_FILE);
+  const agentsExists = existsSync(agentsPath);
+
+  const updateAgents = await p.confirm({
+    message: agentsExists
+      ? "Add Dosu skill to existing AGENTS.md?"
+      : "Create AGENTS.md with Dosu skill?",
+    initialValue: true,
+  });
+
+  if (!p.isCancel(updateAgents) && updateAgents) {
+    const s2 = p.spinner();
+    s2.start(agentsExists ? "Updating AGENTS.md..." : "Creating AGENTS.md...");
+    writeAgentsEntry(agentsPath, agentsExists);
+    s2.stop(agentsExists ? "Updated AGENTS.md" : `Created ${dim(AGENTS_FILE)}`);
+  }
+
+  p.log.success("Dosu initialized for this project");
+  p.log.message(
+    `Available skills:\n` +
+      `  ${info("/dosu-add")}   — Add a public GitHub repo as a library\n` +
+      `  ${info("/dosu-sync")}  — Re-sync an existing library`,
+  );
+
+  p.outro("Done!");
+}
+
+export function generateSkillContent(): string {
+  return `---
+description: Add and sync public GitHub repositories as Dosu libraries
+globs: "**/*"
+---
+
+# Dosu Skills
+
+## /dosu-add
+
+Add a public GitHub repository as a Dosu public library for indexing.
+
+### Usage
+
+\`\`\`
+/dosu-add owner/repo
+\`\`\`
+
+### Steps
+
+1. Run \`dosu add <owner/repo>\` in the terminal
+2. The CLI will detect your GitHub token, validate the repo is public, and add it to Dosu
+3. Once added, you can query it with:
+
+\`\`\`
+ask_public_library(question="your question here", repository_slug="owner/repo")
+\`\`\`
+
+## /dosu-sync
+
+Re-trigger indexing for a previously added public library.
+
+### Usage
+
+\`\`\`
+/dosu-sync owner/repo
+\`\`\`
+
+Or without arguments to pick from a list:
+
+\`\`\`
+/dosu-sync
+\`\`\`
+
+### Steps
+
+1. Run \`dosu sync [owner/repo]\` in the terminal
+2. The CLI will trigger re-indexing for the specified (or selected) library
+`;
+}
+
+const AGENTS_ENTRY = `
+## Dosu
+
+| Skill | Description |
+|-------|-------------|
+| \`/dosu-add <owner/repo>\` | Add a public GitHub repo as a Dosu library |
+| \`/dosu-sync [owner/repo]\` | Re-sync an existing Dosu library |
+
+See \`.claude/skills/dosu/SKILL.md\` for details.
+`;
+
+export function writeAgentsEntry(agentsPath: string, exists: boolean): void {
+  if (exists) {
+    const content = readFileSync(agentsPath, "utf-8");
+    // Don't duplicate if already present
+    if (content.includes(".claude/skills/dosu/SKILL.md")) {
+      return;
+    }
+    writeFileSync(agentsPath, `${content.trimEnd()}\n${AGENTS_ENTRY}`);
+  } else {
+    writeFileSync(agentsPath, `# Agents\n${AGENTS_ENTRY}`);
+  }
+}

--- a/src/sync/flow.test.ts
+++ b/src/sync/flow.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock boundaries
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  isCancel: vi.fn(),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  log: {
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock("../add/github", () => ({
+  parseRepoSlug: vi.fn(),
+  resolveGitHubToken: vi.fn(),
+}));
+
+vi.mock("../add/flow", () => ({
+  createPublicLibrary: vi.fn(),
+}));
+
+import * as p from "@clack/prompts";
+import { createPublicLibrary } from "../add/flow";
+import { parseRepoSlug, resolveGitHubToken } from "../add/github";
+import type { Config } from "../config/config";
+import { saveConfig } from "../config/config";
+import { runSync } from "./flow";
+
+// ── Temp env ───────────────────────────────────────────────────────────────
+
+let tempDir: string;
+let origXDG: string | undefined;
+let origHome: string | undefined;
+
+function makeCfg(overrides: Partial<Config> = {}): Config {
+  return {
+    access_token: "tok",
+    refresh_token: "ref",
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    deployment_id: "dep-123",
+    deployment_name: "TestDeploy",
+    api_key: "key-abc",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-sync-test-"));
+  origXDG = process.env.XDG_CONFIG_HOME;
+  origHome = process.env.HOME;
+  process.env.XDG_CONFIG_HOME = tempDir;
+  process.env.HOME = tempDir;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
+  else delete process.env.XDG_CONFIG_HOME;
+  if (origHome !== undefined) process.env.HOME = origHome;
+  else delete process.env.HOME;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ── runSync ────────────────────────────────────────────────────────────────
+
+describe("runSync", () => {
+  it("fails when no repo specified", async () => {
+    await runSync({});
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Please specify a repository"),
+    );
+  });
+
+  it("fails when not authenticated", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    saveConfig(makeCfg({ access_token: "" }));
+    await runSync({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Not logged in"));
+  });
+
+  it("fails when token expired", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    saveConfig(makeCfg({ expires_at: 1 }));
+    await runSync({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Session expired"));
+  });
+
+  it("fails when no API key", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    saveConfig(makeCfg({ api_key: undefined }));
+    await runSync({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No API key"));
+  });
+
+  it("fails on invalid slug format", async () => {
+    vi.mocked(parseRepoSlug).mockImplementation(() => {
+      throw new Error("invalid");
+    });
+    saveConfig(makeCfg());
+    await runSync({ repo: "bad" });
+    expect(p.log.error).toHaveBeenCalledWith("invalid");
+  });
+
+  it("fails when no GitHub token found", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    vi.mocked(resolveGitHubToken).mockReturnValue(null);
+    saveConfig(makeCfg());
+    await runSync({ repo: "o/r" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("GitHub token"));
+  });
+
+  it("syncs a repo successfully", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    vi.mocked(resolveGitHubToken).mockReturnValue("gh_tok");
+    vi.mocked(createPublicLibrary).mockResolvedValue({
+      status: "already_exists",
+      repo_slug: "o/r",
+      data_source_id: "ds-1",
+      deployment_id: "dep-123",
+      sync_triggered: true,
+    });
+
+    saveConfig(makeCfg());
+    await runSync({ repo: "o/r" });
+
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("o/r"));
+    expect(createPublicLibrary).toHaveBeenCalledWith("key-abc", "o/r", "gh_tok");
+  });
+
+  it("handles backend failure", async () => {
+    vi.mocked(parseRepoSlug).mockReturnValue({ owner: "o", repo: "r" });
+    vi.mocked(resolveGitHubToken).mockReturnValue("gh_tok");
+    vi.mocked(createPublicLibrary).mockRejectedValue(
+      new Error("failed to create public library (status 500): error"),
+    );
+
+    saveConfig(makeCfg());
+    await runSync({ repo: "o/r" });
+
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("status 500"));
+  });
+});

--- a/src/sync/flow.ts
+++ b/src/sync/flow.ts
@@ -1,0 +1,86 @@
+/**
+ * `dosu sync <owner/repo>` — re-trigger indexing for a previously added public library.
+ *
+ * Under the hood this calls the same create endpoint — re-adding an existing repo
+ * refreshes the GitHub token and re-triggers sync.
+ */
+
+import * as p from "@clack/prompts";
+import { createPublicLibrary } from "../add/flow";
+import { parseRepoSlug, resolveGitHubToken } from "../add/github";
+import { isAuthenticated, isTokenExpired, loadConfig } from "../config/config";
+import { info } from "../setup/styles";
+
+export interface SyncOptions {
+  repo?: string;
+}
+
+export async function runSync(opts: SyncOptions): Promise<void> {
+  p.intro("Sync public library");
+
+  // Require repo slug (no list endpoint yet)
+  if (!opts.repo) {
+    p.log.error("Please specify a repository: dosu sync <owner/repo>");
+    p.outro("Failed");
+    return;
+  }
+
+  // Validate slug format
+  let owner: string;
+  let repo: string;
+  try {
+    ({ owner, repo } = parseRepoSlug(opts.repo));
+  } catch (err: unknown) {
+    p.log.error(err instanceof Error ? err.message : String(err));
+    p.outro("Failed");
+    return;
+  }
+
+  // Ensure authenticated
+  const cfg = loadConfig();
+  if (!isAuthenticated(cfg)) {
+    p.log.error(`Not logged in. Run ${info("dosu login")} first.`);
+    p.outro("Failed");
+    return;
+  }
+  if (isTokenExpired(cfg)) {
+    p.log.error(`Session expired. Run ${info("dosu login")} to re-authenticate.`);
+    p.outro("Failed");
+    return;
+  }
+  if (!cfg.api_key) {
+    p.log.error(`No API key configured. Run ${info("dosu setup")} first.`);
+    p.outro("Failed");
+    return;
+  }
+
+  // Detect GitHub token
+  const s = p.spinner();
+  s.start("Detecting GitHub token...");
+  const ghToken = resolveGitHubToken();
+  if (!ghToken) {
+    s.stop("No GitHub token found");
+    p.log.error(
+      `Could not find a GitHub token. Please set GH_TOKEN or run ${info("gh auth login")}.`,
+    );
+    p.outro("Failed");
+    return;
+  }
+  s.stop("GitHub token detected");
+
+  // Re-add triggers sync
+  const repoSlug = `${owner}/${repo}`;
+  s.start(`Syncing ${repoSlug}...`);
+  try {
+    await createPublicLibrary(cfg.api_key, repoSlug, ghToken);
+  } catch (err: unknown) {
+    s.stop("Sync failed");
+    p.log.error(err instanceof Error ? err.message : String(err));
+    p.outro("Failed");
+    return;
+  }
+  s.stop(`Sync triggered for ${repoSlug}`);
+
+  p.log.success(`Re-indexing ${info(repoSlug)}`);
+  p.outro("Done!");
+}


### PR DESCRIPTION
## Summary

- **`dosu add <owner/repo>`** — Detects GitHub token (GH_TOKEN → GITHUB_TOKEN → `gh auth token`), validates the repo is public via GitHub API, then calls `POST /v1/public-libraries` with `X-Dosu-API-Key` auth to create the library and trigger indexing
- **`dosu sync <owner/repo>`** — Re-triggers indexing by re-calling the same create endpoint (refreshes token, re-triggers sync)
- **`dosu init`** — Installs Claude Code skills (`.claude/skills/dosu/SKILL.md`) and optionally creates/updates `AGENTS.md` with `/dosu-add` and `/dosu-sync` skill entries
- **`scripts/mock-backend.ts`** — Local mock server for testing without the real backend

Depends on the backend `POST /v1/public-libraries` endpoint from dosu-ai/dosu#9837.

## Manual test results

All tested against the local backend (`localhost:7001`) with a real API key:

| Test | Result |
|------|--------|
| `dosu add facebook/react` (new) | 201 created, indexing triggered |
| `dosu add facebook/react` (re-add) | 200 "Already exists — sync re-triggered" |
| `dosu sync facebook/react` | Re-triggers indexing via same endpoint |
| `dosu init` (fresh project) | Creates `.claude/skills/dosu/SKILL.md` + `AGENTS.md` |
| `dosu init` (overwrite decline) | Preserves original file |
| `dosu add bad-format` | Slug validation error |
| `dosu add nonexistent/repo` | GitHub 404 error |
| `GH_TOKEN=invalid dosu add facebook/react` | GitHub auth error |
| `dosu sync` (no arg) | "Please specify a repository" |
| MCP `find_public_library("react")` | Returns `facebook/react` |
| MCP `ask_public_library(...)` on `facebook/react` | Returns cited answer at 0.95 confidence |

Automated: 344/344 tests pass, coverage above thresholds (96/92/88/96).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean
- [x] `bun run test` — 344 pass
- [x] Manual: `dosu add` against local backend
- [x] Manual: `dosu sync` against local backend
- [x] Manual: `dosu init` in fresh directory
- [x] Manual: MCP query on added library returns results
- [x] CI passes