### PR TITLE
Add OSS mode to setup flow and MCP config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,12 +58,30 @@ Key modules:
 
 ## Commit Convention
 
-Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/):
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release) for automated versioning and publishing. **Only commits that follow [Conventional Commits](https://www.conventionalcommits.org/) will be recognized by the release pipeline.** Non-conforming commit messages are invisible to semantic-release and will NOT trigger a version bump.
 
-- `fix: xxx` — patch release
-- `feat: xxx` — minor release
-- `feat!:` / `fix!: xxx` — major release (breaking change)
-- `docs` / `chore` / `refactor` / `test` / `ci: xxx` — no release
+### Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types and their release impact
+
+| Type | Release | Example |
+|------|---------|---------|
+| `fix:` | patch (0.0.x) | `fix: handle empty config file without crash` |
+| `feat:` | minor (0.x.0) | `feat: add OSS mode support to setup flow` |
+| `fix!:` / `feat!:` | **major (x.0.0)** | `feat!: remove legacy auth flow` |
+| `docs:` | none | `docs: update README with new CLI flags` |
+| `chore:` | none | `chore: upgrade vitest to v3` |
+| `refactor:` | none | `refactor: extract provider factory` |
+| `test:` | none | `test: add coverage for MCP config edge cases` |
+| `ci:` | none | `ci: upgrade GitHub Actions to v6` |
 
 Scopes are optional: `fix(config): handle empty file without crash`
 
@@ -72,7 +90,3 @@ Scopes are optional: `fix(config): handle empty file without crash`
 - `DOSU_DEV=true` — switches all URLs to localhost dev endpoints
 - `DOSU_WEB_APP_URL`, `DOSU_BACKEND_URL`, `SUPABASE_URL`, `SUPABASE_ANON_KEY` — individual URL overrides
 - `DOSU_VERSION`, `DOSU_COMMIT`, `DOSU_DATE` — injected at build time for version info
-
-## Release Process
-
-Tag-driven via GitHub Actions. Push a tag like `v0.2.0` to `main` to trigger builds for all platforms, npm publish, and Homebrew formula update. Pre-release tags (`-alpha`, `-beta`, `-rc`) publish to npm `next` dist-tag.

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -12,14 +12,17 @@ import { startCallbackServer, type TokenResponse } from "./server";
  * 3. Waits for the web app to redirect back with the token
  * 4. Returns the token or throws
  */
-export async function startOAuthFlow(signal?: AbortSignal): Promise<TokenResponse> {
+export async function startOAuthFlow(
+  signal?: AbortSignal,
+  path: string = "/cli/auth",
+): Promise<TokenResponse> {
   const { server, tokenPromise } = await startCallbackServer();
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   try {
     const callbackURL = `http://localhost:${server.port}/callback`;
-    const authURL = buildAuthURL(callbackURL);
+    const authURL = buildAuthURL(callbackURL, path);
 
     // Open browser — dynamic import to avoid bundling issues
     const open = await import("open");
@@ -29,7 +32,7 @@ export async function startOAuthFlow(signal?: AbortSignal): Promise<TokenRespons
     const timeout = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(
         () => reject(new Error("authentication timeout - please try again")),
-        5 * 60 * 1000,
+        15 * 60 * 1000,
       );
     });
 
@@ -46,8 +49,13 @@ export async function startOAuthFlow(signal?: AbortSignal): Promise<TokenRespons
   }
 }
 
-function buildAuthURL(callbackURL: string): string {
+function buildAuthURL(callbackURL: string, path: string): string {
   const webAppURL = getWebAppURL();
   const params = new URLSearchParams({ callback: callbackURL });
-  return `${webAppURL}/cli/auth?${params}`;
+  // For cli-setup, include redirect so OAuth callback returns to the same page
+  // instead of defaulting to "/". The app's useOAuthRedirect hook reads this param.
+  if (path !== "/cli/auth") {
+    params.set("redirect", `${path}?callback=${encodeURIComponent(callbackURL)}`);
+  }
+  return `${webAppURL}${path}?${params}`;
 }

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -7,6 +7,7 @@ export interface TokenResponse {
   refresh_token: string;
   expires_in: number;
   email?: string;
+  mode?: "oss";
 }
 
 const CALLBACK_HTML_EXTRACT = `<!DOCTYPE html>
@@ -210,6 +211,7 @@ export async function startCallbackServer(): Promise<{
     const refreshToken = url.searchParams.get("refresh_token");
     const expiresIn = url.searchParams.get("expires_in");
     const email = url.searchParams.get("email");
+    const mode = url.searchParams.get("mode");
 
     if (!accessToken) {
       res.writeHead(200, { "Content-Type": "text/html" });
@@ -229,6 +231,7 @@ export async function startCallbackServer(): Promise<{
       refresh_token: refreshToken && refreshToken !== "null" ? refreshToken : "",
       expires_in: expiresInInt,
       email: email ?? undefined,
+      ...(mode === "oss" && { mode: "oss" as const }),
     });
 
     res.writeHead(200, { "Content-Type": "text/html" });

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -2,12 +2,14 @@
  * Local OAuth callback server.
  */
 
+import { MODE_OSS, type SetupMode } from "../config/config";
+
 export interface TokenResponse {
   access_token: string;
   refresh_token: string;
   expires_in: number;
   email?: string;
-  mode?: "oss";
+  mode?: SetupMode;
 }
 
 const CALLBACK_HTML_EXTRACT = `<!DOCTYPE html>
@@ -231,7 +233,7 @@ export async function startCallbackServer(): Promise<{
       refresh_token: refreshToken && refreshToken !== "null" ? refreshToken : "",
       expires_in: expiresInInt,
       email: email ?? undefined,
-      ...(mode === "oss" && { mode: "oss" as const }),
+      ...(mode === MODE_OSS && { mode: MODE_OSS }),
     });
 
     res.writeHead(200, { "Content-Type": "text/html" });

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -93,7 +93,7 @@ export class Client {
     }
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 30_000);
+    const timeout = setTimeout(() => controller.abort(), 10_000);
     options.signal = controller.signal;
 
     try {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -12,6 +12,7 @@ export interface Config {
   deployment_id?: string;
   deployment_name?: string;
   api_key?: string;
+  mode?: "oss";
 }
 
 function getConfigDir(): string {
@@ -72,6 +73,7 @@ export function clearConfig(_cfg: Config): Config {
     deployment_id: undefined,
     deployment_name: undefined,
     api_key: undefined,
+    mode: undefined,
   };
 }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,6 +5,10 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+/** Setup mode: OSS = public libraries only, undefined = standard (cloud) flow. */
+export const MODE_OSS = "oss" as const;
+export type SetupMode = typeof MODE_OSS;
+
 export interface Config {
   access_token: string;
   refresh_token: string;
@@ -12,7 +16,7 @@ export interface Config {
   deployment_id?: string;
   deployment_name?: string;
   api_key?: string;
-  mode?: "oss";
+  mode?: SetupMode;
 }
 
 function getConfigDir(): string {

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -17,6 +17,13 @@ export function mcpURL(deploymentID: string): string {
 }
 
 /**
+ * Returns the base MCP endpoint URL without a deployment ID (for OSS mode).
+ */
+export function mcpBaseURL(): string {
+  return `${getBackendURL()}/v1/mcp`;
+}
+
+/**
  * Returns the standard MCP headers with API key auth.
  */
 export function mcpHeaders(apiKey: string): Record<string, string> {

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -3,7 +3,7 @@
  * Most providers follow the same install/remove pattern — only the config path and top-level key differ.
  */
 
-import { MODE_OSS, type Config } from "../../config/config";
+import { type Config, MODE_OSS } from "../../config/config";
 import {
   installJSONServer,
   isJSONKeyConfigured,

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -3,7 +3,7 @@
  * Most providers follow the same install/remove pattern — only the config path and top-level key differ.
  */
 
-import type { Config } from "../../config/config";
+import { MODE_OSS, type Config } from "../../config/config";
 import {
   installJSONServer,
   isJSONKeyConfigured,
@@ -61,7 +61,7 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     isConfigured: () => isJSONKeyConfigured(expandHome(opts.globalPath), opts.topKey),
 
     install(cfg: Config, global: boolean): void {
-      if (cfg.mode !== "oss" && !cfg.deployment_id) throw new Error("deployment ID is required");
+      if (cfg.mode !== MODE_OSS && !cfg.deployment_id) throw new Error("deployment ID is required");
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
@@ -70,7 +70,7 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
       } else {
         throw new Error(`${opts.providerName} does not support local installation`);
       }
-      const serverBuilder = cfg.mode === "oss" ? defaultBuildOSSServer : buildServer;
+      const serverBuilder = cfg.mode === MODE_OSS ? defaultBuildOSSServer : buildServer;
       installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
     },
 

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -7,6 +7,7 @@ import type { Config } from "../../config/config";
 import {
   installJSONServer,
   isJSONKeyConfigured,
+  mcpBaseURL,
   mcpHeaders,
   mcpURL,
   removeJSONServer,
@@ -39,6 +40,14 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     headers: mcpHeaders(cfg.api_key!),
   });
 
+  // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
+  const defaultBuildOSSServer = (cfg: Config): Record<string, any> => ({
+    type: "http",
+    url: mcpBaseURL(),
+    // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
+    headers: mcpHeaders(cfg.api_key!),
+  });
+
   const buildServer = opts.buildServer ?? defaultBuildServer;
 
   return {
@@ -52,7 +61,7 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     isConfigured: () => isJSONKeyConfigured(expandHome(opts.globalPath), opts.topKey),
 
     install(cfg: Config, global: boolean): void {
-      if (!cfg.deployment_id) throw new Error("deployment ID is required");
+      if (cfg.mode !== "oss" && !cfg.deployment_id) throw new Error("deployment ID is required");
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
@@ -61,7 +70,8 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
       } else {
         throw new Error(`${opts.providerName} does not support local installation`);
       }
-      installJSONServer(configPath, opts.topKey, buildServer(cfg));
+      const serverBuilder = cfg.mode === "oss" ? defaultBuildOSSServer : buildServer;
+      installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
     },
 
     remove(global: boolean): void {

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -63,6 +63,29 @@ describe("createJSONProvider (base)", () => {
     expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
+  it("OSS mode install uses base MCP URL without deployment ID", async () => {
+    const { createJSONProvider } = await import("./base");
+    const globalPath = join(tempDir, "oss-config.json");
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: false,
+      priorityValue: 1,
+      paths: [],
+      globalPath,
+      topKey: "mcpServers",
+    });
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+
+    const cfg = loadJSONConfig(globalPath);
+    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.type).toBe("http");
+    expect(cfg.mcpServers.dosu.url).toContain("/v1/mcp");
+    expect(cfg.mcpServers.dosu.url).not.toContain("/deployments/");
+    expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
   it("install throws when deployment_id is missing", async () => {
     const { createJSONProvider } = await import("./base");
     const provider = createJSONProvider({

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1044,6 +1044,6 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("open source libraries"));
+    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("Dosu MCP"));
   });
 });

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -945,4 +945,107 @@ describe("runSetup integration", () => {
 
     expect(p.log.warn).toHaveBeenCalledWith("Session expired.");
   });
+
+  it("OSS mode skips org selection and fetches first deployment", async () => {
+    const cfg = makeCfg({ mode: "oss", deployment_id: undefined, deployment_name: undefined });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    // Reconfigure prompt → keep current setup
+    vi.mocked(p.select).mockResolvedValueOnce("keep");
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // Should have saved deployment from fetchDeployments
+    const saved = loadConfig();
+    expect(saved.deployment_id).toBe("d1");
+    expect(saved.mode).toBe("oss");
+  });
+
+  it("OSS mode shows OSS-specific outro message", async () => {
+    const cfg = makeCfg({ mode: "oss" });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    // Reconfigure prompt → keep current setup
+    vi.mocked(p.select).mockResolvedValueOnce("keep");
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+
+    await runSetup();
+
+    expect(p.outro).toHaveBeenCalledWith(expect.stringContaining("open-source libraries only"));
+  });
+
+  it("OSS mode reconfigure prompt lets user keep current setup", async () => {
+    const cfg = makeCfg({ mode: "oss" });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    vi.mocked(p.select).mockResolvedValueOnce("keep");
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // Should have shown reconfigure prompt
+    expect(p.select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("open-source libraries") }),
+    );
+  });
+
+  it("OSS mode reconfigure prompt opens browser on reconfigure", async () => {
+    const cfg = makeCfg({ mode: "oss" });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    vi.mocked(p.select).mockResolvedValueOnce("reconfigure");
+    mockStartOAuthFlow.mockResolvedValue({
+      access_token: "new-tok",
+      refresh_token: "new-ref",
+      expires_in: 3600,
+    } as TokenResponse);
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockStartOAuthFlow).toHaveBeenCalled();
+  });
+
+  it("OAuth flow sets OSS mode when token signals it", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    mockStartOAuthFlow.mockResolvedValue({
+      access_token: "oss-tok",
+      refresh_token: "oss-ref",
+      expires_in: 7200,
+      mode: "oss",
+    } as TokenResponse);
+
+    setupAuthenticatedClient();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.mode).toBe("oss");
+  });
+
+  it("OSS mode stepShowSummary uses OSS-specific prompt", async () => {
+    const cfg = makeCfg({ mode: "oss" });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    // Reconfigure prompt → keep current setup
+    vi.mocked(p.select).mockResolvedValueOnce("keep");
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+
+    await runSetup();
+
+    expect(p.log.message).toHaveBeenCalledWith(
+      expect.stringContaining("open source libraries"),
+    );
+  });
 });

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1044,8 +1044,6 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(p.log.message).toHaveBeenCalledWith(
-      expect.stringContaining("open source libraries"),
-    );
+    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("open source libraries"));
   });
 });

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -390,7 +390,7 @@ export function stepShowSummary(results: ConfigResult[], mode?: SetupMode): void
   if (installed.length > 0 || skipped.length > 0) {
     const prompt =
       mode === MODE_OSS
-        ? `Use Dosu to search open source libraries and answer: what are the main components of this project?`
+        ? `What can I do with the Dosu MCP?`
         : `Use Dosu to search our team's documentation and answer: what are the main components of our system?`;
     p.log.message(`Try it out! Paste this into your agent:\n\n${info(prompt)}`);
   }

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -4,7 +4,7 @@
 
 import * as p from "@clack/prompts";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
-import { type Config, loadConfig, saveConfig } from "../config/config";
+import { MODE_OSS, type Config, type SetupMode, loadConfig, saveConfig } from "../config/config";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
 import { dim, info } from "./styles";
 
@@ -42,7 +42,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     if (!d) return;
     cfg.deployment_id = d.deployment_id;
     cfg.deployment_name = d.name;
-  } else if (cfg.mode === "oss") {
+  } else if (cfg.mode === MODE_OSS) {
     // OSS path: fetch first available deployment for API key creation only
     const deployments = await fetchDeployments(apiClient);
     if (deployments.length > 0) {
@@ -84,7 +84,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   const results = stepConfigureTools(cfg, selection);
   stepShowSummary(results, cfg.mode);
 
-  if (cfg.mode === "oss") {
+  if (cfg.mode === MODE_OSS) {
     p.outro(
       "Setup complete! Using open-source libraries only.\nRun `dosu setup` again to connect your own repos.",
     );
@@ -107,7 +107,7 @@ async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
         s.stop("Authenticated");
 
         // If configured for OSS and no --deployment flag, let the user reconfigure
-        if (!opts.deploymentID && cfg.mode === "oss") {
+        if (!opts.deploymentID && cfg.mode === MODE_OSS) {
           const modeLabel = "open-source libraries only";
           const action = await p.select({
             message: `Currently configured for ${modeLabel}. What would you like to do?`,
@@ -163,7 +163,7 @@ async function openBrowserForSetup(cfg: Config, opts: SetupOptions): Promise<Con
     cfg.refresh_token = token.refresh_token;
     cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
     // Only OSS mode is signaled from the browser; absence means cloud (existing flow)
-    if (token.mode === "oss") cfg.mode = "oss";
+    if (token.mode === MODE_OSS) cfg.mode = MODE_OSS;
     saveConfig(cfg);
     return cfg;
   } catch (err: unknown) {
@@ -366,7 +366,7 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
   return results;
 }
 
-export function stepShowSummary(results: ConfigResult[], mode?: "oss"): void {
+export function stepShowSummary(results: ConfigResult[], mode?: SetupMode): void {
   const installed = results.filter((r) => r.action === "install" && !r.error);
   const removed = results.filter((r) => r.action === "remove" && !r.error);
   const skipped = results.filter((r) => r.action === "skip");
@@ -391,7 +391,7 @@ export function stepShowSummary(results: ConfigResult[], mode?: "oss"): void {
 
   if (installed.length > 0 || skipped.length > 0) {
     const prompt =
-      mode === "oss"
+      mode === MODE_OSS
         ? `Use Dosu to search open source libraries and answer: what are the main components of this project?`
         : `Use Dosu to search our team's documentation and answer: what are the main components of our system?`;
     p.log.message(`Try it out! Paste this into your agent:\n\n${info(prompt)}`);

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -30,30 +30,40 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   p.intro("Dosu CLI Setup");
 
   // Step 1: Authenticate
-  const cfg = await stepAuthenticate();
+  const cfg = await stepAuthenticate(opts);
   if (!cfg) return;
 
   const apiClient = new Client(cfg);
 
-  // Step 2: Select deployment
-  let deployment: Deployment;
+  // Step 2: Branch on mode
   if (opts.deploymentID) {
+    // --deployment flag provided, use specified deployment
     const d = await stepResolveDeployment(apiClient, opts.deploymentID);
     if (!d) return;
-    deployment = d;
+    cfg.deployment_id = d.deployment_id;
+    cfg.deployment_name = d.name;
+  } else if (cfg.mode === "oss") {
+    // OSS path: fetch first available deployment for API key creation only
+    const deployments = await fetchDeployments(apiClient);
+    if (deployments.length > 0) {
+      cfg.deployment_id = deployments[0].deployment_id;
+      cfg.deployment_name = deployments[0].name;
+    }
   } else {
-    const org = await stepSelectOrg(apiClient);
-    if (!org) return;
-    const d = await stepSelectDeployment(apiClient, org);
-    if (!d) return;
-    deployment = d;
+    // Standard path: select deployment interactively
+    if (!cfg.deployment_id) {
+      const org = await stepSelectOrg(apiClient);
+      if (!org) return;
+      const d = await stepSelectDeployment(apiClient, org);
+      if (!d) return;
+      cfg.deployment_id = d.deployment_id;
+      cfg.deployment_name = d.name;
+    }
   }
 
-  cfg.deployment_id = deployment.deployment_id;
-  cfg.deployment_name = deployment.name;
   saveConfig(cfg);
 
-  // Step 3: API key
+  // Step 3: API key (needed for both modes)
   const apiKey = await stepMintAPIKey(apiClient, cfg);
   if (!apiKey) return;
   cfg.api_key = apiKey;
@@ -72,12 +82,18 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   if (!selection) return;
 
   const results = stepConfigureTools(cfg, selection);
-  stepShowSummary(results);
+  stepShowSummary(results, cfg.mode);
 
-  p.outro("\uD83C\uDF89 Setup complete!");
+  if (cfg.mode === "oss") {
+    p.outro(
+      "Setup complete! Using open-source libraries only.\nRun `dosu setup` again to connect your own repos.",
+    );
+  } else {
+    p.outro("\uD83C\uDF89 Setup complete!");
+  }
 }
 
-async function stepAuthenticate(): Promise<Config | null> {
+async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
   const cfg = loadConfig();
 
   // If we have a token, verify it against the backend first
@@ -89,6 +105,23 @@ async function stepAuthenticate(): Promise<Config | null> {
       const resp = await apiClient.doRequestRaw("GET", "/v1/mcp/deployments");
       if (resp.status === 200) {
         s.stop("Authenticated");
+
+        // If configured for OSS and no --deployment flag, let the user reconfigure
+        if (!opts.deploymentID && cfg.mode === "oss") {
+          const modeLabel = "open-source libraries only";
+          const action = await p.select({
+            message: `Currently configured for ${modeLabel}. What would you like to do?`,
+            options: [
+              { label: "Reconfigure (opens browser)", value: "reconfigure" },
+              { label: "Keep current setup and update tools", value: "keep" },
+            ],
+          });
+          if (p.isCancel(action)) return null;
+          if (action === "keep") return cfg;
+          // Reconfigure: open browser for mode re-selection
+          return await openBrowserForSetup(cfg, opts);
+        }
+
         return cfg;
       }
       // Any non-200 status — try refresh before giving up
@@ -113,22 +146,38 @@ async function stepAuthenticate(): Promise<Config | null> {
   const shouldLogin = await p.confirm({ message: "Open browser to log in?" });
   if (p.isCancel(shouldLogin) || !shouldLogin) return null;
 
+  return await openBrowserForSetup(cfg, opts);
+}
+
+async function openBrowserForSetup(cfg: Config, opts: SetupOptions): Promise<Config | null> {
   try {
     const { startOAuthFlow } = await import("../auth/flow");
     const s = p.spinner();
     s.start("Waiting for authentication...");
-    const token = await startOAuthFlow();
+    // Use /cli-setup unless a specific deployment was already provided via --deployment flag
+    const authPath = opts.deploymentID ? "/cli/auth" : "/cli-setup";
+    const token = await startOAuthFlow(undefined, authPath);
     s.stop("Authenticated");
 
     cfg.access_token = token.access_token;
     cfg.refresh_token = token.refresh_token;
     cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
+    // Only OSS mode is signaled from the browser; absence means cloud (existing flow)
+    if (token.mode === "oss") cfg.mode = "oss";
     saveConfig(cfg);
     return cfg;
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
     p.log.error(`Authentication failed: ${err instanceof Error ? err.message : String(err)}`);
     return null;
+  }
+}
+
+async function fetchDeployments(apiClient: Client): Promise<Deployment[]> {
+  try {
+    return await apiClient.getDeployments();
+  } catch {
+    return [];
   }
 }
 
@@ -208,8 +257,13 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
 }
 
 async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | null> {
+  if (!cfg.deployment_id) {
+    p.log.error("No deployment available for API key creation");
+    return null;
+  }
+
   if (cfg.api_key) {
-    // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
+    // biome-ignore lint/style/noNonNullAssertion: checked above
     const valid = await apiClient.validateAPIKey(cfg.api_key, cfg.deployment_id!);
     if (valid) {
       p.log.success(`API key\n${dim("using existing")}`);
@@ -219,7 +273,7 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
   }
 
   try {
-    // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
+    // biome-ignore lint/style/noNonNullAssertion: checked above
     const resp = await apiClient.createAPIKey(cfg.deployment_id!, "dosu-cli");
     p.log.success(`API key\n${dim("created")}`);
     return resp.api_key;
@@ -312,7 +366,7 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
   return results;
 }
 
-export function stepShowSummary(results: ConfigResult[]): void {
+export function stepShowSummary(results: ConfigResult[], mode?: "oss"): void {
   const installed = results.filter((r) => r.action === "install" && !r.error);
   const removed = results.filter((r) => r.action === "remove" && !r.error);
   const skipped = results.filter((r) => r.action === "skip");
@@ -336,11 +390,10 @@ export function stepShowSummary(results: ConfigResult[]): void {
   }
 
   if (installed.length > 0 || skipped.length > 0) {
-    p.log.message(
-      `Try it out! Paste this into your agent:\n\n` +
-        info(
-          `Use Dosu to search our team's documentation and answer: what are the main components of our system?`,
-        ),
-    );
+    const prompt =
+      mode === "oss"
+        ? `Use Dosu to search open source libraries and answer: what are the main components of this project?`
+        : `Use Dosu to search our team's documentation and answer: what are the main components of our system?`;
+    p.log.message(`Try it out! Paste this into your agent:\n\n${info(prompt)}`);
   }
 }

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -4,7 +4,7 @@
 
 import * as p from "@clack/prompts";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
-import { MODE_OSS, type Config, type SetupMode, loadConfig, saveConfig } from "../config/config";
+import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
 import { dim, info } from "./styles";
 
@@ -51,14 +51,12 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     }
   } else {
     // Standard path: select deployment interactively
-    if (!cfg.deployment_id) {
-      const org = await stepSelectOrg(apiClient);
-      if (!org) return;
-      const d = await stepSelectDeployment(apiClient, org);
-      if (!d) return;
-      cfg.deployment_id = d.deployment_id;
-      cfg.deployment_name = d.name;
-    }
+    const org = await stepSelectOrg(apiClient);
+    if (!org) return;
+    const d = await stepSelectDeployment(apiClient, org);
+    if (!d) return;
+    cfg.deployment_id = d.deployment_id;
+    cfg.deployment_name = d.name;
   }
 
   saveConfig(cfg);


### PR DESCRIPTION
## Summary
- Adds a browser-driven OSS mode where the web app signals `mode=oss` back to the CLI via the OAuth callback. When active, setup skips interactive deployment selection and uses a base MCP URL (`/v1/mcp`) without a deployment ID.
- Introduces a `/cli-setup` auth path for the new mode-selection flow, with a redirect param so the OAuth callback returns to the correct page.
- Increases auth timeout from 5 to 15 minutes to accommodate the longer browser-based setup.
- Re-running `dosu setup` in OSS mode prompts the user to reconfigure or keep their current setup.

## Test plan
- [ ] Run `dosu setup` fresh — verify browser opens to `/cli-setup` and OSS mode is persisted in config
- [ ] Run `dosu setup --deployment <id>` — verify it uses `/cli-login` and skips OSS path
- [ ] Re-run `dosu setup` after OSS config — verify reconfigure/keep prompt appears
- [ ] Verify MCP server entries use the base URL (no deployment ID) in OSS mode