### PR TITLE
feat: add persistent debug logging and --debug flag

### DIFF
--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -22,6 +22,17 @@ vi.mock("../config/constants", () => ({
   getWebAppURL: mockGetWebAppURL,
 }));
 
+vi.mock("../debug/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    getLogPath: vi.fn(() => "/tmp/test-debug.log"),
+  },
+}));
+
 import { startOAuthFlow } from "./flow";
 
 function createMockServer(): CallbackServer {

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -3,6 +3,7 @@
  */
 
 import { getWebAppURL } from "../config/constants";
+import { logger } from "../debug/logger";
 import { startCallbackServer, type TokenResponse } from "./server";
 
 /**
@@ -22,30 +23,42 @@ export async function startOAuthFlow(
 
   try {
     const callbackURL = `http://localhost:${server.port}/callback`;
+    logger.debug("auth.flow", `Callback URL: ${callbackURL}`);
     const authURL = buildAuthURL(callbackURL, path);
+    logger.info("auth.flow", `Auth URL: ${authURL}`);
 
     // Open browser — dynamic import to avoid bundling issues
     const open = await import("open");
     await open.default(authURL);
+    logger.info("auth.flow", "Browser open command executed");
 
     // Race: token, abort, or timeout
     const timeout = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(
-        () => reject(new Error("authentication timeout - please try again")),
+        () => {
+          logger.warn("auth.flow", "Authentication timed out (15min)");
+          reject(new Error("authentication timeout - please try again"));
+        },
         15 * 60 * 1000,
       );
     });
 
     const abort = signal
       ? new Promise<never>((_, reject) => {
-          signal.addEventListener("abort", () => reject(new Error("authentication cancelled")));
+          signal.addEventListener("abort", () => {
+            logger.warn("auth.flow", "Authentication cancelled via abort");
+            reject(new Error("authentication cancelled"));
+          });
         })
       : new Promise<never>(() => {}); // never resolves
 
-    return await Promise.race([tokenPromise, timeout, abort]);
+    const token = await Promise.race([tokenPromise, timeout, abort]);
+    logger.info("auth.flow", "Token received");
+    return token;
   } finally {
     clearTimeout(timeoutId);
     server.close();
+    logger.debug("auth.flow", "Cleaning up: timeout cleared, server closed");
   }
 }
 

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -1,5 +1,16 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { type CallbackServer, startCallbackServer } from "./server";
+
+vi.mock("../debug/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    getLogPath: vi.fn(() => "/tmp/test-debug.log"),
+  },
+}));
 
 describe("auth callback server", () => {
   let server: CallbackServer | null = null;

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -3,6 +3,7 @@
  */
 
 import { MODE_OSS, type SetupMode } from "../config/config";
+import { logger } from "../debug/logger";
 
 export interface TokenResponse {
   access_token: string;
@@ -183,7 +184,15 @@ export async function startCallbackServer(): Promise<{
   const httpServer = http.createServer((req, res) => {
     const url = new URL(req.url ?? "/", `http://localhost`);
 
+    const cookieLen = (req.headers.cookie ?? "").length;
+    const ua = req.headers["user-agent"] ?? "none";
+    logger.debug(
+      "auth.server",
+      `Request: ${req.method} ${req.url} cookie-len=${cookieLen} ua=${ua} has-token=${url.searchParams.has("access_token")}`,
+    );
+
     if (url.pathname !== "/callback") {
+      logger.debug("auth.server", `404: ${url.pathname}`);
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found");
       return;
@@ -196,6 +205,7 @@ export async function startCallbackServer(): Promise<{
     const mode = url.searchParams.get("mode");
 
     if (!accessToken) {
+      logger.debug("auth.server", "Served extract HTML (no token in query)");
       res.writeHead(200, { "Content-Type": "text/html" });
       res.end(CALLBACK_HTML_EXTRACT);
       return;
@@ -208,6 +218,7 @@ export async function startCallbackServer(): Promise<{
       if (!Number.isNaN(parsed)) expiresInInt = parsed;
     }
 
+    logger.info("auth.server", `Token resolved, email=${email ?? "none"}`);
     resolveToken?.({
       access_token: accessToken,
       refresh_token: refreshToken && refreshToken !== "null" ? refreshToken : "",
@@ -216,6 +227,7 @@ export async function startCallbackServer(): Promise<{
       ...(mode === MODE_OSS && { mode: MODE_OSS }),
     });
 
+    logger.info("auth.server", "Served success HTML");
     res.writeHead(200, { "Content-Type": "text/html" });
     res.end(buildSuccessHtml(email ?? undefined));
   });
@@ -225,6 +237,7 @@ export async function startCallbackServer(): Promise<{
     httpServer.listen(0, "localhost", () => resolve());
   });
   const addr = httpServer.address() as import("node:net").AddressInfo;
+  logger.info("auth.server", `Callback server listening on port ${addr.port}`);
 
   return {
     server: {

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -24,6 +24,21 @@ vi.mock("../setup/flow", () => ({
   runSetup: (...args: unknown[]) => mockRunSetup(...args),
 }));
 
+const { mockLoggerGetLogPath } = vi.hoisted(() => ({
+  mockLoggerGetLogPath: vi.fn(),
+}));
+vi.mock("../debug/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    getLogPath: mockLoggerGetLogPath,
+    _resetForTesting: vi.fn(),
+  },
+}));
+
 // ── Temp dir + env management ───────────────────────────────────────────────
 
 let tempDir: string;
@@ -39,6 +54,7 @@ beforeEach(() => {
   process.env.HOME = tempDir;
 
   vi.clearAllMocks();
+  mockLoggerGetLogPath.mockReturnValue(join(tempDir, "dosu-cli", "debug.log"));
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 });
 
@@ -384,6 +400,48 @@ describe("CLI actions", () => {
       expect(mockRunSetup).toHaveBeenCalledWith({
         deploymentID: "dep_456",
       });
+    });
+  });
+
+  // ── logs ────────────────────────────────────────────────────────────────
+
+  describe("logs", () => {
+    it("prints log file path with no flags", async () => {
+      await run("logs");
+      const output = allLogOutput();
+      expect(output).toContain(join(tempDir, "dosu-cli", "debug.log"));
+    });
+
+    it("--clear deletes the log file", async () => {
+      const logDir = join(tempDir, "dosu-cli");
+      mkdirSync(logDir, { recursive: true });
+      writeFileSync(join(logDir, "debug.log"), "test log content");
+
+      await run("logs", "--clear");
+      expect(logSpy).toHaveBeenCalledWith("Log file deleted.");
+    });
+
+    it("--clear prints message when no file exists", async () => {
+      await run("logs", "--clear");
+      expect(logSpy).toHaveBeenCalledWith("No log file to delete.");
+    });
+
+    it("--tail shows last N lines", async () => {
+      const logDir = join(tempDir, "dosu-cli");
+      mkdirSync(logDir, { recursive: true });
+      const lines = Array.from({ length: 100 }, (_, i) => `line ${i}`).join("\n");
+      writeFileSync(join(logDir, "debug.log"), lines);
+
+      await run("logs", "--tail", "5");
+      const output = allLogOutput();
+      expect(output).toContain("line 99");
+      expect(output).toContain("line 95");
+    });
+
+    it("--tail prints message when no file exists", async () => {
+      await run("logs", "--tail");
+      const output = allLogOutput();
+      expect(output).toContain("No log file found");
     });
   });
 });

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -66,4 +66,19 @@ describe("CLI", () => {
     const globalOpt = addCmd?.options.find((o) => o.long === "--global");
     expect(globalOpt).toBeDefined();
   });
+
+  it("has --debug global option", () => {
+    const program = createProgram();
+    const debugOpt = program.options.find((o) => o.long === "--debug");
+    expect(debugOpt).toBeDefined();
+  });
+
+  it("has logs command with --tail and --clear options", () => {
+    const program = createProgram();
+    const cmd = program.commands.find((c) => c.name() === "logs");
+    expect(cmd).toBeDefined();
+    expect(cmd?.description()).toContain("debug logs");
+    expect(cmd?.options.find((o) => o.long === "--tail")).toBeDefined();
+    expect(cmd?.options.find((o) => o.long === "--clear")).toBeDefined();
+  });
 });

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,4 +1,16 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../debug/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    getLogPath: vi.fn(() => "/tmp/test-debug.log"),
+  },
+}));
+
 import { createProgram } from "./cli";
 
 describe("CLI", () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -2,6 +2,7 @@
  * CLI command definitions using Commander.
  */
 
+import { readFileSync, unlinkSync } from "node:fs";
 import { Command } from "commander";
 import {
   getConfigPath,
@@ -11,6 +12,7 @@ import {
   MODE_OSS,
   saveConfig,
 } from "../config/config";
+import { logger } from "../debug/logger";
 import { allProviders, getProvider, type Provider } from "../mcp/providers";
 import { getVersionString } from "../version/version";
 
@@ -21,6 +23,11 @@ export function createProgram(): Command {
     .name("dosu")
     .description("Dosu CLI - Manage MCP servers for AI tools")
     .version(getVersionString(), "-v, --version")
+    .option("--debug", "Enable debug logging to stderr", false)
+    .hook("preAction", (thisCommand) => {
+      const opts = thisCommand.optsWithGlobals();
+      logger.init({ debug: opts.debug });
+    })
     .action(async () => {
       // Default: launch TUI when no subcommand given
       const { runTUI } = await import("../tui/tui");
@@ -175,6 +182,41 @@ export function createProgram(): Command {
     .action(async (opts: { deployment?: string }) => {
       const { runSetup } = await import("../setup/flow");
       await runSetup({ deploymentID: opts.deployment });
+    });
+
+  // logs
+  program
+    .command("logs")
+    .description("View or manage debug logs")
+    .option("-t, --tail [n]", "Show last N lines (default: 50)")
+    .option("--clear", "Delete the log file")
+    .action((opts: { tail?: string | true; clear?: boolean }) => {
+      const logPath = logger.getLogPath();
+
+      if (opts.clear) {
+        try {
+          unlinkSync(logPath);
+          console.log("Log file deleted.");
+        } catch {
+          console.log("No log file to delete.");
+        }
+        return;
+      }
+
+      if (opts.tail !== undefined) {
+        const n = typeof opts.tail === "string" ? parseInt(opts.tail, 10) || 50 : 50;
+        try {
+          const content = readFileSync(logPath, "utf-8");
+          const lines = content.split("\n");
+          console.log(lines.slice(-n).join("\n"));
+        } catch {
+          console.log(`No log file found at ${logPath}`);
+        }
+        return;
+      }
+
+      // No flags: print log file path
+      console.log(logPath);
     });
 
   return program;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,7 +19,7 @@ export interface Config {
   mode?: SetupMode;
 }
 
-function getConfigDir(): string {
+export function getConfigDir(): string {
   const xdgConfig = process.env.XDG_CONFIG_HOME;
   if (xdgConfig) return join(xdgConfig, "dosu-cli");
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,7 @@ export {
   type Config,
   clearConfig,
   emptyConfig,
+  getConfigDir,
   getConfigPath,
   isAuthenticated,
   isTokenExpired,

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,0 +1,1 @@
+export { logger } from "./logger";

--- a/src/debug/logger.test.ts
+++ b/src/debug/logger.test.ts
@@ -1,0 +1,155 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "./logger";
+
+let tempDir: string;
+let origXDG: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-logger-test-"));
+  origXDG = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = tempDir;
+  logger._resetForTesting();
+});
+
+afterEach(() => {
+  if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
+  else delete process.env.XDG_CONFIG_HOME;
+  rmSync(tempDir, { recursive: true, force: true });
+  logger._resetForTesting();
+});
+
+function logPath(): string {
+  return join(tempDir, "dosu-cli", "debug.log");
+}
+
+describe("logger", () => {
+  describe("getLogPath", () => {
+    it("returns path ending with dosu-cli/debug.log", () => {
+      const p = logger.getLogPath();
+      expect(p).toBe(logPath());
+    });
+  });
+
+  describe("writing", () => {
+    it("writes log entries to file", () => {
+      logger.info("test", "hello world");
+      const content = readFileSync(logPath(), "utf-8");
+      expect(content).toContain("hello world");
+    });
+
+    it("formats entries as [timestamp] [LEVEL] [module] message", () => {
+      logger.info("mymod", "test message");
+      const content = readFileSync(logPath(), "utf-8");
+      const match = content.match(
+        /\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z\] \[INFO\] \[mymod\] test message/,
+      );
+      expect(match).not.toBeNull();
+    });
+
+    it("supports all four log levels", () => {
+      logger.debug("m", "d");
+      logger.info("m", "i");
+      logger.warn("m", "w");
+      logger.error("m", "e");
+
+      const content = readFileSync(logPath(), "utf-8");
+      expect(content).toContain("[DEBUG]");
+      expect(content).toContain("[INFO]");
+      expect(content).toContain("[WARN]");
+      expect(content).toContain("[ERROR]");
+    });
+  });
+
+  describe("session header", () => {
+    it("writes session header on init", () => {
+      logger.init({});
+      const content = readFileSync(logPath(), "utf-8");
+      expect(content).toContain("Session:");
+      expect(content).toContain(process.platform);
+      expect(content).toContain(process.arch);
+      expect(content).toContain("════");
+    });
+  });
+
+  describe("size control", () => {
+    it("truncates log file when it exceeds 1MB", () => {
+      // Write >1MB of data
+      const bigLine = `${"X".repeat(200)}\n`;
+      const chunk = bigLine.repeat(6000); // ~1.2MB
+      const dir = join(tempDir, "dosu-cli");
+      const { mkdirSync } = require("node:fs");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(logPath(), chunk);
+
+      // Re-init triggers truncation
+      logger._resetForTesting();
+      logger.init({});
+
+      const content = readFileSync(logPath(), "utf-8");
+      // File should be smaller than original but contain the session header
+      expect(content.length).toBeLessThan(chunk.length);
+      expect(content.length).toBeGreaterThan(0);
+      expect(content).toContain("Session:");
+    });
+
+    it("does not truncate when file is under 1MB", () => {
+      logger.init({});
+      logger.info("test", "small entry");
+
+      logger._resetForTesting();
+      logger.init({});
+      const content = readFileSync(logPath(), "utf-8");
+
+      // Original entry preserved, plus a second session header appended
+      expect(content).toContain("small entry");
+      // Two session headers (one from each init)
+      const sessionCount = (content.match(/Session:/g) ?? []).length;
+      expect(sessionCount).toBe(2);
+    });
+  });
+
+  describe("debug console output", () => {
+    it("outputs to stderr when debug is enabled", () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      logger.init({ debug: true });
+      logger.info("test", "visible");
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("visible"));
+      spy.mockRestore();
+    });
+
+    it("does not output to stderr when debug is disabled", () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      logger.init({ debug: false });
+      logger.info("test", "invisible");
+      // spy should only be called for the session header, not for log entries
+      // Actually, console.error is only called by writeEntry, not writeSessionHeader
+      // So check that none of the calls contain "invisible"
+      const calls = spy.mock.calls.map((c) => c.join(" "));
+      expect(calls.every((c) => !c.includes("invisible"))).toBe(true);
+      spy.mockRestore();
+    });
+  });
+
+  describe("graceful degradation", () => {
+    it("does not throw when log path is unwritable", () => {
+      // Point to a path that can't be created
+      process.env.XDG_CONFIG_HOME = "/proc/nonexistent";
+      logger._resetForTesting();
+
+      expect(() => logger.info("test", "should not crash")).not.toThrow();
+    });
+  });
+
+  describe("lazy init", () => {
+    it("creates log file on first write without explicit init", () => {
+      expect(existsSync(logPath())).toBe(false);
+      logger.info("test", "lazy");
+      expect(existsSync(logPath())).toBe(true);
+      const content = readFileSync(logPath(), "utf-8");
+      expect(content).toContain("lazy");
+    });
+  });
+});

--- a/src/debug/logger.test.ts
+++ b/src/debug/logger.test.ts
@@ -135,8 +135,8 @@ describe("logger", () => {
 
   describe("graceful degradation", () => {
     it("does not throw when log path is unwritable", () => {
-      // Point to a path that can't be created
-      process.env.XDG_CONFIG_HOME = "/proc/nonexistent";
+      // Point to a path that can't be created (use /dev/null parent — not a directory)
+      process.env.XDG_CONFIG_HOME = "/dev/null";
       logger._resetForTesting();
 
       expect(() => logger.info("test", "should not crash")).not.toThrow();

--- a/src/debug/logger.ts
+++ b/src/debug/logger.ts
@@ -1,0 +1,140 @@
+/**
+ * Debug logger — persistent file logging with optional stderr output.
+ *
+ * Always writes to ~/.config/dosu-cli/debug.log (or XDG equivalent).
+ * When --debug is passed, also prints to stderr.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import pc from "picocolors";
+import { getConfigDir } from "../config/config";
+import { VERSION } from "../version/version";
+
+type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+const MAX_LOG_SIZE = 1_048_576; // 1 MB
+const TRUNCATE_KEEP = 524_288; // 512 KB
+const LOG_FILENAME = "debug.log";
+
+let initialized = false;
+let debugToConsole = false;
+let logFilePath: string | null = null;
+
+function ensureInit(): void {
+  if (!initialized) {
+    initLogger({});
+  }
+}
+
+function resolveLogPath(): string {
+  if (!logFilePath) {
+    const dir = getConfigDir();
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    logFilePath = join(dir, LOG_FILENAME);
+  }
+  return logFilePath;
+}
+
+function truncateIfNeeded(): void {
+  try {
+    const path = resolveLogPath();
+    if (!existsSync(path)) return;
+    const stat = statSync(path);
+    if (stat.size <= MAX_LOG_SIZE) return;
+
+    const content = readFileSync(path);
+    const start = content.length - TRUNCATE_KEEP;
+    // Find the first newline after the cut point to avoid splitting a line
+    let lineStart = start;
+    while (lineStart < content.length && content[lineStart] !== 0x0a) {
+      lineStart++;
+    }
+    lineStart = Math.min(lineStart + 1, content.length);
+
+    writeFileSync(path, content.subarray(lineStart), { mode: 0o600 });
+  } catch {
+    // Graceful degradation — truncation failure is non-fatal
+  }
+}
+
+function writeSessionHeader(): void {
+  try {
+    const now = new Date().toISOString();
+    const header =
+      "\n════════════════════════════════════════\n" +
+      `Session: ${now} | v${VERSION} | ${process.platform} ${process.arch} | node ${process.version}\n` +
+      "════════════════════════════════════════\n";
+    appendFileSync(resolveLogPath(), header, { mode: 0o600 });
+  } catch {
+    // Graceful degradation
+  }
+}
+
+function initLogger(opts: { debug?: boolean }): void {
+  debugToConsole = opts.debug ?? false;
+  try {
+    resolveLogPath();
+    truncateIfNeeded();
+    writeSessionHeader();
+  } catch {
+    // Graceful degradation — if we can't set up the log file, continue without it
+  }
+  initialized = true;
+}
+
+function writeEntry(level: LogLevel, mod: string, message: string): void {
+  ensureInit();
+  const timestamp = new Date().toISOString();
+  const line = `[${timestamp}] [${level}] [${mod}] ${message}\n`;
+
+  try {
+    appendFileSync(resolveLogPath(), line, { mode: 0o600 });
+  } catch {
+    // Graceful degradation — file write failure is non-fatal
+  }
+
+  if (debugToConsole) {
+    const colorize = {
+      DEBUG: pc.dim,
+      INFO: pc.cyan,
+      WARN: pc.yellow,
+      ERROR: pc.red,
+    }[level];
+    console.error(colorize(line.trimEnd()));
+  }
+}
+
+export const logger = {
+  init: initLogger,
+  getLogPath(): string {
+    return resolveLogPath();
+  },
+  debug(mod: string, message: string): void {
+    writeEntry("DEBUG", mod, message);
+  },
+  info(mod: string, message: string): void {
+    writeEntry("INFO", mod, message);
+  },
+  warn(mod: string, message: string): void {
+    writeEntry("WARN", mod, message);
+  },
+  error(mod: string, message: string): void {
+    writeEntry("ERROR", mod, message);
+  },
+  /** Reset singleton state — test use only. */
+  _resetForTesting(): void {
+    initialized = false;
+    debugToConsole = false;
+    logFilePath = null;
+  },
+};

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -29,6 +29,17 @@ vi.mock("../auth/flow", () => ({
   startOAuthFlow: vi.fn(),
 }));
 
+vi.mock("../debug/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    getLogPath: vi.fn(() => "/tmp/test-debug.log"),
+  },
+}));
+
 vi.mock("../client/client", () => {
   const SessionExpiredError = class extends Error {
     constructor() {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -5,6 +5,7 @@
 import * as p from "@clack/prompts";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
 import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
+import { logger } from "../debug/logger";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
 import { dim, info } from "./styles";
 
@@ -27,6 +28,10 @@ export interface ToolSelection {
 }
 
 export async function runSetup(opts: SetupOptions = {}): Promise<void> {
+  logger.info(
+    "setup",
+    `Setup flow started${opts.deploymentID ? ` deployment=${opts.deploymentID}` : ""}`,
+  );
   p.intro("Dosu CLI Setup");
 
   // Step 1: Authenticate
@@ -94,6 +99,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
 }
 
 async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
+  logger.info("setup", "Step: authenticate");
   const cfg = loadConfig();
 
   // If we have a token, verify it against the backend first
@@ -104,6 +110,7 @@ async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
       const apiClient = new Client(cfg);
       const resp = await apiClient.doRequestRaw("GET", "/v1/mcp/deployments");
       if (resp.status === 200) {
+        logger.info("setup", `Session verified, status=${resp.status}`);
         s.stop("Authenticated");
 
         // If configured for OSS and no --deployment flag, let the user reconfigure
@@ -126,6 +133,7 @@ async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
       }
       // Any non-200 status — try refresh before giving up
       try {
+        logger.debug("setup", "Attempting token refresh");
         await apiClient.refreshToken();
         const resp2 = await apiClient.doRequestRaw("GET", "/v1/mcp/deployments");
         if (resp2.status === 200) {
@@ -136,6 +144,7 @@ async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
         // refresh failed, fall through to login
       }
       s.stop("Session expired");
+      logger.warn("setup", "Session expired");
       p.log.warn("Session expired.");
     } catch {
       s.stop("Session verification failed");
@@ -158,6 +167,7 @@ async function openBrowserForSetup(cfg: Config, opts: SetupOptions): Promise<Con
     const authPath = opts.deploymentID ? "/cli/auth" : "/cli/setup";
     const token = await startOAuthFlow(undefined, authPath);
     s.stop("Authenticated");
+    logger.info("setup", `Browser auth completed, mode=${token.mode ?? "cloud"}`);
 
     cfg.access_token = token.access_token;
     cfg.refresh_token = token.refresh_token;
@@ -167,7 +177,9 @@ async function openBrowserForSetup(cfg: Config, opts: SetupOptions): Promise<Con
     saveConfig(cfg);
     return cfg;
   } catch (err: unknown) {
-    /* v8 ignore next -- err is always Error in practice */
+    /* v8 ignore next 2 -- err is always Error in practice */
+    const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    logger.error("setup", `Auth failed: ${msg}`);
     p.log.error(`Authentication failed: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
@@ -189,6 +201,7 @@ async function stepSelectOrg(apiClient: Client): Promise<Org | null> {
       return null;
     }
     if (orgs.length === 1) {
+      logger.info("setup", `Selected org: ${orgs[0].name} (auto, only one)`);
       p.log.success(`Organization\n${dim(orgs[0].name)}`);
       return orgs[0];
     }
@@ -197,7 +210,9 @@ async function stepSelectOrg(apiClient: Client): Promise<Org | null> {
       options: orgs.map((o) => ({ label: o.name, value: o.org_id })),
     });
     if (p.isCancel(selected)) return null;
-    return orgs.find((o) => o.org_id === selected) ?? null;
+    const org = orgs.find((o) => o.org_id === selected) ?? null;
+    if (org) logger.info("setup", `Selected org: ${org.name}`);
+    return org;
   } catch (err: unknown) {
     if (err instanceof SessionExpiredError) {
       p.log.warn(`Session expired. Please run ${info("dosu setup")} again.`);
@@ -216,9 +231,11 @@ async function stepResolveDeployment(apiClient: Client, id: string): Promise<Dep
     const deployments = await apiClient.getDeployments();
     const d = deployments.find((d) => d.deployment_id === id);
     if (!d) {
+      logger.warn("setup", `Deployment ${id} not found`);
       p.log.error(`Deployment ${id} not found`);
       return null;
     }
+    logger.info("setup", `Resolved deployment: ${d.name}`);
     p.log.success(`Using deployment\n${dim(d.name)}`);
     return d;
   } catch (err: unknown) {
@@ -240,6 +257,7 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
       return null;
     }
     if (deployments.length === 1) {
+      logger.info("setup", `Selected deployment: ${deployments[0].name} (auto, only one)`);
       p.log.success(`Using deployment\n${dim(deployments[0].name)}`);
       return deployments[0];
     }
@@ -248,7 +266,9 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
       options: deployments.map((d) => ({ label: d.name, value: d.deployment_id })),
     });
     if (p.isCancel(selected)) return null;
-    return deployments.find((d) => d.deployment_id === selected) ?? null;
+    const d = deployments.find((d) => d.deployment_id === selected) ?? null;
+    if (d) logger.info("setup", `Selected deployment: ${d.name}`);
+    return d;
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
     p.log.error(`Deployment selection failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -265,6 +285,7 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
   if (cfg.api_key) {
     // biome-ignore lint/style/noNonNullAssertion: checked above
     const valid = await apiClient.validateAPIKey(cfg.api_key, cfg.deployment_id!);
+    logger.debug("setup", `Existing API key valid=${valid}`);
     if (valid) {
       p.log.success(`API key\n${dim("using existing")}`);
       return cfg.api_key;
@@ -275,6 +296,7 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
   try {
     // biome-ignore lint/style/noNonNullAssertion: checked above
     const resp = await apiClient.createAPIKey(cfg.deployment_id!, "dosu-cli");
+    logger.info("setup", "API key created");
     p.log.success(`API key\n${dim("created")}`);
     return resp.api_key;
   } catch (err: unknown) {
@@ -337,10 +359,15 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
   for (const provider of selection.toInstall) {
     try {
       provider.install(cfg, true);
+      logger.info("setup", `Configured ${provider.name()}`);
       results.push({ provider, action: "install" });
     } catch (err: unknown) {
       /* v8 ignore next -- err is always Error in practice */
       const error = err instanceof Error ? err : new Error(String(err));
+      logger.error(
+        "setup",
+        `Config failed for ${provider.name()}: ${error.stack ?? error.message}`,
+      );
       p.log.error(`Failed to configure ${provider.name()}: ${error.message}`);
       results.push({ provider, action: "install", error });
     }
@@ -349,10 +376,15 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
   for (const provider of selection.toRemove) {
     try {
       provider.remove(true);
+      logger.info("setup", `Removed ${provider.name()}`);
       results.push({ provider, action: "remove" });
     } catch (err: unknown) {
       /* v8 ignore next -- err is always Error in practice */
       const error = err instanceof Error ? err : new Error(String(err));
+      logger.error(
+        "setup",
+        `Remove failed for ${provider.name()}: ${error.stack ?? error.message}`,
+      );
       p.log.error(`Failed to remove ${provider.name()}: ${error.message}`);
       results.push({ provider, action: "remove", error });
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     pool: "forks",
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
## Summary

- Adds a persistent debug logger (`src/debug/logger.ts`) that always writes to `~/.config/dosu-cli/debug.log` with automatic 1MB rotation
- Instruments the OAuth callback server, auth flow, and setup wizard with diagnostic logging — captures request details, cookie header size, user-agent, port, timing, and error stack traces to help diagnose the intermittent redirect failure (ENG-74)
- Adds `--debug` global flag to print color-coded logs to stderr in real-time (dim=DEBUG, cyan=INFO, yellow=WARN, red=ERROR)
- Adds `dosu logs` subcommand to view log path, tail logs, or clear the log file

## Test plan
- [x] 11 new tests for logger (write, format, truncation, debug mode, graceful degradation, lazy init)
- [x] 7 new CLI tests for `--debug` option, `logs` command, and `logs` actions (--tail, --clear, no-file cases)
- [x] Logger mocked in all instrumented test files (auth/server, auth/flow, setup/flow, cli-actions)
- [x] Full suite: 327 tests passing, typecheck and lint clean