### PR TITLE
fix: add fallback UI when window.close() is blocked by browser

### DIFF
--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -130,23 +130,26 @@ describe("auth callback server", () => {
     expect(html).toContain("viewBox");
   });
 
-  it("success page includes 10s auto-close countdown", async () => {
+  it("success page includes 10s auto-close countdown with fallback", async () => {
     const result = await startCallbackServer();
     server = result.server;
 
     const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
     const html = await resp.text();
     expect(html).toContain('id="countdown">10</span>');
+    expect(html).toContain("tryClose()");
     expect(html).toContain("window.close()");
+    // Fallback: updates UI when window.close() doesn't work
+    expect(html).toContain("You can close this tab now.");
   });
 
-  it("success page card is clickable to close", async () => {
+  it("success page card is clickable to close with fallback", async () => {
     const result = await startCallbackServer();
     server = result.server;
 
     const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
     const html = await resp.text();
-    expect(html).toContain('class="card" onclick="window.close()"');
+    expect(html).toContain('id="close-card" onclick="tryClose()"');
     expect(html).toContain("cursor: pointer");
   });
 

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -168,12 +168,24 @@ h1 {
     <h1>Authentication Successful</h1>
     <p class="subtitle">You're all set. The CLI is now authenticated.</p>
     ${emailLine}
-    <div class="card" onclick="window.close()">Close this tab and return to your terminal.</div>
-    <p class="close-hint">This tab will close automatically in <span id="countdown">10</span>s</p>
+    <div class="card" id="close-card" onclick="tryClose()">Close this tab and return to your terminal.</div>
+    <p class="close-hint" id="close-hint">This tab will close automatically in <span id="countdown">10</span>s</p>
 </div>
 <script>
+function tryClose(){
+    window.close();
+    setTimeout(function(){
+        var c=document.getElementById('close-card');
+        c.textContent='You can close this tab now.';
+        c.style.cursor='default';
+        c.onclick=null;
+        var h=document.getElementById('close-hint');
+        if(h)h.style.display='none';
+        clearInterval(t);
+    },500);
+}
 var s=10,el=document.getElementById('countdown');
-var t=setInterval(function(){if(--s<=0){clearInterval(t);window.close();}el.textContent=s;},1000);
+var t=setInterval(function(){if(--s<=0){clearInterval(t);tryClose();}el.textContent=s;},1000);
 </script>
 </body>
 </html>`;


### PR DESCRIPTION
## Summary

- Browsers often block `window.close()` for tabs not opened via JavaScript. The auth success page previously left users staring at a broken countdown when this happened.
- Adds a `tryClose()` wrapper that attempts `window.close()`, then after 500ms detects if the tab is still open and shows a "You can close this tab now" fallback message.
- Updates tests to verify the fallback behavior.

## Test plan

- [x] `bun run test` passes with updated assertions
- [ ] Manual: complete OAuth login flow in a browser that blocks `window.close()` — verify fallback message appears
- [ ] Manual: complete OAuth login flow in a browser that allows `window.close()` — verify tab closes normally