### PR TITLE
fix(setup): clear OSS mode when selecting a deployment

### DIFF
--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -609,6 +609,44 @@ describe("runSetup integration", () => {
     expect(savedCfg.deployment_name).toBe("Deploy2");
   });
 
+  it("clears OSS mode when re-running setup with a specific deployment", async () => {
+    const cfg = makeCfg({
+      mode: "oss",
+      deployment_id: undefined,
+      deployment_name: undefined,
+    });
+    saveConfig(cfg);
+
+    const clientMethods = setupAuthenticatedClient({
+      getDeployments: vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
+        { deployment_id: "d2", name: "Deploy2", org_id: "o1", org_name: "Org1" },
+      ]),
+      validateAPIKey: vi.fn().mockResolvedValue(false),
+      createAPIKey: vi.fn().mockResolvedValue({ api_key: "fresh-key" }),
+    });
+
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+
+    await runSetup({ deploymentID: "d2" });
+
+    expect(clientMethods.getDeployments).toHaveBeenCalled();
+    expect(p.select).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("open-source libraries") }),
+    );
+
+    const savedCfg = loadConfig();
+    expect(savedCfg.mode).toBeUndefined();
+    expect(savedCfg.deployment_id).toBe("d2");
+    expect(savedCfg.api_key).toBe("fresh-key");
+
+    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp/deployments/d2");
+    expect(cursorConfig.mcpServers.dosu.url).not.toBe("https://api.dosu.dev/v1/mcp");
+  });
+
   it("creates new API key when existing one is invalid", async () => {
     const cfg = makeCfg({ api_key: "bad-key" });
     saveConfig(cfg);

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -40,7 +40,6 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     // --deployment flag provided, use specified deployment
     const d = await stepResolveDeployment(apiClient, opts.deploymentID);
     if (!d) return;
-    // Selecting a concrete deployment exits OSS mode and restores deployment-scoped MCP config.
     cfg.mode = undefined;
     cfg.deployment_id = d.deployment_id;
     cfg.deployment_name = d.name;

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -40,6 +40,8 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     // --deployment flag provided, use specified deployment
     const d = await stepResolveDeployment(apiClient, opts.deploymentID);
     if (!d) return;
+    // Selecting a concrete deployment exits OSS mode and restores deployment-scoped MCP config.
+    cfg.mode = undefined;
     cfg.deployment_id = d.deployment_id;
     cfg.deployment_name = d.name;
   } else if (cfg.mode === MODE_OSS) {
@@ -55,6 +57,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     if (!org) return;
     const d = await stepSelectDeployment(apiClient, org);
     if (!d) return;
+    cfg.mode = undefined;
     cfg.deployment_id = d.deployment_id;
     cfg.deployment_name = d.name;
   }


### PR DESCRIPTION
## Summary
- Clears `cfg.mode` when re-running setup with `--deployment` flag or when interactively selecting a deployment, so stale OSS mode doesn't persist
- Ensures MCP config is written with the correct deployment-scoped URL instead of the generic OSS endpoint
- Adds a test verifying that a config previously in OSS mode gets properly reset when a specific deployment is chosen

## Test plan
- [x] New test: `clears OSS mode when re-running setup with a specific deployment`
- [ ] Run `bun run test` — all tests pass
- [ ] Manual: run `dosu setup --deployment <id>` from an OSS-mode config and verify the resulting MCP URLs are deployment-scoped