### PR TITLE
fix: bake env vars into compiled binary via --define

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "dev:local": "DOSU_DEV=true bun run src/index.ts",
-    "build": "bun --env-file=.env.production build --compile --env=DOSU_* --env=SUPABASE_* src/index.ts --outfile bin/dosu",
+    "build": "bun --env-file=.env.production run scripts/build-compile.ts",
     "build:npm": "bun --env-file=.env.production run scripts/build-npm.ts",
     "build:all": "bun --env-file=.env.production run scripts/build-all.ts",
     "test": "bunx vitest run",

--- a/scripts/build-all.test.ts
+++ b/scripts/build-all.test.ts
@@ -17,8 +17,6 @@ describe("build-all script", () => {
     expect(content).toContain("bun-linux-x64-musl");
     expect(content).toContain("bun-linux-arm64-musl");
     expect(content).toContain("bun-windows-x64-baseline");
-    expect(content).toContain("--env=DOSU_*");
-    expect(content).toContain("--env=SUPABASE_*");
   });
 });
 

--- a/scripts/build-all.test.ts
+++ b/scripts/build-all.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildDefines } from "./build-all";
@@ -9,7 +9,6 @@ describe("build-all script", () => {
   });
 
   it("defines correct target platforms", () => {
-    const { readFileSync } = require("node:fs");
     const content = readFileSync(join(__dirname, "build-all.ts"), "utf-8");
     expect(content).toContain("bun-darwin-arm64");
     expect(content).toContain("bun-darwin-x64");
@@ -28,15 +27,11 @@ describe("buildDefines", () => {
 
   beforeEach(() => {
     envBackup.DOSU_VERSION = process.env.DOSU_VERSION;
-    envBackup.DOSU_COMMIT = process.env.DOSU_COMMIT;
-    envBackup.DOSU_DATE = process.env.DOSU_DATE;
     envBackup.DOSU_WEB_APP_URL = process.env.DOSU_WEB_APP_URL;
     envBackup.DOSU_BACKEND_URL = process.env.DOSU_BACKEND_URL;
     envBackup.SUPABASE_URL = process.env.SUPABASE_URL;
     envBackup.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
     delete process.env.DOSU_VERSION;
-    delete process.env.DOSU_COMMIT;
-    delete process.env.DOSU_DATE;
     delete process.env.DOSU_WEB_APP_URL;
     delete process.env.DOSU_BACKEND_URL;
     delete process.env.SUPABASE_URL;
@@ -50,30 +45,22 @@ describe("buildDefines", () => {
     }
   });
 
-  it("should return dev defaults when env vars are not set", () => {
+  it("should read version from package.json when DOSU_VERSION is unset", () => {
+    const packageVersion = JSON.parse(readFileSync("package.json", "utf8")).version;
     const defines = buildDefines();
-    expect(defines).toEqual([
-      "--define",
-      'process.env.DOSU_VERSION="dev"',
-      "--define",
-      'process.env.DOSU_COMMIT="none"',
-      "--define",
-      'process.env.DOSU_DATE="unknown"',
-      "--define",
-      'process.env.DOSU_WEB_APP_URL=""',
-      "--define",
-      'process.env.DOSU_BACKEND_URL=""',
-      "--define",
-      'process.env.SUPABASE_URL=""',
-      "--define",
-      'process.env.SUPABASE_ANON_KEY=""',
-    ]);
+    expect(defines).toContain(`process.env.DOSU_VERSION=${JSON.stringify(packageVersion)}`);
+  });
+
+  it("should return empty strings for URL vars when env vars are not set", () => {
+    const defines = buildDefines();
+    expect(defines).toContain('process.env.DOSU_WEB_APP_URL=""');
+    expect(defines).toContain('process.env.DOSU_BACKEND_URL=""');
+    expect(defines).toContain('process.env.SUPABASE_URL=""');
+    expect(defines).toContain('process.env.SUPABASE_ANON_KEY=""');
   });
 
   it("should use env vars when set", () => {
     process.env.DOSU_VERSION = "1.2.3";
-    process.env.DOSU_COMMIT = "abc1234";
-    process.env.DOSU_DATE = "2026-03-30T00:00:00Z";
     process.env.DOSU_WEB_APP_URL = "https://app.test.dev";
     process.env.DOSU_BACKEND_URL = "https://api.test.dev";
     process.env.SUPABASE_URL = "https://db.test.dev";
@@ -83,10 +70,6 @@ describe("buildDefines", () => {
     expect(defines).toEqual([
       "--define",
       'process.env.DOSU_VERSION="1.2.3"',
-      "--define",
-      'process.env.DOSU_COMMIT="abc1234"',
-      "--define",
-      'process.env.DOSU_DATE="2026-03-30T00:00:00Z"',
       "--define",
       'process.env.DOSU_WEB_APP_URL="https://app.test.dev"',
       "--define",
@@ -100,18 +83,14 @@ describe("buildDefines", () => {
 
   it("should produce valid JSON-stringified values", () => {
     process.env.DOSU_VERSION = 'has"quotes';
-
     const defines = buildDefines();
-    // JSON.stringify escapes inner quotes
     expect(defines[1]).toBe('process.env.DOSU_VERSION="has\\"quotes"');
   });
 
-  it("should return exactly 14 elements (7 pairs of --define + value)", () => {
+  it("should return exactly 10 elements (5 pairs of --define + value)", () => {
     const defines = buildDefines();
-    expect(defines).toHaveLength(14);
+    expect(defines).toHaveLength(10);
     expect(defines.filter((_, i) => i % 2 === 0)).toEqual([
-      "--define",
-      "--define",
       "--define",
       "--define",
       "--define",

--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -75,8 +75,6 @@ async function main() {
         "bun",
         "build",
         "--compile",
-        "--env=DOSU_*",
-        "--env=SUPABASE_*",
         ...defines,
         "--target",
         target,

--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -5,8 +5,13 @@
  * Builds standalone binaries for all supported platforms using `bun build --compile`.
  */
 
-import { existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR =
+  typeof import.meta.dir === "string" ? import.meta.dir : dirname(fileURLToPath(import.meta.url));
+const PACKAGE_JSON_PATH = join(SCRIPT_DIR, "..", "package.json");
 
 const TARGETS = [
   { target: "bun-darwin-arm64", output: "dosu-darwin-arm64" },
@@ -18,20 +23,23 @@ const TARGETS = [
   { target: "bun-windows-x64-baseline", output: "dosu-windows-x64.exe" },
 ];
 
+function readPackageVersion(): string {
+  try {
+    return JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")).version ?? "dev";
+  } catch {
+    return "dev";
+  }
+}
+
 /**
- * Build --define flags to bake version info into the compiled binary.
+ * Build --define flags to bake config into compiled/bundled output.
  *
  * `bun build --compile` produces a standalone executable that does NOT inherit
  * the build-time environment, so `process.env.X` reads return undefined at
- * runtime. `--define` replaces identifiers at compile time, turning e.g.
- *   process.env.DOSU_VERSION ?? "dev"
- * into
- *   "0.2.0" ?? "dev"          →  "0.2.0"
+ * runtime. `--define` replaces identifiers at compile time.
  */
 export function buildDefines(): string[] {
-  const version = process.env.DOSU_VERSION ?? "dev";
-  const commit = process.env.DOSU_COMMIT ?? "none";
-  const date = process.env.DOSU_DATE ?? "unknown";
+  const version = process.env.DOSU_VERSION ?? readPackageVersion();
   const webAppURL = process.env.DOSU_WEB_APP_URL ?? "";
   const backendURL = process.env.DOSU_BACKEND_URL ?? "";
   const supabaseURL = process.env.SUPABASE_URL ?? "";
@@ -40,10 +48,6 @@ export function buildDefines(): string[] {
   return [
     "--define",
     `process.env.DOSU_VERSION=${JSON.stringify(version)}`,
-    "--define",
-    `process.env.DOSU_COMMIT=${JSON.stringify(commit)}`,
-    "--define",
-    `process.env.DOSU_DATE=${JSON.stringify(date)}`,
     "--define",
     `process.env.DOSU_WEB_APP_URL=${JSON.stringify(webAppURL)}`,
     "--define",
@@ -56,7 +60,7 @@ export function buildDefines(): string[] {
 }
 
 async function main() {
-  const distDir = join(import.meta.dir, "..", "dist");
+  const distDir = join(SCRIPT_DIR, "..", "dist");
   if (!existsSync(distDir)) mkdirSync(distDir, { recursive: true });
 
   const defines = buildDefines();

--- a/scripts/build-compile.test.ts
+++ b/scripts/build-compile.test.ts
@@ -18,9 +18,8 @@ describe("build-compile script", () => {
     expect(content).toContain("...defines");
   });
 
-  it("inlines Dosu and Supabase environment variables", () => {
+  it("does not use redundant --env flags", () => {
     const content = readFileSync(join(__dirname, "build-compile.ts"), "utf-8");
-    expect(content).toContain("--env=DOSU_*");
-    expect(content).toContain("--env=SUPABASE_*");
+    expect(content).not.toContain("--env=");
   });
 });

--- a/scripts/build-compile.test.ts
+++ b/scripts/build-compile.test.ts
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("build-compile script", () => {
+  it("script file exists", () => {
+    expect(existsSync(join(__dirname, "build-compile.ts"))).toBe(true);
+  });
+
+  it("uses --compile flag for standalone binary", () => {
+    const content = readFileSync(join(__dirname, "build-compile.ts"), "utf-8");
+    expect(content).toContain("--compile");
+  });
+
+  it("uses --define via buildDefines from build-all", () => {
+    const content = readFileSync(join(__dirname, "build-compile.ts"), "utf-8");
+    expect(content).toContain('import { buildDefines } from "./build-all"');
+    expect(content).toContain("...defines");
+  });
+
+  it("inlines Dosu and Supabase environment variables", () => {
+    const content = readFileSync(join(__dirname, "build-compile.ts"), "utf-8");
+    expect(content).toContain("--env=DOSU_*");
+    expect(content).toContain("--env=SUPABASE_*");
+  });
+});

--- a/scripts/build-compile.ts
+++ b/scripts/build-compile.ts
@@ -25,8 +25,6 @@ async function main() {
       "bun",
       "build",
       "--compile",
-      "--env=DOSU_*",
-      "--env=SUPABASE_*",
       ...defines,
       "src/index.ts",
       "--outfile",

--- a/scripts/build-compile.ts
+++ b/scripts/build-compile.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env bun
+/**
+ * Single-platform compile build.
+ *
+ * Produces a standalone binary for the current platform using `bun build --compile`.
+ * Uses --define to bake env vars at compile time (same as build-all.ts).
+ */
+
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildDefines } from "./build-all";
+
+const SCRIPT_DIR =
+  typeof import.meta.dir === "string" ? import.meta.dir : dirname(fileURLToPath(import.meta.url));
+const OUTFILE = join(SCRIPT_DIR, "..", "bin", "dosu");
+
+async function main() {
+  mkdirSync(dirname(OUTFILE), { recursive: true });
+
+  const defines = buildDefines();
+
+  const proc = Bun.spawn(
+    [
+      "bun",
+      "build",
+      "--compile",
+      "--env=DOSU_*",
+      "--env=SUPABASE_*",
+      ...defines,
+      "src/index.ts",
+      "--outfile",
+      OUTFILE,
+    ],
+    { stdout: "inherit", stderr: "inherit", env: process.env },
+  );
+
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) process.exit(1);
+
+  console.log(`Built standalone binary at ${OUTFILE}`);
+}
+
+const isDirectRun = process.argv[1]?.endsWith("build-compile.ts");
+
+if (isDirectRun) await main();

--- a/scripts/build-compile.ts
+++ b/scripts/build-compile.ts
@@ -21,15 +21,7 @@ async function main() {
   const defines = buildDefines();
 
   const proc = Bun.spawn(
-    [
-      "bun",
-      "build",
-      "--compile",
-      ...defines,
-      "src/index.ts",
-      "--outfile",
-      OUTFILE,
-    ],
+    ["bun", "build", "--compile", ...defines, "src/index.ts", "--outfile", OUTFILE],
     { stdout: "inherit", stderr: "inherit", env: process.env },
   );
 

--- a/scripts/build-npm.test.ts
+++ b/scripts/build-npm.test.ts
@@ -17,48 +17,11 @@ describe("build-npm script", () => {
     expect(output).toBe("#!/usr/bin/env node\nconsole.log('hi')\n");
   });
 
-  it("buildDefines defaults to the package version", () => {
-    const packageVersion = JSON.parse(readFileSync("package.json", "utf8")).version;
+  it("re-exports buildDefines from build-all", () => {
+    // buildDefines should be the same function from build-all.ts
     const defines = buildDefines();
-    expect(defines).toContain(`process.env.DOSU_VERSION=${JSON.stringify(packageVersion)}`);
-    expect(defines).toContain(`process.env.DOSU_COMMIT=${JSON.stringify("none")}`);
-    expect(defines).toContain(`process.env.DOSU_DATE=${JSON.stringify("unknown")}`);
-    expect(defines).toContain('process.env.DOSU_WEB_APP_URL=""');
-    expect(defines).toContain('process.env.DOSU_BACKEND_URL=""');
-    expect(defines).toContain('process.env.SUPABASE_URL=""');
-    expect(defines).toContain('process.env.SUPABASE_ANON_KEY=""');
-  });
-
-  it("buildDefines prefers explicit environment overrides", () => {
-    process.env.DOSU_VERSION = "9.9.9";
-    process.env.DOSU_COMMIT = "abc123";
-    process.env.DOSU_DATE = "2026-03-30T00:00:00Z";
-    process.env.DOSU_WEB_APP_URL = "https://app.test.dev";
-    process.env.DOSU_BACKEND_URL = "https://api.test.dev";
-    process.env.SUPABASE_URL = "https://db.test.dev";
-    process.env.SUPABASE_ANON_KEY = "anon-test-key";
-
-    const defines = buildDefines();
-
-    expect(defines).toContain(`process.env.DOSU_VERSION=${JSON.stringify("9.9.9")}`);
-    expect(defines).toContain(`process.env.DOSU_COMMIT=${JSON.stringify("abc123")}`);
-    expect(defines).toContain(`process.env.DOSU_DATE=${JSON.stringify("2026-03-30T00:00:00Z")}`);
-    expect(defines).toContain(
-      `process.env.DOSU_WEB_APP_URL=${JSON.stringify("https://app.test.dev")}`,
-    );
-    expect(defines).toContain(
-      `process.env.DOSU_BACKEND_URL=${JSON.stringify("https://api.test.dev")}`,
-    );
-    expect(defines).toContain(`process.env.SUPABASE_URL=${JSON.stringify("https://db.test.dev")}`);
-    expect(defines).toContain(`process.env.SUPABASE_ANON_KEY=${JSON.stringify("anon-test-key")}`);
-
-    delete process.env.DOSU_VERSION;
-    delete process.env.DOSU_COMMIT;
-    delete process.env.DOSU_DATE;
-    delete process.env.DOSU_WEB_APP_URL;
-    delete process.env.DOSU_BACKEND_URL;
-    delete process.env.SUPABASE_URL;
-    delete process.env.SUPABASE_ANON_KEY;
+    expect(defines).toContain("--define");
+    expect(defines.some((d) => d.startsWith("process.env.DOSU_VERSION="))).toBe(true);
   });
 
   it("inlines Dosu and Supabase environment variables into the bundle", () => {

--- a/scripts/build-npm.test.ts
+++ b/scripts/build-npm.test.ts
@@ -24,9 +24,8 @@ describe("build-npm script", () => {
     expect(defines.some((d) => d.startsWith("process.env.DOSU_VERSION="))).toBe(true);
   });
 
-  it("inlines Dosu and Supabase environment variables into the bundle", () => {
+  it("does not use redundant --env flags", () => {
     const content = readFileSync("scripts/build-npm.ts", "utf8");
-    expect(content).toContain("--env=DOSU_*");
-    expect(content).toContain("--env=SUPABASE_*");
+    expect(content).not.toContain("--env=");
   });
 });

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -3,48 +3,14 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildDefines } from "./build-all";
 
 const SCRIPT_DIR =
   typeof import.meta.dir === "string" ? import.meta.dir : dirname(fileURLToPath(import.meta.url));
-const PACKAGE_JSON_PATH = join(SCRIPT_DIR, "..", "package.json");
 const OUTFILE = join(SCRIPT_DIR, "..", "bin", "dosu.js");
 const NODE_SHEBANG = "#!/usr/bin/env node";
 
-interface PackageJSON {
-  version?: string;
-}
-
-function readPackageJSON(): PackageJSON {
-  return JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as PackageJSON;
-}
-
-export function buildDefines(): string[] {
-  const packageJSON = readPackageJSON();
-  const version = process.env.DOSU_VERSION ?? packageJSON.version ?? "dev";
-  const commit = process.env.DOSU_COMMIT ?? "none";
-  const date = process.env.DOSU_DATE ?? "unknown";
-  const webAppURL = process.env.DOSU_WEB_APP_URL ?? "";
-  const backendURL = process.env.DOSU_BACKEND_URL ?? "";
-  const supabaseURL = process.env.SUPABASE_URL ?? "";
-  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY ?? "";
-
-  return [
-    "--define",
-    `process.env.DOSU_VERSION=${JSON.stringify(version)}`,
-    "--define",
-    `process.env.DOSU_COMMIT=${JSON.stringify(commit)}`,
-    "--define",
-    `process.env.DOSU_DATE=${JSON.stringify(date)}`,
-    "--define",
-    `process.env.DOSU_WEB_APP_URL=${JSON.stringify(webAppURL)}`,
-    "--define",
-    `process.env.DOSU_BACKEND_URL=${JSON.stringify(backendURL)}`,
-    "--define",
-    `process.env.SUPABASE_URL=${JSON.stringify(supabaseURL)}`,
-    "--define",
-    `process.env.SUPABASE_ANON_KEY=${JSON.stringify(supabaseAnonKey)}`,
-  ];
-}
+export { buildDefines } from "./build-all";
 
 export function normalizeNodeBundle(content: string): string {
   const lines = content.split("\n");

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -33,16 +33,7 @@ async function main() {
   mkdirSync(dirname(OUTFILE), { recursive: true });
 
   const proc = Bun.spawn(
-    [
-      "bun",
-      "build",
-      "--target",
-      "node",
-      ...buildDefines(),
-      "src/index.ts",
-      "--outfile",
-      OUTFILE,
-    ],
+    ["bun", "build", "--target", "node", ...buildDefines(), "src/index.ts", "--outfile", OUTFILE],
     { stdout: "pipe", stderr: "pipe", env: process.env },
   );
 

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -38,8 +38,6 @@ async function main() {
       "build",
       "--target",
       "node",
-      "--env=DOSU_*",
-      "--env=SUPABASE_*",
       ...buildDefines(),
       "src/index.ts",
       "--outfile",

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -19,7 +19,7 @@ describe("CLI", () => {
 
   it("has version flag", () => {
     const program = createProgram();
-    expect(program.version()).toMatch(/dosu .+/);
+    expect(program.version()).toMatch(/^v\d+/);
   });
 
   it("has login command", () => {

--- a/src/config/constants.test.ts
+++ b/src/config/constants.test.ts
@@ -8,7 +8,6 @@ describe("constants", () => {
     "DOSU_BACKEND_URL",
     "SUPABASE_URL",
     "SUPABASE_ANON_KEY",
-    "DOSU_DEV",
   ];
 
   beforeEach(() => {

--- a/src/config/constants.test.ts
+++ b/src/config/constants.test.ts
@@ -3,12 +3,7 @@ import { getBackendURL, getSupabaseAnonKey, getSupabaseURL, getWebAppURL } from 
 
 describe("constants", () => {
   const savedEnv: Record<string, string | undefined> = {};
-  const ENV_KEYS = [
-    "DOSU_WEB_APP_URL",
-    "DOSU_BACKEND_URL",
-    "SUPABASE_URL",
-    "SUPABASE_ANON_KEY",
-  ];
+  const ENV_KEYS = ["DOSU_WEB_APP_URL", "DOSU_BACKEND_URL", "SUPABASE_URL", "SUPABASE_ANON_KEY"];
 
   beforeEach(() => {
     for (const key of ENV_KEYS) {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,10 +5,6 @@
  * See .env.example for the full list of supported variables.
  */
 
-export function isDev(): boolean {
-  return process.env.DOSU_DEV === "true";
-}
-
 export function getWebAppURL(): string {
   return process.env.DOSU_WEB_APP_URL ?? "";
 }

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1068,6 +1068,26 @@ describe("runSetup integration", () => {
     expect(mockStartOAuthFlow).toHaveBeenCalled();
   });
 
+  it("OSS mode reconfigure clears mode when token has no OSS signal", async () => {
+    const cfg = makeCfg({ mode: "oss" });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    vi.mocked(p.select).mockResolvedValueOnce("reconfigure");
+    // Token WITHOUT mode: "oss" means user switched to cloud/standard flow
+    mockStartOAuthFlow.mockResolvedValue({
+      access_token: "new-tok",
+      refresh_token: "new-ref",
+      expires_in: 3600,
+    } as TokenResponse);
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.mode).toBeUndefined();
+  });
+
   it("OAuth flow sets OSS mode when token signals it", async () => {
     vi.mocked(p.confirm).mockResolvedValue(true);
     mockStartOAuthFlow.mockResolvedValue({

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -160,8 +160,8 @@ async function openBrowserForSetup(cfg: Config, opts: SetupOptions): Promise<Con
     cfg.access_token = token.access_token;
     cfg.refresh_token = token.refresh_token;
     cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
-    // Only OSS mode is signaled from the browser; absence means cloud (existing flow)
-    if (token.mode === MODE_OSS) cfg.mode = MODE_OSS;
+    // Sync mode from browser: OSS when signaled, clear otherwise (cloud flow)
+    cfg.mode = token.mode === MODE_OSS ? MODE_OSS : undefined;
     saveConfig(cfg);
     return cfg;
   } catch (err: unknown) {

--- a/src/version/version.test.ts
+++ b/src/version/version.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { COMMIT, DATE, getVersionString, VERSION } from "./version";
+import { getVersionString, VERSION } from "./version";
 
 describe("version", () => {
-  it("should have default values when env vars are not set", () => {
-    expect(VERSION).toBe("dev");
-    expect(COMMIT).toBe("none");
-    expect(DATE).toBe("unknown");
+  it("should read version from package.json in dev mode", () => {
+    // When DOSU_VERSION is not set (dev mode), falls back to package.json
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
   });
 
-  it("should return formatted version string", () => {
+  it("should return clean version string", () => {
     const result = getVersionString();
-    expect(result).toMatch(/^dosu .+ \(.+, .+\)$/);
-    expect(result).toContain("dev");
+    expect(result).toMatch(/^v\d+\.\d+\.\d+/);
   });
 });

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -5,7 +5,7 @@
 
 function readPackageVersion(): string {
   try {
-    return require("../../package.json").version ?? "dev";
+    return require("../../package.json").version;
     /* v8 ignore next 3 -- unreachable in test: package.json always exists */
   } catch {
     return "dev";

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -1,14 +1,21 @@
 /**
- * Version information — injected at build time, with dev fallbacks for local source runs.
+ * Version information — injected at build time via --define.
+ * When running from source (bun run dev), falls back to package.json.
  */
 
-export const VERSION = process.env.DOSU_VERSION ?? "dev";
-export const COMMIT = process.env.DOSU_COMMIT ?? "none";
-export const DATE = process.env.DOSU_DATE ?? "unknown";
+function readPackageVersion(): string {
+  try {
+    return require("../../package.json").version ?? "dev";
+  } catch {
+    return "dev";
+  }
+}
+
+export const VERSION = process.env.DOSU_VERSION ?? readPackageVersion();
 
 /**
- * Returns a formatted version string.
+ * Returns a formatted version string, e.g. "dosu v0.3.1".
  */
 export function getVersionString(): string {
-  return `dosu ${VERSION} (${COMMIT}, ${DATE})`;
+  return `v${VERSION}`;
 }

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -6,6 +6,7 @@
 function readPackageVersion(): string {
   try {
     return require("../../package.json").version ?? "dev";
+  /* v8 ignore next 3 -- unreachable in test: package.json always exists */
   } catch {
     return "dev";
   }

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -6,7 +6,7 @@
 function readPackageVersion(): string {
   try {
     return require("../../package.json").version ?? "dev";
-  /* v8 ignore next 3 -- unreachable in test: package.json always exists */
+    /* v8 ignore next 3 -- unreachable in test: package.json always exists */
   } catch {
     return "dev";
   }


### PR DESCRIPTION
## Summary

- The `bun run build` command used `--env` which does not inline `process.env` references in `bun build --compile`, causing the compiled binary to read `.env` files at runtime — redirecting OAuth to `localhost` when run from the source directory.
- Added `scripts/build-compile.ts` using `--define` flags (consistent with `build-all` and `build-npm`), and consolidated the duplicated `buildDefines()` into a single source in `build-all.ts`.
- Removed unused `COMMIT`/`DATE` constants and simplified version output from `dosu 0.3.1 (commit, date)` to `v0.3.1`.
- Version now reads from `package.json` in dev mode so `bun run dev -- -v` shows the real version instead of `dev`.
- Fixed OSS mode not clearing when user switches back to cloud flow during reconfiguration.

## Test plan
- [x] `bun run build && ./bin/dosu -v` → `v0.3.1` with `https://app.dosu.dev` baked in
- [x] `bun run build:npm && node bin/dosu.js -v` → `v0.3.1`
- [x] `bun run dev -- -v` → `v0.3.1` (reads package.json)
- [x] All 305 tests pass
- [x] Typecheck and lint pass