### PR TITLE
Improve setup guidance prompts

### DIFF
--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -390,8 +390,8 @@ export function stepShowSummary(results: ConfigResult[], mode?: SetupMode): void
   if (installed.length > 0 || skipped.length > 0) {
     const prompt =
       mode === MODE_OSS
-        ? `What can I do with the Dosu MCP?`
-        : `Use Dosu to search our team's documentation and answer: what are the main components of our system?`;
+        ? `What can Dosu MCP help me do in this repo? Briefly explain, then tell me the main components, request flow, and where to start.`
+        : `I'm new to this codebase. Give me a 5-minute mental model: main services, request flow, where to start.`;
     p.log.message(`Try it out! Paste this into your agent:\n\n${info(prompt)}`);
   }
 }


### PR DESCRIPTION
## Summary
- Update setup onboarding prompts to better guide first-time users when MCP setup completes.
- For OSS mode, the prompt now asks for a brief repo-oriented explanation including components, request flow, and starting points.
- For non-OSS mode, the prompt now requests a 5-minute mental model of services, request flow, and where to begin.

## Notes
Only the summary prompt strings in `src/setup/flow.ts` were changed. Existing behavior for display and wiring is unchanged.
