### PR TITLE
test: add missing coverage for OSS mode paths

### DIFF
--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -151,6 +151,23 @@ describe("startOAuthFlow", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("includes redirect param when path is not /cli/auth", async () => {
+    const flowPromise = startOAuthFlow(undefined, "/cli-setup");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockOpenDefault).toHaveBeenCalledOnce();
+    const calledURL = new URL(mockOpenDefault.mock.calls[0]?.[0] as string);
+
+    expect(calledURL.pathname).toBe("/cli-setup");
+    expect(calledURL.searchParams.get("callback")).toBe("http://localhost:12345/callback");
+    const redirect = calledURL.searchParams.get("redirect") ?? "";
+    expect(redirect).toContain("/cli-setup?callback=");
+    expect(redirect).toContain(encodeURIComponent("http://localhost:12345/callback"));
+
+    resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
+    await flowPromise;
+  });
+
   it("uses the configured web app URL for building the auth URL", async () => {
     mockGetWebAppURL.mockReturnValue("http://localhost:3001");
 

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -161,6 +161,24 @@ describe("auth callback server", () => {
     expect(html).toContain("<strong>test@dosu.dev</strong>");
   });
 
+  it("includes mode in token when mode=oss is in query params", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    await fetch(`http://localhost:${server.port}/callback?access_token=tok&mode=oss`);
+    const token = await result.tokenPromise;
+    expect(token.mode).toBe("oss");
+  });
+
+  it("omits mode from token when mode is not oss", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+
+    await fetch(`http://localhost:${server.port}/callback?access_token=tok&mode=cloud`);
+    const token = await result.tokenPromise;
+    expect(token.mode).toBeUndefined();
+  });
+
   it("treats literal string 'null' in refresh_token as empty", async () => {
     const result = await startCallbackServer();
     server = result.server;

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -276,6 +276,25 @@ describe("stepConfigureTools", () => {
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Claude Desktop"));
   });
 
+  it("handles remove errors and records them in results", () => {
+    const claudeDesktop = ClaudeDesktopProvider();
+    const cfg = makeCfg();
+    // ClaudeDesktopProvider.remove() always throws
+    const selection: ToolSelection = {
+      toInstall: [],
+      toRemove: [claudeDesktop],
+      skipped: [],
+    };
+
+    const results = stepConfigureTools(cfg, selection);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe("remove");
+    expect(results[0].error).toBeDefined();
+    expect(results[0].error?.message).toContain("stdio");
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Claude Desktop"));
+  });
+
   it("handles mixed install, remove, and skip in one call", () => {
     const cfg = makeCfg();
     const _cursor = CursorProvider();
@@ -1029,6 +1048,41 @@ describe("runSetup integration", () => {
 
     const saved = loadConfig();
     expect(saved.mode).toBe("oss");
+  });
+
+  it("removes provider config when user deselects a previously configured tool", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+
+    // Create detect paths for both cursor and opencode
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    mkdirSync(join(tempDir, ".config", "opencode"), { recursive: true });
+
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [
+      CursorProvider(),
+      OpenCodeProvider(),
+    ]);
+
+    // Pre-configure both providers so isConfigured() returns true
+    CursorProvider().install(cfg, true);
+    OpenCodeProvider().install(cfg, true);
+
+    // User deselects opencode but keeps cursor
+    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+
+    await runSetup();
+
+    // OpenCode should have been removed (configured + deselected)
+    const opencodeConfig = loadJSONConfig(join(tempDir, ".config", "opencode", "opencode.json"));
+    expect(opencodeConfig.mcp?.dosu).toBeUndefined();
+
+    // Cursor config should still have dosu entry (was skipped)
+    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers?.dosu).toBeDefined();
+
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 tool"));
   });
 
   it("OSS mode stepShowSummary uses OSS-specific prompt", async () => {


### PR DESCRIPTION
## Summary
PR #32 (OSS mode support) introduced new code paths that lacked test coverage, dropping statement coverage from 96.84% to 96.52% and branch coverage from 93.36% to 92.58%. This PR adds 5 targeted tests across 3 files to recover and exceed the original coverage levels:

- **auth/flow.test.ts**: Test `startOAuthFlow` with custom path (`/cli-setup`) to verify redirect param generation
- **auth/server.test.ts**: Test `mode=oss` query param forwarding to token response, and non-oss mode exclusion
- **setup/flow.test.ts**: Test `provider.remove()` error handling in `stepConfigureTools`, and end-to-end tool deselection triggering config removal

After this change: statements 96.96% (+0.44), branches 93.84% (+1.26). `auth/flow.ts` reaches 100% coverage.

## Test plan
- [x] `bun run test` — 298 tests pass
- [x] `bun run test -- --coverage` — all thresholds met
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean