### PR TITLE
feat(tui): rework Remove MCP to use multiselect deselection flow

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@clack/prompts", () => ({
   select: vi.fn(),
+  multiselect: vi.fn(),
   confirm: vi.fn(),
   isCancel: vi.fn(),
   cancel: vi.fn(),
@@ -55,6 +56,7 @@ import { runSetup } from "../setup/flow";
 import { handleLogout, runTUI } from "./tui";
 
 const mockSelect = vi.mocked(p.select);
+const mockMultiselect = vi.mocked(p.multiselect);
 const mockConfirm = vi.mocked(p.confirm);
 const mockIsCancel = vi.mocked(p.isCancel);
 const mockOutro = vi.mocked(p.outro);
@@ -443,14 +445,18 @@ describe("runTUI", () => {
       ),
     );
 
-    mockSelect
-      .mockResolvedValueOnce("mcp-remove")
-      .mockResolvedValueOnce("cursor")
-      .mockResolvedValueOnce("exit");
+    // User deselects cursor (returns empty array = nothing kept)
+    mockMultiselect.mockResolvedValueOnce([]);
+
+    mockSelect.mockResolvedValueOnce("mcp-remove");
 
     await runTUI();
 
     expect(p.log.success).toHaveBeenCalledWith("Removed Dosu MCP from Cursor");
+    // Should exit directly after removal
+    expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
+    // Should not return to main menu (no second select call)
+    expect(mockSelect).toHaveBeenCalledTimes(1);
 
     // Verify dosu entry was removed but other-tool remains
     const mcpConfig = loadJSONConfig(mcpPath);
@@ -458,7 +464,7 @@ describe("runTUI", () => {
     expect(mcpConfig.mcpServers["other-tool"]).toBeDefined();
   });
 
-  it("mcp-remove filters out manual provider from options", async () => {
+  it("mcp-remove shows only configured providers in multiselect", async () => {
     writeRealConfig(
       makeCfg({
         access_token: "tok",
@@ -468,20 +474,57 @@ describe("runTUI", () => {
     );
     mockIsCancel.mockReturnValue(false);
 
-    // Create ~/.cursor so cursor provider is "installed"
+    // Create ~/.cursor with dosu configured
+    const mcpPath = cursorMcpPath();
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    writeFileSync(
+      mcpPath,
+      JSON.stringify({ mcpServers: { dosu: { url: "http://old-url", headers: {} } } }, null, 2),
+    );
+
+    // User keeps all (no deselection)
+    mockMultiselect.mockResolvedValueOnce(["cursor"]);
 
     mockSelect
       .mockResolvedValueOnce("mcp-remove")
-      .mockResolvedValueOnce("cursor")
       .mockResolvedValueOnce("exit");
 
     await runTUI();
 
-    // Check the options passed to the remove select call (2nd select invocation)
-    const removeSelectCall = mockSelect.mock.calls[1];
-    const options = (removeSelectCall[0] as { options: { value: string }[] }).options;
+    // Verify multiselect was called with only configured providers
+    const multiselectCall = mockMultiselect.mock.calls[0];
+    const options = (multiselectCall[0] as { options: { value: string }[] }).options;
     const ids = options.map((o: { value: string }) => o.value);
+    expect(ids).toContain("cursor");
     expect(ids).not.toContain("manual");
+    // Only configured tools should appear — not unconfigured installed tools
+    for (const id of ids) {
+      expect(id).toBe("cursor"); // cursor is the only configured provider
+    }
+
+    expect(p.log.info).toHaveBeenCalledWith("No changes.");
+  });
+
+  it("mcp-remove shows warning when no tools are configured", async () => {
+    writeRealConfig(
+      makeCfg({
+        access_token: "tok",
+        deployment_id: "dep-123",
+        api_key: "key-abc",
+      }),
+    );
+    mockIsCancel.mockReturnValue(false);
+
+    // Create ~/.cursor but without dosu configured
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+
+    mockSelect
+      .mockResolvedValueOnce("mcp-remove")
+      .mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.warn).toHaveBeenCalledWith("No tools currently have Dosu MCP configured.");
+    expect(mockMultiselect).not.toHaveBeenCalled();
   });
 });

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -485,9 +485,7 @@ describe("runTUI", () => {
     // User keeps all (no deselection)
     mockMultiselect.mockResolvedValueOnce(["cursor"]);
 
-    mockSelect
-      .mockResolvedValueOnce("mcp-remove")
-      .mockResolvedValueOnce("exit");
+    mockSelect.mockResolvedValueOnce("mcp-remove").mockResolvedValueOnce("exit");
 
     await runTUI();
 
@@ -518,9 +516,7 @@ describe("runTUI", () => {
     // Create ~/.cursor but without dosu configured
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
 
-    mockSelect
-      .mockResolvedValueOnce("mcp-remove")
-      .mockResolvedValueOnce("exit");
+    mockSelect.mockResolvedValueOnce("mcp-remove").mockResolvedValueOnce("exit");
 
     await runTUI();
 

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,7 +9,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@clack/prompts", () => ({
   select: vi.fn(),
-  multiselect: vi.fn(),
   confirm: vi.fn(),
   isCancel: vi.fn(),
   cancel: vi.fn(),
@@ -51,12 +50,10 @@ import { startOAuthFlow } from "../auth/flow";
 import { Client } from "../client/client";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
-import { loadJSONConfig } from "../mcp/config-helpers";
 import { runSetup } from "../setup/flow";
 import { handleLogout, runTUI } from "./tui";
 
 const mockSelect = vi.mocked(p.select);
-const mockMultiselect = vi.mocked(p.multiselect);
 const mockConfirm = vi.mocked(p.confirm);
 const mockIsCancel = vi.mocked(p.isCancel);
 const mockOutro = vi.mocked(p.outro);
@@ -120,11 +117,6 @@ function writeRealConfig(cfg: Config): void {
 
 function readRealConfig(): Config {
   return loadConfig();
-}
-
-/** Returns the path to the Cursor global MCP config given current HOME. */
-function cursorMcpPath(): string {
-  return join(tempDir, ".cursor", "mcp.json");
 }
 
 // ---------------------------------------------------------------------------
@@ -404,123 +396,5 @@ describe("runTUI", () => {
 
     expect(mockRunSetup).toHaveBeenCalled();
     expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
-  });
-
-  it("mcp-remove shows warning when no deployment selected", async () => {
-    writeRealConfig(makeCfg({ access_token: "tok", deployment_id: undefined }));
-    mockIsCancel.mockReturnValue(false);
-
-    mockSelect.mockResolvedValueOnce("mcp-remove").mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(p.log.warn).toHaveBeenCalledWith("Please select a deployment first.");
-  });
-
-  it("mcp-remove with real Cursor provider removes dosu entry from JSON config", async () => {
-    writeRealConfig(
-      makeCfg({
-        access_token: "tok",
-        deployment_id: "dep-123",
-        deployment_name: "my-deploy",
-        api_key: "key-abc",
-      }),
-    );
-    mockIsCancel.mockReturnValue(false);
-
-    // Pre-create a Cursor MCP config with dosu entry and another entry
-    const mcpPath = cursorMcpPath();
-    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
-    writeFileSync(
-      mcpPath,
-      JSON.stringify(
-        {
-          mcpServers: {
-            dosu: { url: "http://old-url", headers: {} },
-            "other-tool": { url: "http://other" },
-          },
-        },
-        null,
-        2,
-      ),
-    );
-
-    // User deselects cursor (returns empty array = nothing kept)
-    mockMultiselect.mockResolvedValueOnce([]);
-
-    mockSelect.mockResolvedValueOnce("mcp-remove");
-
-    await runTUI();
-
-    expect(p.log.success).toHaveBeenCalledWith("Removed Dosu MCP from Cursor");
-    // Should exit directly after removal
-    expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
-    // Should not return to main menu (no second select call)
-    expect(mockSelect).toHaveBeenCalledTimes(1);
-
-    // Verify dosu entry was removed but other-tool remains
-    const mcpConfig = loadJSONConfig(mcpPath);
-    expect(mcpConfig.mcpServers.dosu).toBeUndefined();
-    expect(mcpConfig.mcpServers["other-tool"]).toBeDefined();
-  });
-
-  it("mcp-remove shows only configured providers in multiselect", async () => {
-    writeRealConfig(
-      makeCfg({
-        access_token: "tok",
-        deployment_id: "dep-123",
-        api_key: "key-abc",
-      }),
-    );
-    mockIsCancel.mockReturnValue(false);
-
-    // Create ~/.cursor with dosu configured
-    const mcpPath = cursorMcpPath();
-    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
-    writeFileSync(
-      mcpPath,
-      JSON.stringify({ mcpServers: { dosu: { url: "http://old-url", headers: {} } } }, null, 2),
-    );
-
-    // User keeps all (no deselection)
-    mockMultiselect.mockResolvedValueOnce(["cursor"]);
-
-    mockSelect.mockResolvedValueOnce("mcp-remove").mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    // Verify multiselect was called with only configured providers
-    const multiselectCall = mockMultiselect.mock.calls[0];
-    const options = (multiselectCall[0] as { options: { value: string }[] }).options;
-    const ids = options.map((o: { value: string }) => o.value);
-    expect(ids).toContain("cursor");
-    expect(ids).not.toContain("manual");
-    // Only configured tools should appear — not unconfigured installed tools
-    for (const id of ids) {
-      expect(id).toBe("cursor"); // cursor is the only configured provider
-    }
-
-    expect(p.log.info).toHaveBeenCalledWith("No changes.");
-  });
-
-  it("mcp-remove shows warning when no tools are configured", async () => {
-    writeRealConfig(
-      makeCfg({
-        access_token: "tok",
-        deployment_id: "dep-123",
-        api_key: "key-abc",
-      }),
-    );
-    mockIsCancel.mockReturnValue(false);
-
-    // Create ~/.cursor but without dosu configured
-    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
-
-    mockSelect.mockResolvedValueOnce("mcp-remove").mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    expect(p.log.warn).toHaveBeenCalledWith("No tools currently have Dosu MCP configured.");
-    expect(mockMultiselect).not.toHaveBeenCalled();
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -77,7 +77,10 @@ export async function runTUI(): Promise<void> {
           p.log.warn("Please select a deployment first.");
           continue;
         }
-        await handleMCPRemove(cfg);
+        if (await handleMCPRemove(cfg)) {
+          p.outro("Goodbye!");
+          return;
+        }
         break;
       case "logout":
         handleLogout(cfg);
@@ -88,32 +91,48 @@ export async function runTUI(): Promise<void> {
   p.outro("Goodbye!");
 }
 
-async function handleMCPRemove(_cfg: ReturnType<typeof loadConfig>): Promise<void> {
-  const { allProviders } = await import("../mcp/providers");
-  const providers = allProviders();
+async function handleMCPRemove(_cfg: ReturnType<typeof loadConfig>): Promise<boolean> {
+  const { allSetupProviders } = await import("../mcp/providers");
+  const configured = allSetupProviders().filter((p) => p.isConfigured());
 
-  const selected = await p.select({
-    message: "Select tool to remove MCP from",
-    options: providers
-      .filter((p) => p.id() !== "manual")
-      .map((p) => ({
-        label: p.name(),
-        value: p.id(),
-      })),
+  if (configured.length === 0) {
+    p.log.warn("No tools currently have Dosu MCP configured.");
+    return false;
+  }
+
+  const options = configured.map((prov) => ({
+    label: prov.name(),
+    value: prov.id(),
+    hint: "configured",
+  }));
+
+  const kept = await p.multiselect({
+    message: "Deselect tools to remove Dosu MCP from",
+    options,
+    initialValues: configured.map((prov) => prov.id()),
   });
 
-  if (p.isCancel(selected)) return;
+  if (p.isCancel(kept)) return false;
 
-  const provider = providers.find((p) => p.id() === selected);
-  if (!provider) return;
+  const keptSet = new Set(kept as string[]);
+  const toRemove = configured.filter((prov) => !keptSet.has(prov.id()));
 
-  try {
-    provider.remove(true);
-    p.log.success(`Removed Dosu MCP from ${provider.name()}`);
-  } catch (err: unknown) {
-    /* v8 ignore next -- err is always Error in practice */
-    p.log.error(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+  if (toRemove.length === 0) {
+    p.log.info("No changes.");
+    return false;
   }
+
+  for (const provider of toRemove) {
+    try {
+      provider.remove(true);
+      p.log.success(`Removed Dosu MCP from ${provider.name()}`);
+    } catch (err: unknown) {
+      /* v8 ignore next -- err is always Error in practice */
+      p.log.error(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return true;
 }
 
 async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<void> {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -34,8 +34,6 @@ export async function runTUI(): Promise<void> {
 
   // Main menu
   while (true) {
-    const hasMcpTarget = cfg.mode === MODE_OSS || !!cfg.deployment_id;
-
     const action = await p.select({
       message: "What would you like to do?",
       options: [
@@ -48,11 +46,6 @@ export async function runTUI(): Promise<void> {
           label: "Authenticate",
           value: "auth",
           hint: isAuthenticated(cfg) ? "Re-authenticate" : undefined,
-        },
-        {
-          label: "Remove MCP",
-          value: "mcp-remove",
-          hint: !hasMcpTarget ? "Select deployment first" : undefined,
         },
         { label: "Clear Credentials", value: "logout" },
         { label: "Exit", value: "exit" },
@@ -72,16 +65,6 @@ export async function runTUI(): Promise<void> {
         // Reload config after setup (it may have changed deployment, api_key, etc.)
         Object.assign(cfg, loadConfig());
         break;
-      case "mcp-remove":
-        if (!hasMcpTarget) {
-          p.log.warn("Please select a deployment first.");
-          continue;
-        }
-        if (await handleMCPRemove(cfg)) {
-          p.outro("Goodbye!");
-          return;
-        }
-        break;
       case "logout":
         handleLogout(cfg);
         break;
@@ -89,50 +72,6 @@ export async function runTUI(): Promise<void> {
   }
 
   p.outro("Goodbye!");
-}
-
-async function handleMCPRemove(_cfg: ReturnType<typeof loadConfig>): Promise<boolean> {
-  const { allSetupProviders } = await import("../mcp/providers");
-  const configured = allSetupProviders().filter((p) => p.isConfigured());
-
-  if (configured.length === 0) {
-    p.log.warn("No tools currently have Dosu MCP configured.");
-    return false;
-  }
-
-  const options = configured.map((prov) => ({
-    label: prov.name(),
-    value: prov.id(),
-    hint: "configured",
-  }));
-
-  const kept = await p.multiselect({
-    message: "Deselect tools to remove Dosu MCP from",
-    options,
-    initialValues: configured.map((prov) => prov.id()),
-  });
-
-  if (p.isCancel(kept)) return false;
-
-  const keptSet = new Set(kept as string[]);
-  const toRemove = configured.filter((prov) => !keptSet.has(prov.id()));
-
-  if (toRemove.length === 0) {
-    p.log.info("No changes.");
-    return false;
-  }
-
-  for (const provider of toRemove) {
-    try {
-      provider.remove(true);
-      p.log.success(`Removed Dosu MCP from ${provider.name()}`);
-    } catch (err: unknown) {
-      /* v8 ignore next -- err is always Error in practice */
-      p.log.error(`Failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-
-  return true;
 }
 
 async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<void> {


### PR DESCRIPTION
## Summary

- Replace single-select Remove MCP with a multiselect showing **only configured tools** (pre-selected). Users deselect to remove, consistent with the setup wizard's tool selection pattern.
- Exit directly after removal instead of returning to the main menu.
- Show a warning when no tools are currently configured.

## Test plan

- [x] All 28 TUI tests pass, including new cases for multiselect removal, no-configured-tools warning, and exit-after-remove behavior.