### PR TITLE
fix: address review feedback for version update checker

### DIFF
--- a/src/version/update-check.test.ts
+++ b/src/version/update-check.test.ts
@@ -196,17 +196,26 @@ describe("checkForUpdates", () => {
     });
   });
 
-  it("writes lastCheck even when fetch rejects", async () => {
-    const fetchMock = vi.fn().mockRejectedValue(new Error("offline"));
+  it("creates config directory if it does not exist when writing cache", async () => {
+    const { existsSync } = require("node:fs");
+    const configDir = join(tempDir, "dosu-cli");
+    // Ensure the dir does NOT exist before checkForUpdates
+    expect(existsSync(configDir)).toBe(false);
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ latest: "1.0.0" }),
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     vi.spyOn(console, "error").mockImplementation(() => {});
     checkForUpdates();
 
-    const cachePath = join(tempDir, "dosu-cli", "update-check.json");
+    const cachePath = join(configDir, "update-check.json");
     await vi.waitFor(() => {
+      expect(existsSync(cachePath)).toBe(true);
       const updated = JSON.parse(readFileSync(cachePath, "utf-8"));
-      expect(updated.lastCheck).toBeGreaterThan(0);
+      expect(updated.latestVersion).toBe("1.0.0");
     });
   });
 

--- a/src/version/update-check.test.ts
+++ b/src/version/update-check.test.ts
@@ -31,6 +31,13 @@ describe("isNewerVersion", () => {
     expect(isNewerVersion("1.0.0.1", "1.0.0")).toBe(true);
     expect(isNewerVersion("1.0.0", "1.0.0.1")).toBe(false);
   });
+
+  it("strips pre-release and build metadata before comparing", () => {
+    expect(isNewerVersion("2.0.0-beta.1", "1.0.0")).toBe(true);
+    expect(isNewerVersion("1.0.0-beta.1", "1.0.0")).toBe(false);
+    expect(isNewerVersion("1.0.1-rc.1+build.123", "1.0.0")).toBe(true);
+    expect(isNewerVersion("1.0.0+build.456", "1.0.0")).toBe(false);
+  });
 });
 
 describe("fetchLatestVersion", () => {
@@ -173,6 +180,34 @@ describe("checkForUpdates", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     checkForUpdates();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("writes lastCheck even when fetch returns null", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForUpdates();
+
+    const cachePath = join(tempDir, "dosu-cli", "update-check.json");
+    await vi.waitFor(() => {
+      const updated = JSON.parse(readFileSync(cachePath, "utf-8"));
+      expect(updated.lastCheck).toBeGreaterThan(0);
+    });
+  });
+
+  it("writes lastCheck even when fetch rejects", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForUpdates();
+
+    const cachePath = join(tempDir, "dosu-cli", "update-check.json");
+    await vi.waitFor(() => {
+      const updated = JSON.parse(readFileSync(cachePath, "utf-8"));
+      expect(updated.lastCheck).toBeGreaterThan(0);
+    });
   });
 
   it("handles corrupt cache file gracefully", () => {

--- a/src/version/update-check.ts
+++ b/src/version/update-check.ts
@@ -7,7 +7,7 @@
  * 3. If the cache is stale (>24 h), fires a background fetch to the npm registry (not awaited).
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import pc from "picocolors";
 import { getConfigDir } from "../config/config";
@@ -24,10 +24,15 @@ interface UpdateCache {
   latestVersion: string;
 }
 
+/** Strip pre-release/build metadata from a semver string (e.g. "1.2.3-beta.1+build" → "1.2.3"). */
+function stripPrerelease(version: string): string {
+  return version.replace(/[-+].*$/, "");
+}
+
 /** Compare two semver strings. Returns true if `latest` is newer than `current`. */
 export function isNewerVersion(latest: string, current: string): boolean {
-  const a = latest.split(".").map(Number);
-  const b = current.split(".").map(Number);
+  const a = stripPrerelease(latest).split(".").map(Number);
+  const b = stripPrerelease(current).split(".").map(Number);
   const len = Math.max(a.length, b.length);
   for (let i = 0; i < len; i++) {
     const av = a[i] ?? 0;
@@ -58,6 +63,10 @@ function readCache(): UpdateCache | null {
 
 function writeCache(cache: UpdateCache): void {
   try {
+    const dir = getConfigDir();
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
     writeFileSync(getCachePath(), JSON.stringify(cache), { mode: 0o600 });
   } catch {
     // Graceful degradation — cache write failure is non-fatal
@@ -108,12 +117,21 @@ export function checkForUpdates(): void {
     if (isStale) {
       fetchLatestVersion()
         .then((latest) => {
+          // Always update lastCheck to throttle retries (even on failure)
+          writeCache({
+            lastCheck: Date.now(),
+            latestVersion: latest ?? cache?.latestVersion ?? VERSION,
+          });
           if (latest) {
-            writeCache({ lastCheck: Date.now(), latestVersion: latest });
             logger.debug("update-check", `Cached latest version: ${latest}`);
           }
         })
         .catch((err) => {
+          // Still update timestamp so offline users aren't retried every run
+          writeCache({
+            lastCheck: Date.now(),
+            latestVersion: cache?.latestVersion ?? VERSION,
+          });
           logger.error("update-check", `Background fetch failed: ${err}`);
         });
     }

--- a/src/version/update-check.ts
+++ b/src/version/update-check.ts
@@ -126,14 +126,11 @@ export function checkForUpdates(): void {
             logger.debug("update-check", `Cached latest version: ${latest}`);
           }
         })
-        .catch((err) => {
-          // Still update timestamp so offline users aren't retried every run
-          writeCache({
-            lastCheck: Date.now(),
-            latestVersion: cache?.latestVersion ?? VERSION,
-          });
-          logger.error("update-check", `Background fetch failed: ${err}`);
-        });
+        .catch(
+          /* v8 ignore next -- fetchLatestVersion never rejects */ (err) => {
+            logger.error("update-check", `Background fetch failed: ${err}`);
+          },
+        );
     }
   } catch (err) {
     logger.error("update-check", `Update check failed: ${err}`);


### PR DESCRIPTION
## Summary

Follow-up fixes from [#49](https://github.com/dosu-ai/dosu-cli/pull/49) review comments:

- **Throttle retries on failure**: Write `lastCheck` timestamp even when fetch fails or returns null, so offline users aren't retried on every CLI invocation
- **Pre-release semver handling**: Strip `-prerelease` and `+build` metadata before comparing versions, so strings like `1.2.3-beta.1` don't produce `NaN` during comparison
- **Ensure config dir in writeCache**: Create the config directory if missing before writing the cache file, consistent with `getConfigPath()` and the logger

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` — all 346 tests pass (3 new tests for the fixes)
- [x] `bun run check` — Biome lint/format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)