### PR TITLE
feat: add CLI version update notifications

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -14,6 +14,7 @@ import {
 } from "../config/config";
 import { logger } from "../debug/logger";
 import { allProviders, getProvider, type Provider } from "../mcp/providers";
+import { checkForUpdates } from "../version/update-check";
 import { getVersionString } from "../version/version";
 
 export function createProgram(): Command {
@@ -27,6 +28,7 @@ export function createProgram(): Command {
     .hook("preAction", (thisCommand) => {
       const opts = thisCommand.optsWithGlobals();
       logger.init({ debug: opts.debug });
+      checkForUpdates();
     })
     .action(async () => {
       // Default: launch TUI when no subcommand given

--- a/src/version/update-check.test.ts
+++ b/src/version/update-check.test.ts
@@ -1,0 +1,188 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkForUpdates, fetchLatestVersion, isNewerVersion } from "./update-check";
+
+describe("isNewerVersion", () => {
+  it("returns true when latest is a higher major", () => {
+    expect(isNewerVersion("2.0.0", "1.0.0")).toBe(true);
+  });
+
+  it("returns true when latest is a higher minor", () => {
+    expect(isNewerVersion("1.1.0", "1.0.0")).toBe(true);
+  });
+
+  it("returns true when latest is a higher patch", () => {
+    expect(isNewerVersion("1.0.1", "1.0.0")).toBe(true);
+  });
+
+  it("returns false when versions are equal", () => {
+    expect(isNewerVersion("1.0.0", "1.0.0")).toBe(false);
+  });
+
+  it("returns false when current is newer", () => {
+    expect(isNewerVersion("1.0.0", "2.0.0")).toBe(false);
+    expect(isNewerVersion("1.0.0", "1.1.0")).toBe(false);
+    expect(isNewerVersion("1.0.0", "1.0.1")).toBe(false);
+  });
+
+  it("handles different segment counts", () => {
+    expect(isNewerVersion("1.0.0.1", "1.0.0")).toBe(true);
+    expect(isNewerVersion("1.0.0", "1.0.0.1")).toBe(false);
+  });
+});
+
+describe("fetchLatestVersion", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns latest version from registry", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ latest: "9.9.9" }),
+      }),
+    );
+    const result = await fetchLatestVersion();
+    expect(result).toBe("9.9.9");
+  });
+
+  it("returns null on non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    const result = await fetchLatestVersion();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when response has no latest field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ next: "1.0.0" }),
+      }),
+    );
+    const result = await fetchLatestVersion();
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network failure")));
+    const result = await fetchLatestVersion();
+    expect(result).toBeNull();
+  });
+});
+
+describe("checkForUpdates", () => {
+  let tempDir: string;
+  let origXDG: string | undefined;
+
+  beforeEach(() => {
+    origXDG = process.env.XDG_CONFIG_HOME;
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-update-test-"));
+    process.env.XDG_CONFIG_HOME = tempDir;
+
+    // Stub fetch to prevent real network calls
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ latest: "0.0.1" }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    if (origXDG !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXDG;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("does not print when no cache exists", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForUpdates();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("prints notice when cached version is newer", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cachePath = join(tempDir, "dosu-cli", "update-check.json");
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(cachePath, JSON.stringify({ lastCheck: Date.now(), latestVersion: "99.0.0" }));
+
+    checkForUpdates();
+    expect(spy).toHaveBeenCalled();
+    const output = spy.mock.calls[0][0] as string;
+    expect(output).toContain("Update available");
+    expect(output).toContain("99.0.0");
+  });
+
+  it("does not print when cached version is current or older", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cachePath = join(tempDir, "dosu-cli", "update-check.json");
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(cachePath, JSON.stringify({ lastCheck: Date.now(), latestVersion: "0.0.1" }));
+
+    checkForUpdates();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("fires background fetch when cache is stale", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ latest: "1.2.3" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    const cachePath = join(tempDir, "dosu-cli", "update-check.json");
+    // Cache from 2 days ago
+    writeFileSync(
+      cachePath,
+      JSON.stringify({ lastCheck: Date.now() - 2 * 24 * 60 * 60 * 1000, latestVersion: "0.0.1" }),
+    );
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForUpdates();
+
+    // Wait for the background promise chain to settle (fetch + cache write)
+    await vi.waitFor(() => {
+      const updated = JSON.parse(readFileSync(cachePath, "utf-8"));
+      expect(updated.latestVersion).toBe("1.2.3");
+    });
+  });
+
+  it("does not fetch when cache is fresh", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    const cachePath = join(tempDir, "dosu-cli", "update-check.json");
+    writeFileSync(cachePath, JSON.stringify({ lastCheck: Date.now(), latestVersion: "0.0.1" }));
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForUpdates();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("handles corrupt cache file gracefully", () => {
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(join(tempDir, "dosu-cli", "update-check.json"), "NOT JSON{{{");
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => checkForUpdates()).not.toThrow();
+    // No notice displayed for corrupt cache
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/version/update-check.ts
+++ b/src/version/update-check.ts
@@ -1,0 +1,123 @@
+/**
+ * Non-blocking version update checker.
+ *
+ * Uses a "check now, display next run" pattern:
+ * 1. On startup, reads a cached latest version from disk.
+ * 2. If the cached version is newer than the running version, prints a notice to stderr.
+ * 3. If the cache is stale (>24 h), fires a background fetch to the npm registry (not awaited).
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import pc from "picocolors";
+import { getConfigDir } from "../config/config";
+import { logger } from "../debug/logger";
+import { VERSION } from "./version";
+
+const CACHE_FILENAME = "update-check.json";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const FETCH_TIMEOUT_MS = 5_000;
+const REGISTRY_URL = "https://registry.npmjs.org/-/package/@dosu/cli/dist-tags";
+
+interface UpdateCache {
+  lastCheck: number;
+  latestVersion: string;
+}
+
+/** Compare two semver strings. Returns true if `latest` is newer than `current`. */
+export function isNewerVersion(latest: string, current: string): boolean {
+  const a = latest.split(".").map(Number);
+  const b = current.split(".").map(Number);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av > bv) return true;
+    if (av < bv) return false;
+  }
+  return false;
+}
+
+function getCachePath(): string {
+  return join(getConfigDir(), CACHE_FILENAME);
+}
+
+function readCache(): UpdateCache | null {
+  try {
+    const path = getCachePath();
+    if (!existsSync(path)) return null;
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    if (typeof data.lastCheck === "number" && typeof data.latestVersion === "string") {
+      return data as UpdateCache;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(cache: UpdateCache): void {
+  try {
+    writeFileSync(getCachePath(), JSON.stringify(cache), { mode: 0o600 });
+  } catch {
+    // Graceful degradation — cache write failure is non-fatal
+  }
+}
+
+/** Fetch the latest published version from the npm registry. */
+export async function fetchLatestVersion(): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(REGISTRY_URL, { signal: controller.signal });
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as Record<string, string>;
+    const latest = data.latest;
+    return typeof latest === "string" ? latest : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function displayNotice(current: string, latest: string): void {
+  const msg =
+    `\n${pc.yellow(`  Update available: ${current} → ${latest}`)}\n` +
+    `${pc.dim('  Run "npm update -g @dosu/cli" or visit https://github.com/dosu-ai/dosu-cli/releases')}\n`;
+  console.error(msg);
+}
+
+/**
+ * Check for updates — called synchronously from the preAction hook.
+ *
+ * Reads cached version info and displays a notice if outdated.
+ * Fires a background fetch if the cache is stale (>24 h).
+ */
+export function checkForUpdates(): void {
+  try {
+    const cache = readCache();
+
+    // Display notice if cached latest is newer than running version
+    if (cache && isNewerVersion(cache.latestVersion, VERSION)) {
+      displayNotice(VERSION, cache.latestVersion);
+    }
+
+    // Fire background fetch if cache is missing or stale
+    const isStale = !cache || Date.now() - cache.lastCheck > CHECK_INTERVAL_MS;
+    if (isStale) {
+      fetchLatestVersion()
+        .then((latest) => {
+          if (latest) {
+            writeCache({ lastCheck: Date.now(), latestVersion: latest });
+            logger.debug("update-check", `Cached latest version: ${latest}`);
+          }
+        })
+        .catch((err) => {
+          logger.error("update-check", `Background fetch failed: ${err}`);
+        });
+    }
+  } catch (err) {
+    logger.error("update-check", `Update check failed: ${err}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a non-blocking version update checker that queries the npm registry and displays an update notice when a newer version of `@dosu/cli` is available
- Uses a "check now, display next run" pattern: the registry fetch runs in the background (fire-and-forget) and the result is cached to `~/.config/dosu-cli/update-check.json`. On the next invocation the cached version is compared and a notice is printed to stderr if outdated
- Throttled to one registry check per 24 hours with a 5-second fetch timeout — zero startup latency impact

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` — all 343 tests pass (16 new tests for update-check)
- [x] `bun run check` — Biome lint/format passes
- [x] Manual: run `bun run dev`, confirm no notice on first run. Write a fake cache file with `latestVersion: "99.0.0"` and re-run to see the styled update notice on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)