### PR TITLE
refactor: rename 'deployment' to 'MCP' in select prompts

### DIFF
--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -728,7 +728,7 @@ describe("runSetup integration", () => {
     await runSetup();
 
     expect(p.select).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Select a deployment" }),
+      expect.objectContaining({ message: "Select an MCP" }),
     );
     const saved = loadConfig();
     expect(saved.deployment_id).toBe("d2");

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -727,9 +727,7 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(p.select).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Select an MCP" }),
-    );
+    expect(p.select).toHaveBeenCalledWith(expect.objectContaining({ message: "Select an MCP" }));
     const saved = loadConfig();
     expect(saved.deployment_id).toBe("d2");
   });

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -242,7 +242,7 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
       return deployments[0];
     }
     const selected = await p.select({
-      message: "Select a deployment",
+      message: "Select an MCP",
       options: deployments.map((d) => ({ label: d.name, value: d.deployment_id })),
     });
     if (p.isCancel(selected)) return null;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -44,7 +44,7 @@ export async function runTUI(): Promise<void> {
           hint: isAuthenticated(cfg) ? "Re-authenticate" : undefined,
         },
         {
-          label: "Choose Deployment",
+          label: "Choose MCP",
           value: "deployments",
           hint: !isAuthenticated(cfg) ? "Login first" : undefined,
         },
@@ -112,7 +112,7 @@ async function handleDeployments(cfg: ReturnType<typeof loadConfig>): Promise<vo
     }
 
     const selected = await p.select({
-      message: "Select a deployment",
+      message: "Select an MCP",
       options: deployments.map((d) => ({
         label: `${d.name} ${pc.dim(`(${d.org_name})`)}`,
         value: d.deployment_id,


### PR DESCRIPTION
## Summary
- Renamed "Choose Deployment" → "Choose MCP" in the TUI main menu
- Renamed "Select a deployment" → "Select an MCP" in TUI deployment handler and setup flow
- Updated corresponding test expectation

## Test plan
- [ ] Run `bun run test` to verify tests pass
- [ ] Run `dosu` and confirm the TUI menu shows "Choose MCP"
- [ ] Run `dosu setup` and confirm the deployment selection prompt says "Select an MCP"

🤖 Generated with [Claude Code](https://claude.com/claude-code)