### PR TITLE
fix: TUI Authenticate only authenticates, not full setup

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -9,19 +9,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@clack/prompts", () => ({
   select: vi.fn(),
+  confirm: vi.fn(),
   isCancel: vi.fn(),
   cancel: vi.fn(),
   outro: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
   log: {
     warn: vi.fn(),
     success: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
   },
-}));
-
-vi.mock("../setup/flow", () => ({
-  runSetup: vi.fn(),
 }));
 
 vi.mock("../client/client", () => ({
@@ -44,13 +42,12 @@ import { Client } from "../client/client";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
 import { loadJSONConfig } from "../mcp/config-helpers";
-import { runSetup } from "../setup/flow";
 import { handleLogout, runTUI } from "./tui";
 
 const mockSelect = vi.mocked(p.select);
+const mockConfirm = vi.mocked(p.confirm);
 const mockIsCancel = vi.mocked(p.isCancel);
 const mockOutro = vi.mocked(p.outro);
-const mockRunSetup = vi.mocked(runSetup);
 
 // ---------------------------------------------------------------------------
 // Temp directory setup — real config on disk
@@ -173,13 +170,14 @@ describe("handleLogout (direct)", () => {
 // ---------------------------------------------------------------------------
 
 describe("runTUI", () => {
-  it("calls runSetup when not authenticated (real config, no file on disk)", async () => {
+  it("prompts to authenticate when not authenticated (real config, no file on disk)", async () => {
     // No config file exists, so loadConfig returns empty → not authenticated
-    mockRunSetup.mockResolvedValue(undefined);
+    // User declines to open browser → TUI exits
+    mockConfirm.mockResolvedValueOnce(false);
 
     await runTUI();
 
-    expect(mockRunSetup).toHaveBeenCalledOnce();
+    expect(mockConfirm).toHaveBeenCalledWith({ message: "Open browser to log in?" });
     expect(mockSelect).not.toHaveBeenCalled();
   });
 
@@ -204,16 +202,20 @@ describe("runTUI", () => {
     expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
   });
 
-  it("calls runSetup when user selects setup action", async () => {
+  it("verifies session when user selects auth action with existing token", async () => {
     writeRealConfig(makeCfg({ access_token: "tok" }));
     mockIsCancel.mockReturnValue(false);
-    mockRunSetup.mockResolvedValue(undefined);
 
-    mockSelect.mockResolvedValueOnce("setup").mockResolvedValueOnce("exit");
+    const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 200 });
+    vi.mocked(Client).mockImplementation(
+      () => ({ doRequestRaw: mockDoRequestRaw }) as unknown as Client,
+    );
+
+    mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
 
     await runTUI();
 
-    expect(mockRunSetup).toHaveBeenCalledOnce();
+    expect(mockDoRequestRaw).toHaveBeenCalledWith("GET", "/v1/mcp/deployments");
     expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
   });
 

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -26,6 +26,10 @@ vi.mock("../client/client", () => ({
   Client: vi.fn(),
 }));
 
+vi.mock("../auth/flow", () => ({
+  startOAuthFlow: vi.fn(),
+}));
+
 vi.mock("picocolors", () => ({
   default: {
     magenta: (s: string) => s,
@@ -38,6 +42,7 @@ vi.mock("picocolors", () => ({
 // ---------------------------------------------------------------------------
 
 import * as p from "@clack/prompts";
+import { startOAuthFlow } from "../auth/flow";
 import { Client } from "../client/client";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
@@ -48,6 +53,7 @@ const mockSelect = vi.mocked(p.select);
 const mockConfirm = vi.mocked(p.confirm);
 const mockIsCancel = vi.mocked(p.isCancel);
 const mockOutro = vi.mocked(p.outro);
+const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
 
 // ---------------------------------------------------------------------------
 // Temp directory setup — real config on disk
@@ -64,7 +70,13 @@ beforeEach(() => {
   process.env.XDG_CONFIG_HOME = tempDir;
   process.env.HOME = tempDir;
 
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+  // Restore spinner factory cleared by resetAllMocks
+  vi.mocked(p.spinner).mockReturnValue({
+    start: vi.fn(),
+    stop: vi.fn(),
+    message: vi.fn(),
+  } as ReturnType<typeof p.spinner>);
   vi.spyOn(console, "log").mockImplementation(() => {});
 });
 
@@ -217,6 +229,125 @@ describe("runTUI", () => {
 
     expect(mockDoRequestRaw).toHaveBeenCalledWith("GET", "/v1/mcp/deployments");
     expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
+  });
+
+  it("refreshes token when verification returns non-200", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok" }));
+    mockIsCancel.mockReturnValue(false);
+
+    const mockRefreshToken = vi.fn().mockResolvedValue(undefined);
+    const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 401 });
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({ doRequestRaw: mockDoRequestRaw, refreshToken: mockRefreshToken }) as unknown as Client,
+    );
+
+    mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockRefreshToken).toHaveBeenCalled();
+  });
+
+  it("falls through to login when refresh fails", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok" }));
+    mockIsCancel.mockReturnValue(false);
+
+    const mockRefreshToken = vi.fn().mockRejectedValue(new Error("refresh failed"));
+    const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 401 });
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({ doRequestRaw: mockDoRequestRaw, refreshToken: mockRefreshToken }) as unknown as Client,
+    );
+
+    // User declines to open browser
+    mockConfirm.mockResolvedValueOnce(false);
+
+    mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockConfirm).toHaveBeenCalledWith({ message: "Open browser to log in?" });
+  });
+
+  it("falls through to login when verification throws", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok" }));
+    mockIsCancel.mockReturnValue(false);
+
+    const mockDoRequestRaw = vi.fn().mockRejectedValue(new Error("network error"));
+    vi.mocked(Client).mockImplementation(
+      () => ({ doRequestRaw: mockDoRequestRaw }) as unknown as Client,
+    );
+
+    // User declines to open browser
+    mockConfirm.mockResolvedValueOnce(false);
+
+    mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockConfirm).toHaveBeenCalledWith({ message: "Open browser to log in?" });
+  });
+
+  it("opens browser and saves token on successful OAuth flow", async () => {
+    writeRealConfig(makeCfg({ access_token: "" }));
+    mockIsCancel.mockReturnValue(false);
+    mockConfirm.mockResolvedValueOnce(true);
+
+    mockStartOAuthFlow.mockResolvedValueOnce({
+      access_token: "new-tok",
+      refresh_token: "new-ref",
+      expires_in: 3600,
+    });
+
+    mockSelect.mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockStartOAuthFlow).toHaveBeenCalledWith(undefined, "/cli/auth");
+    const ondisk = readRealConfig();
+    expect(ondisk.access_token).toBe("new-tok");
+    expect(ondisk.refresh_token).toBe("new-ref");
+  });
+
+  it("saves OSS mode from OAuth token response", async () => {
+    writeRealConfig(makeCfg({ access_token: "" }));
+    mockIsCancel.mockReturnValue(false);
+    mockConfirm.mockResolvedValueOnce(true);
+
+    mockStartOAuthFlow.mockResolvedValueOnce({
+      access_token: "new-tok",
+      refresh_token: "new-ref",
+      expires_in: 3600,
+      mode: "oss",
+    });
+
+    mockSelect.mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    const ondisk = readRealConfig();
+    expect(ondisk.mode).toBe("oss");
+  });
+
+  it("shows error when OAuth flow fails", async () => {
+    writeRealConfig(makeCfg({ access_token: "" }));
+    mockConfirm.mockResolvedValueOnce(true);
+    mockStartOAuthFlow.mockRejectedValueOnce(new Error("auth timeout"));
+
+    await runTUI();
+
+    expect(p.log.error).toHaveBeenCalledWith("Authentication failed: auth timeout");
+  });
+
+  it("does nothing when user cancels confirm prompt", async () => {
+    writeRealConfig(makeCfg({ access_token: "" }));
+    mockIsCancel.mockReturnValue(true);
+    mockConfirm.mockResolvedValueOnce(Symbol.for("cancel") as unknown as boolean);
+
+    await runTUI();
+
+    expect(mockStartOAuthFlow).not.toHaveBeenCalled();
   });
 
   it("logout action clears real config on disk", async () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -7,8 +7,7 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { Client } from "../client/client";
-import { isAuthenticated, loadConfig, saveConfig } from "../config/config";
-import { runSetup } from "../setup/flow";
+import { MODE_OSS, isAuthenticated, loadConfig, saveConfig } from "../config/config";
 
 const LOGO = `
  /$$$$$$$
@@ -26,10 +25,10 @@ export async function runTUI(): Promise<void> {
 
   const cfg = loadConfig();
 
-  // If not authenticated, open setup immediately
+  // If not authenticated, authenticate first
   if (!isAuthenticated(cfg)) {
-    await runSetup();
-    return;
+    await handleAuthenticate(cfg);
+    if (!isAuthenticated(cfg)) return;
   }
 
   // Main menu
@@ -41,7 +40,7 @@ export async function runTUI(): Promise<void> {
       options: [
         {
           label: "Authenticate",
-          value: "setup",
+          value: "auth",
           hint: isAuthenticated(cfg) ? "Re-authenticate" : undefined,
         },
         {
@@ -69,8 +68,8 @@ export async function runTUI(): Promise<void> {
     }
 
     switch (action) {
-      case "setup":
-        await runSetup();
+      case "auth":
+        await handleAuthenticate(cfg);
         break;
       case "deployments":
         await handleDeployments(cfg);
@@ -187,6 +186,51 @@ async function handleMCPRemove(_cfg: ReturnType<typeof loadConfig>): Promise<voi
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
     p.log.error(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<void> {
+  if (cfg.access_token) {
+    const s = p.spinner();
+    s.start("Verifying session...");
+    try {
+      const apiClient = new Client(cfg);
+      const resp = await apiClient.doRequestRaw("GET", "/v1/mcp/deployments");
+      if (resp.status === 200) {
+        s.stop("Already authenticated.");
+        return;
+      }
+      try {
+        await apiClient.refreshToken();
+        s.stop("Session refreshed.");
+        return;
+      } catch {
+        // refresh failed, fall through to login
+      }
+      s.stop("Session expired.");
+    } catch {
+      s.stop("Verification failed.");
+    }
+  }
+
+  const shouldLogin = await p.confirm({ message: "Open browser to log in?" });
+  if (p.isCancel(shouldLogin) || !shouldLogin) return;
+
+  try {
+    const { startOAuthFlow } = await import("../auth/flow");
+    const s = p.spinner();
+    s.start("Waiting for authentication...");
+    const token = await startOAuthFlow(undefined, "/cli/auth");
+    s.stop("Authenticated");
+
+    cfg.access_token = token.access_token;
+    cfg.refresh_token = token.refresh_token;
+    cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
+    cfg.mode = token.mode === MODE_OSS ? MODE_OSS : undefined;
+    saveConfig(cfg);
+  } catch (err: unknown) {
+    /* v8 ignore next -- err is always Error in practice */
+    p.log.error(`Authentication failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -7,7 +7,7 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { Client } from "../client/client";
-import { MODE_OSS, isAuthenticated, loadConfig, saveConfig } from "../config/config";
+import { isAuthenticated, loadConfig, MODE_OSS, saveConfig } from "../config/config";
 
 const LOGO = `
  /$$$$$$$


### PR DESCRIPTION
## Summary
- The TUI menu's "Authenticate" option was calling `runSetup()`, which ran the entire setup wizard (org/deployment selection, API key minting, tool detection, MCP configuration)
- Replaced with a dedicated `handleAuthenticate()` that only verifies the session or opens the browser for login, then returns to the main menu
- Updated tests to match the new auth-only behavior

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` — 304 tests pass
- [ ] Manual: `bun run dev` → Clear Credentials → Authenticate → should auth and return to menu, not run full setup