### PR TITLE
fix: simplify auth success page and add Tips prefix to OSS outro

### DIFF
--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -130,27 +130,15 @@ describe("auth callback server", () => {
     expect(html).toContain("viewBox");
   });
 
-  it("success page includes 10s auto-close countdown with fallback", async () => {
+  it("success page shows static close message without scripts", async () => {
     const result = await startCallbackServer();
     server = result.server;
 
     const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
     const html = await resp.text();
-    expect(html).toContain('id="countdown">10</span>');
-    expect(html).toContain("tryClose()");
-    expect(html).toContain("window.close()");
-    // Fallback: updates UI when window.close() doesn't work
-    expect(html).toContain("You can close this tab now.");
-  });
-
-  it("success page card is clickable to close with fallback", async () => {
-    const result = await startCallbackServer();
-    server = result.server;
-
-    const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
-    const html = await resp.text();
-    expect(html).toContain('id="close-card" onclick="tryClose()"');
-    expect(html).toContain("cursor: pointer");
+    expect(html).toContain("You can close this tab and return to your terminal.");
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("countdown");
   });
 
   it("email is rendered bold in success page", async () => {

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -127,25 +127,10 @@ h1 {
     color: #999;
     margin-bottom: 28px;
 }
-.card {
-    background: #fff;
-    border: 1px solid #eaeaea;
-    border-radius: 8px;
-    padding: 16px 20px;
+.close-msg {
+    margin-top: 4px;
     font-size: 16px;
     color: #666;
-    line-height: 1.5;
-    cursor: pointer;
-    transition: background 0.15s, border-color 0.15s;
-}
-.card:hover {
-    background: #f5f5f5;
-    border-color: #ccc;
-}
-.close-hint {
-    margin-top: 20px;
-    font-size: 14px;
-    color: #999;
 }
 </style>
 </head>
@@ -168,25 +153,8 @@ h1 {
     <h1>Authentication Successful</h1>
     <p class="subtitle">You're all set. The CLI is now authenticated.</p>
     ${emailLine}
-    <div class="card" id="close-card" onclick="tryClose()">Close this tab and return to your terminal.</div>
-    <p class="close-hint" id="close-hint">This tab will close automatically in <span id="countdown">10</span>s</p>
+    <p class="close-msg">You can close this tab and return to your terminal.</p>
 </div>
-<script>
-function tryClose(){
-    window.close();
-    setTimeout(function(){
-        var c=document.getElementById('close-card');
-        c.textContent='You can close this tab now.';
-        c.style.cursor='default';
-        c.onclick=null;
-        var h=document.getElementById('close-hint');
-        if(h)h.style.display='none';
-        clearInterval(t);
-    },500);
-}
-var s=10,el=document.getElementById('countdown');
-var t=setInterval(function(){if(--s<=0){clearInterval(t);tryClose();}el.textContent=s;},1000);
-</script>
 </body>
 </html>`;
 }

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -84,7 +84,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
 
   if (cfg.mode === MODE_OSS) {
     p.outro(
-      "Setup complete! Using open-source libraries only.\nRun `dosu setup` again to connect your own repos.",
+      "Setup complete! Using open-source libraries only.\n\nTips: Run `dosu setup` again to connect your own repos.",
     );
   } else {
     p.outro("\uD83C\uDF89 Setup complete!");


### PR DESCRIPTION
## Summary
- Remove the close button, countdown timer, and all JavaScript from the OAuth success page — replaced with a single static message: "You can close this tab and return to your terminal."
- Add a newline and "Tips:" prefix before the "Run `dosu setup` again" hint in the OSS setup outro, so it no longer runs into the previous line.

## Test plan
- [x] All 304 tests pass (19 test files)
- [ ] Run `dosu setup` in OSS mode and verify the outro formatting
- [ ] Complete an OAuth login and verify the simplified success page renders correctly