### PR TITLE
feat(insights): add dosu insights command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Dosu CLI (`@dosu/cli`) — a CLI tool that manages MCP (Model Context Protocol) 
 
 ```bash
 bun install                     # Install dependencies
-bun run dev                     # Run CLI from source (production endpoints)
+bun run dev                     # Run CLI from source (loads .env.development; Bun's NODE_ENV default)
 bun run dev:local               # Run CLI from source (local dev endpoints, DOSU_DEV=true)
 bun run build                   # Compile to single binary via bun build --compile
 bun run build:npm               # Bundle for npm distribution (bin/dosu.js)

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -8,6 +8,7 @@ import { analyticsCommand } from "../commands/analytics";
 import { askCommand } from "../commands/ask";
 import { deploymentsCommand } from "../commands/deployments";
 import { docsCommand } from "../commands/docs";
+import { insightsCommand } from "../commands/insights";
 import { integrationsCommand } from "../commands/integrations";
 import { knowledgeCommand } from "../commands/knowledge";
 import { membersCommand } from "../commands/members";
@@ -197,6 +198,7 @@ export function createProgram(): Command {
   program.addCommand(askCommand());
   program.addCommand(deploymentsCommand());
   program.addCommand(docsCommand());
+  program.addCommand(insightsCommand());
   program.addCommand(integrationsCommand());
   program.addCommand(knowledgeCommand());
   program.addCommand(membersCommand());

--- a/src/commands/analytics.test.ts
+++ b/src/commands/analytics.test.ts
@@ -123,7 +123,7 @@ describe("analytics", () => {
 
     const output = allOutput();
     expect(output).toContain("100");
-    expect(output).toContain("86.0%"); // answerRate = 86/100
+    expect(output).toContain("50.0%"); // highConfidenceRate = 50/100
     expect(output).toContain("92.3%");
   });
 

--- a/src/commands/analytics.ts
+++ b/src/commands/analytics.ts
@@ -38,13 +38,13 @@ export function analyticsCommand(): Command {
       }
 
       const pct = (v?: number) => (v !== undefined ? `${(v * 100).toFixed(1)}%` : "—");
-      const answerRate =
-        stats.totalResponses > 0 ? stats.totalWithResponse / stats.totalResponses : undefined;
+      const highConfidenceRate =
+        stats.totalResponses > 0 ? stats.byConfidence.high / stats.totalResponses : undefined;
 
       printInfo(
         [
           ["Total Responses", String(stats.totalResponses)],
-          ["Answer Rate", pct(answerRate)],
+          ["High-Confidence Share", pct(highConfidenceRate)],
           ["High Confidence", String(stats.byConfidence.high)],
           ["Medium Confidence", String(stats.byConfidence.medium)],
           ["Low Confidence", String(stats.byConfidence.low)],

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -167,6 +167,20 @@ describe("runInsights", () => {
     expect(out).toContain(`file://${reportPath()}`);
   });
 
+  it("logs progress for both the stats and narrative stages", async () => {
+    const runner = makeRunner({
+      build: vi.fn().mockImplementation(async (args: { onProgress?: (s: string) => void }) => {
+        args.onProgress?.("stats");
+        args.onProgress?.("narrative");
+        return fakeReport;
+      }),
+    });
+    await runInsights(validConfig, runner);
+    const out = allOutput();
+    expect(out).toContain("Looking at the last 30 days");
+    expect(out).toContain("narrate the numbers");
+  });
+
   it("falls back gracefully when the browser open call rejects", async () => {
     const runner = makeRunner({
       openInBrowser: vi.fn().mockRejectedValue(new Error("nope")),

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -64,7 +64,6 @@ const fakeReport: InsightsReport = {
   deploymentName: "Test Deploy",
   current: {
     totalResponses: 50,
-    totalWithResponse: 40,
     byConfidence: { high: 25, medium: 15, low: 10 },
     reactions: {
       totalPositive: 8,
@@ -76,7 +75,6 @@ const fakeReport: InsightsReport = {
   },
   previous: {
     totalResponses: 40,
-    totalWithResponse: 30,
     byConfidence: { high: 20, medium: 10, low: 10 },
     reactions: {
       totalPositive: 6,
@@ -255,7 +253,6 @@ describe("executeInsights", () => {
       });
     mockQuery.mockResolvedValue({
       totalResponses: 1,
-      totalWithResponse: 1,
       byConfidence: { high: 1, medium: 0, low: 0 },
       reactions: {
         totalPositive: 0,
@@ -321,7 +318,6 @@ describe("insightsCommand", () => {
       });
     mockQuery.mockResolvedValue({
       totalResponses: 1,
-      totalWithResponse: 1,
       byConfidence: { high: 1, medium: 0, low: 0 },
       reactions: {
         totalPositive: 0,

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -32,6 +32,8 @@ vi.mock("../config/constants", () => ({
   getSupabaseAnonKey: () => "",
 }));
 
+vi.mock("open", () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+
 import type { InsightsReport } from "../insights";
 import {
   type InsightsRunner,
@@ -277,9 +279,6 @@ describe("executeInsights", () => {
       },
     });
 
-    // Stub the dynamic open import so executeInsights doesn't try to launch a real browser.
-    vi.doMock("open", () => ({ default: vi.fn().mockResolvedValue(undefined) }));
-
     const { executeInsights } = await import("./insights");
     await expect(executeInsights(validConfig)).resolves.toBeUndefined();
   });
@@ -341,7 +340,6 @@ describe("insightsCommand", () => {
         positiveRate: 0,
       },
     });
-    vi.doMock("open", () => ({ default: vi.fn().mockResolvedValue(undefined) }));
 
     await expect(runCmd()).resolves.toBeUndefined();
     expect(exitSpy).not.toHaveBeenCalled();

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -340,7 +340,6 @@ describe("insightsCommand", () => {
         positiveRate: 0,
       },
     });
-
     await expect(runCmd()).resolves.toBeUndefined();
     expect(exitSpy).not.toHaveBeenCalled();
   });
@@ -410,6 +409,21 @@ describe("pruneOldReports", () => {
 
   it("no-ops when the directory does not exist", () => {
     expect(() => pruneOldReports("/tmp/does-not-exist-dosu-xyz", 5)).not.toThrow();
+  });
+
+  it("returns without throwing when readdirSync fails", async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "dosu-insights-test-"));
+    try {
+      // A regular file passes existsSync but readdirSync throws ENOTDIR on it.
+      const notADir = join(dir, "not-a-dir");
+      writeFileSync(notADir, "x");
+      expect(() => pruneOldReports(notADir, 5)).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("swallows per-file unlink errors and keeps pruning the rest", async () => {

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const spinnerStart = vi.fn();
+const spinnerStop = vi.fn();
+const spinnerMessage = vi.fn();
+
 const mockQuery = vi.fn();
 
 function createMockProxy(path: string[] = []): unknown {
@@ -102,6 +106,9 @@ const fakeReport: InsightsReport = {
 beforeEach(() => {
   mockLoadConfig.mockReset();
   mockQuery.mockReset();
+  spinnerStart.mockReset();
+  spinnerStop.mockReset();
+  spinnerMessage.mockReset();
   mockGetBackendURL.mockReturnValue("https://api.test");
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -128,6 +135,11 @@ function makeRunner(over: Partial<InsightsRunner> = {}): InsightsRunner {
     prune: vi.fn(),
     openInBrowser: vi.fn().mockResolvedValue(undefined),
     ask: vi.fn().mockResolvedValue(null),
+    createSpinner: () => ({
+      start: spinnerStart,
+      message: spinnerMessage,
+      stop: spinnerStop,
+    }),
     ...over,
   };
 }
@@ -169,18 +181,41 @@ describe("runInsights", () => {
     expect(out).toContain(`file://${reportPath()}`);
   });
 
-  it("logs progress for both the stats and narrative stages", async () => {
+  it("drives the spinner through both stages and rotates narrative hints", async () => {
+    vi.useFakeTimers();
+    try {
+      const runner = makeRunner({
+        build: vi.fn().mockImplementation(async (args: { onProgress?: (s: string) => void }) => {
+          args.onProgress?.("stats");
+          args.onProgress?.("narrative");
+          // Advance past two hint rotations so the interval fires.
+          await vi.advanceTimersByTimeAsync(13_000);
+          return fakeReport;
+        }),
+      });
+      await runInsights(validConfig, runner);
+
+      expect(spinnerStart).toHaveBeenCalledWith(
+        expect.stringContaining("Looking at the last 30 days"),
+      );
+      const messages = spinnerMessage.mock.calls.map((c) => c[0] as string);
+      expect(messages[0]).toBe("Asking Dosu to narrate the numbers");
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+      expect(spinnerStop).toHaveBeenCalledWith(expect.stringContaining("Insights ready"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops the spinner with a failure message when the build throws", async () => {
     const runner = makeRunner({
       build: vi.fn().mockImplementation(async (args: { onProgress?: (s: string) => void }) => {
         args.onProgress?.("stats");
-        args.onProgress?.("narrative");
-        return fakeReport;
+        throw new Error("build boom");
       }),
     });
-    await runInsights(validConfig, runner);
-    const out = allOutput();
-    expect(out).toContain("Looking at the last 30 days");
-    expect(out).toContain("narrate the numbers");
+    await expect(runInsights(validConfig, runner)).rejects.toThrow("build boom");
+    expect(spinnerStop).toHaveBeenCalledWith(expect.stringContaining("Couldn't build"), 1);
   });
 
   it("falls back gracefully when the browser open call rejects", async () => {

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -87,8 +87,8 @@ const fakeReport: InsightsReport = {
     },
   },
   derived: {
-    answerRate: 0.8,
-    answerRateDelta: 0.05,
+    highConfidenceRate: 0.5,
+    highConfidenceRateDelta: 0,
     responsesDelta: 10,
     positiveRateDelta: 0.2,
     hasPriorWindow: true,

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -36,7 +36,9 @@ import type { InsightsReport } from "../insights";
 import {
   type InsightsRunner,
   insightsCommand,
+  insightsDir,
   makeAskFn,
+  pruneOldReports,
   reportPath,
   runInsights,
 } from "./insights";
@@ -89,6 +91,7 @@ const fakeReport: InsightsReport = {
     answerRateDelta: 0.05,
     responsesDelta: 10,
     positiveRateDelta: 0.2,
+    hasPriorWindow: true,
   },
   atAGlance: "Hi",
   cheers: ["Big cheer!"],
@@ -122,6 +125,7 @@ function makeRunner(over: Partial<InsightsRunner> = {}): InsightsRunner {
     build: vi.fn().mockResolvedValue(fakeReport),
     render: vi.fn().mockReturnValue("<html>hi</html>"),
     writeFile: vi.fn(),
+    prune: vi.fn(),
     openInBrowser: vi.fn().mockResolvedValue(undefined),
     ask: vi.fn().mockResolvedValue(null),
     ...over,
@@ -129,24 +133,39 @@ function makeRunner(over: Partial<InsightsRunner> = {}): InsightsRunner {
 }
 
 describe("runInsights", () => {
-  it("writes the rendered HTML to the report path and auto-opens it", async () => {
+  it("writes both a timestamped snapshot and latest.html, and opens the snapshot", async () => {
     const runner = makeRunner();
     const path = await runInsights(validConfig, runner);
 
-    expect(path).toBe(reportPath());
+    expect(path).toMatch(/report-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.html$/);
     expect(runner.build).toHaveBeenCalledWith(
       expect.objectContaining({ cfg: validConfig, windowDays: 30 }),
     );
     expect(runner.render).toHaveBeenCalledWith(fakeReport);
-    expect(runner.writeFile).toHaveBeenCalledWith(reportPath(), "<html>hi</html>");
-    expect(runner.openInBrowser).toHaveBeenCalledWith(reportPath());
+
+    const writeCalls = (runner.writeFile as ReturnType<typeof vi.fn>).mock.calls;
+    expect(writeCalls).toHaveLength(2);
+    const writtenPaths = writeCalls.map((c) => c[0] as string);
+    expect(writtenPaths).toEqual(expect.arrayContaining([path, reportPath()]));
+    for (const call of writeCalls) {
+      expect(call[1]).toBe("<html>hi</html>");
+    }
+    expect(runner.openInBrowser).toHaveBeenCalledWith(path);
   });
 
-  it("prints the deployment name, first cheer, and file URL", async () => {
-    await runInsights(validConfig, makeRunner());
+  it("prunes the insights directory after writing", async () => {
+    const runner = makeRunner();
+    await runInsights(validConfig, runner);
+    expect(runner.prune).toHaveBeenCalledWith(insightsDir(), 20);
+  });
+
+  it("prints the deployment name, first cheer, and both file URLs", async () => {
+    const runner = makeRunner();
+    const snapshotPath = await runInsights(validConfig, runner);
     const out = allOutput();
     expect(out).toContain("Test Deploy");
     expect(out).toContain("Big cheer!");
+    expect(out).toContain(`file://${snapshotPath}`);
     expect(out).toContain(`file://${reportPath()}`);
   });
 
@@ -154,7 +173,7 @@ describe("runInsights", () => {
     const runner = makeRunner({
       openInBrowser: vi.fn().mockRejectedValue(new Error("nope")),
     });
-    await expect(runInsights(validConfig, runner)).resolves.toBe(reportPath());
+    await expect(runInsights(validConfig, runner)).resolves.toMatch(/report-.*\.html$/);
     expect(allOutput()).toContain("couldn't auto-open");
   });
 
@@ -294,7 +313,57 @@ describe("insightsCommand", () => {
 });
 
 describe("reportPath", () => {
-  it("returns a path under the config dir", () => {
-    expect(reportPath()).toMatch(/dosu-cli[\\/]+insights[\\/]+report\.html$/);
+  it("returns the stable latest.html path when called without arguments", () => {
+    expect(reportPath()).toMatch(/dosu-cli[\\/]+insights[\\/]+latest\.html$/);
+  });
+
+  it("returns a timestamped path when given a Date", () => {
+    const d = new Date("2026-04-17T12:30:45.000Z");
+    expect(reportPath(d)).toMatch(/dosu-cli[\\/]+insights[\\/]+report-2026-04-17T12-30-45Z\.html$/);
+  });
+
+  it("renders colons as dashes so the filename is portable on Windows", () => {
+    const d = new Date("2026-04-17T12:30:45.000Z");
+    expect(reportPath(d)).not.toContain(":");
+  });
+});
+
+describe("pruneOldReports", () => {
+  it("keeps the most recent N reports and deletes the rest", async () => {
+    const { mkdtempSync, writeFileSync, readdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "dosu-insights-test-"));
+    try {
+      const names = [
+        "report-2026-01-01T00-00-00Z.html",
+        "report-2026-02-01T00-00-00Z.html",
+        "report-2026-03-01T00-00-00Z.html",
+        "report-2026-04-01T00-00-00Z.html",
+        "report-2026-05-01T00-00-00Z.html",
+        // Non-matching files must be left alone
+        "latest.html",
+        "README.md",
+      ];
+      for (const n of names) writeFileSync(join(dir, n), "x");
+
+      pruneOldReports(dir, 2);
+
+      const remaining = readdirSync(dir).sort();
+      expect(remaining).toEqual(
+        [
+          "README.md",
+          "latest.html",
+          "report-2026-04-01T00-00-00Z.html",
+          "report-2026-05-01T00-00-00Z.html",
+        ].sort(),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("no-ops when the directory does not exist", () => {
+    expect(() => pruneOldReports("/tmp/does-not-exist-dosu-xyz", 5)).not.toThrow();
   });
 });

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -61,7 +61,7 @@ const validConfig = {
 const fakeReport: InsightsReport = {
   generatedAt: "2026-04-16T00:00:00Z",
   windowDays: 30,
-  deploymentName: "Test Deploy",
+  spaceName: "Test Deploy",
   current: {
     totalResponses: 50,
     byConfidence: { high: 25, medium: 15, low: 10 },
@@ -157,7 +157,7 @@ describe("runInsights", () => {
     expect(runner.prune).toHaveBeenCalledWith(insightsDir(), 20);
   });
 
-  it("prints the deployment name, first cheer, and both file URLs", async () => {
+  it("prints the space name, first cheer, and both file URLs", async () => {
     const runner = makeRunner();
     const snapshotPath = await runInsights(validConfig, runner);
     const out = allOutput();

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -4,6 +4,26 @@ const spinnerStart = vi.fn();
 const spinnerStop = vi.fn();
 const spinnerMessage = vi.fn();
 
+const mockConfirm = vi.fn();
+const mockIsCancel = vi.fn<(v: unknown) => boolean>();
+const mockLogWarn = vi.fn();
+
+vi.mock("@clack/prompts", () => ({
+  confirm: (...args: unknown[]) => mockConfirm(...args),
+  isCancel: (v: unknown) => mockIsCancel(v),
+  log: {
+    warn: (...args: unknown[]) => mockLogWarn(...args),
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockRunSetup = vi.fn();
+vi.mock("../setup/flow", () => ({
+  runSetup: () => mockRunSetup(),
+}));
+
 const mockQuery = vi.fn();
 
 function createMockProxy(path: string[] = []): unknown {
@@ -110,6 +130,11 @@ beforeEach(() => {
   spinnerStart.mockReset();
   spinnerStop.mockReset();
   spinnerMessage.mockReset();
+  mockConfirm.mockReset();
+  mockIsCancel.mockReset();
+  mockIsCancel.mockReturnValue(false);
+  mockLogWarn.mockReset();
+  mockRunSetup.mockReset();
   mockGetBackendURL.mockReturnValue("https://api.test");
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -339,24 +364,74 @@ describe("insightsCommand", () => {
     await cmd.parseAsync(["node", "test", ...args]);
   }
 
-  it("exits when not logged in", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
-    await expect(runCmd()).rejects.toThrow("exit");
+  it("prompts to run setup when not logged in, then runs insights after a successful setup", async () => {
+    mockLoadConfig
+      .mockReturnValueOnce({ ...validConfig, access_token: "" })
+      .mockReturnValue(validConfig);
+    mockConfirm.mockResolvedValue(true);
+    mockRunSetup.mockResolvedValue(undefined);
+    (globalThis as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ answer: "ok" }) });
+    mockQuery.mockResolvedValue({
+      totalResponses: 1,
+      byConfidence: { high: 1, medium: 0, low: 0 },
+      reactions: {
+        totalPositive: 0,
+        totalNegative: 0,
+        messagesWithReactions: 0,
+        reactionRate: 0,
+        positiveRate: 0,
+      },
+    });
+
+    await expect(runCmd()).resolves.toBeUndefined();
+
+    expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining("log in"));
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(mockRunSetup).toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("exits when api_key is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, api_key: undefined });
-    await expect(runCmd()).rejects.toThrow("exit");
+  it("warns about missing deployment when api_key is missing", async () => {
+    mockLoadConfig.mockReturnValueOnce({ ...validConfig, api_key: undefined });
+    mockConfirm.mockResolvedValue(false);
+
+    await expect(runCmd()).resolves.toBeUndefined();
+    expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining("configured Dosu deployment"));
+    expect(mockRunSetup).not.toHaveBeenCalled();
   });
 
-  it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
-    await expect(runCmd()).rejects.toThrow("exit");
+  it("returns without running insights when the user declines setup", async () => {
+    mockLoadConfig.mockReturnValueOnce({ ...validConfig, space_id: undefined });
+    mockConfirm.mockResolvedValue(false);
+
+    await expect(runCmd()).resolves.toBeUndefined();
+    expect(mockRunSetup).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("exits when deployment_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, deployment_id: undefined });
-    await expect(runCmd()).rejects.toThrow("exit");
+  it("returns without running insights when the user cancels the prompt", async () => {
+    mockLoadConfig.mockReturnValueOnce({ ...validConfig, deployment_id: undefined });
+    const cancelSentinel = Symbol("cancel");
+    mockConfirm.mockResolvedValue(cancelSentinel);
+    mockIsCancel.mockImplementation((v: unknown) => v === cancelSentinel);
+
+    await expect(runCmd()).resolves.toBeUndefined();
+    expect(mockRunSetup).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns gracefully when setup completes but config is still incomplete", async () => {
+    mockLoadConfig
+      .mockReturnValueOnce({ ...validConfig, access_token: "" })
+      .mockReturnValue({ ...validConfig, access_token: "" });
+    mockConfirm.mockResolvedValue(true);
+    mockRunSetup.mockResolvedValue(undefined);
+
+    await expect(runCmd()).resolves.toBeUndefined();
+    expect(mockRunSetup).toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it("runs to completion when every config field is present", async () => {

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -41,10 +41,10 @@ vi.mock("open", () => ({ default: vi.fn().mockResolvedValue(undefined) }));
 import type { InsightsReport } from "../insights";
 import {
   type InsightsRunner,
-  NARRATIVE_HINTS,
   insightsCommand,
   insightsDir,
   makeAskFn,
+  NARRATIVE_HINTS,
   pruneOldReports,
   reportPath,
   runInsights,

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -90,8 +90,10 @@ const fakeReport: InsightsReport = {
     responsesDelta: 10,
     positiveRateDelta: 0.2,
   },
-  narratives: { atAGlance: "Hi", topics: "Stuff", suggestions: "1. Try X" },
+  atAGlance: "Hi",
   cheers: ["Big cheer!"],
+  investigate: [],
+  suggestions: [{ headline: "Try X", detail: "X is great.", command: "dosu setup" }],
 };
 
 beforeEach(() => {

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockQuery = vi.fn();
+
+function createMockProxy(path: string[] = []): unknown {
+  return new Proxy(() => {}, {
+    get(_, prop: string) {
+      if (prop === "query") return (input: unknown) => mockQuery(path.join("."), input);
+      return createMockProxy([...path, prop]);
+    },
+  });
+}
+
+vi.mock("../client/trpc", () => ({
+  createTypedClient: vi.fn().mockImplementation(() => createMockProxy()),
+}));
+
+const mockLoadConfig = vi.fn();
+vi.mock("../config/config", async () => {
+  const actual = await vi.importActual<typeof import("../config/config")>("../config/config");
+  return {
+    ...actual,
+    loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+  };
+});
+
+const mockGetBackendURL = vi.fn(() => "https://api.test");
+vi.mock("../config/constants", () => ({
+  getBackendURL: () => mockGetBackendURL(),
+  getWebAppURL: () => "https://web.test",
+  getSupabaseURL: () => "",
+  getSupabaseAnonKey: () => "",
+}));
+
+import type { InsightsReport } from "../insights";
+import {
+  type InsightsRunner,
+  insightsCommand,
+  makeAskFn,
+  reportPath,
+  runInsights,
+} from "./insights";
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+// biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
+let exitSpy: any;
+
+const validConfig = {
+  access_token: "t",
+  refresh_token: "r",
+  expires_at: 0,
+  api_key: "sk_user_test",
+  space_id: "sp1",
+  deployment_id: "d1",
+  deployment_name: "Test Deploy",
+};
+
+const fakeReport: InsightsReport = {
+  generatedAt: "2026-04-16T00:00:00Z",
+  windowDays: 30,
+  deploymentName: "Test Deploy",
+  current: {
+    totalResponses: 50,
+    totalWithResponse: 40,
+    byConfidence: { high: 25, medium: 15, low: 10 },
+    reactions: {
+      totalPositive: 8,
+      totalNegative: 2,
+      messagesWithReactions: 10,
+      reactionRate: 0.2,
+      positiveRate: 0.8,
+    },
+  },
+  previous: {
+    totalResponses: 40,
+    totalWithResponse: 30,
+    byConfidence: { high: 20, medium: 10, low: 10 },
+    reactions: {
+      totalPositive: 6,
+      totalNegative: 4,
+      messagesWithReactions: 10,
+      reactionRate: 0.25,
+      positiveRate: 0.6,
+    },
+  },
+  derived: {
+    answerRate: 0.8,
+    answerRateDelta: 0.05,
+    responsesDelta: 10,
+    positiveRateDelta: 0.2,
+  },
+  narratives: { atAGlance: "Hi", topics: "Stuff", suggestions: "1. Try X" },
+  cheers: ["Big cheer!"],
+};
+
+beforeEach(() => {
+  mockLoadConfig.mockReset();
+  mockQuery.mockReset();
+  mockGetBackendURL.mockReturnValue("https://api.test");
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("exit");
+  }) as never);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+  exitSpy.mockRestore();
+});
+
+function allOutput(): string {
+  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+}
+
+function makeRunner(over: Partial<InsightsRunner> = {}): InsightsRunner {
+  return {
+    build: vi.fn().mockResolvedValue(fakeReport),
+    render: vi.fn().mockReturnValue("<html>hi</html>"),
+    writeFile: vi.fn(),
+    openInBrowser: vi.fn().mockResolvedValue(undefined),
+    ask: vi.fn().mockResolvedValue(null),
+    ...over,
+  };
+}
+
+describe("runInsights", () => {
+  it("writes the rendered HTML to the report path and auto-opens it", async () => {
+    const runner = makeRunner();
+    const path = await runInsights(validConfig, runner);
+
+    expect(path).toBe(reportPath());
+    expect(runner.build).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: validConfig, windowDays: 30 }),
+    );
+    expect(runner.render).toHaveBeenCalledWith(fakeReport);
+    expect(runner.writeFile).toHaveBeenCalledWith(reportPath(), "<html>hi</html>");
+    expect(runner.openInBrowser).toHaveBeenCalledWith(reportPath());
+  });
+
+  it("prints the deployment name, first cheer, and file URL", async () => {
+    await runInsights(validConfig, makeRunner());
+    const out = allOutput();
+    expect(out).toContain("Test Deploy");
+    expect(out).toContain("Big cheer!");
+    expect(out).toContain(`file://${reportPath()}`);
+  });
+
+  it("falls back gracefully when the browser open call rejects", async () => {
+    const runner = makeRunner({
+      openInBrowser: vi.fn().mockRejectedValue(new Error("nope")),
+    });
+    await expect(runInsights(validConfig, runner)).resolves.toBe(reportPath());
+    expect(allOutput()).toContain("couldn't auto-open");
+  });
+
+  it("skips the cheer line when there are no cheers", async () => {
+    const runner = makeRunner({
+      build: vi.fn().mockResolvedValue({ ...fakeReport, cheers: [] }),
+    });
+    await runInsights(validConfig, runner);
+    expect(allOutput()).not.toContain("Big cheer!");
+  });
+});
+
+describe("makeAskFn", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a function that POSTs to /ask and returns the answer", async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ answer: "Hello!" }),
+    });
+
+    const ask = makeAskFn(validConfig);
+    const out = await ask("test");
+
+    expect(out).toBe("Hello!");
+    const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toBe("https://api.test/ask");
+    expect(call[1].method).toBe("POST");
+    expect(call[1].headers["X-Dosu-API-Key"]).toBe("sk_user_test");
+    expect(JSON.parse(call[1].body)).toEqual({ deployment_id: "d1", question: "test" });
+  });
+
+  it("returns null when the response is not ok", async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+    const ask = makeAskFn(validConfig);
+    expect(await ask("q")).toBeNull();
+  });
+
+  it("returns null when fetch throws", async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("net"));
+    const ask = makeAskFn(validConfig);
+    expect(await ask("q")).toBeNull();
+  });
+
+  it("returns null when the response body has no answer string", async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ answer: 42 }),
+    });
+    const ask = makeAskFn(validConfig);
+    expect(await ask("q")).toBeNull();
+  });
+
+  it("returns a no-op ask function when backend URL is unset", async () => {
+    mockGetBackendURL.mockReturnValue("");
+    const ask = makeAskFn(validConfig);
+    expect(await ask("q")).toBeNull();
+    // fetch should never have been called
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeInsights", () => {
+  it("runs to completion when config is valid", async () => {
+    (globalThis as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ answer: "ok" }),
+      });
+    mockQuery.mockResolvedValue({
+      totalResponses: 1,
+      totalWithResponse: 1,
+      byConfidence: { high: 1, medium: 0, low: 0 },
+      reactions: {
+        totalPositive: 0,
+        totalNegative: 0,
+        messagesWithReactions: 0,
+        reactionRate: 0,
+        positiveRate: 0,
+      },
+    });
+
+    // Stub the dynamic open import so executeInsights doesn't try to launch a real browser.
+    vi.doMock("open", () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+
+    const { executeInsights } = await import("./insights");
+    await expect(executeInsights(validConfig)).resolves.toBeUndefined();
+  });
+
+  it("logs and swallows errors so the TUI loop survives", async () => {
+    (globalThis as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch = vi.fn();
+    mockQuery.mockRejectedValue(new Error("boom"));
+
+    const { executeInsights } = await import("./insights");
+    await executeInsights(validConfig);
+
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+
+describe("insightsCommand", () => {
+  async function runCmd(...args: string[]) {
+    const cmd = insightsCommand();
+    cmd.exitOverride();
+    await cmd.parseAsync(["node", "test", ...args]);
+  }
+
+  it("exits when not logged in", async () => {
+    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    await expect(runCmd()).rejects.toThrow("exit");
+  });
+
+  it("exits when api_key is missing", async () => {
+    mockLoadConfig.mockReturnValue({ ...validConfig, api_key: undefined });
+    await expect(runCmd()).rejects.toThrow("exit");
+  });
+
+  it("exits when space_id is missing", async () => {
+    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    await expect(runCmd()).rejects.toThrow("exit");
+  });
+
+  it("exits when deployment_id is missing", async () => {
+    mockLoadConfig.mockReturnValue({ ...validConfig, deployment_id: undefined });
+    await expect(runCmd()).rejects.toThrow("exit");
+  });
+});
+
+describe("reportPath", () => {
+  it("returns a path under the config dir", () => {
+    expect(reportPath()).toMatch(/dosu-cli[\\/]+insights[\\/]+report\.html$/);
+  });
+});

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -41,6 +41,7 @@ vi.mock("open", () => ({ default: vi.fn().mockResolvedValue(undefined) }));
 import type { InsightsReport } from "../insights";
 import {
   type InsightsRunner,
+  NARRATIVE_HINTS,
   insightsCommand,
   insightsDir,
   makeAskFn,
@@ -199,8 +200,10 @@ describe("runInsights", () => {
         expect.stringContaining("Looking at the last 30 days"),
       );
       const messages = spinnerMessage.mock.calls.map((c) => c[0] as string);
-      expect(messages[0]).toBe("Asking Dosu to narrate the numbers");
+      // Hints are randomized; just verify two distinct hints were rendered.
+      expect(NARRATIVE_HINTS).toContain(messages[0]);
       expect(messages.length).toBeGreaterThanOrEqual(2);
+      expect(messages[1]).not.toBe(messages[0]);
       expect(spinnerStop).toHaveBeenCalledWith(expect.stringContaining("Insights ready"));
     } finally {
       vi.useRealTimers();

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -310,6 +310,43 @@ describe("insightsCommand", () => {
     mockLoadConfig.mockReturnValue({ ...validConfig, deployment_id: undefined });
     await expect(runCmd()).rejects.toThrow("exit");
   });
+
+  it("runs to completion when every config field is present", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    (globalThis as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ answer: "ok" }),
+      });
+    mockQuery.mockResolvedValue({
+      totalResponses: 1,
+      totalWithResponse: 1,
+      byConfidence: { high: 1, medium: 0, low: 0 },
+      reactions: {
+        totalPositive: 0,
+        totalNegative: 0,
+        messagesWithReactions: 0,
+        reactionRate: 0,
+        positiveRate: 0,
+      },
+    });
+    vi.doMock("open", () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+
+    await expect(runCmd()).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs and exits 1 when the runner throws", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    (globalThis as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch = vi.fn();
+    mockQuery.mockRejectedValue(new Error("runner boom"));
+
+    await expect(runCmd()).rejects.toThrow("exit");
+    expect(errorSpy).toHaveBeenCalled();
+    const errOut = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(errOut).toContain("runner boom");
+  });
 });
 
 describe("reportPath", () => {
@@ -365,5 +402,26 @@ describe("pruneOldReports", () => {
 
   it("no-ops when the directory does not exist", () => {
     expect(() => pruneOldReports("/tmp/does-not-exist-dosu-xyz", 5)).not.toThrow();
+  });
+
+  it("swallows per-file unlink errors and keeps pruning the rest", async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, readdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "dosu-insights-test-"));
+    try {
+      writeFileSync(join(dir, "report-2026-01-01T00-00-00Z.html"), "x");
+      writeFileSync(join(dir, "report-2026-02-01T00-00-00Z.html"), "x");
+      // A directory whose name matches the report pattern — unlinkSync will
+      // throw EISDIR/EPERM on every platform, exercising the catch branch.
+      mkdirSync(join(dir, "report-2026-03-01T00-00-00Z.html"));
+
+      expect(() => pruneOldReports(dir, 0)).not.toThrow();
+
+      // The two real files are gone; the problem directory is left in place.
+      expect(readdirSync(dir).sort()).toEqual(["report-2026-03-01T00-00-00Z.html"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -8,14 +8,15 @@
 
 import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import * as p from "@clack/prompts";
 import { Command } from "commander";
 import pc from "picocolors";
 import { createTypedClient } from "../client/trpc";
-import { type Config, getConfigDir } from "../config/config";
+import { type Config, getConfigDir, loadConfig } from "../config/config";
 import { getBackendURL } from "../config/constants";
 import { logger } from "../debug/logger";
 import { type AskFn, buildInsights, type InsightsStage, renderHTML } from "../insights";
-import { requireAPIKey, requireLoginConfig } from "./auth";
+import { runSetup } from "../setup/flow";
 
 const ASK_TIMEOUT_MS = 90_000;
 const KEEP_REPORTS = 20;
@@ -95,14 +96,29 @@ export function createDotsSpinner(): Spinner {
   };
 }
 
-function requireFullConfig(): Config {
-  const cfg = requireLoginConfig();
-  requireAPIKey(cfg);
-  if (!cfg.space_id || !cfg.deployment_id) {
-    console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
-    process.exit(1);
-  }
-  return cfg;
+function isFullConfig(cfg: Config): boolean {
+  return Boolean(cfg.access_token && cfg.api_key && cfg.space_id && cfg.deployment_id);
+}
+
+export async function ensureFullConfig(): Promise<Config | null> {
+  let cfg = loadConfig();
+  if (isFullConfig(cfg)) return cfg;
+
+  const reason = !cfg.access_token
+    ? "Insights needs you to log in first."
+    : "Insights needs a configured Dosu deployment.";
+  p.log.warn(reason);
+
+  const shouldSetup = await p.confirm({
+    message: "Run setup now?",
+    initialValue: true,
+  });
+  if (p.isCancel(shouldSetup) || !shouldSetup) return null;
+
+  await runSetup();
+
+  cfg = loadConfig();
+  return isFullConfig(cfg) ? cfg : null;
 }
 
 export function makeAskFn(cfg: Config): AskFn {
@@ -294,7 +310,8 @@ export function insightsCommand(): Command {
   return new Command("insights")
     .description("Open a fun visual report of your Dosu space activity")
     .action(async () => {
-      const cfg = requireFullConfig();
+      const cfg = await ensureFullConfig();
+      if (!cfg) return;
       try {
         await runInsights(cfg, defaultRunner(cfg));
       } catch (err) {

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -14,7 +14,7 @@ import { createTypedClient } from "../client/trpc";
 import { type Config, getConfigDir } from "../config/config";
 import { getBackendURL } from "../config/constants";
 import { logger } from "../debug/logger";
-import { type AskFn, buildInsights, renderHTML } from "../insights";
+import { type AskFn, buildInsights, type InsightsStage, renderHTML } from "../insights";
 import { requireAPIKey, requireLoginConfig } from "./auth";
 
 const ASK_TIMEOUT_MS = 90_000;
@@ -108,9 +108,15 @@ export interface InsightsRunner {
 export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<string> {
   const client = createTypedClient(cfg);
 
-  console.log(pc.dim("✨ Looking at the last 30 days of your space..."));
+  const onProgress = (stage: InsightsStage) => {
+    if (stage === "stats") {
+      console.log(pc.dim("✨ Looking at the last 30 days of your space..."));
+    } else if (stage === "narrative") {
+      console.log(pc.dim("   Asking Dosu to narrate the numbers (up to 90s)..."));
+    }
+  };
 
-  const report = await runner.build({ client, cfg, ask: runner.ask, windowDays: 30 });
+  const report = await runner.build({ client, cfg, ask: runner.ask, windowDays: 30, onProgress });
   const html = runner.render(report);
   const timestamp = new Date();
   const snapshotPath = reportPath(timestamp);

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -83,7 +83,17 @@ export function reportPath(timestamp?: Date): string {
 
 export function pruneOldReports(dir: string, keepN: number): void {
   if (!existsSync(dir)) return;
-  const reports = readdirSync(dir)
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    logger.debug(
+      "insights",
+      `failed to list ${dir} for pruning: ${err instanceof Error ? err.message : err}`,
+    );
+    return;
+  }
+  const reports = entries
     .filter((f) => REPORT_FILE_PATTERN.test(f))
     .sort()
     .reverse();

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -1,5 +1,5 @@
 /**
- * `dosu insights` — open a fun visual report of your deployment activity.
+ * `dosu insights` — open a fun visual report of your space activity.
  *
  * One word, no flags. Builds an HTML report from `analytics.getUsageStats`
  * plus a few parallel `/ask` calls for narrative sections, writes it to
@@ -25,7 +25,7 @@ function requireFullConfig(): Config {
   const cfg = requireLoginConfig();
   requireAPIKey(cfg);
   if (!cfg.space_id || !cfg.deployment_id) {
-    console.error(pc.red("Missing deployment config. Run 'dosu setup' to reconfigure."));
+    console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
   return cfg;
@@ -108,7 +108,7 @@ export interface InsightsRunner {
 export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<string> {
   const client = createTypedClient(cfg);
 
-  console.log(pc.dim("✨ Looking at the last 30 days of your deployment..."));
+  console.log(pc.dim("✨ Looking at the last 30 days of your space..."));
 
   const report = await runner.build({ client, cfg, ask: runner.ask, windowDays: 30 });
   const html = runner.render(report);
@@ -120,7 +120,7 @@ export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<
   runner.prune(insightsDir(), KEEP_REPORTS);
 
   console.log("");
-  console.log(pc.bold(`📊 Dosu Insights — ${report.deploymentName}`));
+  console.log(pc.bold(`📊 Dosu Insights — ${report.spaceName}`));
   if (report.cheers[0]) {
     console.log(pc.green(`   ${report.cheers[0]}`));
   }
@@ -172,7 +172,7 @@ export async function executeInsights(cfg: Config): Promise<void> {
 
 export function insightsCommand(): Command {
   return new Command("insights")
-    .description("Open a fun visual report of your Dosu deployment activity")
+    .description("Open a fun visual report of your Dosu space activity")
     .action(async () => {
       const cfg = requireFullConfig();
       try {

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -1,5 +1,5 @@
 /**
- * `dosu insights` — open a fun visual report of your space activity.
+ * `dosu insights`: open a fun visual report of your space activity.
  *
  * One word, no flags. Builds an HTML report from `analytics.getUsageStats`
  * plus a few parallel `/ask` calls for narrative sections, writes it to
@@ -20,6 +20,62 @@ import { requireAPIKey, requireLoginConfig } from "./auth";
 const ASK_TIMEOUT_MS = 90_000;
 const KEEP_REPORTS = 20;
 const REPORT_FILE_PATTERN = /^report-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.html$/;
+const HINT_INTERVAL_MS = 6_000;
+const NARRATIVE_HINTS = [
+  "Asking Dosu to narrate the numbers",
+  "Reading reactions and confidence levels",
+  "Looking for the story in the data",
+  "Drafting your at-a-glance summary",
+  "Polishing the narrative",
+  "Almost there",
+];
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPINNER_INTERVAL_MS = 80;
+
+export interface Spinner {
+  start(message: string): void;
+  message(message: string): void;
+  stop(message: string, code?: number): void;
+}
+
+export function createDotsSpinner(): Spinner {
+  let frameIdx = 0;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let current = "";
+  const isTTY = Boolean(process.stdout.isTTY) && process.env.CI !== "true";
+
+  const draw = () => {
+    process.stdout.write(`\r\x1b[2K${pc.cyan(SPINNER_FRAMES[frameIdx])} ${current}`);
+    frameIdx = (frameIdx + 1) % SPINNER_FRAMES.length;
+  };
+
+  return {
+    start(msg) {
+      current = msg;
+      if (!isTTY) {
+        process.stdout.write(`${msg}\n`);
+        return;
+      }
+      draw();
+      timer = setInterval(draw, SPINNER_INTERVAL_MS);
+    },
+    message(msg) {
+      current = msg;
+    },
+    stop(msg, code = 0) {
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+      const symbol = code === 0 ? pc.green("✓") : pc.red("✗");
+      if (isTTY) {
+        process.stdout.write(`\r\x1b[2K${symbol} ${msg}\n`);
+      } else {
+        process.stdout.write(`${symbol} ${msg}\n`);
+      }
+    },
+  };
+}
 
 function requireFullConfig(): Config {
   const cfg = requireLoginConfig();
@@ -113,20 +169,48 @@ export interface InsightsRunner {
   prune: (dir: string, keepN: number) => void;
   openInBrowser: (path: string) => Promise<void>;
   ask: AskFn;
+  createSpinner: () => Spinner;
 }
 
 export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<string> {
   const client = createTypedClient(cfg);
+  const spinner = runner.createSpinner();
+  let hintTimer: ReturnType<typeof setInterval> | undefined;
+  let spinnerActive = false;
 
-  const onProgress = (stage: InsightsStage) => {
-    if (stage === "stats") {
-      console.log(pc.dim("✨ Looking at the last 30 days of your space..."));
-    } else if (stage === "narrative") {
-      console.log(pc.dim("   Asking Dosu to narrate the numbers (up to 90s)..."));
+  const stopHints = () => {
+    if (hintTimer) {
+      clearInterval(hintTimer);
+      hintTimer = undefined;
     }
   };
 
-  const report = await runner.build({ client, cfg, ask: runner.ask, windowDays: 30, onProgress });
+  const onProgress = (stage: InsightsStage) => {
+    if (stage === "stats") {
+      spinner.start("Looking at the last 30 days of your space");
+      spinnerActive = true;
+    } else if (stage === "narrative") {
+      let hintIdx = 0;
+      spinner.message(NARRATIVE_HINTS[hintIdx]);
+      stopHints();
+      hintTimer = setInterval(() => {
+        hintIdx = (hintIdx + 1) % NARRATIVE_HINTS.length;
+        spinner.message(NARRATIVE_HINTS[hintIdx]);
+      }, HINT_INTERVAL_MS);
+    }
+  };
+
+  let report: Awaited<ReturnType<typeof runner.build>>;
+  try {
+    report = await runner.build({ client, cfg, ask: runner.ask, windowDays: 30, onProgress });
+  } catch (err) {
+    stopHints();
+    if (spinnerActive) spinner.stop("Couldn't build your insights", 1);
+    throw err;
+  }
+  stopHints();
+  if (spinnerActive) spinner.stop("Insights ready");
+
   const html = runner.render(report);
   const timestamp = new Date();
   const snapshotPath = reportPath(timestamp);
@@ -136,7 +220,7 @@ export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<
   runner.prune(insightsDir(), KEEP_REPORTS);
 
   console.log("");
-  console.log(pc.bold(`📊 Dosu Insights — ${report.spaceName}`));
+  console.log(pc.bold(`📊 Dosu Insights · ${report.spaceName}`));
   if (report.cheers[0]) {
     console.log(pc.green(`   ${report.cheers[0]}`));
   }
@@ -148,7 +232,7 @@ export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<
   try {
     await runner.openInBrowser(snapshotPath);
   } catch {
-    console.log(pc.dim("   (couldn't auto-open — copy the link above)"));
+    console.log(pc.dim("   (couldn't auto-open. Copy the link above.)"));
   }
 
   return snapshotPath;
@@ -169,6 +253,7 @@ export function defaultRunner(cfg: Config): InsightsRunner {
       await open.default(path);
     },
     ask: makeAskFn(cfg),
+    createSpinner: createDotsSpinner,
   };
 }
 
@@ -176,7 +261,7 @@ export function defaultRunner(cfg: Config): InsightsRunner {
  * Run the insights flow with the default runner. Shared by the CLI command
  * and the TUI menu so both surfaces produce identical output.
  *
- * Logs and swallows errors — callers (TUI) shouldn't crash on one bad insights run.
+ * Logs and swallows errors so callers (TUI) shouldn't crash on one bad insights run.
  */
 export async function executeInsights(cfg: Config): Promise<void> {
   try {

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -21,14 +21,32 @@ const ASK_TIMEOUT_MS = 90_000;
 const KEEP_REPORTS = 20;
 const REPORT_FILE_PATTERN = /^report-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.html$/;
 const HINT_INTERVAL_MS = 6_000;
-const NARRATIVE_HINTS = [
-  "Asking Dosu to narrate the numbers",
-  "Reading reactions and confidence levels",
-  "Looking for the story in the data",
+export const NARRATIVE_HINTS = [
+  "Reading your reactions and confidence levels",
+  "Looking for the story in your numbers",
   "Drafting your at-a-glance summary",
-  "Polishing the narrative",
-  "Almost there",
+  "Spotting the highlights of the week",
+  "Sifting through signal and noise",
+  "Tracking what changed week over week",
+  "Following the threads with the most reactions",
+  "Pulling together the highlights",
+  "Tuning the headlines for clarity",
+  "Surfacing the wins worth sharing",
+  "Pondering the patterns",
+  "Composing your weekly recap",
+  "Crunching the deltas",
+  "Catching the standouts",
+  "Polishing the writeup",
 ];
+
+function shuffled<T>(arr: readonly T[]): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const SPINNER_INTERVAL_MS = 80;
 
@@ -190,12 +208,13 @@ export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<
       spinner.start("Looking at the last 30 days of your space");
       spinnerActive = true;
     } else if (stage === "narrative") {
+      const hints = shuffled(NARRATIVE_HINTS);
       let hintIdx = 0;
-      spinner.message(NARRATIVE_HINTS[hintIdx]);
+      spinner.message(hints[hintIdx]);
       stopHints();
       hintTimer = setInterval(() => {
-        hintIdx = (hintIdx + 1) % NARRATIVE_HINTS.length;
-        spinner.message(NARRATIVE_HINTS[hintIdx]);
+        hintIdx = (hintIdx + 1) % hints.length;
+        spinner.message(hints[hintIdx]);
       }, HINT_INTERVAL_MS);
     }
   };

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -1,0 +1,154 @@
+/**
+ * `dosu insights` — open a fun visual report of your deployment activity.
+ *
+ * One word, no flags. Builds an HTML report from `analytics.getUsageStats`
+ * plus a few parallel `/ask` calls for narrative sections, writes it to
+ * ~/.config/dosu-cli/insights/report.html, and opens it in the default browser.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { Command } from "commander";
+import pc from "picocolors";
+import { createTypedClient } from "../client/trpc";
+import { type Config, getConfigDir } from "../config/config";
+import { getBackendURL } from "../config/constants";
+import { logger } from "../debug/logger";
+import { type AskFn, buildInsights, renderHTML } from "../insights";
+import { requireAPIKey, requireLoginConfig } from "./auth";
+
+const ASK_TIMEOUT_MS = 90_000;
+
+function requireFullConfig(): Config {
+  const cfg = requireLoginConfig();
+  requireAPIKey(cfg);
+  if (!cfg.space_id || !cfg.deployment_id) {
+    console.error(pc.red("Missing deployment config. Run 'dosu setup' to reconfigure."));
+    process.exit(1);
+  }
+  return cfg;
+}
+
+export function makeAskFn(cfg: Config): AskFn {
+  const backendURL = getBackendURL();
+  if (!backendURL) {
+    logger.warn("insights", "Backend URL not configured; narrative sections will be skipped.");
+    return async () => null;
+  }
+  return async (question) => {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), ASK_TIMEOUT_MS);
+    try {
+      const resp = await fetch(`${backendURL}/ask`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          // biome-ignore lint/style/noNonNullAssertion: checked in requireFullConfig
+          "X-Dosu-API-Key": cfg.api_key!,
+        },
+        body: JSON.stringify({
+          // biome-ignore lint/style/noNonNullAssertion: checked in requireFullConfig
+          deployment_id: cfg.deployment_id!,
+          question,
+        }),
+        signal: controller.signal,
+      });
+      if (!resp.ok) {
+        logger.debug("insights", `ask returned ${resp.status}`);
+        return null;
+      }
+      const body = (await resp.json()) as { answer?: unknown };
+      return typeof body.answer === "string" ? body.answer : null;
+    } catch (err) {
+      logger.debug("insights", `ask failed: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    } finally {
+      clearTimeout(t);
+    }
+  };
+}
+
+export function reportPath(): string {
+  return join(getConfigDir(), "insights", "report.html");
+}
+
+export interface InsightsRunner {
+  build: typeof buildInsights;
+  render: typeof renderHTML;
+  writeFile: (path: string, content: string) => void;
+  openInBrowser: (path: string) => Promise<void>;
+  ask: AskFn;
+}
+
+export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<string> {
+  const client = createTypedClient(cfg);
+
+  console.log(pc.dim("✨ Looking at the last 30 days of your deployment..."));
+
+  const report = await runner.build({ client, cfg, ask: runner.ask, windowDays: 30 });
+  const html = runner.render(report);
+  const path = reportPath();
+  runner.writeFile(path, html);
+
+  console.log("");
+  console.log(pc.bold(`📊 Dosu Insights — ${report.deploymentName}`));
+  if (report.cheers[0]) {
+    console.log(pc.green(`   ${report.cheers[0]}`));
+  }
+  console.log("");
+  console.log(`   Report: ${pc.cyan(`file://${path}`)}`);
+  console.log(pc.dim("   Opening in your browser..."));
+
+  try {
+    await runner.openInBrowser(path);
+  } catch {
+    console.log(pc.dim("   (couldn't auto-open — copy the link above)"));
+  }
+
+  return path;
+}
+
+export function defaultRunner(cfg: Config): InsightsRunner {
+  return {
+    build: buildInsights,
+    render: renderHTML,
+    writeFile: (path, content) => {
+      const dir = dirname(path);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+      writeFileSync(path, content, { mode: 0o600 });
+    },
+    openInBrowser: async (path) => {
+      const open = await import("open");
+      await open.default(path);
+    },
+    ask: makeAskFn(cfg),
+  };
+}
+
+/**
+ * Run the insights flow with the default runner. Shared by the CLI command
+ * and the TUI menu so both surfaces produce identical output.
+ *
+ * Logs and swallows errors — callers (TUI) shouldn't crash on one bad insights run.
+ */
+export async function executeInsights(cfg: Config): Promise<void> {
+  try {
+    await runInsights(cfg, defaultRunner(cfg));
+  } catch (err) {
+    console.error(pc.red(`Error: ${err instanceof Error ? err.message : String(err)}`));
+  }
+}
+
+export function insightsCommand(): Command {
+  return new Command("insights")
+    .description("Open a fun visual report of your Dosu deployment activity")
+    .action(async () => {
+      const cfg = requireFullConfig();
+      try {
+        await runInsights(cfg, defaultRunner(cfg));
+      } catch (err) {
+        console.error(pc.red(`Error: ${err instanceof Error ? err.message : String(err)}`));
+        process.exit(1);
+      }
+    });
+}

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -3,10 +3,10 @@
  *
  * One word, no flags. Builds an HTML report from `analytics.getUsageStats`
  * plus a few parallel `/ask` calls for narrative sections, writes it to
- * ~/.config/dosu-cli/insights/report.html, and opens it in the default browser.
+ * ~/.config/dosu-cli/insights/ (timestamped snapshot + latest.html), and opens it in the default browser.
  */
 
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Command } from "commander";
 import pc from "picocolors";
@@ -18,6 +18,8 @@ import { type AskFn, buildInsights, renderHTML } from "../insights";
 import { requireAPIKey, requireLoginConfig } from "./auth";
 
 const ASK_TIMEOUT_MS = 90_000;
+const KEEP_REPORTS = 20;
+const REPORT_FILE_PATTERN = /^report-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.html$/;
 
 function requireFullConfig(): Config {
   const cfg = requireLoginConfig();
@@ -68,14 +70,37 @@ export function makeAskFn(cfg: Config): AskFn {
   };
 }
 
-export function reportPath(): string {
-  return join(getConfigDir(), "insights", "report.html");
+export function insightsDir(): string {
+  return join(getConfigDir(), "insights");
+}
+
+export function reportPath(timestamp?: Date): string {
+  const dir = insightsDir();
+  if (!timestamp) return join(dir, "latest.html");
+  const iso = timestamp.toISOString().slice(0, 19).replace(/:/g, "-");
+  return join(dir, `report-${iso}Z.html`);
+}
+
+export function pruneOldReports(dir: string, keepN: number): void {
+  if (!existsSync(dir)) return;
+  const reports = readdirSync(dir)
+    .filter((f) => REPORT_FILE_PATTERN.test(f))
+    .sort()
+    .reverse();
+  for (const f of reports.slice(keepN)) {
+    try {
+      unlinkSync(join(dir, f));
+    } catch (err) {
+      logger.debug("insights", `failed to prune ${f}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
 }
 
 export interface InsightsRunner {
   build: typeof buildInsights;
   render: typeof renderHTML;
   writeFile: (path: string, content: string) => void;
+  prune: (dir: string, keepN: number) => void;
   openInBrowser: (path: string) => Promise<void>;
   ask: AskFn;
 }
@@ -87,8 +112,12 @@ export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<
 
   const report = await runner.build({ client, cfg, ask: runner.ask, windowDays: 30 });
   const html = runner.render(report);
-  const path = reportPath();
-  runner.writeFile(path, html);
+  const timestamp = new Date();
+  const snapshotPath = reportPath(timestamp);
+  const latestPath = reportPath();
+  runner.writeFile(snapshotPath, html);
+  runner.writeFile(latestPath, html);
+  runner.prune(insightsDir(), KEEP_REPORTS);
 
   console.log("");
   console.log(pc.bold(`📊 Dosu Insights — ${report.deploymentName}`));
@@ -96,16 +125,17 @@ export async function runInsights(cfg: Config, runner: InsightsRunner): Promise<
     console.log(pc.green(`   ${report.cheers[0]}`));
   }
   console.log("");
-  console.log(`   Report: ${pc.cyan(`file://${path}`)}`);
+  console.log(`   Snapshot: ${pc.cyan(`file://${snapshotPath}`)}`);
+  console.log(`   Latest:   ${pc.cyan(`file://${latestPath}`)}`);
   console.log(pc.dim("   Opening in your browser..."));
 
   try {
-    await runner.openInBrowser(path);
+    await runner.openInBrowser(snapshotPath);
   } catch {
     console.log(pc.dim("   (couldn't auto-open — copy the link above)"));
   }
 
-  return path;
+  return snapshotPath;
 }
 
 export function defaultRunner(cfg: Config): InsightsRunner {
@@ -117,6 +147,7 @@ export function defaultRunner(cfg: Config): InsightsRunner {
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
       writeFileSync(path, content, { mode: 0o600 });
     },
+    prune: pruneOldReports,
     openInBrowser: async (path) => {
       const open = await import("open");
       await open.default(path);

--- a/src/insights/index.ts
+++ b/src/insights/index.ts
@@ -3,10 +3,9 @@ export {
   type BuildInsightsArgs,
   buildAtAGlancePrompt,
   buildInsights,
-  buildSuggestionsPrompt,
-  buildTopicsPrompt,
-  type InsightsNarratives,
+  fallbackAtAGlance,
   type InsightsReport,
+  type Suggestion,
   type UsageStats,
 } from "./insights";
 export { renderHTML } from "./render-html";

--- a/src/insights/index.ts
+++ b/src/insights/index.ts
@@ -5,6 +5,8 @@ export {
   buildInsights,
   fallbackAtAGlance,
   type InsightsReport,
+  type InsightsStage,
+  type ProgressFn,
   type Suggestion,
   type UsageStats,
 } from "./insights";

--- a/src/insights/index.ts
+++ b/src/insights/index.ts
@@ -1,0 +1,12 @@
+export {
+  type AskFn,
+  type BuildInsightsArgs,
+  buildAtAGlancePrompt,
+  buildInsights,
+  buildSuggestionsPrompt,
+  buildTopicsPrompt,
+  type InsightsNarratives,
+  type InsightsReport,
+  type UsageStats,
+} from "./insights";
+export { renderHTML } from "./render-html";

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -420,7 +420,7 @@ describe("suggestions", () => {
     const r = await build({ current: stats(), combined: stats() });
     expect(r.suggestions).toHaveLength(2);
     expect(r.suggestions[0].command).toBe("dosu setup");
-    expect(r.suggestions[1].command).toBe("dosu integrations");
+    expect(r.suggestions[1].command).toBe("dosu integrations list");
   });
 
   it("suggests auditing low-confidence threads when they grow", async () => {
@@ -503,7 +503,7 @@ describe("suggestions", () => {
       combined: stats({ totalResponses: 50 }),
     });
     const ride = r.suggestions.find((s) => /momentum/.test(s.headline));
-    expect(ride?.command).toBe("dosu integrations");
+    expect(ride?.command).toBe("dosu integrations list");
   });
 
   it("always includes at least one suggestion (fallback)", async () => {

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -244,7 +244,7 @@ describe("cheers", () => {
         },
       }),
     });
-    expect(r.cheers.some((c) => /positive feedback/.test(c))).toBe(true);
+    expect(r.cheers.some((c) => /positive/.test(c))).toBe(true);
   });
 
   it("celebrates rising volume", async () => {
@@ -536,6 +536,25 @@ describe("suggestions", () => {
     const audit = r.suggestions.find((s) => /Audit/.test(s.headline));
     expect(audit).toBeDefined();
     expect(audit?.detail).not.toMatch(/vs prior/);
+  });
+
+  it("dedupes suggestions by command so the same CTA never appears twice", async () => {
+    // Both audit-low-confidence and rising-volume use `dosu threads list`.
+    // Trigger both: low-conf elevated AND volume up >= 10.
+    const r = await build({
+      current: stats({
+        totalResponses: 50,
+        byConfidence: { high: 10, medium: 15, low: 25 },
+      }),
+      combined: stats({
+        totalResponses: 80,
+        byConfidence: { high: 20, medium: 30, low: 30 },
+      }),
+    });
+    const threadsListCount = r.suggestions.filter((s) => s.command === "dosu threads list").length;
+    expect(threadsListCount).toBe(1);
+    // Audit wins because it appears earlier in the priority order
+    expect(r.suggestions.find((s) => s.command === "dosu threads list")?.headline).toMatch(/Audit/);
   });
 
   it("caps suggestions at 4 to keep the report scannable", async () => {

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -4,8 +4,7 @@ import {
   type AskFn,
   buildAtAGlancePrompt,
   buildInsights,
-  buildSuggestionsPrompt,
-  buildTopicsPrompt,
+  fallbackAtAGlance,
   type UsageStats,
 } from "./insights";
 
@@ -57,19 +56,21 @@ function stats(over: Partial<UsageStats> = {}): UsageStats {
 
 const okAsk: AskFn = async (q) => `answered: ${q.slice(0, 16)}`;
 
+async function build(opts: { current: UsageStats; combined: UsageStats; ask?: AskFn }) {
+  mockQuery.mockResolvedValueOnce(opts.current);
+  mockQuery.mockResolvedValueOnce(opts.combined);
+  return buildInsights({
+    client: createMockClient() as never,
+    cfg,
+    ask: opts.ask ?? okAsk,
+    windowDays: 30,
+    now: NOW,
+  });
+}
+
 describe("buildInsights", () => {
-  it("queries current window and combined window", async () => {
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 50, totalWithResponse: 40 }));
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 90, totalWithResponse: 70 }));
-
-    await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
-    });
-
+  it("queries current and combined windows", async () => {
+    await build({ current: stats(), combined: stats() });
     expect(mockQuery).toHaveBeenNthCalledWith(1, "analytics.getUsageStats", {
       spaceId: "sp1",
       days: 30,
@@ -80,71 +81,26 @@ describe("buildInsights", () => {
     });
   });
 
-  it("derives previous window by subtracting current from combined", async () => {
-    mockQuery.mockResolvedValueOnce(
-      stats({
-        totalResponses: 50,
-        totalWithResponse: 40,
-        byConfidence: { high: 30, medium: 15, low: 5 },
-        reactions: {
-          totalPositive: 10,
-          totalNegative: 2,
-          messagesWithReactions: 12,
-          reactionRate: 0.24,
-          positiveRate: 0.83,
-        },
-      }),
-    );
-    mockQuery.mockResolvedValueOnce(
-      stats({
-        totalResponses: 90,
-        totalWithResponse: 70,
-        byConfidence: { high: 50, medium: 25, low: 15 },
-        reactions: {
-          totalPositive: 14,
-          totalNegative: 6,
-          messagesWithReactions: 20,
-          reactionRate: 0.22,
-          positiveRate: 0.7,
-        },
-      }),
-    );
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
+  it("derives previous window via subtraction", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 50, totalWithResponse: 40 }),
+      combined: stats({ totalResponses: 90, totalWithResponse: 70 }),
     });
-
     expect(r.previous.totalResponses).toBe(40);
     expect(r.previous.totalWithResponse).toBe(30);
-    expect(r.previous.byConfidence).toEqual({ high: 20, medium: 10, low: 10 });
-    expect(r.previous.reactions.totalPositive).toBe(4);
-    expect(r.previous.reactions.totalNegative).toBe(4);
-    expect(r.previous.reactions.positiveRate).toBeCloseTo(0.5, 5);
   });
 
-  it("clamps subtraction to zero when combined is smaller than current (defensive)", async () => {
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 50 }));
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 30 }));
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
+  it("clamps subtraction to zero defensively", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 50 }),
+      combined: stats({ totalResponses: 30 }),
     });
-
     expect(r.previous.totalResponses).toBe(0);
   });
 
-  it("computes answer-rate delta between windows", async () => {
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 100, totalWithResponse: 90 }));
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 200, totalWithResponse: 160 }));
-
+  it("normalizes nullish API responses", async () => {
+    mockQuery.mockResolvedValueOnce(null);
+    mockQuery.mockResolvedValueOnce(undefined);
     const r = await buildInsights({
       client: createMockClient() as never,
       cfg,
@@ -152,52 +108,20 @@ describe("buildInsights", () => {
       windowDays: 30,
       now: NOW,
     });
-
-    // current = 90/100 = 0.9; previous = 70/100 = 0.7; delta = 0.2
-    expect(r.derived.answerRate).toBeCloseTo(0.9, 5);
-    expect(r.derived.answerRateDelta).toBeCloseTo(0.2, 5);
-    expect(r.derived.responsesDelta).toBe(0);
+    expect(r.current.totalResponses).toBe(0);
+    expect(r.previous.totalResponses).toBe(0);
   });
 
-  it("returns null answer-rate when there are no responses", async () => {
+  it("uses real Date when `now` is not provided", async () => {
     mockQuery.mockResolvedValueOnce(stats());
     mockQuery.mockResolvedValueOnce(stats());
-
     const r = await buildInsights({
       client: createMockClient() as never,
       cfg,
       ask: okAsk,
       windowDays: 30,
-      now: NOW,
     });
-
-    expect(r.derived.answerRate).toBeNull();
-    expect(r.derived.answerRateDelta).toBeNull();
-    expect(r.derived.positiveRateDelta).toBeNull();
-  });
-
-  it("preserves narrative answers and tolerates per-call failures", async () => {
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 10, totalWithResponse: 8 }));
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 12, totalWithResponse: 10 }));
-
-    let n = 0;
-    const ask: AskFn = async (q) => {
-      n += 1;
-      if (n === 2) return null; // simulate failure
-      return `OK: ${q.slice(0, 8)}`;
-    };
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask,
-      windowDays: 30,
-      now: NOW,
-    });
-
-    expect(r.narratives.atAGlance).toMatch(/^OK: /);
-    expect(r.narratives.topics).toBeNull();
-    expect(r.narratives.suggestions).toMatch(/^OK: /);
+    expect(r.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   it("throws when space_id is missing", async () => {
@@ -210,153 +134,9 @@ describe("buildInsights", () => {
     ).rejects.toThrow(/space_id/);
   });
 
-  it("returns the welcome cheer when there are no responses", async () => {
+  it("falls back to 'your deployment' when name is missing", async () => {
     mockQuery.mockResolvedValueOnce(stats());
     mockQuery.mockResolvedValueOnce(stats());
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
-    });
-
-    expect(r.cheers).toHaveLength(1);
-    expect(r.cheers[0]).toMatch(/brand new/);
-  });
-
-  it("celebrates a high answer rate", async () => {
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 100, totalWithResponse: 95 }));
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 100, totalWithResponse: 95 }));
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
-    });
-
-    expect(r.cheers.some((c) => /answer rate/.test(c))).toBe(true);
-  });
-
-  it("celebrates dominant high-confidence responses", async () => {
-    mockQuery.mockResolvedValueOnce(
-      stats({
-        totalResponses: 30,
-        totalWithResponse: 28,
-        byConfidence: { high: 20, medium: 5, low: 5 },
-      }),
-    );
-    mockQuery.mockResolvedValueOnce(
-      stats({
-        totalResponses: 30,
-        totalWithResponse: 28,
-        byConfidence: { high: 20, medium: 5, low: 5 },
-      }),
-    );
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
-    });
-
-    expect(r.cheers.some((c) => /high-confidence/.test(c))).toBe(true);
-  });
-
-  it("celebrates positive feedback when rate >= 80%", async () => {
-    mockQuery.mockResolvedValueOnce(
-      stats({
-        totalResponses: 50,
-        totalWithResponse: 40,
-        reactions: {
-          totalPositive: 9,
-          totalNegative: 1,
-          messagesWithReactions: 10,
-          reactionRate: 0.2,
-          positiveRate: 0.9,
-        },
-      }),
-    );
-    mockQuery.mockResolvedValueOnce(
-      stats({
-        totalResponses: 50,
-        totalWithResponse: 40,
-        reactions: {
-          totalPositive: 9,
-          totalNegative: 1,
-          messagesWithReactions: 10,
-          reactionRate: 0.2,
-          positiveRate: 0.9,
-        },
-      }),
-    );
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
-    });
-
-    expect(r.cheers.some((c) => /positive feedback/.test(c))).toBe(true);
-  });
-
-  it("celebrates rising volume", async () => {
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 80, totalWithResponse: 60 }));
-    // combined 30 means previous = 0; current 80 - prev 0 = +80
-    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 80, totalWithResponse: 60 }));
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
-    });
-
-    expect(r.cheers.some((c) => /Volume is up/.test(c))).toBe(true);
-  });
-
-  it("falls back to a generic cheer when no rules trigger", async () => {
-    // 30 responses, mediocre rates everywhere — no celebratable signal, and the
-    // combined window is double so previous == current → no volume delta.
-    mockQuery.mockResolvedValueOnce(
-      stats({
-        totalResponses: 30,
-        totalWithResponse: 15,
-        byConfidence: { high: 5, medium: 10, low: 15 },
-      }),
-    );
-    mockQuery.mockResolvedValueOnce(
-      stats({
-        totalResponses: 60,
-        totalWithResponse: 30,
-        byConfidence: { high: 10, medium: 20, low: 30 },
-      }),
-    );
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
-    });
-
-    expect(r.cheers).toHaveLength(1);
-    expect(r.cheers[0]).toMatch(/30 responses logged/);
-  });
-
-  it("falls back to 'your deployment' when deployment_name is missing", async () => {
-    mockQuery.mockResolvedValueOnce(stats());
-    mockQuery.mockResolvedValueOnce(stats());
-
     const r = await buildInsights({
       client: createMockClient() as never,
       cfg: { ...cfg, deployment_name: undefined },
@@ -364,61 +144,416 @@ describe("buildInsights", () => {
       windowDays: 30,
       now: NOW,
     });
-
     expect(r.deploymentName).toBe("your deployment");
   });
 
-  it("normalizes nullish stats from the API", async () => {
-    mockQuery.mockResolvedValueOnce(null);
-    mockQuery.mockResolvedValueOnce(undefined);
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
-      now: NOW,
+  it("uses /ask answer for atAGlance when available", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 10, totalWithResponse: 8 }),
+      combined: stats({ totalResponses: 12, totalWithResponse: 10 }),
+      ask: async () => "Custom prose from Dosu.",
     });
-
-    expect(r.current.totalResponses).toBe(0);
-    expect(r.previous.totalResponses).toBe(0);
+    expect(r.atAGlance).toBe("Custom prose from Dosu.");
   });
 
-  it("uses real Date when `now` is not provided", async () => {
-    mockQuery.mockResolvedValueOnce(stats());
-    mockQuery.mockResolvedValueOnce(stats());
-
-    const r = await buildInsights({
-      client: createMockClient() as never,
-      cfg,
-      ask: okAsk,
-      windowDays: 30,
+  it("falls back to a stats-grounded atAGlance when /ask returns null", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 10, totalWithResponse: 8 }),
+      combined: stats({ totalResponses: 12, totalWithResponse: 10 }),
+      ask: async () => null,
     });
-
-    // Should be a valid ISO timestamp from "now"
-    expect(() => new Date(r.generatedAt)).not.toThrow();
-    expect(r.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    // The fallback is always non-null and should reference the real numbers.
+    expect(r.atAGlance).toContain("10 responses");
+    expect(r.atAGlance).toContain("80%");
   });
 });
 
-describe("prompt builders", () => {
+describe("cheers", () => {
+  it("welcomes empty deployments", async () => {
+    const r = await build({ current: stats(), combined: stats() });
+    expect(r.cheers).toHaveLength(1);
+    expect(r.cheers[0]).toMatch(/brand new/);
+  });
+
+  it("celebrates a high answer rate", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 100, totalWithResponse: 95 }),
+      combined: stats({ totalResponses: 100, totalWithResponse: 95 }),
+    });
+    expect(r.cheers.some((c) => /answer rate/.test(c))).toBe(true);
+  });
+
+  it("celebrates dominant high-confidence", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 30,
+        totalWithResponse: 28,
+        byConfidence: { high: 20, medium: 5, low: 5 },
+      }),
+      combined: stats({
+        totalResponses: 30,
+        totalWithResponse: 28,
+        byConfidence: { high: 20, medium: 5, low: 5 },
+      }),
+    });
+    expect(r.cheers.some((c) => /high-confidence/.test(c))).toBe(true);
+  });
+
+  it("celebrates positive feedback", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 50,
+        totalWithResponse: 40,
+        reactions: {
+          totalPositive: 9,
+          totalNegative: 1,
+          messagesWithReactions: 10,
+          reactionRate: 0.2,
+          positiveRate: 0.9,
+        },
+      }),
+      combined: stats({
+        totalResponses: 50,
+        totalWithResponse: 40,
+        reactions: {
+          totalPositive: 9,
+          totalNegative: 1,
+          messagesWithReactions: 10,
+          reactionRate: 0.2,
+          positiveRate: 0.9,
+        },
+      }),
+    });
+    expect(r.cheers.some((c) => /positive feedback/.test(c))).toBe(true);
+  });
+
+  it("celebrates rising volume", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 80, totalWithResponse: 60 }),
+      combined: stats({ totalResponses: 80, totalWithResponse: 60 }),
+    });
+    expect(r.cheers.some((c) => /Volume is up/.test(c))).toBe(true);
+  });
+
+  it("falls back to a generic cheer when no rule fires", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 30,
+        totalWithResponse: 15,
+        byConfidence: { high: 5, medium: 10, low: 15 },
+      }),
+      combined: stats({
+        totalResponses: 60,
+        totalWithResponse: 30,
+        byConfidence: { high: 10, medium: 20, low: 30 },
+      }),
+    });
+    expect(r.cheers).toHaveLength(1);
+    expect(r.cheers[0]).toMatch(/30 responses logged/);
+  });
+});
+
+describe("investigate", () => {
+  it("is empty for a brand-new deployment", async () => {
+    const r = await build({ current: stats(), combined: stats() });
+    expect(r.investigate).toHaveLength(0);
+  });
+
+  it("flags a meaningful drop in answer rate", async () => {
+    const r = await build({
+      // current: 60/100 = 60%; previous: 90/100 = 90% → delta -30 pts
+      current: stats({ totalResponses: 100, totalWithResponse: 60 }),
+      combined: stats({ totalResponses: 200, totalWithResponse: 150 }),
+    });
+    expect(r.investigate.some((c) => /Answer rate dropped/.test(c))).toBe(true);
+  });
+
+  it("flags growing low-confidence count", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 40,
+        totalWithResponse: 30,
+        byConfidence: { high: 10, medium: 10, low: 20 },
+      }),
+      combined: stats({
+        totalResponses: 60,
+        totalWithResponse: 50,
+        byConfidence: { high: 20, medium: 20, low: 25 },
+      }),
+    });
+    expect(r.investigate.some((c) => /Low-confidence answers grew/.test(c))).toBe(true);
+  });
+
+  it("flags a drop in positive feedback rate", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 50,
+        totalWithResponse: 40,
+        reactions: {
+          totalPositive: 5,
+          totalNegative: 5,
+          messagesWithReactions: 10,
+          reactionRate: 0.2,
+          positiveRate: 0.5,
+        },
+      }),
+      combined: stats({
+        totalResponses: 100,
+        totalWithResponse: 90,
+        reactions: {
+          totalPositive: 14,
+          totalNegative: 6,
+          messagesWithReactions: 20,
+          reactionRate: 0.2,
+          positiveRate: 0.7,
+        },
+      }),
+    });
+    expect(r.investigate.some((c) => /Positive feedback fell/.test(c))).toBe(true);
+  });
+
+  it("flags more negative than positive feedback", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 30,
+        totalWithResponse: 25,
+        reactions: {
+          totalPositive: 2,
+          totalNegative: 5,
+          messagesWithReactions: 7,
+          reactionRate: 0.23,
+          positiveRate: 0.29,
+        },
+      }),
+      combined: stats({
+        totalResponses: 30,
+        totalWithResponse: 25,
+        reactions: {
+          totalPositive: 2,
+          totalNegative: 5,
+          messagesWithReactions: 7,
+          reactionRate: 0.23,
+          positiveRate: 0.29,
+        },
+      }),
+    });
+    expect(r.investigate.some((c) => /negative reactions vs.*positive/.test(c))).toBe(true);
+  });
+
+  it("flags a meaningful drop in volume", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 30, totalWithResponse: 25 }),
+      combined: stats({ totalResponses: 100, totalWithResponse: 80 }),
+    });
+    expect(r.investigate.some((c) => /Volume is down/.test(c))).toBe(true);
+  });
+
+  it("flags a low overall answer rate independent of trend", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 20, totalWithResponse: 8 }),
+      combined: stats({ totalResponses: 40, totalWithResponse: 16 }),
+    });
+    expect(r.investigate.some((c) => /went without an answer/.test(c))).toBe(true);
+  });
+});
+
+describe("suggestions", () => {
+  it("recommends setup + integrations for empty deployments", async () => {
+    const r = await build({ current: stats(), combined: stats() });
+    expect(r.suggestions).toHaveLength(2);
+    expect(r.suggestions[0].command).toBe("dosu setup");
+    expect(r.suggestions[1].command).toBe("dosu integrations");
+  });
+
+  it("suggests auditing low-confidence threads when they grow", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 30,
+        totalWithResponse: 25,
+        byConfidence: { high: 5, medium: 10, low: 15 },
+      }),
+      combined: stats({
+        totalResponses: 60,
+        totalWithResponse: 50,
+        byConfidence: { high: 10, medium: 20, low: 22 },
+      }),
+    });
+    const audit = r.suggestions.find((s) => /Audit/.test(s.headline));
+    expect(audit).toBeDefined();
+    expect(audit?.command).toBe("dosu threads list");
+    expect(audit?.detail).toContain("15");
+  });
+
+  it("suggests refreshing sources when positive rate drops", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 50,
+        totalWithResponse: 40,
+        reactions: {
+          totalPositive: 5,
+          totalNegative: 5,
+          messagesWithReactions: 10,
+          reactionRate: 0.2,
+          positiveRate: 0.5,
+        },
+      }),
+      combined: stats({
+        totalResponses: 100,
+        totalWithResponse: 90,
+        reactions: {
+          totalPositive: 14,
+          totalNegative: 6,
+          messagesWithReactions: 20,
+          reactionRate: 0.2,
+          positiveRate: 0.7,
+        },
+      }),
+    });
+    const refresh = r.suggestions.find((s) => /Refresh/.test(s.headline));
+    expect(refresh?.command).toBe("dosu sources list");
+  });
+
+  it("suggests investigating unanswered threads when answer rate is low", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 20, totalWithResponse: 8 }),
+      combined: stats({ totalResponses: 40, totalWithResponse: 20 }),
+    });
+    const inv = r.suggestions.find((s) => /Investigate/.test(s.headline));
+    expect(inv?.command).toBe("dosu threads list");
+    expect(inv?.detail).toContain("12");
+  });
+
+  it("suggests sharing the win when metrics are healthy and volume is high", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 100,
+        totalWithResponse: 90,
+        byConfidence: { high: 80, medium: 8, low: 2 },
+        reactions: {
+          totalPositive: 9,
+          totalNegative: 1,
+          messagesWithReactions: 10,
+          reactionRate: 0.1,
+          positiveRate: 0.9,
+        },
+      }),
+      combined: stats({
+        totalResponses: 100,
+        totalWithResponse: 90,
+        byConfidence: { high: 80, medium: 8, low: 2 },
+        reactions: {
+          totalPositive: 9,
+          totalNegative: 1,
+          messagesWithReactions: 10,
+          reactionRate: 0.1,
+          positiveRate: 0.9,
+        },
+      }),
+    });
+    const share = r.suggestions.find((s) => /Share/.test(s.headline));
+    expect(share).toBeDefined();
+    expect(share?.command).toBeUndefined();
+  });
+
+  it("recommends adding a source when volume is rising", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 40, totalWithResponse: 35 }),
+      combined: stats({ totalResponses: 50, totalWithResponse: 42 }),
+    });
+    const ride = r.suggestions.find((s) => /momentum/.test(s.headline));
+    expect(ride?.command).toBe("dosu integrations");
+  });
+
+  it("always includes at least one suggestion (fallback)", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 5, totalWithResponse: 5 }),
+      combined: stats({ totalResponses: 10, totalWithResponse: 10 }),
+    });
+    expect(r.suggestions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("caps suggestions at 4 to keep the report scannable", async () => {
+    const r = await build({
+      // Trigger every rule simultaneously: low-conf grew, positive rate dropped,
+      // low answer rate, volume rising
+      current: stats({
+        totalResponses: 50,
+        totalWithResponse: 25,
+        byConfidence: { high: 5, medium: 10, low: 35 },
+        reactions: {
+          totalPositive: 3,
+          totalNegative: 7,
+          messagesWithReactions: 10,
+          reactionRate: 0.2,
+          positiveRate: 0.3,
+        },
+      }),
+      combined: stats({
+        totalResponses: 90,
+        totalWithResponse: 70,
+        byConfidence: { high: 30, medium: 30, low: 30 },
+        reactions: {
+          totalPositive: 18,
+          totalNegative: 2,
+          messagesWithReactions: 20,
+          reactionRate: 0.22,
+          positiveRate: 0.9,
+        },
+      }),
+    });
+    expect(r.suggestions.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("at-a-glance helpers", () => {
   const s = stats({ totalResponses: 10, totalWithResponse: 8 });
   const d = { answerRate: 0.8, answerRateDelta: 0.05, responsesDelta: 2, positiveRateDelta: null };
 
-  it("at-a-glance prompt embeds the stats", () => {
+  it("buildAtAGlancePrompt embeds the stats", () => {
     const p = buildAtAGlancePrompt(s, d, 30);
     expect(p).toContain("last 30 days");
     expect(p).toContain("10 total responses");
     expect(p).toContain("80% answer rate");
   });
 
-  it("topics prompt names the window", () => {
-    expect(buildTopicsPrompt(7)).toContain("last 7 days");
+  it("fallbackAtAGlance handles empty deployments warmly", () => {
+    const f = fallbackAtAGlance(
+      stats(),
+      {
+        answerRate: null,
+        answerRateDelta: null,
+        responsesDelta: 0,
+        positiveRateDelta: null,
+      },
+      30,
+    );
+    expect(f).toContain("brand new");
+    expect(f).toContain("30 days");
   });
 
-  it("suggestions prompt asks for actionable items", () => {
-    const p = buildSuggestionsPrompt(s, d, 30);
-    expect(p).toContain("numbered list");
-    expect(p).toContain("actionable");
+  it("fallbackAtAGlance mentions volume rising", () => {
+    const f = fallbackAtAGlance(s, { ...d, responsesDelta: 12 }, 30);
+    expect(f).toContain("Volume is up 12");
+  });
+
+  it("fallbackAtAGlance mentions volume dropping", () => {
+    const f = fallbackAtAGlance(s, { ...d, responsesDelta: -7 }, 30);
+    expect(f).toContain("Volume is down 7");
+  });
+
+  it("fallbackAtAGlance includes positive feedback rate when reactions exist", () => {
+    const withReactions = stats({
+      totalResponses: 10,
+      totalWithResponse: 8,
+      reactions: {
+        totalPositive: 4,
+        totalNegative: 1,
+        messagesWithReactions: 5,
+        reactionRate: 0.5,
+        positiveRate: 0.8,
+      },
+    });
+    const f = fallbackAtAGlance(withReactions, d, 30);
+    expect(f).toContain("80% positive feedback");
   });
 });

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -416,11 +416,11 @@ describe("investigate", () => {
 });
 
 describe("suggestions", () => {
-  it("recommends setup + integrations for empty spaces", async () => {
+  it("points empty spaces at setup and a try-it-yourself ask", async () => {
     const r = await build({ current: stats(), combined: stats() });
     expect(r.suggestions).toHaveLength(2);
     expect(r.suggestions[0].command).toBe("dosu setup");
-    expect(r.suggestions[1].command).toBe("dosu integrations list");
+    expect(r.suggestions[1].command).toBe('dosu ask "what is Dosu?"');
   });
 
   it("suggests auditing low-confidence threads when they grow", async () => {
@@ -497,13 +497,13 @@ describe("suggestions", () => {
     expect(share?.command).toBeUndefined();
   });
 
-  it("recommends adding a source when volume is rising", async () => {
+  it("suggests browsing recent threads when volume is rising", async () => {
     const r = await build({
       current: stats({ totalResponses: 40 }),
       combined: stats({ totalResponses: 50 }),
     });
-    const ride = r.suggestions.find((s) => /momentum/.test(s.headline));
-    expect(ride?.command).toBe("dosu integrations list");
+    const rising = r.suggestions.find((s) => /what your team is asking/.test(s.headline));
+    expect(rising?.command).toBe("dosu threads list");
   });
 
   it("always includes at least one suggestion (fallback)", async () => {
@@ -514,12 +514,12 @@ describe("suggestions", () => {
     expect(r.suggestions.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("does not emit 'Ride the momentum' when prior window is empty", async () => {
+  it("does not emit the rising-volume suggestion when prior window is empty", async () => {
     const r = await build({
       current: stats({ totalResponses: 40 }),
       combined: stats({ totalResponses: 40 }),
     });
-    expect(r.suggestions.some((s) => /momentum/.test(s.headline))).toBe(false);
+    expect(r.suggestions.some((s) => /what your team is asking/.test(s.headline))).toBe(false);
   });
 
   it("audit-low-confidence fires on absolute threshold without '(+X vs prior)' suffix", async () => {

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -158,11 +158,18 @@ describe("buildInsights", () => {
 
   it("falls back to a stats-grounded atAGlance when /ask returns null", async () => {
     const r = await build({
-      current: stats({ totalResponses: 10, totalWithResponse: 8 }),
-      combined: stats({ totalResponses: 12, totalWithResponse: 10 }),
+      current: stats({
+        totalResponses: 10,
+        totalWithResponse: 10,
+        byConfidence: { high: 8, medium: 1, low: 1 },
+      }),
+      combined: stats({
+        totalResponses: 12,
+        totalWithResponse: 12,
+        byConfidence: { high: 9, medium: 2, low: 1 },
+      }),
       ask: async () => null,
     });
-    // The fallback is always non-null and should reference the real numbers.
     expect(r.atAGlance).toContain("10 responses");
     expect(r.atAGlance).toContain("80%");
   });
@@ -175,12 +182,20 @@ describe("cheers", () => {
     expect(r.cheers[0]).toMatch(/brand new/);
   });
 
-  it("celebrates a high answer rate", async () => {
+  it("celebrates a high high-confidence share", async () => {
     const r = await build({
-      current: stats({ totalResponses: 100, totalWithResponse: 95 }),
-      combined: stats({ totalResponses: 100, totalWithResponse: 95 }),
+      current: stats({
+        totalResponses: 100,
+        totalWithResponse: 100,
+        byConfidence: { high: 90, medium: 8, low: 2 },
+      }),
+      combined: stats({
+        totalResponses: 100,
+        totalWithResponse: 100,
+        byConfidence: { high: 90, medium: 8, low: 2 },
+      }),
     });
-    expect(r.cheers.some((c) => /answer rate/.test(c))).toBe(true);
+    expect(r.cheers.some((c) => /high-confidence/.test(c))).toBe(true);
   });
 
   it("celebrates dominant high-confidence", async () => {
@@ -267,13 +282,23 @@ describe("investigate", () => {
     expect(r.investigate).toHaveLength(0);
   });
 
-  it("flags a meaningful drop in answer rate with exact before/after percentages", async () => {
+  it("flags a meaningful drop in high-confidence share with exact before/after percentages", async () => {
     const r = await build({
-      // current: 60/100 = 60%; previous: 90/100 = 90% → delta -30 pts
-      current: stats({ totalResponses: 100, totalWithResponse: 60 }),
-      combined: stats({ totalResponses: 200, totalWithResponse: 150 }),
+      // current: 60/100 = 60% high; previous: 90/100 = 90% high → delta -30 pts
+      current: stats({
+        totalResponses: 100,
+        totalWithResponse: 100,
+        byConfidence: { high: 60, medium: 20, low: 20 },
+      }),
+      combined: stats({
+        totalResponses: 200,
+        totalWithResponse: 200,
+        byConfidence: { high: 150, medium: 30, low: 20 },
+      }),
     });
-    expect(r.investigate.some((c) => /Answer rate dropped from 90% to 60%/.test(c))).toBe(true);
+    expect(r.investigate.some((c) => /High-confidence share dropped from 90% to 60%/.test(c))).toBe(
+      true,
+    );
   });
 
   it("flags growing low-confidence count", async () => {
@@ -357,12 +382,21 @@ describe("investigate", () => {
     expect(r.investigate.some((c) => /Volume is down/.test(c))).toBe(true);
   });
 
-  it("flags a low overall answer rate independent of trend", async () => {
+  it("flags a low overall high-confidence share independent of trend", async () => {
     const r = await build({
-      current: stats({ totalResponses: 20, totalWithResponse: 8 }),
-      combined: stats({ totalResponses: 40, totalWithResponse: 16 }),
+      // current: 8/20 high = 40%; previous: 8/20 high = 40%
+      current: stats({
+        totalResponses: 20,
+        totalWithResponse: 20,
+        byConfidence: { high: 8, medium: 6, low: 6 },
+      }),
+      combined: stats({
+        totalResponses: 40,
+        totalWithResponse: 40,
+        byConfidence: { high: 16, medium: 12, low: 12 },
+      }),
     });
-    expect(r.investigate.some((c) => /didn't get an answer/.test(c))).toBe(true);
+    expect(r.investigate.some((c) => /medium- or low-confidence/.test(c))).toBe(true);
   });
 
   it("does not flag 'low-confidence growing' when prior window is empty", async () => {
@@ -446,16 +480,6 @@ describe("suggestions", () => {
     expect(refresh?.command).toBe("dosu sources list");
   });
 
-  it("suggests investigating unanswered threads when answer rate is low", async () => {
-    const r = await build({
-      current: stats({ totalResponses: 20, totalWithResponse: 8 }),
-      combined: stats({ totalResponses: 40, totalWithResponse: 20 }),
-    });
-    const inv = r.suggestions.find((s) => /Investigate/.test(s.headline));
-    expect(inv?.command).toBe("dosu threads list");
-    expect(inv?.detail).toContain("12");
-  });
-
   it("suggests sharing the win when metrics are healthy and volume is high", async () => {
     const r = await build({
       current: stats({
@@ -534,7 +558,7 @@ describe("suggestions", () => {
   it("caps suggestions at 4 to keep the report scannable", async () => {
     const r = await build({
       // Trigger every rule simultaneously: low-conf grew, positive rate dropped,
-      // low answer rate, volume rising
+      // low high-confidence share, volume rising
       current: stats({
         totalResponses: 50,
         totalWithResponse: 25,
@@ -565,10 +589,14 @@ describe("suggestions", () => {
 });
 
 describe("at-a-glance helpers", () => {
-  const s = stats({ totalResponses: 10, totalWithResponse: 8 });
+  const s = stats({
+    totalResponses: 10,
+    totalWithResponse: 10,
+    byConfidence: { high: 8, medium: 1, low: 1 },
+  });
   const d = {
-    answerRate: 0.8,
-    answerRateDelta: 0.05,
+    highConfidenceRate: 0.8,
+    highConfidenceRateDelta: 0.05,
     responsesDelta: 2,
     positiveRateDelta: null,
     hasPriorWindow: true,
@@ -578,7 +606,7 @@ describe("at-a-glance helpers", () => {
     const p = buildAtAGlancePrompt(s, d, 30);
     expect(p).toContain("last 30 days");
     expect(p).toContain("10 total responses");
-    expect(p).toContain("80% answer rate");
+    expect(p).toContain("80% high-confidence share");
   });
 
   it("buildAtAGlancePrompt includes a 'first window' note when prior is empty", () => {
@@ -596,8 +624,8 @@ describe("at-a-glance helpers", () => {
     const f = fallbackAtAGlance(
       stats(),
       {
-        answerRate: null,
-        answerRateDelta: null,
+        highConfidenceRate: null,
+        highConfidenceRateDelta: null,
         responsesDelta: 0,
         positiveRateDelta: null,
         hasPriorWindow: false,

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -652,6 +652,12 @@ describe("at-a-glance helpers", () => {
     expect(f).toContain("Volume is down 7");
   });
 
+  it("fallbackAtAGlance omits any volume trend text when deltas are flat", () => {
+    const f = fallbackAtAGlance(s, { ...d, responsesDelta: 0 }, 30);
+    expect(f).not.toContain("Volume is up");
+    expect(f).not.toContain("Volume is down");
+  });
+
   it("fallbackAtAGlance includes positive feedback rate when reactions exist", () => {
     const withReactions = stats({
       totalResponses: 10,

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -132,7 +132,7 @@ describe("buildInsights", () => {
     ).rejects.toThrow(/space_id/);
   });
 
-  it("falls back to 'your deployment' when name is missing", async () => {
+  it("falls back to 'your space' when name is missing", async () => {
     mockQuery.mockResolvedValueOnce(stats());
     mockQuery.mockResolvedValueOnce(stats());
     const r = await buildInsights({
@@ -142,7 +142,7 @@ describe("buildInsights", () => {
       windowDays: 30,
       now: NOW,
     });
-    expect(r.deploymentName).toBe("your deployment");
+    expect(r.spaceName).toBe("your space");
   });
 
   it("uses /ask answer for atAGlance when available", async () => {
@@ -172,7 +172,7 @@ describe("buildInsights", () => {
 });
 
 describe("cheers", () => {
-  it("welcomes empty deployments", async () => {
+  it("welcomes empty spaces", async () => {
     const r = await build({ current: stats(), combined: stats() });
     expect(r.cheers).toHaveLength(1);
     expect(r.cheers[0]).toMatch(/brand new/);
@@ -265,7 +265,7 @@ describe("cheers", () => {
 });
 
 describe("investigate", () => {
-  it("is empty for a brand-new deployment", async () => {
+  it("is empty for a brand-new space", async () => {
     const r = await build({ current: stats(), combined: stats() });
     expect(r.investigate).toHaveLength(0);
   });
@@ -401,7 +401,7 @@ describe("investigate", () => {
 });
 
 describe("suggestions", () => {
-  it("recommends setup + integrations for empty deployments", async () => {
+  it("recommends setup + integrations for empty spaces", async () => {
     const r = await build({ current: stats(), combined: stats() });
     expect(r.suggestions).toHaveLength(2);
     expect(r.suggestions[0].command).toBe("dosu setup");
@@ -585,7 +585,7 @@ describe("at-a-glance helpers", () => {
     expect(p).not.toMatch(/first 30-day window/);
   });
 
-  it("fallbackAtAGlance handles empty deployments warmly", () => {
+  it("fallbackAtAGlance handles empty spaces warmly", () => {
     const f = fallbackAtAGlance(
       stats(),
       {

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -110,6 +110,21 @@ describe("buildInsights", () => {
     expect(r.previous.totalResponses).toBe(0);
   });
 
+  it("fires onProgress before each slow phase", async () => {
+    const stages: string[] = [];
+    mockQuery.mockResolvedValueOnce(stats());
+    mockQuery.mockResolvedValueOnce(stats());
+    await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+      onProgress: (s) => stages.push(s),
+    });
+    expect(stages).toEqual(["stats", "narrative"]);
+  });
+
   it("uses real Date when `now` is not provided", async () => {
     mockQuery.mockResolvedValueOnce(stats());
     mockQuery.mockResolvedValueOnce(stats());

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -230,9 +230,17 @@ describe("cheers", () => {
   it("celebrates rising volume", async () => {
     const r = await build({
       current: stats({ totalResponses: 80, totalWithResponse: 60 }),
-      combined: stats({ totalResponses: 80, totalWithResponse: 60 }),
+      combined: stats({ totalResponses: 130, totalWithResponse: 100 }),
     });
     expect(r.cheers.some((c) => /Volume is up/.test(c))).toBe(true);
+  });
+
+  it("does not celebrate 'rising volume' when prior window is empty", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 80, totalWithResponse: 60 }),
+      combined: stats({ totalResponses: 80, totalWithResponse: 60 }),
+    });
+    expect(r.cheers.some((c) => /Volume is up/.test(c))).toBe(false);
   });
 
   it("falls back to a generic cheer when no rule fires", async () => {
@@ -355,6 +363,30 @@ describe("investigate", () => {
     });
     expect(r.investigate.some((c) => /went without an answer/.test(c))).toBe(true);
   });
+
+  it("does not flag 'low-confidence growing' when prior window is empty", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 20,
+        totalWithResponse: 15,
+        byConfidence: { high: 5, medium: 5, low: 10 },
+      }),
+      combined: stats({
+        totalResponses: 20,
+        totalWithResponse: 15,
+        byConfidence: { high: 5, medium: 5, low: 10 },
+      }),
+    });
+    expect(r.investigate.some((c) => /Low-confidence answers grew/.test(c))).toBe(false);
+  });
+
+  it("does not flag 'volume is down' when prior window is empty", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 5, totalWithResponse: 5 }),
+      combined: stats({ totalResponses: 5, totalWithResponse: 5 }),
+    });
+    expect(r.investigate.some((c) => /Volume is down/.test(c))).toBe(false);
+  });
 });
 
 describe("suggestions", () => {
@@ -472,6 +504,32 @@ describe("suggestions", () => {
     expect(r.suggestions.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("does not emit 'Ride the momentum' when prior window is empty", async () => {
+    const r = await build({
+      current: stats({ totalResponses: 40, totalWithResponse: 35 }),
+      combined: stats({ totalResponses: 40, totalWithResponse: 35 }),
+    });
+    expect(r.suggestions.some((s) => /momentum/.test(s.headline))).toBe(false);
+  });
+
+  it("audit-low-confidence fires on absolute threshold without '(+X vs prior)' suffix", async () => {
+    const r = await build({
+      current: stats({
+        totalResponses: 20,
+        totalWithResponse: 15,
+        byConfidence: { high: 5, medium: 5, low: 10 },
+      }),
+      combined: stats({
+        totalResponses: 20,
+        totalWithResponse: 15,
+        byConfidence: { high: 5, medium: 5, low: 10 },
+      }),
+    });
+    const audit = r.suggestions.find((s) => /Audit/.test(s.headline));
+    expect(audit).toBeDefined();
+    expect(audit?.detail).not.toMatch(/vs prior/);
+  });
+
   it("caps suggestions at 4 to keep the report scannable", async () => {
     const r = await build({
       // Trigger every rule simultaneously: low-conf grew, positive rate dropped,
@@ -507,13 +565,30 @@ describe("suggestions", () => {
 
 describe("at-a-glance helpers", () => {
   const s = stats({ totalResponses: 10, totalWithResponse: 8 });
-  const d = { answerRate: 0.8, answerRateDelta: 0.05, responsesDelta: 2, positiveRateDelta: null };
+  const d = {
+    answerRate: 0.8,
+    answerRateDelta: 0.05,
+    responsesDelta: 2,
+    positiveRateDelta: null,
+    hasPriorWindow: true,
+  };
 
   it("buildAtAGlancePrompt embeds the stats", () => {
     const p = buildAtAGlancePrompt(s, d, 30);
     expect(p).toContain("last 30 days");
     expect(p).toContain("10 total responses");
     expect(p).toContain("80% answer rate");
+  });
+
+  it("buildAtAGlancePrompt includes a 'first window' note when prior is empty", () => {
+    const p = buildAtAGlancePrompt(s, { ...d, hasPriorWindow: false }, 30);
+    expect(p).toMatch(/first 30-day window/);
+    expect(p).toMatch(/do NOT compare to a prior period/);
+  });
+
+  it("buildAtAGlancePrompt omits the 'first window' note when prior exists", () => {
+    const p = buildAtAGlancePrompt(s, d, 30);
+    expect(p).not.toMatch(/first 30-day window/);
   });
 
   it("fallbackAtAGlance handles empty deployments warmly", () => {
@@ -524,11 +599,18 @@ describe("at-a-glance helpers", () => {
         answerRateDelta: null,
         responsesDelta: 0,
         positiveRateDelta: null,
+        hasPriorWindow: false,
       },
       30,
     );
     expect(f).toContain("brand new");
     expect(f).toContain("30 days");
+  });
+
+  it("fallbackAtAGlance uses 'first window' copy when prior is empty", () => {
+    const f = fallbackAtAGlance(s, { ...d, hasPriorWindow: false, responsesDelta: 10 }, 30);
+    expect(f).toContain("first 30-day window");
+    expect(f).not.toContain("Volume is up");
   });
 
   it("fallbackAtAGlance mentions volume rising", () => {

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -267,13 +267,13 @@ describe("investigate", () => {
     expect(r.investigate).toHaveLength(0);
   });
 
-  it("flags a meaningful drop in answer rate", async () => {
+  it("flags a meaningful drop in answer rate with exact before/after percentages", async () => {
     const r = await build({
       // current: 60/100 = 60%; previous: 90/100 = 90% → delta -30 pts
       current: stats({ totalResponses: 100, totalWithResponse: 60 }),
       combined: stats({ totalResponses: 200, totalWithResponse: 150 }),
     });
-    expect(r.investigate.some((c) => /Answer rate dropped/.test(c))).toBe(true);
+    expect(r.investigate.some((c) => /Answer rate dropped from 90% to 60%/.test(c))).toBe(true);
   });
 
   it("flags growing low-confidence count", async () => {
@@ -292,7 +292,8 @@ describe("investigate", () => {
     expect(r.investigate.some((c) => /Low-confidence answers grew/.test(c))).toBe(true);
   });
 
-  it("flags a drop in positive feedback rate", async () => {
+  it("flags a drop in positive feedback rate with exact before/after percentages", async () => {
+    // current: 5 pos / 5 neg → 50%; previous (via subtraction): 9 pos / 1 neg → 90%
     const r = await build({
       current: stats({
         totalResponses: 50,
@@ -317,7 +318,7 @@ describe("investigate", () => {
         },
       }),
     });
-    expect(r.investigate.some((c) => /Positive feedback fell/.test(c))).toBe(true);
+    expect(r.investigate.some((c) => /Positive feedback fell from 90% to 50%/.test(c))).toBe(true);
   });
 
   it("flags more negative than positive feedback", async () => {

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -41,7 +41,6 @@ beforeEach(() => {
 function stats(over: Partial<UsageStats> = {}): UsageStats {
   return {
     totalResponses: 0,
-    totalWithResponse: 0,
     byConfidence: { high: 0, medium: 0, low: 0 },
     reactions: {
       totalPositive: 0,
@@ -83,11 +82,10 @@ describe("buildInsights", () => {
 
   it("derives previous window via subtraction", async () => {
     const r = await build({
-      current: stats({ totalResponses: 50, totalWithResponse: 40 }),
-      combined: stats({ totalResponses: 90, totalWithResponse: 70 }),
+      current: stats({ totalResponses: 50 }),
+      combined: stats({ totalResponses: 90 }),
     });
     expect(r.previous.totalResponses).toBe(40);
-    expect(r.previous.totalWithResponse).toBe(30);
   });
 
   it("clamps subtraction to zero defensively", async () => {
@@ -149,8 +147,8 @@ describe("buildInsights", () => {
 
   it("uses /ask answer for atAGlance when available", async () => {
     const r = await build({
-      current: stats({ totalResponses: 10, totalWithResponse: 8 }),
-      combined: stats({ totalResponses: 12, totalWithResponse: 10 }),
+      current: stats({ totalResponses: 10 }),
+      combined: stats({ totalResponses: 12 }),
       ask: async () => "Custom prose from Dosu.",
     });
     expect(r.atAGlance).toBe("Custom prose from Dosu.");
@@ -160,12 +158,10 @@ describe("buildInsights", () => {
     const r = await build({
       current: stats({
         totalResponses: 10,
-        totalWithResponse: 10,
         byConfidence: { high: 8, medium: 1, low: 1 },
       }),
       combined: stats({
         totalResponses: 12,
-        totalWithResponse: 12,
         byConfidence: { high: 9, medium: 2, low: 1 },
       }),
       ask: async () => null,
@@ -186,12 +182,10 @@ describe("cheers", () => {
     const r = await build({
       current: stats({
         totalResponses: 100,
-        totalWithResponse: 100,
         byConfidence: { high: 90, medium: 8, low: 2 },
       }),
       combined: stats({
         totalResponses: 100,
-        totalWithResponse: 100,
         byConfidence: { high: 90, medium: 8, low: 2 },
       }),
     });
@@ -202,12 +196,10 @@ describe("cheers", () => {
     const r = await build({
       current: stats({
         totalResponses: 30,
-        totalWithResponse: 28,
         byConfidence: { high: 20, medium: 5, low: 5 },
       }),
       combined: stats({
         totalResponses: 30,
-        totalWithResponse: 28,
         byConfidence: { high: 20, medium: 5, low: 5 },
       }),
     });
@@ -218,7 +210,6 @@ describe("cheers", () => {
     const r = await build({
       current: stats({
         totalResponses: 50,
-        totalWithResponse: 40,
         reactions: {
           totalPositive: 9,
           totalNegative: 1,
@@ -229,7 +220,6 @@ describe("cheers", () => {
       }),
       combined: stats({
         totalResponses: 50,
-        totalWithResponse: 40,
         reactions: {
           totalPositive: 9,
           totalNegative: 1,
@@ -244,16 +234,16 @@ describe("cheers", () => {
 
   it("celebrates rising volume", async () => {
     const r = await build({
-      current: stats({ totalResponses: 80, totalWithResponse: 60 }),
-      combined: stats({ totalResponses: 130, totalWithResponse: 100 }),
+      current: stats({ totalResponses: 80 }),
+      combined: stats({ totalResponses: 130 }),
     });
     expect(r.cheers.some((c) => /Volume is up/.test(c))).toBe(true);
   });
 
   it("does not celebrate 'rising volume' when prior window is empty", async () => {
     const r = await build({
-      current: stats({ totalResponses: 80, totalWithResponse: 60 }),
-      combined: stats({ totalResponses: 80, totalWithResponse: 60 }),
+      current: stats({ totalResponses: 80 }),
+      combined: stats({ totalResponses: 80 }),
     });
     expect(r.cheers.some((c) => /Volume is up/.test(c))).toBe(false);
   });
@@ -262,12 +252,10 @@ describe("cheers", () => {
     const r = await build({
       current: stats({
         totalResponses: 30,
-        totalWithResponse: 15,
         byConfidence: { high: 5, medium: 10, low: 15 },
       }),
       combined: stats({
         totalResponses: 60,
-        totalWithResponse: 30,
         byConfidence: { high: 10, medium: 20, low: 30 },
       }),
     });
@@ -287,12 +275,10 @@ describe("investigate", () => {
       // current: 60/100 = 60% high; previous: 90/100 = 90% high → delta -30 pts
       current: stats({
         totalResponses: 100,
-        totalWithResponse: 100,
         byConfidence: { high: 60, medium: 20, low: 20 },
       }),
       combined: stats({
         totalResponses: 200,
-        totalWithResponse: 200,
         byConfidence: { high: 150, medium: 30, low: 20 },
       }),
     });
@@ -305,12 +291,10 @@ describe("investigate", () => {
     const r = await build({
       current: stats({
         totalResponses: 40,
-        totalWithResponse: 30,
         byConfidence: { high: 10, medium: 10, low: 20 },
       }),
       combined: stats({
         totalResponses: 60,
-        totalWithResponse: 50,
         byConfidence: { high: 20, medium: 20, low: 25 },
       }),
     });
@@ -322,7 +306,6 @@ describe("investigate", () => {
     const r = await build({
       current: stats({
         totalResponses: 50,
-        totalWithResponse: 40,
         reactions: {
           totalPositive: 5,
           totalNegative: 5,
@@ -333,7 +316,6 @@ describe("investigate", () => {
       }),
       combined: stats({
         totalResponses: 100,
-        totalWithResponse: 90,
         reactions: {
           totalPositive: 14,
           totalNegative: 6,
@@ -350,7 +332,6 @@ describe("investigate", () => {
     const r = await build({
       current: stats({
         totalResponses: 30,
-        totalWithResponse: 25,
         reactions: {
           totalPositive: 2,
           totalNegative: 5,
@@ -361,7 +342,6 @@ describe("investigate", () => {
       }),
       combined: stats({
         totalResponses: 30,
-        totalWithResponse: 25,
         reactions: {
           totalPositive: 2,
           totalNegative: 5,
@@ -376,8 +356,8 @@ describe("investigate", () => {
 
   it("flags a meaningful drop in volume", async () => {
     const r = await build({
-      current: stats({ totalResponses: 30, totalWithResponse: 25 }),
-      combined: stats({ totalResponses: 100, totalWithResponse: 80 }),
+      current: stats({ totalResponses: 30 }),
+      combined: stats({ totalResponses: 100 }),
     });
     expect(r.investigate.some((c) => /Volume is down/.test(c))).toBe(true);
   });
@@ -387,12 +367,10 @@ describe("investigate", () => {
       // current: 8/20 high = 40%; previous: 8/20 high = 40%
       current: stats({
         totalResponses: 20,
-        totalWithResponse: 20,
         byConfidence: { high: 8, medium: 6, low: 6 },
       }),
       combined: stats({
         totalResponses: 40,
-        totalWithResponse: 40,
         byConfidence: { high: 16, medium: 12, low: 12 },
       }),
     });
@@ -403,12 +381,10 @@ describe("investigate", () => {
     const r = await build({
       current: stats({
         totalResponses: 20,
-        totalWithResponse: 15,
         byConfidence: { high: 5, medium: 5, low: 10 },
       }),
       combined: stats({
         totalResponses: 20,
-        totalWithResponse: 15,
         byConfidence: { high: 5, medium: 5, low: 10 },
       }),
     });
@@ -417,8 +393,8 @@ describe("investigate", () => {
 
   it("does not flag 'volume is down' when prior window is empty", async () => {
     const r = await build({
-      current: stats({ totalResponses: 5, totalWithResponse: 5 }),
-      combined: stats({ totalResponses: 5, totalWithResponse: 5 }),
+      current: stats({ totalResponses: 5 }),
+      combined: stats({ totalResponses: 5 }),
     });
     expect(r.investigate.some((c) => /Volume is down/.test(c))).toBe(false);
   });
@@ -436,12 +412,10 @@ describe("suggestions", () => {
     const r = await build({
       current: stats({
         totalResponses: 30,
-        totalWithResponse: 25,
         byConfidence: { high: 5, medium: 10, low: 15 },
       }),
       combined: stats({
         totalResponses: 60,
-        totalWithResponse: 50,
         byConfidence: { high: 10, medium: 20, low: 22 },
       }),
     });
@@ -455,7 +429,6 @@ describe("suggestions", () => {
     const r = await build({
       current: stats({
         totalResponses: 50,
-        totalWithResponse: 40,
         reactions: {
           totalPositive: 5,
           totalNegative: 5,
@@ -466,7 +439,6 @@ describe("suggestions", () => {
       }),
       combined: stats({
         totalResponses: 100,
-        totalWithResponse: 90,
         reactions: {
           totalPositive: 14,
           totalNegative: 6,
@@ -484,7 +456,6 @@ describe("suggestions", () => {
     const r = await build({
       current: stats({
         totalResponses: 100,
-        totalWithResponse: 90,
         byConfidence: { high: 80, medium: 8, low: 2 },
         reactions: {
           totalPositive: 9,
@@ -496,7 +467,6 @@ describe("suggestions", () => {
       }),
       combined: stats({
         totalResponses: 100,
-        totalWithResponse: 90,
         byConfidence: { high: 80, medium: 8, low: 2 },
         reactions: {
           totalPositive: 9,
@@ -514,8 +484,8 @@ describe("suggestions", () => {
 
   it("recommends adding a source when volume is rising", async () => {
     const r = await build({
-      current: stats({ totalResponses: 40, totalWithResponse: 35 }),
-      combined: stats({ totalResponses: 50, totalWithResponse: 42 }),
+      current: stats({ totalResponses: 40 }),
+      combined: stats({ totalResponses: 50 }),
     });
     const ride = r.suggestions.find((s) => /momentum/.test(s.headline));
     expect(ride?.command).toBe("dosu integrations");
@@ -523,16 +493,16 @@ describe("suggestions", () => {
 
   it("always includes at least one suggestion (fallback)", async () => {
     const r = await build({
-      current: stats({ totalResponses: 5, totalWithResponse: 5 }),
-      combined: stats({ totalResponses: 10, totalWithResponse: 10 }),
+      current: stats({ totalResponses: 5 }),
+      combined: stats({ totalResponses: 10 }),
     });
     expect(r.suggestions.length).toBeGreaterThanOrEqual(1);
   });
 
   it("does not emit 'Ride the momentum' when prior window is empty", async () => {
     const r = await build({
-      current: stats({ totalResponses: 40, totalWithResponse: 35 }),
-      combined: stats({ totalResponses: 40, totalWithResponse: 35 }),
+      current: stats({ totalResponses: 40 }),
+      combined: stats({ totalResponses: 40 }),
     });
     expect(r.suggestions.some((s) => /momentum/.test(s.headline))).toBe(false);
   });
@@ -541,12 +511,10 @@ describe("suggestions", () => {
     const r = await build({
       current: stats({
         totalResponses: 20,
-        totalWithResponse: 15,
         byConfidence: { high: 5, medium: 5, low: 10 },
       }),
       combined: stats({
         totalResponses: 20,
-        totalWithResponse: 15,
         byConfidence: { high: 5, medium: 5, low: 10 },
       }),
     });
@@ -561,7 +529,6 @@ describe("suggestions", () => {
       // low high-confidence share, volume rising
       current: stats({
         totalResponses: 50,
-        totalWithResponse: 25,
         byConfidence: { high: 5, medium: 10, low: 35 },
         reactions: {
           totalPositive: 3,
@@ -573,7 +540,6 @@ describe("suggestions", () => {
       }),
       combined: stats({
         totalResponses: 90,
-        totalWithResponse: 70,
         byConfidence: { high: 30, medium: 30, low: 30 },
         reactions: {
           totalPositive: 18,
@@ -591,7 +557,6 @@ describe("suggestions", () => {
 describe("at-a-glance helpers", () => {
   const s = stats({
     totalResponses: 10,
-    totalWithResponse: 10,
     byConfidence: { high: 8, medium: 1, low: 1 },
   });
   const d = {
@@ -661,7 +626,6 @@ describe("at-a-glance helpers", () => {
   it("fallbackAtAGlance includes positive feedback rate when reactions exist", () => {
     const withReactions = stats({
       totalResponses: 10,
-      totalWithResponse: 8,
       reactions: {
         totalPositive: 4,
         totalNegative: 1,

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -1,0 +1,424 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../config/config";
+import {
+  type AskFn,
+  buildAtAGlancePrompt,
+  buildInsights,
+  buildSuggestionsPrompt,
+  buildTopicsPrompt,
+  type UsageStats,
+} from "./insights";
+
+const mockQuery = vi.fn();
+
+function createMockClient(): unknown {
+  function proxy(path: string[] = []): unknown {
+    return new Proxy(() => {}, {
+      get(_, prop: string) {
+        if (prop === "query") return (input: unknown) => mockQuery(path.join("."), input);
+        return proxy([...path, prop]);
+      },
+    });
+  }
+  return proxy();
+}
+
+const cfg: Config = {
+  access_token: "t",
+  refresh_token: "r",
+  expires_at: 0,
+  space_id: "sp1",
+  deployment_id: "d1",
+  deployment_name: "Acme Docs",
+  api_key: "sk_user_test",
+};
+
+const NOW = () => new Date("2026-04-16T12:00:00Z");
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function stats(over: Partial<UsageStats> = {}): UsageStats {
+  return {
+    totalResponses: 0,
+    totalWithResponse: 0,
+    byConfidence: { high: 0, medium: 0, low: 0 },
+    reactions: {
+      totalPositive: 0,
+      totalNegative: 0,
+      messagesWithReactions: 0,
+      reactionRate: 0,
+      positiveRate: 0,
+    },
+    ...over,
+  };
+}
+
+const okAsk: AskFn = async (q) => `answered: ${q.slice(0, 16)}`;
+
+describe("buildInsights", () => {
+  it("queries current window and combined window", async () => {
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 50, totalWithResponse: 40 }));
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 90, totalWithResponse: 70 }));
+
+    await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(mockQuery).toHaveBeenNthCalledWith(1, "analytics.getUsageStats", {
+      spaceId: "sp1",
+      days: 30,
+    });
+    expect(mockQuery).toHaveBeenNthCalledWith(2, "analytics.getUsageStats", {
+      spaceId: "sp1",
+      days: 60,
+    });
+  });
+
+  it("derives previous window by subtracting current from combined", async () => {
+    mockQuery.mockResolvedValueOnce(
+      stats({
+        totalResponses: 50,
+        totalWithResponse: 40,
+        byConfidence: { high: 30, medium: 15, low: 5 },
+        reactions: {
+          totalPositive: 10,
+          totalNegative: 2,
+          messagesWithReactions: 12,
+          reactionRate: 0.24,
+          positiveRate: 0.83,
+        },
+      }),
+    );
+    mockQuery.mockResolvedValueOnce(
+      stats({
+        totalResponses: 90,
+        totalWithResponse: 70,
+        byConfidence: { high: 50, medium: 25, low: 15 },
+        reactions: {
+          totalPositive: 14,
+          totalNegative: 6,
+          messagesWithReactions: 20,
+          reactionRate: 0.22,
+          positiveRate: 0.7,
+        },
+      }),
+    );
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.previous.totalResponses).toBe(40);
+    expect(r.previous.totalWithResponse).toBe(30);
+    expect(r.previous.byConfidence).toEqual({ high: 20, medium: 10, low: 10 });
+    expect(r.previous.reactions.totalPositive).toBe(4);
+    expect(r.previous.reactions.totalNegative).toBe(4);
+    expect(r.previous.reactions.positiveRate).toBeCloseTo(0.5, 5);
+  });
+
+  it("clamps subtraction to zero when combined is smaller than current (defensive)", async () => {
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 50 }));
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 30 }));
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.previous.totalResponses).toBe(0);
+  });
+
+  it("computes answer-rate delta between windows", async () => {
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 100, totalWithResponse: 90 }));
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 200, totalWithResponse: 160 }));
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    // current = 90/100 = 0.9; previous = 70/100 = 0.7; delta = 0.2
+    expect(r.derived.answerRate).toBeCloseTo(0.9, 5);
+    expect(r.derived.answerRateDelta).toBeCloseTo(0.2, 5);
+    expect(r.derived.responsesDelta).toBe(0);
+  });
+
+  it("returns null answer-rate when there are no responses", async () => {
+    mockQuery.mockResolvedValueOnce(stats());
+    mockQuery.mockResolvedValueOnce(stats());
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.derived.answerRate).toBeNull();
+    expect(r.derived.answerRateDelta).toBeNull();
+    expect(r.derived.positiveRateDelta).toBeNull();
+  });
+
+  it("preserves narrative answers and tolerates per-call failures", async () => {
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 10, totalWithResponse: 8 }));
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 12, totalWithResponse: 10 }));
+
+    let n = 0;
+    const ask: AskFn = async (q) => {
+      n += 1;
+      if (n === 2) return null; // simulate failure
+      return `OK: ${q.slice(0, 8)}`;
+    };
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.narratives.atAGlance).toMatch(/^OK: /);
+    expect(r.narratives.topics).toBeNull();
+    expect(r.narratives.suggestions).toMatch(/^OK: /);
+  });
+
+  it("throws when space_id is missing", async () => {
+    await expect(
+      buildInsights({
+        client: createMockClient() as never,
+        cfg: { ...cfg, space_id: undefined },
+        ask: okAsk,
+      }),
+    ).rejects.toThrow(/space_id/);
+  });
+
+  it("returns the welcome cheer when there are no responses", async () => {
+    mockQuery.mockResolvedValueOnce(stats());
+    mockQuery.mockResolvedValueOnce(stats());
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.cheers).toHaveLength(1);
+    expect(r.cheers[0]).toMatch(/brand new/);
+  });
+
+  it("celebrates a high answer rate", async () => {
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 100, totalWithResponse: 95 }));
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 100, totalWithResponse: 95 }));
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.cheers.some((c) => /answer rate/.test(c))).toBe(true);
+  });
+
+  it("celebrates dominant high-confidence responses", async () => {
+    mockQuery.mockResolvedValueOnce(
+      stats({
+        totalResponses: 30,
+        totalWithResponse: 28,
+        byConfidence: { high: 20, medium: 5, low: 5 },
+      }),
+    );
+    mockQuery.mockResolvedValueOnce(
+      stats({
+        totalResponses: 30,
+        totalWithResponse: 28,
+        byConfidence: { high: 20, medium: 5, low: 5 },
+      }),
+    );
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.cheers.some((c) => /high-confidence/.test(c))).toBe(true);
+  });
+
+  it("celebrates positive feedback when rate >= 80%", async () => {
+    mockQuery.mockResolvedValueOnce(
+      stats({
+        totalResponses: 50,
+        totalWithResponse: 40,
+        reactions: {
+          totalPositive: 9,
+          totalNegative: 1,
+          messagesWithReactions: 10,
+          reactionRate: 0.2,
+          positiveRate: 0.9,
+        },
+      }),
+    );
+    mockQuery.mockResolvedValueOnce(
+      stats({
+        totalResponses: 50,
+        totalWithResponse: 40,
+        reactions: {
+          totalPositive: 9,
+          totalNegative: 1,
+          messagesWithReactions: 10,
+          reactionRate: 0.2,
+          positiveRate: 0.9,
+        },
+      }),
+    );
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.cheers.some((c) => /positive feedback/.test(c))).toBe(true);
+  });
+
+  it("celebrates rising volume", async () => {
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 80, totalWithResponse: 60 }));
+    // combined 30 means previous = 0; current 80 - prev 0 = +80
+    mockQuery.mockResolvedValueOnce(stats({ totalResponses: 80, totalWithResponse: 60 }));
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.cheers.some((c) => /Volume is up/.test(c))).toBe(true);
+  });
+
+  it("falls back to a generic cheer when no rules trigger", async () => {
+    // 30 responses, mediocre rates everywhere — no celebratable signal, and the
+    // combined window is double so previous == current → no volume delta.
+    mockQuery.mockResolvedValueOnce(
+      stats({
+        totalResponses: 30,
+        totalWithResponse: 15,
+        byConfidence: { high: 5, medium: 10, low: 15 },
+      }),
+    );
+    mockQuery.mockResolvedValueOnce(
+      stats({
+        totalResponses: 60,
+        totalWithResponse: 30,
+        byConfidence: { high: 10, medium: 20, low: 30 },
+      }),
+    );
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.cheers).toHaveLength(1);
+    expect(r.cheers[0]).toMatch(/30 responses logged/);
+  });
+
+  it("falls back to 'your deployment' when deployment_name is missing", async () => {
+    mockQuery.mockResolvedValueOnce(stats());
+    mockQuery.mockResolvedValueOnce(stats());
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg: { ...cfg, deployment_name: undefined },
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.deploymentName).toBe("your deployment");
+  });
+
+  it("normalizes nullish stats from the API", async () => {
+    mockQuery.mockResolvedValueOnce(null);
+    mockQuery.mockResolvedValueOnce(undefined);
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(r.current.totalResponses).toBe(0);
+    expect(r.previous.totalResponses).toBe(0);
+  });
+
+  it("uses real Date when `now` is not provided", async () => {
+    mockQuery.mockResolvedValueOnce(stats());
+    mockQuery.mockResolvedValueOnce(stats());
+
+    const r = await buildInsights({
+      client: createMockClient() as never,
+      cfg,
+      ask: okAsk,
+      windowDays: 30,
+    });
+
+    // Should be a valid ISO timestamp from "now"
+    expect(() => new Date(r.generatedAt)).not.toThrow();
+    expect(r.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("prompt builders", () => {
+  const s = stats({ totalResponses: 10, totalWithResponse: 8 });
+  const d = { answerRate: 0.8, answerRateDelta: 0.05, responsesDelta: 2, positiveRateDelta: null };
+
+  it("at-a-glance prompt embeds the stats", () => {
+    const p = buildAtAGlancePrompt(s, d, 30);
+    expect(p).toContain("last 30 days");
+    expect(p).toContain("10 total responses");
+    expect(p).toContain("80% answer rate");
+  });
+
+  it("topics prompt names the window", () => {
+    expect(buildTopicsPrompt(7)).toContain("last 7 days");
+  });
+
+  it("suggestions prompt asks for actionable items", () => {
+    const p = buildSuggestionsPrompt(s, d, 30);
+    expect(p).toContain("numbered list");
+    expect(p).toContain("actionable");
+  });
+});

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -361,7 +361,7 @@ describe("investigate", () => {
       current: stats({ totalResponses: 20, totalWithResponse: 8 }),
       combined: stats({ totalResponses: 40, totalWithResponse: 16 }),
     });
-    expect(r.investigate.some((c) => /went without an answer/.test(c))).toBe(true);
+    expect(r.investigate.some((c) => /didn't get an answer/.test(c))).toBe(true);
   });
 
   it("does not flag 'low-confidence growing' when prior window is empty", async () => {

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -44,6 +44,7 @@ export interface InsightsReport {
     answerRateDelta: number | null;
     responsesDelta: number;
     positiveRateDelta: number | null;
+    hasPriorWindow: boolean;
   };
   atAGlance: string;
   cheers: string[];
@@ -184,6 +185,7 @@ function computeDerived(current: UsageStats, previous: UsageStats): InsightsRepo
     answerRateDelta,
     responsesDelta: current.totalResponses - previous.totalResponses,
     positiveRateDelta,
+    hasPriorWindow: previous.totalResponses > 0,
   };
 }
 
@@ -213,7 +215,7 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
       `${pct(stats.reactions.positiveRate)} positive feedback — your team is loving the answers.`,
     );
   }
-  if (derived.responsesDelta > 0) {
+  if (derived.hasPriorWindow && derived.responsesDelta > 0) {
     out.push(`Volume is up by ${derived.responsesDelta} responses vs the prior window. 📈`);
   }
   if (out.length === 0) {
@@ -241,9 +243,8 @@ function computeInvestigate(
     );
   }
 
-  // Low confidence growing in absolute terms
   const lowDelta = current.byConfidence.low - previous.byConfidence.low;
-  if (lowDelta >= 5 && current.byConfidence.low > 0) {
+  if (derived.hasPriorWindow && lowDelta >= 5 && current.byConfidence.low > 0) {
     out.push(
       `Low-confidence answers grew by ${lowDelta} (now ${current.byConfidence.low} this window). Each one is a hint that your knowledge base has gaps.`,
     );
@@ -268,8 +269,7 @@ function computeInvestigate(
     );
   }
 
-  // Volume dropped meaningfully
-  if (derived.responsesDelta <= -10 && previous.totalResponses > 0) {
+  if (derived.hasPriorWindow && derived.responsesDelta <= -10) {
     out.push(
       `Volume is down by ${Math.abs(derived.responsesDelta)} responses. If your team stopped asking, find out why.`,
     );
@@ -310,13 +310,15 @@ function computeSuggestions(
     return out;
   }
 
-  // Low-confidence growing
   const lowDelta = current.byConfidence.low - previous.byConfidence.low;
-  if (lowDelta >= 5 || current.byConfidence.low >= Math.max(5, current.totalResponses * 0.3)) {
+  const lowGrewSignificantly = derived.hasPriorWindow && lowDelta >= 5;
+  const lowHighInAbsoluteTerms =
+    current.byConfidence.low >= Math.max(5, current.totalResponses * 0.3);
+  if (lowGrewSignificantly || lowHighInAbsoluteTerms) {
     out.push({
       headline: "Audit recent low-confidence answers",
       detail: `${current.byConfidence.low} answers had low confidence this window${
-        lowDelta > 0 ? ` (+${lowDelta} vs prior)` : ""
+        lowGrewSignificantly ? ` (+${lowDelta} vs prior)` : ""
       }. Open them to see exactly what knowledge is missing.`,
       command: "dosu threads list",
     });
@@ -358,8 +360,7 @@ function computeSuggestions(
     });
   }
 
-  // Volume rising — momentum suggestion
-  if (derived.responsesDelta >= 10) {
+  if (derived.hasPriorWindow && derived.responsesDelta >= 10) {
     out.push({
       headline: "Ride the momentum — add another source",
       detail: `Volume is up by ${derived.responsesDelta} responses vs the prior window. Connect another source while engagement is high.`,
@@ -404,9 +405,12 @@ export function buildAtAGlancePrompt(
   derived: InsightsReport["derived"],
   days: number,
 ): string {
+  const priorNote = derived.hasPriorWindow
+    ? ""
+    : `\n\nNote: this is the deployment's first ${days}-day window — do NOT compare to a prior period. Focus on what's present.`;
   return `You're writing the "At a Glance" panel for a Dosu deployment insights report. Here are the real stats from the last ${days} days:
 
-${statsBlock(stats, derived)}
+${statsBlock(stats, derived)}${priorNote}
 
 Write 2-3 short sentences (no bullets, no headers, no markdown) that synthesize what's interesting or worth celebrating. Be warm, specific, and a little fun. Don't just list the numbers — interpret them. Speak directly to the reader ("you" / "your team").`;
 }
@@ -422,6 +426,9 @@ export function fallbackAtAGlance(
   const ar = derived.answerRate !== null ? pct(derived.answerRate) : "—";
   const reactions = stats.reactions.totalPositive + stats.reactions.totalNegative;
   const pr = reactions > 0 ? `, with ${pct(stats.reactions.positiveRate)} positive feedback` : "";
+  if (!derived.hasPriorWindow) {
+    return `In your first ${days}-day window you logged ${stats.totalResponses} responses with a ${ar} answer rate${pr}. Check back after another ${days} days for trend comparisons.`;
+  }
   const trend =
     derived.responsesDelta > 0
       ? ` Volume is up ${derived.responsesDelta} vs the prior ${days} days — the team is leaning on Dosu more.`

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -1,0 +1,263 @@
+/**
+ * Build an InsightsReport for the user's Dosu deployment.
+ *
+ * Combines hard numbers from `analytics.getUsageStats` with narrative prose
+ * pulled from the Dosu `/ask` workflow. Each /ask call is independent — if one
+ * fails or times out, the report still renders with the others.
+ */
+
+import type { TypedClient } from "../client/trpc";
+import type { Config } from "../config/config";
+
+export interface UsageStats {
+  totalResponses: number;
+  totalWithResponse: number;
+  byConfidence: { high: number; medium: number; low: number };
+  reactions: {
+    totalPositive: number;
+    totalNegative: number;
+    messagesWithReactions: number;
+    reactionRate: number;
+    positiveRate: number;
+  };
+}
+
+export interface InsightsNarratives {
+  atAGlance: string | null;
+  topics: string | null;
+  suggestions: string | null;
+}
+
+export interface InsightsReport {
+  generatedAt: string;
+  windowDays: number;
+  deploymentName: string;
+  current: UsageStats;
+  previous: UsageStats;
+  derived: {
+    answerRate: number | null;
+    answerRateDelta: number | null;
+    responsesDelta: number;
+    positiveRateDelta: number | null;
+  };
+  narratives: InsightsNarratives;
+  cheers: string[];
+}
+
+export type AskFn = (question: string) => Promise<string | null>;
+
+export interface BuildInsightsArgs {
+  client: TypedClient;
+  cfg: Config;
+  ask: AskFn;
+  windowDays?: number;
+  now?: () => Date;
+}
+
+const EMPTY_STATS: UsageStats = {
+  totalResponses: 0,
+  totalWithResponse: 0,
+  byConfidence: { high: 0, medium: 0, low: 0 },
+  reactions: {
+    totalPositive: 0,
+    totalNegative: 0,
+    messagesWithReactions: 0,
+    reactionRate: 0,
+    positiveRate: 0,
+  },
+};
+
+export async function buildInsights({
+  client,
+  cfg,
+  ask,
+  windowDays = 30,
+  now = () => new Date(),
+}: BuildInsightsArgs): Promise<InsightsReport> {
+  if (!cfg.space_id) {
+    throw new Error("space_id missing — run 'dosu setup' first");
+  }
+  const spaceId = cfg.space_id;
+
+  const [currentRaw, combinedRaw] = await Promise.all([
+    client.analytics.getUsageStats.query({ spaceId, days: windowDays }),
+    client.analytics.getUsageStats.query({ spaceId, days: windowDays * 2 }),
+  ]);
+
+  const current = normalizeStats(currentRaw);
+  const combined = normalizeStats(combinedRaw);
+  const previous = subtractStats(combined, current);
+
+  const derived = computeDerived(current, previous);
+  const cheers = computeCheers(current, derived);
+
+  const [atAGlance, topics, suggestions] = await Promise.all([
+    ask(buildAtAGlancePrompt(current, derived, windowDays)),
+    ask(buildTopicsPrompt(windowDays)),
+    ask(buildSuggestionsPrompt(current, derived, windowDays)),
+  ]);
+
+  return {
+    generatedAt: now().toISOString(),
+    windowDays,
+    deploymentName: cfg.deployment_name ?? "your deployment",
+    current,
+    previous,
+    derived,
+    narratives: { atAGlance, topics, suggestions },
+    cheers,
+  };
+}
+
+function normalizeStats(raw: UsageStats | null | undefined): UsageStats {
+  if (!raw) return { ...EMPTY_STATS };
+  return {
+    totalResponses: raw.totalResponses ?? 0,
+    totalWithResponse: raw.totalWithResponse ?? 0,
+    byConfidence: {
+      high: raw.byConfidence?.high ?? 0,
+      medium: raw.byConfidence?.medium ?? 0,
+      low: raw.byConfidence?.low ?? 0,
+    },
+    reactions: {
+      totalPositive: raw.reactions?.totalPositive ?? 0,
+      totalNegative: raw.reactions?.totalNegative ?? 0,
+      messagesWithReactions: raw.reactions?.messagesWithReactions ?? 0,
+      reactionRate: raw.reactions?.reactionRate ?? 0,
+      positiveRate: raw.reactions?.positiveRate ?? 0,
+    },
+  };
+}
+
+function subtractStats(combined: UsageStats, current: UsageStats): UsageStats {
+  const totalResponses = Math.max(0, combined.totalResponses - current.totalResponses);
+  const totalWithResponse = Math.max(0, combined.totalWithResponse - current.totalWithResponse);
+  const positive = Math.max(0, combined.reactions.totalPositive - current.reactions.totalPositive);
+  const negative = Math.max(0, combined.reactions.totalNegative - current.reactions.totalNegative);
+  const reactionMsgs = Math.max(
+    0,
+    combined.reactions.messagesWithReactions - current.reactions.messagesWithReactions,
+  );
+  const totalReactions = positive + negative;
+  return {
+    totalResponses,
+    totalWithResponse,
+    byConfidence: {
+      high: Math.max(0, combined.byConfidence.high - current.byConfidence.high),
+      medium: Math.max(0, combined.byConfidence.medium - current.byConfidence.medium),
+      low: Math.max(0, combined.byConfidence.low - current.byConfidence.low),
+    },
+    reactions: {
+      totalPositive: positive,
+      totalNegative: negative,
+      messagesWithReactions: reactionMsgs,
+      reactionRate: totalResponses > 0 ? reactionMsgs / totalResponses : 0,
+      positiveRate: totalReactions > 0 ? positive / totalReactions : 0,
+    },
+  };
+}
+
+function computeDerived(current: UsageStats, previous: UsageStats): InsightsReport["derived"] {
+  const answerRate =
+    current.totalResponses > 0 ? current.totalWithResponse / current.totalResponses : null;
+  const prevAnswerRate =
+    previous.totalResponses > 0 ? previous.totalWithResponse / previous.totalResponses : null;
+  const answerRateDelta =
+    answerRate !== null && prevAnswerRate !== null ? answerRate - prevAnswerRate : null;
+
+  const positiveRateDelta =
+    current.reactions.totalPositive + current.reactions.totalNegative > 0 &&
+    previous.reactions.totalPositive + previous.reactions.totalNegative > 0
+      ? current.reactions.positiveRate - previous.reactions.positiveRate
+      : null;
+
+  return {
+    answerRate,
+    answerRateDelta,
+    responsesDelta: current.totalResponses - previous.totalResponses,
+    positiveRateDelta,
+  };
+}
+
+function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): string[] {
+  const out: string[] = [];
+  if (stats.totalResponses === 0) {
+    out.push(
+      "Your deployment is brand new and ready to roll. Share `dosu setup` with your team to start asking questions.",
+    );
+    return out;
+  }
+  if (derived.answerRate !== null && derived.answerRate >= 0.9) {
+    out.push(
+      `${pct(derived.answerRate)} answer rate — Dosu is finding answers for almost everything you throw at it.`,
+    );
+  }
+  if (stats.byConfidence.high > stats.byConfidence.low * 2 && stats.byConfidence.high > 0) {
+    out.push(
+      `${stats.byConfidence.high} high-confidence answers vs ${stats.byConfidence.low} low — your knowledge base has the receipts.`,
+    );
+  }
+  if (
+    stats.reactions.totalPositive + stats.reactions.totalNegative > 0 &&
+    stats.reactions.positiveRate >= 0.8
+  ) {
+    out.push(
+      `${pct(stats.reactions.positiveRate)} positive feedback — your team is loving the answers.`,
+    );
+  }
+  if (derived.responsesDelta > 0) {
+    out.push(`Volume is up by ${derived.responsesDelta} responses vs the prior window. 📈`);
+  }
+  if (out.length === 0) {
+    out.push(
+      `${stats.totalResponses} responses logged this window — every one is a chance to learn what your team needs.`,
+    );
+  }
+  return out;
+}
+
+function pct(v: number): string {
+  return `${(v * 100).toFixed(0)}%`;
+}
+
+function statsBlock(stats: UsageStats, derived: InsightsReport["derived"]): string {
+  const ar = derived.answerRate !== null ? pct(derived.answerRate) : "n/a";
+  const pr =
+    stats.reactions.totalPositive + stats.reactions.totalNegative > 0
+      ? pct(stats.reactions.positiveRate)
+      : "n/a";
+  return [
+    `- ${stats.totalResponses} total responses`,
+    `- ${stats.totalWithResponse} with answers (${ar} answer rate)`,
+    `- Confidence: ${stats.byConfidence.high} high, ${stats.byConfidence.medium} medium, ${stats.byConfidence.low} low`,
+    `- Reactions: ${stats.reactions.totalPositive} positive, ${stats.reactions.totalNegative} negative (${pr} positive rate)`,
+  ].join("\n");
+}
+
+export function buildAtAGlancePrompt(
+  stats: UsageStats,
+  derived: InsightsReport["derived"],
+  days: number,
+): string {
+  return `You're writing the "At a Glance" panel for a Dosu deployment insights report. Here are the real stats from the last ${days} days:
+
+${statsBlock(stats, derived)}
+
+Write 2-3 short sentences (no bullets, no headers, no markdown) that synthesize what's interesting or worth celebrating. Be warm, specific, and a little fun. Don't just list the numbers — interpret them. Speak directly to the reader ("you" / "your team").`;
+}
+
+export function buildTopicsPrompt(days: number): string {
+  return `Looking at the questions and threads in this Dosu deployment over the last ${days} days, what are the most common topics or themes people have been asking about? Reply in 2-3 friendly sentences naming specific topic areas. No bullet points, no headers — plain prose. If you don't have enough signal yet, say so honestly in one sentence.`;
+}
+
+export function buildSuggestionsPrompt(
+  stats: UsageStats,
+  derived: InsightsReport["derived"],
+  days: number,
+): string {
+  return `Given this Dosu deployment's activity over the last ${days} days:
+
+${statsBlock(stats, derived)}
+
+Suggest 2-3 concrete, specific things the team could do this week to get more value from Dosu. Format as a short numbered list with one sentence each. Be actionable, not generic.`;
+}

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -325,10 +325,10 @@ function computeSuggestions(
       command: "dosu setup",
     });
     out.push({
-      headline: "Connect a knowledge source",
+      headline: "Try a question yourself",
       detail:
-        "Dosu is only as good as what it can read. Add at least one source so it has material to draw from.",
-      command: "dosu integrations list",
+        "See what Dosu does without configuring anything else. Replace the example with whatever you're curious about.",
+      command: 'dosu ask "what is Dosu?"',
     });
     return out;
   }
@@ -373,19 +373,19 @@ function computeSuggestions(
 
   if (derived.hasPriorWindow && derived.responsesDelta >= 10) {
     out.push({
-      headline: "Ride the momentum: add another source",
-      detail: `Volume is up by ${derived.responsesDelta} responses vs the prior window. Connect another source while engagement is high.`,
-      command: "dosu integrations list",
+      headline: "See what your team is asking",
+      detail: `Volume is up by ${derived.responsesDelta} responses vs the prior window. Browsing recent threads is the fastest way to spot patterns and gaps.`,
+      command: "dosu threads list",
     });
   }
 
   // Always-available fallback so we never ship an empty list
   if (out.length === 0) {
     out.push({
-      headline: "Connect more knowledge sources",
+      headline: "Find your knowledge gaps",
       detail:
-        "Each new source expands what Dosu can answer. Even a single new repo or doc set typically lifts high-confidence share.",
-      command: "dosu integrations list",
+        "Dosu surfaces document suggestions from real questions. A quick scan often reveals what's worth writing next.",
+      command: "dosu suggest list",
     });
   }
 

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -1,9 +1,14 @@
 /**
  * Build an InsightsReport for the user's Dosu deployment.
  *
- * Combines hard numbers from `analytics.getUsageStats` with narrative prose
- * pulled from the Dosu `/ask` workflow. Each /ask call is independent — if one
- * fails or times out, the report still renders with the others.
+ * Hard numbers come from `analytics.getUsageStats` for the current and prior
+ * windows. The "investigate" warnings, "cheers" wins, and "suggestions" CTAs
+ * are all derived locally from those numbers — every report has actionable
+ * content even if the optional /ask narrative call fails.
+ *
+ * The single /ask call powers only the warm at-a-glance prose. If it fails or
+ * times out, we fall back to a stats-grounded summary so atAGlance is never
+ * empty.
  */
 
 import type { TypedClient } from "../client/trpc";
@@ -22,10 +27,10 @@ export interface UsageStats {
   };
 }
 
-export interface InsightsNarratives {
-  atAGlance: string | null;
-  topics: string | null;
-  suggestions: string | null;
+export interface Suggestion {
+  headline: string;
+  detail: string;
+  command?: string;
 }
 
 export interface InsightsReport {
@@ -40,8 +45,10 @@ export interface InsightsReport {
     responsesDelta: number;
     positiveRateDelta: number | null;
   };
-  narratives: InsightsNarratives;
+  atAGlance: string;
   cheers: string[];
+  investigate: string[];
+  suggestions: Suggestion[];
 }
 
 export type AskFn = (question: string) => Promise<string | null>;
@@ -90,12 +97,11 @@ export async function buildInsights({
 
   const derived = computeDerived(current, previous);
   const cheers = computeCheers(current, derived);
+  const investigate = computeInvestigate(current, previous, derived);
+  const suggestions = computeSuggestions(current, previous, derived);
 
-  const [atAGlance, topics, suggestions] = await Promise.all([
-    ask(buildAtAGlancePrompt(current, derived, windowDays)),
-    ask(buildTopicsPrompt(windowDays)),
-    ask(buildSuggestionsPrompt(current, derived, windowDays)),
-  ]);
+  const atAGlanceFromAsk = await ask(buildAtAGlancePrompt(current, derived, windowDays));
+  const atAGlance = atAGlanceFromAsk ?? fallbackAtAGlance(current, derived, windowDays);
 
   return {
     generatedAt: now().toISOString(),
@@ -104,8 +110,10 @@ export async function buildInsights({
     current,
     previous,
     derived,
-    narratives: { atAGlance, topics, suggestions },
+    atAGlance,
     cheers,
+    investigate,
+    suggestions,
   };
 }
 
@@ -216,6 +224,163 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
   return out;
 }
 
+function computeInvestigate(
+  current: UsageStats,
+  previous: UsageStats,
+  derived: InsightsReport["derived"],
+): string[] {
+  const out: string[] = [];
+  if (current.totalResponses === 0) return out;
+
+  // Answer rate dropped meaningfully
+  if (derived.answerRateDelta !== null && derived.answerRateDelta <= -0.05) {
+    const before = pct((derived.answerRate ?? 0) - derived.answerRateDelta);
+    const now = pct(derived.answerRate ?? 0);
+    out.push(
+      `Answer rate dropped from ${before} to ${now}. Usually a sign of a new product area Dosu doesn't have docs for yet.`,
+    );
+  }
+
+  // Low confidence growing in absolute terms
+  const lowDelta = current.byConfidence.low - previous.byConfidence.low;
+  if (lowDelta >= 5 && current.byConfidence.low > 0) {
+    out.push(
+      `Low-confidence answers grew by ${lowDelta} (now ${current.byConfidence.low} this window). Each one is a hint that your knowledge base has gaps.`,
+    );
+  }
+
+  // Positive reaction rate dropped
+  if (derived.positiveRateDelta !== null && derived.positiveRateDelta <= -0.05) {
+    const before = pct(current.reactions.positiveRate - derived.positiveRateDelta);
+    const now = pct(current.reactions.positiveRate);
+    out.push(
+      `Positive feedback fell from ${before} to ${now}. The negative reactions are the most actionable signal — open them first.`,
+    );
+  }
+
+  // More negative than positive feedback
+  if (
+    current.reactions.totalNegative > current.reactions.totalPositive &&
+    current.reactions.totalNegative >= 3
+  ) {
+    out.push(
+      `${current.reactions.totalNegative} negative reactions vs ${current.reactions.totalPositive} positive. Worth a look — what changed?`,
+    );
+  }
+
+  // Volume dropped meaningfully
+  if (derived.responsesDelta <= -10 && previous.totalResponses > 0) {
+    out.push(
+      `Volume is down by ${Math.abs(derived.responsesDelta)} responses. If your team stopped asking, find out why.`,
+    );
+  }
+
+  // Low overall answer rate (independent of trend)
+  if (derived.answerRate !== null && derived.answerRate < 0.6 && current.totalResponses >= 5) {
+    const unanswered = current.totalResponses - current.totalWithResponse;
+    out.push(
+      `${unanswered} of ${current.totalResponses} responses went without an answer. The unanswered ones show what your knowledge base doesn't cover yet.`,
+    );
+  }
+
+  return out;
+}
+
+function computeSuggestions(
+  current: UsageStats,
+  previous: UsageStats,
+  derived: InsightsReport["derived"],
+): Suggestion[] {
+  const out: Suggestion[] = [];
+
+  // Empty deployment — single most important CTA
+  if (current.totalResponses === 0) {
+    out.push({
+      headline: "Get your team using Dosu",
+      detail:
+        "No responses logged yet. The fastest unlock is wiring Dosu into the tools your team already uses — ask Dosu in Slack, your editor, or anywhere else.",
+      command: "dosu setup",
+    });
+    out.push({
+      headline: "Connect a knowledge source",
+      detail:
+        "Dosu is only as good as what it can read. Add at least one source so it has material to draw from.",
+      command: "dosu integrations",
+    });
+    return out;
+  }
+
+  // Low-confidence growing
+  const lowDelta = current.byConfidence.low - previous.byConfidence.low;
+  if (lowDelta >= 5 || current.byConfidence.low >= Math.max(5, current.totalResponses * 0.3)) {
+    out.push({
+      headline: "Audit recent low-confidence answers",
+      detail: `${current.byConfidence.low} answers had low confidence this window${
+        lowDelta > 0 ? ` (+${lowDelta} vs prior)` : ""
+      }. Open them to see exactly what knowledge is missing.`,
+      command: "dosu threads list",
+    });
+  }
+
+  // Positive rate dropping
+  if (derived.positiveRateDelta !== null && derived.positiveRateDelta <= -0.05) {
+    out.push({
+      headline: "Refresh your sources",
+      detail:
+        "Positive feedback is trending down. Usually a stale doc, a moved page, or a new product area Dosu hasn't seen.",
+      command: "dosu sources list",
+    });
+  }
+
+  // Low answer rate
+  if (derived.answerRate !== null && derived.answerRate < 0.7 && current.totalResponses >= 5) {
+    out.push({
+      headline: "Investigate unanswered questions",
+      detail: `${
+        current.totalResponses - current.totalWithResponse
+      } questions went unanswered. They map directly to the topics your knowledge base doesn't cover.`,
+      command: "dosu threads list",
+    });
+  }
+
+  // High volume + good metrics → share the wins
+  if (
+    current.totalResponses >= 50 &&
+    derived.answerRate !== null &&
+    derived.answerRate >= 0.8 &&
+    out.length === 0
+  ) {
+    out.push({
+      headline: "Share the win with your team",
+      detail: `${current.totalResponses} questions answered with a ${pct(
+        derived.answerRate,
+      )} answer rate. People are getting unblocked — make sure your team knows it's working.`,
+    });
+  }
+
+  // Volume rising — momentum suggestion
+  if (derived.responsesDelta >= 10) {
+    out.push({
+      headline: "Ride the momentum — add another source",
+      detail: `Volume is up by ${derived.responsesDelta} responses vs the prior window. Connect another source while engagement is high.`,
+      command: "dosu integrations",
+    });
+  }
+
+  // Always-available fallback so we never ship an empty list
+  if (out.length === 0) {
+    out.push({
+      headline: "Connect more knowledge sources",
+      detail:
+        "Each new source expands what Dosu can answer. Even a single new repo or doc set typically lifts answer rate.",
+      command: "dosu integrations",
+    });
+  }
+
+  // Cap at 4 to keep the report scannable
+  return out.slice(0, 4);
+}
+
 function pct(v: number): string {
   return `${(v * 100).toFixed(0)}%`;
 }
@@ -246,18 +411,22 @@ ${statsBlock(stats, derived)}
 Write 2-3 short sentences (no bullets, no headers, no markdown) that synthesize what's interesting or worth celebrating. Be warm, specific, and a little fun. Don't just list the numbers — interpret them. Speak directly to the reader ("you" / "your team").`;
 }
 
-export function buildTopicsPrompt(days: number): string {
-  return `Looking at the questions and threads in this Dosu deployment over the last ${days} days, what are the most common topics or themes people have been asking about? Reply in 2-3 friendly sentences naming specific topic areas. No bullet points, no headers — plain prose. If you don't have enough signal yet, say so honestly in one sentence.`;
-}
-
-export function buildSuggestionsPrompt(
+export function fallbackAtAGlance(
   stats: UsageStats,
   derived: InsightsReport["derived"],
   days: number,
 ): string {
-  return `Given this Dosu deployment's activity over the last ${days} days:
-
-${statsBlock(stats, derived)}
-
-Suggest 2-3 concrete, specific things the team could do this week to get more value from Dosu. Format as a short numbered list with one sentence each. Be actionable, not generic.`;
+  if (stats.totalResponses === 0) {
+    return `Your deployment is brand new. The next ${days} days will give us something to talk about — let's see what your team asks first.`;
+  }
+  const ar = derived.answerRate !== null ? pct(derived.answerRate) : "—";
+  const reactions = stats.reactions.totalPositive + stats.reactions.totalNegative;
+  const pr = reactions > 0 ? `, with ${pct(stats.reactions.positiveRate)} positive feedback` : "";
+  const trend =
+    derived.responsesDelta > 0
+      ? ` Volume is up ${derived.responsesDelta} vs the prior ${days} days — the team is leaning on Dosu more.`
+      : derived.responsesDelta < 0
+        ? ` Volume is down ${Math.abs(derived.responsesDelta)} vs the prior ${days} days — worth a quick look.`
+        : "";
+  return `In the last ${days} days you logged ${stats.totalResponses} responses with a ${ar} answer rate${pr}.${trend}`;
 }

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -218,12 +218,12 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
   }
   if (derived.highConfidenceRate !== null && derived.highConfidenceRate >= 0.8) {
     out.push(
-      `${pct(derived.highConfidenceRate)} of responses were high-confidence. Dosu's knowledge base is paying off.`,
+      `${pct(derived.highConfidenceRate)} of responses came back high-confidence. Your sources are covering most of what your team's asking about.`,
     );
   }
   if (stats.byConfidence.high > stats.byConfidence.low * 2 && stats.byConfidence.high > 0) {
     out.push(
-      `${stats.byConfidence.high} high-confidence answers vs ${stats.byConfidence.low} low. Your knowledge base has the receipts.`,
+      `${stats.byConfidence.high} high-confidence answers vs ${stats.byConfidence.low} low. Most questions have a clear source to point to.`,
     );
   }
   if (
@@ -231,11 +231,13 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
     stats.reactions.positiveRate >= 0.8
   ) {
     out.push(
-      `${pct(stats.reactions.positiveRate)} positive feedback. Your team is loving the answers.`,
+      `${pct(stats.reactions.positiveRate)} of reactions were positive. The answers your team's engaging with are landing.`,
     );
   }
   if (derived.hasPriorWindow && derived.responsesDelta > 0) {
-    out.push(`Volume is up by ${derived.responsesDelta} responses vs the prior window. 📈`);
+    out.push(
+      `Volume is up ${derived.responsesDelta} responses vs the prior window. Your team is leaning on Dosu more.`,
+    );
   }
   if (out.length === 0) {
     out.push(
@@ -389,8 +391,17 @@ function computeSuggestions(
     });
   }
 
+  // Drop later suggestions that repeat a command already used — same CTA twice is noise
+  const seen = new Set<string>();
+  const deduped = out.filter((s) => {
+    if (!s.command) return true;
+    if (seen.has(s.command)) return false;
+    seen.add(s.command);
+    return true;
+  });
+
   // Cap at 4 to keep the report scannable
-  return out.slice(0, 4);
+  return deduped.slice(0, 4);
 }
 
 function pct(v: number): string {

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -275,11 +275,10 @@ function computeInvestigate(
     );
   }
 
-  // Low overall answer rate (independent of trend)
   if (derived.answerRate !== null && derived.answerRate < 0.6 && current.totalResponses >= 5) {
-    const unanswered = current.totalResponses - current.totalWithResponse;
+    const noAnswer = current.totalResponses - current.totalWithResponse;
     out.push(
-      `${unanswered} of ${current.totalResponses} responses went without an answer. The unanswered ones show what your knowledge base doesn't cover yet.`,
+      `${noAnswer} of ${current.totalResponses} questions didn't get an answer. Open the threads to see the mix — some will be knowledge gaps, others out-of-scope or spam.`,
     );
   }
 
@@ -334,13 +333,12 @@ function computeSuggestions(
     });
   }
 
-  // Low answer rate
   if (derived.answerRate !== null && derived.answerRate < 0.7 && current.totalResponses >= 5) {
     out.push({
-      headline: "Investigate unanswered questions",
+      headline: "Investigate questions without an answer",
       detail: `${
         current.totalResponses - current.totalWithResponse
-      } questions went unanswered. They map directly to the topics your knowledge base doesn't cover.`,
+      } questions didn't get an answer this window. Open them to see the mix — knowledge gaps, out-of-scope asks, and spam look different up close.`,
       command: "dosu threads list",
     });
   }
@@ -354,9 +352,9 @@ function computeSuggestions(
   ) {
     out.push({
       headline: "Share the win with your team",
-      detail: `${current.totalResponses} questions answered with a ${pct(
+      detail: `${current.totalWithResponse} of ${current.totalResponses} questions got an answer (${pct(
         derived.answerRate,
-      )} answer rate. People are getting unblocked — make sure your team knows it's working.`,
+      )} answer rate). People are getting unblocked — make sure your team knows it's working.`,
     });
   }
 

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -40,8 +40,8 @@ export interface InsightsReport {
   current: UsageStats;
   previous: UsageStats;
   derived: {
-    answerRate: number | null;
-    answerRateDelta: number | null;
+    highConfidenceRate: number | null;
+    highConfidenceRateDelta: number | null;
     responsesDelta: number;
     positiveRateDelta: number | null;
     hasPriorWindow: boolean;
@@ -167,12 +167,14 @@ function subtractStats(combined: UsageStats, current: UsageStats): UsageStats {
 }
 
 function computeDerived(current: UsageStats, previous: UsageStats): InsightsReport["derived"] {
-  const answerRate =
-    current.totalResponses > 0 ? current.totalWithResponse / current.totalResponses : null;
-  const prevAnswerRate =
-    previous.totalResponses > 0 ? previous.totalWithResponse / previous.totalResponses : null;
-  const answerRateDelta =
-    answerRate !== null && prevAnswerRate !== null ? answerRate - prevAnswerRate : null;
+  const highConfidenceRate =
+    current.totalResponses > 0 ? current.byConfidence.high / current.totalResponses : null;
+  const prevHighConfidenceRate =
+    previous.totalResponses > 0 ? previous.byConfidence.high / previous.totalResponses : null;
+  const highConfidenceRateDelta =
+    highConfidenceRate !== null && prevHighConfidenceRate !== null
+      ? highConfidenceRate - prevHighConfidenceRate
+      : null;
 
   const positiveRateDelta =
     current.reactions.totalPositive + current.reactions.totalNegative > 0 &&
@@ -181,8 +183,8 @@ function computeDerived(current: UsageStats, previous: UsageStats): InsightsRepo
       : null;
 
   return {
-    answerRate,
-    answerRateDelta,
+    highConfidenceRate,
+    highConfidenceRateDelta,
     responsesDelta: current.totalResponses - previous.totalResponses,
     positiveRateDelta,
     hasPriorWindow: previous.totalResponses > 0,
@@ -197,9 +199,9 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
     );
     return out;
   }
-  if (derived.answerRate !== null && derived.answerRate >= 0.9) {
+  if (derived.highConfidenceRate !== null && derived.highConfidenceRate >= 0.8) {
     out.push(
-      `${pct(derived.answerRate)} answer rate — Dosu is finding answers for almost everything you throw at it.`,
+      `${pct(derived.highConfidenceRate)} of responses were high-confidence — Dosu's knowledge base is paying off.`,
     );
   }
   if (stats.byConfidence.high > stats.byConfidence.low * 2 && stats.byConfidence.high > 0) {
@@ -234,11 +236,15 @@ function computeInvestigate(
   const out: string[] = [];
   if (current.totalResponses === 0) return out;
 
-  if (derived.answerRateDelta !== null && derived.answerRateDelta <= -0.05) {
-    const before = pct(previous.totalWithResponse / previous.totalResponses);
-    const now = pct(current.totalWithResponse / current.totalResponses);
+  if (
+    derived.highConfidenceRateDelta !== null &&
+    derived.highConfidenceRateDelta <= -0.05 &&
+    previous.totalResponses > 0
+  ) {
+    const before = pct(previous.byConfidence.high / previous.totalResponses);
+    const now = pct(current.byConfidence.high / current.totalResponses);
     out.push(
-      `Answer rate dropped from ${before} to ${now}. Usually a sign of a new product area Dosu doesn't have docs for yet.`,
+      `High-confidence share dropped from ${before} to ${now}. Usually a sign of a new product area Dosu doesn't have docs for yet.`,
     );
   }
 
@@ -257,7 +263,6 @@ function computeInvestigate(
     );
   }
 
-  // More negative than positive feedback
   if (
     current.reactions.totalNegative > current.reactions.totalPositive &&
     current.reactions.totalNegative >= 3
@@ -273,10 +278,14 @@ function computeInvestigate(
     );
   }
 
-  if (derived.answerRate !== null && derived.answerRate < 0.6 && current.totalResponses >= 5) {
-    const noAnswer = current.totalResponses - current.totalWithResponse;
+  if (
+    derived.highConfidenceRate !== null &&
+    derived.highConfidenceRate < 0.5 &&
+    current.totalResponses >= 5
+  ) {
+    const lowAndMed = current.byConfidence.low + current.byConfidence.medium;
     out.push(
-      `${noAnswer} of ${current.totalResponses} questions didn't get an answer. Open the threads to see the mix — some will be knowledge gaps, others out-of-scope or spam.`,
+      `${lowAndMed} of ${current.totalResponses} responses were medium- or low-confidence. Open the threads to see where the knowledge base needs more material.`,
     );
   }
 
@@ -331,28 +340,17 @@ function computeSuggestions(
     });
   }
 
-  if (derived.answerRate !== null && derived.answerRate < 0.7 && current.totalResponses >= 5) {
-    out.push({
-      headline: "Investigate questions without an answer",
-      detail: `${
-        current.totalResponses - current.totalWithResponse
-      } questions didn't get an answer this window. Open them to see the mix — knowledge gaps, out-of-scope asks, and spam look different up close.`,
-      command: "dosu threads list",
-    });
-  }
-
-  // High volume + good metrics → share the wins
   if (
     current.totalResponses >= 50 &&
-    derived.answerRate !== null &&
-    derived.answerRate >= 0.8 &&
+    derived.highConfidenceRate !== null &&
+    derived.highConfidenceRate >= 0.7 &&
     out.length === 0
   ) {
     out.push({
       headline: "Share the win with your team",
-      detail: `${current.totalWithResponse} of ${current.totalResponses} questions got an answer (${pct(
-        derived.answerRate,
-      )} answer rate). People are getting unblocked — make sure your team knows it's working.`,
+      detail: `${current.byConfidence.high} of ${current.totalResponses} responses landed with high confidence (${pct(
+        derived.highConfidenceRate,
+      )}). People are getting unblocked — make sure your team knows it's working.`,
     });
   }
 
@@ -369,7 +367,7 @@ function computeSuggestions(
     out.push({
       headline: "Connect more knowledge sources",
       detail:
-        "Each new source expands what Dosu can answer. Even a single new repo or doc set typically lifts answer rate.",
+        "Each new source expands what Dosu can answer. Even a single new repo or doc set typically lifts high-confidence share.",
       command: "dosu integrations",
     });
   }
@@ -383,15 +381,14 @@ function pct(v: number): string {
 }
 
 function statsBlock(stats: UsageStats, derived: InsightsReport["derived"]): string {
-  const ar = derived.answerRate !== null ? pct(derived.answerRate) : "n/a";
+  const hc = derived.highConfidenceRate !== null ? pct(derived.highConfidenceRate) : "n/a";
   const pr =
     stats.reactions.totalPositive + stats.reactions.totalNegative > 0
       ? pct(stats.reactions.positiveRate)
       : "n/a";
   return [
     `- ${stats.totalResponses} total responses`,
-    `- ${stats.totalWithResponse} with answers (${ar} answer rate)`,
-    `- Confidence: ${stats.byConfidence.high} high, ${stats.byConfidence.medium} medium, ${stats.byConfidence.low} low`,
+    `- Confidence: ${stats.byConfidence.high} high, ${stats.byConfidence.medium} medium, ${stats.byConfidence.low} low (${hc} high-confidence share)`,
     `- Reactions: ${stats.reactions.totalPositive} positive, ${stats.reactions.totalNegative} negative (${pr} positive rate)`,
   ].join("\n");
 }
@@ -419,11 +416,11 @@ export function fallbackAtAGlance(
   if (stats.totalResponses === 0) {
     return `Your deployment is brand new. The next ${days} days will give us something to talk about — let's see what your team asks first.`;
   }
-  const ar = derived.answerRate !== null ? pct(derived.answerRate) : "—";
+  const hc = derived.highConfidenceRate !== null ? pct(derived.highConfidenceRate) : "—";
   const reactions = stats.reactions.totalPositive + stats.reactions.totalNegative;
   const pr = reactions > 0 ? `, with ${pct(stats.reactions.positiveRate)} positive feedback` : "";
   if (!derived.hasPriorWindow) {
-    return `In your first ${days}-day window you logged ${stats.totalResponses} responses with a ${ar} answer rate${pr}. Check back after another ${days} days for trend comparisons.`;
+    return `In your first ${days}-day window you logged ${stats.totalResponses} responses, ${hc} of them high-confidence${pr}. Check back after another ${days} days for trend comparisons.`;
   }
   const trend =
     derived.responsesDelta > 0
@@ -431,5 +428,5 @@ export function fallbackAtAGlance(
       : derived.responsesDelta < 0
         ? ` Volume is down ${Math.abs(derived.responsesDelta)} vs the prior ${days} days — worth a quick look.`
         : "";
-  return `In the last ${days} days you logged ${stats.totalResponses} responses with a ${ar} answer rate${pr}.${trend}`;
+  return `In the last ${days} days you logged ${stats.totalResponses} responses, ${hc} of them high-confidence${pr}.${trend}`;
 }

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -123,10 +123,24 @@ export async function buildInsights({
   };
 }
 
-function normalizeStats(raw: UsageStats | null | undefined): UsageStats {
+interface RawUsageStats {
+  totalResponses?: number;
+  byConfidence?: { high?: number; medium?: number; low?: number };
+  reactions?: {
+    totalPositive?: number;
+    totalNegative?: number;
+    messagesWithReactions?: number;
+    reactionRate?: number;
+    positiveRate?: number;
+  };
+}
+
+function normalizeStats(raw: RawUsageStats | null | undefined): UsageStats {
   if (!raw) return { ...EMPTY_STATS };
+  const totalResponses = raw.totalResponses ?? 0;
+  const reactionMsgs = raw.reactions?.messagesWithReactions ?? 0;
   return {
-    totalResponses: raw.totalResponses ?? 0,
+    totalResponses,
     byConfidence: {
       high: raw.byConfidence?.high ?? 0,
       medium: raw.byConfidence?.medium ?? 0,
@@ -135,8 +149,9 @@ function normalizeStats(raw: UsageStats | null | undefined): UsageStats {
     reactions: {
       totalPositive: raw.reactions?.totalPositive ?? 0,
       totalNegative: raw.reactions?.totalNegative ?? 0,
-      messagesWithReactions: raw.reactions?.messagesWithReactions ?? 0,
-      reactionRate: raw.reactions?.reactionRate ?? 0,
+      messagesWithReactions: reactionMsgs,
+      reactionRate:
+        raw.reactions?.reactionRate ?? (totalResponses > 0 ? reactionMsgs / totalResponses : 0),
       positiveRate: raw.reactions?.positiveRate ?? 0,
     },
   };

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -53,12 +53,16 @@ export interface InsightsReport {
 
 export type AskFn = (question: string) => Promise<string | null>;
 
+export type InsightsStage = "stats" | "narrative";
+export type ProgressFn = (stage: InsightsStage) => void;
+
 export interface BuildInsightsArgs {
   client: TypedClient;
   cfg: Config;
   ask: AskFn;
   windowDays?: number;
   now?: () => Date;
+  onProgress?: ProgressFn;
 }
 
 const EMPTY_STATS: UsageStats = {
@@ -79,12 +83,14 @@ export async function buildInsights({
   ask,
   windowDays = 30,
   now = () => new Date(),
+  onProgress,
 }: BuildInsightsArgs): Promise<InsightsReport> {
   if (!cfg.space_id) {
     throw new Error("space_id missing — run 'dosu setup' first");
   }
   const spaceId = cfg.space_id;
 
+  onProgress?.("stats");
   const [currentRaw, combinedRaw] = await Promise.all([
     client.analytics.getUsageStats.query({ spaceId, days: windowDays }),
     client.analytics.getUsageStats.query({ spaceId, days: windowDays * 2 }),
@@ -99,6 +105,7 @@ export async function buildInsights({
   const investigate = computeInvestigate(current, previous, derived);
   const suggestions = computeSuggestions(current, previous, derived);
 
+  onProgress?.("narrative");
   const atAGlanceFromAsk = await ask(buildAtAGlancePrompt(current, derived, windowDays));
   const atAGlance = atAGlanceFromAsk ?? fallbackAtAGlance(current, derived, windowDays);
 

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -16,7 +16,6 @@ import type { Config } from "../config/config";
 
 export interface UsageStats {
   totalResponses: number;
-  totalWithResponse: number;
   byConfidence: { high: number; medium: number; low: number };
   reactions: {
     totalPositive: number;
@@ -64,7 +63,6 @@ export interface BuildInsightsArgs {
 
 const EMPTY_STATS: UsageStats = {
   totalResponses: 0,
-  totalWithResponse: 0,
   byConfidence: { high: 0, medium: 0, low: 0 },
   reactions: {
     totalPositive: 0,
@@ -122,7 +120,6 @@ function normalizeStats(raw: UsageStats | null | undefined): UsageStats {
   if (!raw) return { ...EMPTY_STATS };
   return {
     totalResponses: raw.totalResponses ?? 0,
-    totalWithResponse: raw.totalWithResponse ?? 0,
     byConfidence: {
       high: raw.byConfidence?.high ?? 0,
       medium: raw.byConfidence?.medium ?? 0,
@@ -140,7 +137,6 @@ function normalizeStats(raw: UsageStats | null | undefined): UsageStats {
 
 function subtractStats(combined: UsageStats, current: UsageStats): UsageStats {
   const totalResponses = Math.max(0, combined.totalResponses - current.totalResponses);
-  const totalWithResponse = Math.max(0, combined.totalWithResponse - current.totalWithResponse);
   const positive = Math.max(0, combined.reactions.totalPositive - current.reactions.totalPositive);
   const negative = Math.max(0, combined.reactions.totalNegative - current.reactions.totalNegative);
   const reactionMsgs = Math.max(
@@ -150,7 +146,6 @@ function subtractStats(combined: UsageStats, current: UsageStats): UsageStats {
   const totalReactions = positive + negative;
   return {
     totalResponses,
-    totalWithResponse,
     byConfidence: {
       high: Math.max(0, combined.byConfidence.high - current.byConfidence.high),
       medium: Math.max(0, combined.byConfidence.medium - current.byConfidence.medium),

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -234,10 +234,9 @@ function computeInvestigate(
   const out: string[] = [];
   if (current.totalResponses === 0) return out;
 
-  // Answer rate dropped meaningfully
   if (derived.answerRateDelta !== null && derived.answerRateDelta <= -0.05) {
-    const before = pct((derived.answerRate ?? 0) - derived.answerRateDelta);
-    const now = pct(derived.answerRate ?? 0);
+    const before = pct(previous.totalWithResponse / previous.totalResponses);
+    const now = pct(current.totalWithResponse / current.totalResponses);
     out.push(
       `Answer rate dropped from ${before} to ${now}. Usually a sign of a new product area Dosu doesn't have docs for yet.`,
     );
@@ -250,9 +249,8 @@ function computeInvestigate(
     );
   }
 
-  // Positive reaction rate dropped
   if (derived.positiveRateDelta !== null && derived.positiveRateDelta <= -0.05) {
-    const before = pct(current.reactions.positiveRate - derived.positiveRateDelta);
+    const before = pct(previous.reactions.positiveRate);
     const now = pct(current.reactions.positiveRate);
     out.push(
       `Positive feedback fell from ${before} to ${now}. The negative reactions are the most actionable signal — open them first.`,

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -1,9 +1,9 @@
 /**
- * Build an InsightsReport for the user's Dosu deployment.
+ * Build an InsightsReport for the user's Dosu space.
  *
  * Hard numbers come from `analytics.getUsageStats` for the current and prior
  * windows. The "investigate" warnings, "cheers" wins, and "suggestions" CTAs
- * are all derived locally from those numbers — every report has actionable
+ * are all derived locally from those numbers, so every report has actionable
  * content even if the optional /ask narrative call fails.
  *
  * The single /ask call powers only the warm at-a-glance prose. If it fails or
@@ -35,7 +35,7 @@ export interface Suggestion {
 export interface InsightsReport {
   generatedAt: string;
   windowDays: number;
-  deploymentName: string;
+  spaceName: string;
   current: UsageStats;
   previous: UsageStats;
   derived: {
@@ -105,7 +105,7 @@ export async function buildInsights({
   return {
     generatedAt: now().toISOString(),
     windowDays,
-    deploymentName: cfg.deployment_name ?? "your deployment",
+    spaceName: cfg.deployment_name ?? "your space",
     current,
     previous,
     derived,
@@ -190,7 +190,7 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
   const out: string[] = [];
   if (stats.totalResponses === 0) {
     out.push(
-      "Your deployment is brand new and ready to roll. Share `dosu setup` with your team to start asking questions.",
+      "Your space is brand new and ready to roll. Share `dosu setup` with your team to start asking questions.",
     );
     return out;
   }
@@ -294,7 +294,7 @@ function computeSuggestions(
 ): Suggestion[] {
   const out: Suggestion[] = [];
 
-  // Empty deployment — single most important CTA
+  // Empty space: single most important CTA
   if (current.totalResponses === 0) {
     out.push({
       headline: "Get your team using Dosu",
@@ -395,8 +395,8 @@ export function buildAtAGlancePrompt(
 ): string {
   const priorNote = derived.hasPriorWindow
     ? ""
-    : `\n\nNote: this is the deployment's first ${days}-day window — do NOT compare to a prior period. Focus on what's present.`;
-  return `You're writing the "At a Glance" panel for a Dosu deployment insights report. Here are the real stats from the last ${days} days:
+    : `\n\nNote: this is the space's first ${days}-day window, so do NOT compare to a prior period. Focus on what's present.`;
+  return `You're writing the "At a Glance" panel for a Dosu space insights report. Here are the real stats from the last ${days} days:
 
 ${statsBlock(stats, derived)}${priorNote}
 
@@ -409,7 +409,7 @@ export function fallbackAtAGlance(
   days: number,
 ): string {
   if (stats.totalResponses === 0) {
-    return `Your deployment is brand new. The next ${days} days will give us something to talk about — let's see what your team asks first.`;
+    return `Your space is brand new. The next ${days} days will give us something to talk about, so let's see what your team asks first.`;
   }
   const hc = derived.highConfidenceRate !== null ? pct(derived.highConfidenceRate) : "—";
   const reactions = stats.reactions.totalPositive + stats.reactions.totalNegative;

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -86,7 +86,7 @@ export async function buildInsights({
   onProgress,
 }: BuildInsightsArgs): Promise<InsightsReport> {
   if (!cfg.space_id) {
-    throw new Error("space_id missing — run 'dosu setup' first");
+    throw new Error("space_id missing. Run 'dosu setup' first");
   }
   const spaceId = cfg.space_id;
 
@@ -218,12 +218,12 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
   }
   if (derived.highConfidenceRate !== null && derived.highConfidenceRate >= 0.8) {
     out.push(
-      `${pct(derived.highConfidenceRate)} of responses were high-confidence — Dosu's knowledge base is paying off.`,
+      `${pct(derived.highConfidenceRate)} of responses were high-confidence. Dosu's knowledge base is paying off.`,
     );
   }
   if (stats.byConfidence.high > stats.byConfidence.low * 2 && stats.byConfidence.high > 0) {
     out.push(
-      `${stats.byConfidence.high} high-confidence answers vs ${stats.byConfidence.low} low — your knowledge base has the receipts.`,
+      `${stats.byConfidence.high} high-confidence answers vs ${stats.byConfidence.low} low. Your knowledge base has the receipts.`,
     );
   }
   if (
@@ -231,7 +231,7 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
     stats.reactions.positiveRate >= 0.8
   ) {
     out.push(
-      `${pct(stats.reactions.positiveRate)} positive feedback — your team is loving the answers.`,
+      `${pct(stats.reactions.positiveRate)} positive feedback. Your team is loving the answers.`,
     );
   }
   if (derived.hasPriorWindow && derived.responsesDelta > 0) {
@@ -239,7 +239,7 @@ function computeCheers(stats: UsageStats, derived: InsightsReport["derived"]): s
   }
   if (out.length === 0) {
     out.push(
-      `${stats.totalResponses} responses logged this window — every one is a chance to learn what your team needs.`,
+      `${stats.totalResponses} responses logged this window. Every one is a chance to learn what your team needs.`,
     );
   }
   return out;
@@ -276,7 +276,7 @@ function computeInvestigate(
     const before = pct(previous.reactions.positiveRate);
     const now = pct(current.reactions.positiveRate);
     out.push(
-      `Positive feedback fell from ${before} to ${now}. The negative reactions are the most actionable signal — open them first.`,
+      `Positive feedback fell from ${before} to ${now}. The negative reactions are the most actionable signal. Open them first.`,
     );
   }
 
@@ -285,7 +285,7 @@ function computeInvestigate(
     current.reactions.totalNegative >= 3
   ) {
     out.push(
-      `${current.reactions.totalNegative} negative reactions vs ${current.reactions.totalPositive} positive. Worth a look — what changed?`,
+      `${current.reactions.totalNegative} negative reactions vs ${current.reactions.totalPositive} positive. Worth a look. What changed?`,
     );
   }
 
@@ -321,14 +321,14 @@ function computeSuggestions(
     out.push({
       headline: "Get your team using Dosu",
       detail:
-        "No responses logged yet. The fastest unlock is wiring Dosu into the tools your team already uses — ask Dosu in Slack, your editor, or anywhere else.",
+        "No responses logged yet. The fastest unlock is wiring Dosu into the tools your team already uses. Ask Dosu in Slack, your editor, or anywhere else.",
       command: "dosu setup",
     });
     out.push({
       headline: "Connect a knowledge source",
       detail:
         "Dosu is only as good as what it can read. Add at least one source so it has material to draw from.",
-      command: "dosu integrations",
+      command: "dosu integrations list",
     });
     return out;
   }
@@ -367,15 +367,15 @@ function computeSuggestions(
       headline: "Share the win with your team",
       detail: `${current.byConfidence.high} of ${current.totalResponses} responses landed with high confidence (${pct(
         derived.highConfidenceRate,
-      )}). People are getting unblocked — make sure your team knows it's working.`,
+      )}). People are getting unblocked. Make sure your team knows it's working.`,
     });
   }
 
   if (derived.hasPriorWindow && derived.responsesDelta >= 10) {
     out.push({
-      headline: "Ride the momentum — add another source",
+      headline: "Ride the momentum: add another source",
       detail: `Volume is up by ${derived.responsesDelta} responses vs the prior window. Connect another source while engagement is high.`,
-      command: "dosu integrations",
+      command: "dosu integrations list",
     });
   }
 
@@ -385,7 +385,7 @@ function computeSuggestions(
       headline: "Connect more knowledge sources",
       detail:
         "Each new source expands what Dosu can answer. Even a single new repo or doc set typically lifts high-confidence share.",
-      command: "dosu integrations",
+      command: "dosu integrations list",
     });
   }
 
@@ -422,7 +422,7 @@ export function buildAtAGlancePrompt(
 
 ${statsBlock(stats, derived)}${priorNote}
 
-Write 2-3 short sentences (no bullets, no headers, no markdown) that synthesize what's interesting or worth celebrating. Be warm, specific, and a little fun. Don't just list the numbers — interpret them. Speak directly to the reader ("you" / "your team").`;
+Write 2-3 short sentences (no bullets, no headers, no markdown, no em dashes) that synthesize what's interesting or worth celebrating. Be warm, specific, and a little fun. Don't just list the numbers; interpret them. Speak directly to the reader ("you" / "your team").`;
 }
 
 export function fallbackAtAGlance(
@@ -433,7 +433,7 @@ export function fallbackAtAGlance(
   if (stats.totalResponses === 0) {
     return `Your space is brand new. The next ${days} days will give us something to talk about, so let's see what your team asks first.`;
   }
-  const hc = derived.highConfidenceRate !== null ? pct(derived.highConfidenceRate) : "—";
+  const hc = derived.highConfidenceRate !== null ? pct(derived.highConfidenceRate) : "n/a";
   const reactions = stats.reactions.totalPositive + stats.reactions.totalNegative;
   const pr = reactions > 0 ? `, with ${pct(stats.reactions.positiveRate)} positive feedback` : "";
   if (!derived.hasPriorWindow) {
@@ -441,9 +441,9 @@ export function fallbackAtAGlance(
   }
   const trend =
     derived.responsesDelta > 0
-      ? ` Volume is up ${derived.responsesDelta} vs the prior ${days} days — the team is leaning on Dosu more.`
+      ? ` Volume is up ${derived.responsesDelta} vs the prior ${days} days. The team is leaning on Dosu more.`
       : derived.responsesDelta < 0
-        ? ` Volume is down ${Math.abs(derived.responsesDelta)} vs the prior ${days} days — worth a quick look.`
+        ? ` Volume is down ${Math.abs(derived.responsesDelta)} vs the prior ${days} days. Worth a quick look.`
         : "";
   return `In the last ${days} days you logged ${stats.totalResponses} responses, ${hc} of them high-confidence${pr}.${trend}`;
 }

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -32,8 +32,8 @@ function makeReport(over: Partial<InsightsReport> = {}): InsightsReport {
       },
     },
     derived: {
-      answerRate: 0.8,
-      answerRateDelta: 0.05,
+      highConfidenceRate: 0.625,
+      highConfidenceRateDelta: 0.125,
       responsesDelta: 20,
       positiveRateDelta: 0.057,
       hasPriorWindow: true,
@@ -149,8 +149,8 @@ describe("renderHTML", () => {
     const html = renderHTML(
       makeReport({
         derived: {
-          answerRate: 0.6,
-          answerRateDelta: -0.2,
+          highConfidenceRate: 0.4,
+          highConfidenceRateDelta: -0.2,
           responsesDelta: -15,
           positiveRateDelta: -0.1,
           hasPriorWindow: true,
@@ -165,8 +165,8 @@ describe("renderHTML", () => {
     const html = renderHTML(
       makeReport({
         derived: {
-          answerRate: 0.8,
-          answerRateDelta: 0,
+          highConfidenceRate: 0.8,
+          highConfidenceRateDelta: 0,
           responsesDelta: 0,
           positiveRateDelta: 0,
           hasPriorWindow: true,
@@ -189,8 +189,8 @@ describe("renderHTML", () => {
       makeReport({
         current: { ...makeReport().current, totalResponses: 50 },
         derived: {
-          answerRate: 0.8,
-          answerRateDelta: 0,
+          highConfidenceRate: 0.8,
+          highConfidenceRateDelta: 0,
           responsesDelta: -30,
           positiveRateDelta: 0,
           hasPriorWindow: true,
@@ -207,8 +207,8 @@ describe("renderHTML", () => {
       makeReport({
         current: { ...makeReport().current, totalResponses: 80 },
         derived: {
-          answerRate: 0.8,
-          answerRateDelta: 0,
+          highConfidenceRate: 0.8,
+          highConfidenceRateDelta: 0,
           responsesDelta: 0,
           positiveRateDelta: 0,
           hasPriorWindow: true,
@@ -232,20 +232,24 @@ describe("renderHTML", () => {
     expect(html).toContain("Triple digits");
   });
 
-  it("uses chef's-kiss flair when answer rate is at least 95%", () => {
+  it("uses chef's-kiss flair when high-confidence share is at least 90%", () => {
     const html = renderHTML(
       makeReport({
-        current: { ...makeReport().current, totalResponses: 30 },
+        current: {
+          ...makeReport().current,
+          totalResponses: 30,
+          byConfidence: { high: 29, medium: 1, low: 0 },
+        },
         derived: {
-          answerRate: 0.97,
-          answerRateDelta: 0,
+          highConfidenceRate: 0.97,
+          highConfidenceRateDelta: 0,
           responsesDelta: 0,
           positiveRateDelta: 0,
           hasPriorWindow: true,
         },
       }),
     );
-    expect(html).toContain("Almost everything got answered");
+    expect(html).toContain("Almost every response landed with high confidence");
   });
 
   it("uses Day-One flair for empty deployments", () => {
@@ -262,8 +266,8 @@ describe("renderHTML", () => {
       makeReport({
         current: { ...makeReport().current, totalResponses: 30 },
         derived: {
-          answerRate: 0.5,
-          answerRateDelta: 0,
+          highConfidenceRate: 0.5,
+          highConfidenceRateDelta: 0,
           responsesDelta: 0,
           positiveRateDelta: 0,
           hasPriorWindow: true,
@@ -382,8 +386,8 @@ describe("renderHTML", () => {
           totalResponses: 0,
         },
         derived: {
-          answerRate: 0.8,
-          answerRateDelta: null,
+          highConfidenceRate: 0.625,
+          highConfidenceRateDelta: null,
           responsesDelta: 100,
           positiveRateDelta: null,
           hasPriorWindow: false,
@@ -392,7 +396,6 @@ describe("renderHTML", () => {
     );
     expect(html).toContain("first 30 days of data");
     expect(html).not.toMatch(/vs the prior 30 days/);
-    // Delta indicators should be suppressed everywhere (headline + stats row)
     expect(html).not.toMatch(/▲ \+?100/);
   });
 
@@ -401,8 +404,8 @@ describe("renderHTML", () => {
       makeReport({
         previous: { ...makeReport().previous, totalResponses: 0 },
         derived: {
-          answerRate: 0.8,
-          answerRateDelta: null,
+          highConfidenceRate: 0.625,
+          highConfidenceRateDelta: null,
           responsesDelta: 100,
           positiveRateDelta: null,
           hasPriorWindow: false,
@@ -417,8 +420,8 @@ describe("renderHTML", () => {
       makeReport({
         previous: { ...makeReport().previous, totalResponses: 0 },
         derived: {
-          answerRate: 0.8,
-          answerRateDelta: null,
+          highConfidenceRate: 0.625,
+          highConfidenceRateDelta: null,
           responsesDelta: 100,
           positiveRateDelta: null,
           hasPriorWindow: false,
@@ -435,8 +438,8 @@ describe("renderHTML", () => {
       makeReport({
         previous: { ...makeReport().previous, totalResponses: 0 },
         derived: {
-          answerRate: 0.8,
-          answerRateDelta: null,
+          highConfidenceRate: 0.625,
+          highConfidenceRateDelta: null,
           responsesDelta: 100,
           positiveRateDelta: null,
           hasPriorWindow: false,
@@ -447,11 +450,11 @@ describe("renderHTML", () => {
     expect(html).not.toContain("3.3");
   });
 
-  it("renders the scorecard with a letter grade and three mini bars", () => {
+  it("renders the scorecard with a letter grade and mini bars", () => {
     const html = renderHTML(makeReport());
     expect(html).toContain('class="scorecard"');
     expect(html).toContain("grade-letter");
-    expect(html).toContain("Answer rate");
+    expect(html).not.toContain("Answer rate");
     expect(html).toContain("High-confidence");
     expect(html).toContain("Sentiment");
   });
@@ -472,13 +475,13 @@ describe("renderHTML", () => {
   });
 
   it("excludes sentiment from the grade when no reactions exist and shows — in the mini-bar", () => {
-    // answer = 0.9, conf = 81/90 = 0.9, no sentiment → score = round((0.9 + 0.9) / 2 * 100) = 90 → A+ Outstanding
+    // conf = 90/100 = 0.9, no sentiment → score = round(0.9 * 100) = 90 → A+ Outstanding
     const html = renderHTML(
       makeReport({
         current: {
           totalResponses: 100,
           totalWithResponse: 90,
-          byConfidence: { high: 81, medium: 9, low: 0 },
+          byConfidence: { high: 90, medium: 9, low: 0 },
           reactions: {
             totalPositive: 0,
             totalNegative: 0,
@@ -488,8 +491,8 @@ describe("renderHTML", () => {
           },
         },
         derived: {
-          answerRate: 0.9,
-          answerRateDelta: 0,
+          highConfidenceRate: 0.9,
+          highConfidenceRateDelta: 0,
           responsesDelta: 0,
           positiveRateDelta: null,
           hasPriorWindow: true,
@@ -511,7 +514,7 @@ describe("renderHTML", () => {
       makeReport({
         current: {
           totalResponses: 50,
-          totalWithResponse: 15, // 30% answer rate
+          totalWithResponse: 15,
           byConfidence: { high: 2, medium: 5, low: 8 },
           reactions: {
             totalPositive: 1,
@@ -522,8 +525,8 @@ describe("renderHTML", () => {
           },
         },
         derived: {
-          answerRate: 0.3,
-          answerRateDelta: -0.4,
+          highConfidenceRate: 0.04,
+          highConfidenceRateDelta: -0.4,
           responsesDelta: 0,
           positiveRateDelta: -0.5,
           hasPriorWindow: true,
@@ -588,7 +591,7 @@ describe("renderHTML", () => {
     expect(html).toContain("This window");
     expect(html).toContain("Prior window");
     expect(html).toContain("Responses");
-    expect(html).toContain("Answer rate");
+    expect(html).toContain("High-confidence share");
     expect(html).toContain("Negative reactions");
   });
 

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -9,7 +9,6 @@ function makeReport(over: Partial<InsightsReport> = {}): InsightsReport {
     deploymentName: "Acme Docs",
     current: {
       totalResponses: 100,
-      totalWithResponse: 80,
       byConfidence: { high: 50, medium: 20, low: 10 },
       reactions: {
         totalPositive: 30,
@@ -21,7 +20,6 @@ function makeReport(over: Partial<InsightsReport> = {}): InsightsReport {
     },
     previous: {
       totalResponses: 80,
-      totalWithResponse: 60,
       byConfidence: { high: 40, medium: 20, low: 10 },
       reactions: {
         totalPositive: 20,
@@ -462,7 +460,7 @@ describe("renderHTML", () => {
   it("hides the scorecard for empty deployments", () => {
     const html = renderHTML(
       makeReport({
-        current: { ...makeReport().current, totalResponses: 0, totalWithResponse: 0 },
+        current: { ...makeReport().current, totalResponses: 0 },
       }),
     );
     expect(html).not.toContain('class="scorecard"');
@@ -480,7 +478,6 @@ describe("renderHTML", () => {
       makeReport({
         current: {
           totalResponses: 100,
-          totalWithResponse: 90,
           byConfidence: { high: 90, medium: 9, low: 0 },
           reactions: {
             totalPositive: 0,
@@ -514,7 +511,6 @@ describe("renderHTML", () => {
       makeReport({
         current: {
           totalResponses: 50,
-          totalWithResponse: 15,
           byConfidence: { high: 2, medium: 5, low: 8 },
           reactions: {
             totalPositive: 1,
@@ -551,7 +547,6 @@ describe("renderHTML", () => {
         current: {
           ...makeReport().current,
           totalResponses: 0,
-          totalWithResponse: 0,
           byConfidence: { high: 0, medium: 0, low: 0 },
         },
       }),
@@ -686,7 +681,6 @@ describe("renderHTML", () => {
       makeReport({
         current: {
           totalResponses: 0,
-          totalWithResponse: 0,
           byConfidence: { high: 0, medium: 0, low: 0 },
           reactions: {
             totalPositive: 0,
@@ -744,7 +738,6 @@ describe("renderHTML", () => {
       makeReport({
         previous: {
           totalResponses: 0,
-          totalWithResponse: 0,
           byConfidence: { high: 0, medium: 0, low: 0 },
           reactions: {
             totalPositive: 0,

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -472,7 +472,7 @@ describe("renderHTML", () => {
     expect(html).toMatch(/grade-(great|good)/);
   });
 
-  it("excludes sentiment from the grade when no reactions exist and shows — in the mini-bar", () => {
+  it("excludes sentiment from the grade when no reactions exist and shows n/a in the mini-bar", () => {
     // conf = 90/100 = 0.9, no sentiment → score = round(0.9 * 100) = 90 → A+ Outstanding
     const html = renderHTML(
       makeReport({
@@ -498,10 +498,10 @@ describe("renderHTML", () => {
     );
     expect(html).toContain('<div class="grade-score">90 / 100</div>');
     expect(html).toContain('<div class="grade-letter">A+</div>');
-    expect(html).toContain("no reactions yet — excluded from grade");
-    // The Sentiment mini-bar specifically renders "—", not the old 70% magic number
+    expect(html).toContain("no reactions yet, excluded from grade");
+    // The Sentiment mini-bar specifically renders "n/a", not the old 70% magic number
     expect(html).toMatch(
-      /<span class="mini-label">Sentiment<\/span>\s*<span class="mini-value">—<\/span>/,
+      /<span class="mini-label">Sentiment<\/span>\s*<span class="mini-value">n\/a<\/span>/,
     );
     expect(html).not.toContain("neutral default");
   });
@@ -700,7 +700,7 @@ describe("renderHTML", () => {
       }),
     );
     expect(html).toMatch(
-      /<div class="stat-value">—<\/div>\s*<div class="stat-label">High-confidence<\/div>/,
+      /<div class="stat-value">n\/a<\/div>\s*<div class="stat-label">High-confidence<\/div>/,
     );
   });
 
@@ -733,7 +733,7 @@ describe("renderHTML", () => {
     );
   });
 
-  it("shows em-dash for the prior high-confidence share when previous total is 0", () => {
+  it("shows n/a for the prior high-confidence share when previous total is 0", () => {
     const html = renderHTML(
       makeReport({
         previous: {
@@ -756,6 +756,6 @@ describe("renderHTML", () => {
         },
       }),
     );
-    expect(html).toMatch(/High-confidence share[\s\S]*?<td class="num prior">—<\/td>/);
+    expect(html).toMatch(/High-confidence share[\s\S]*?<td class="num prior">n\/a<\/td>/);
   });
 });

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -110,7 +110,9 @@ describe("renderHTML", () => {
     const html = renderHTML(makeReport());
     expect(html).toContain("Audit recent low-confidence answers");
     expect(html).toContain("10 answers had low confidence");
-    expect(html).toContain("$ dosu threads list");
+    expect(html).toContain("dosu threads list");
+    // CTA uses a terminal-prompt accent
+    expect(html).toContain('class="cta-prompt"');
   });
 
   it("omits the CTA block for suggestions with no command", () => {
@@ -263,14 +265,77 @@ describe("renderHTML", () => {
 
   it("does not include a dark-mode media query (always-light)", () => {
     const html = renderHTML(makeReport());
-    expect(html).not.toContain("prefers-color-scheme");
+    expect(html).not.toContain("prefers-color-scheme: dark");
+  });
+
+  it("renders a terminal-prompt brand line with a blinking cursor", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain('class="prompt"');
+    expect(html).toContain("dosu insights");
+    expect(html).toContain('class="cursor"');
+    // The blink keyframes power the cursor animation
+    expect(html).toContain("@keyframes blink");
+  });
+
+  it("includes a time-of-day greeting in the subtitle", () => {
+    // 12:00 UTC → 04:00 PT (depending on test runner TZ this can land in
+    // various hour buckets, but the structure is constant).
+    const html = renderHTML(makeReport());
+    expect(html).toMatch(
+      /(Late )?(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) (morning|afternoon|evening|night)/,
+    );
+  });
+
+  it("falls back to 'Snapshot' when generatedAt is unparseable", () => {
+    const html = renderHTML(makeReport({ generatedAt: "not-a-date" }));
+    expect(html).toContain("Snapshot");
+  });
+
+  it("section headings include emoji icons", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain('<span class="section-icon">📊</span> Confidence Breakdown');
+    expect(html).toContain('<span class="section-icon">🎯</span> Suggested Next Steps');
+    expect(html).toContain('<span class="section-icon">📋</span> Period Comparison');
+    expect(html).toContain('<span class="section-icon">💬</span> Reactions');
+  });
+
+  it("varies the headline label by count", () => {
+    // count=100 → 100 % 4 = 0 → "responses shipped"
+    expect(
+      renderHTML(makeReport({ current: { ...makeReport().current, totalResponses: 100 } })),
+    ).toContain("responses shipped");
+    // count=101 → 1 → "questions tackled"
+    expect(
+      renderHTML(makeReport({ current: { ...makeReport().current, totalResponses: 101 } })),
+    ).toContain("questions tackled");
+  });
+
+  it("shows the report file path in the fun-ending footer", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain('class="fun-path"');
+    expect(html).toContain("~/.config/dosu-cli/insights/report.html");
+  });
+
+  it("provides hover transitions on suggestion + chart cards", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain(".suggestion:hover");
+    expect(html).toContain(".stacked-bar-card:hover");
+    expect(html).toContain(".compare-card:hover");
+  });
+
+  it("respects prefers-reduced-motion by disabling animations", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain("prefers-reduced-motion");
   });
 
   it("renders the headline metric with the response count", () => {
     const html = renderHTML(makeReport());
     expect(html).toContain('class="headline"');
     expect(html).toContain('class="headline-number">100</div>');
-    expect(html).toContain("responses answered");
+    // The label varies by count (responses shipped / questions tackled / etc.)
+    expect(html).toMatch(
+      /responses (shipped|answered)|questions tackled|answers delivered|moments of help/,
+    );
   });
 
   it("includes a percent change in the headline when prior > 0", () => {
@@ -373,7 +438,7 @@ describe("renderHTML", () => {
 
   it("renders the reactions stacked bar when reactions exist", () => {
     const html = renderHTML(makeReport());
-    expect(html).toMatch(/<h2[^>]*>Reactions<\/h2>/);
+    expect(html).toMatch(/<h2[^>]*>[\s\S]*?Reactions<\/h2>/);
     expect(html).toContain("positive");
     expect(html).toContain("negative");
   });

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -471,6 +471,41 @@ describe("renderHTML", () => {
     expect(html).toMatch(/grade-(great|good)/);
   });
 
+  it("excludes sentiment from the grade when no reactions exist and shows — in the mini-bar", () => {
+    // answer = 0.9, conf = 81/90 = 0.9, no sentiment → score = round((0.9 + 0.9) / 2 * 100) = 90 → A+ Outstanding
+    const html = renderHTML(
+      makeReport({
+        current: {
+          totalResponses: 100,
+          totalWithResponse: 90,
+          byConfidence: { high: 81, medium: 9, low: 0 },
+          reactions: {
+            totalPositive: 0,
+            totalNegative: 0,
+            messagesWithReactions: 0,
+            reactionRate: 0,
+            positiveRate: 0,
+          },
+        },
+        derived: {
+          answerRate: 0.9,
+          answerRateDelta: 0,
+          responsesDelta: 0,
+          positiveRateDelta: null,
+          hasPriorWindow: true,
+        },
+      }),
+    );
+    expect(html).toContain('<div class="grade-score">90 / 100</div>');
+    expect(html).toContain('<div class="grade-letter">A+</div>');
+    expect(html).toContain("no reactions yet — excluded from grade");
+    // The Sentiment mini-bar specifically renders "—", not the old 70% magic number
+    expect(html).toMatch(
+      /<span class="mini-label">Sentiment<\/span>\s*<span class="mini-value">—<\/span>/,
+    );
+    expect(html).not.toContain("neutral default");
+  });
+
   it("uses an alarm grade for struggling deployments", () => {
     const html = renderHTML(
       makeReport({

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -637,4 +637,132 @@ describe("renderHTML", () => {
     const html = renderHTML(makeReport());
     expect(html).toMatch(/Apr 1[56]/);
   });
+
+  describe("pickGreeting time-of-day branches", () => {
+    // Build an ISO string that parses back to the given local hour, regardless
+    // of the runner's timezone (pickGreeting uses Date.getHours()).
+    function localIsoAtHour(hour: number): string {
+      const d = new Date();
+      d.setHours(hour, 0, 0, 0);
+      return d.toISOString();
+    }
+
+    it("uses 'Late … night' for early-morning hours (<5)", () => {
+      const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(3) }));
+      expect(html).toMatch(
+        /Late (Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) night ·/,
+      );
+    });
+
+    it("uses a morning greeting for hours 5–11", () => {
+      const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(9) }));
+      expect(html).toMatch(/(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) morning ·/);
+      expect(html).not.toContain("Late ");
+    });
+
+    it("uses an afternoon greeting for hours 12–16", () => {
+      const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(14) }));
+      expect(html).toMatch(
+        /(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) afternoon ·/,
+      );
+    });
+
+    it("uses an evening greeting for hours 17–20", () => {
+      const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(19) }));
+      expect(html).toMatch(/(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) evening ·/);
+    });
+
+    it("uses a bare '<day> night' greeting for hours 21+", () => {
+      const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(22) }));
+      expect(html).toMatch(/(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) night ·/);
+      expect(html).not.toMatch(
+        /Late (Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) night/,
+      );
+    });
+  });
+
+  it("shows em-dash in the stats row when highConfidenceRate is null", () => {
+    const html = renderHTML(
+      makeReport({
+        current: {
+          totalResponses: 0,
+          totalWithResponse: 0,
+          byConfidence: { high: 0, medium: 0, low: 0 },
+          reactions: {
+            totalPositive: 0,
+            totalNegative: 0,
+            messagesWithReactions: 0,
+            reactionRate: 0,
+            positiveRate: 0,
+          },
+        },
+        derived: {
+          highConfidenceRate: null,
+          highConfidenceRateDelta: null,
+          responsesDelta: 0,
+          positiveRateDelta: null,
+          hasPriorWindow: true,
+        },
+      }),
+    );
+    expect(html).toMatch(
+      /<div class="stat-value">—<\/div>\s*<div class="stat-label">High-confidence<\/div>/,
+    );
+  });
+
+  it("omits the headline percent when hasPriorWindow but prior total is 0", () => {
+    const html = renderHTML(
+      makeReport({
+        previous: { ...makeReport().previous, totalResponses: 0 },
+        derived: {
+          highConfidenceRate: 0.625,
+          highConfidenceRateDelta: null,
+          responsesDelta: 100,
+          positiveRateDelta: null,
+          hasPriorWindow: true,
+        },
+      }),
+    );
+    expect(html).toMatch(/▲ \+100 vs the prior 30 days/);
+    expect(html).not.toMatch(/▲ \+100 \(\+?\d+%\)/);
+  });
+
+  it("formats responses/day to two decimals when below 1.0", () => {
+    const html = renderHTML(
+      makeReport({
+        current: { ...makeReport().current, totalResponses: 15 },
+      }),
+    );
+    // 15 / 30 = 0.5 → "0.50"
+    expect(html).toMatch(
+      /<div class="stat-value">0\.50<\/div>\s*<div class="stat-label">Responses \/ day<\/div>/,
+    );
+  });
+
+  it("shows em-dash for the prior high-confidence share when previous total is 0", () => {
+    const html = renderHTML(
+      makeReport({
+        previous: {
+          totalResponses: 0,
+          totalWithResponse: 0,
+          byConfidence: { high: 0, medium: 0, low: 0 },
+          reactions: {
+            totalPositive: 0,
+            totalNegative: 0,
+            messagesWithReactions: 0,
+            reactionRate: 0,
+            positiveRate: 0,
+          },
+        },
+        derived: {
+          highConfidenceRate: 0.5,
+          highConfidenceRateDelta: null,
+          responsesDelta: 100,
+          positiveRateDelta: null,
+          hasPriorWindow: true,
+        },
+      }),
+    );
+    expect(html).toMatch(/High-confidence share[\s\S]*?<td class="num prior">—<\/td>/);
+  });
 });

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -36,6 +36,7 @@ function makeReport(over: Partial<InsightsReport> = {}): InsightsReport {
       answerRateDelta: 0.05,
       responsesDelta: 20,
       positiveRateDelta: 0.057,
+      hasPriorWindow: true,
     },
     atAGlance: "You're crushing it this month.",
     cheers: ["Big win this week."],
@@ -152,6 +153,7 @@ describe("renderHTML", () => {
           answerRateDelta: -0.2,
           responsesDelta: -15,
           positiveRateDelta: -0.1,
+          hasPriorWindow: true,
         },
       }),
     );
@@ -162,7 +164,13 @@ describe("renderHTML", () => {
   it("shows 'no change' when a delta is essentially zero", () => {
     const html = renderHTML(
       makeReport({
-        derived: { answerRate: 0.8, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+        derived: {
+          answerRate: 0.8,
+          answerRateDelta: 0,
+          responsesDelta: 0,
+          positiveRateDelta: 0,
+          hasPriorWindow: true,
+        },
       }),
     );
     expect(html).toContain("no change");
@@ -185,6 +193,7 @@ describe("renderHTML", () => {
           answerRateDelta: 0,
           responsesDelta: -30,
           positiveRateDelta: 0,
+          hasPriorWindow: true,
         },
       }),
     );
@@ -197,7 +206,13 @@ describe("renderHTML", () => {
     const html = renderHTML(
       makeReport({
         current: { ...makeReport().current, totalResponses: 80 },
-        derived: { answerRate: 0.8, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+        derived: {
+          answerRate: 0.8,
+          answerRateDelta: 0,
+          responsesDelta: 0,
+          positiveRateDelta: 0,
+          hasPriorWindow: true,
+        },
       }),
     );
     expect(html).toContain("→");
@@ -221,7 +236,13 @@ describe("renderHTML", () => {
     const html = renderHTML(
       makeReport({
         current: { ...makeReport().current, totalResponses: 30 },
-        derived: { answerRate: 0.97, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+        derived: {
+          answerRate: 0.97,
+          answerRateDelta: 0,
+          responsesDelta: 0,
+          positiveRateDelta: 0,
+          hasPriorWindow: true,
+        },
       }),
     );
     expect(html).toContain("Almost everything got answered");
@@ -240,7 +261,13 @@ describe("renderHTML", () => {
     const html = renderHTML(
       makeReport({
         current: { ...makeReport().current, totalResponses: 30 },
-        derived: { answerRate: 0.5, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+        derived: {
+          answerRate: 0.5,
+          answerRateDelta: 0,
+          responsesDelta: 0,
+          positiveRateDelta: 0,
+          hasPriorWindow: true,
+        },
       }),
     );
     expect(html).toContain("Keep the questions coming");
@@ -291,12 +318,14 @@ describe("renderHTML", () => {
     expect(html).toContain("Snapshot");
   });
 
-  it("section headings include emoji icons", () => {
+  it("section headings render as plain text without decorative emoji", () => {
     const html = renderHTML(makeReport());
-    expect(html).toContain('<span class="section-icon">📊</span> Confidence Breakdown');
-    expect(html).toContain('<span class="section-icon">🎯</span> Suggested Next Steps');
-    expect(html).toContain('<span class="section-icon">📋</span> Period Comparison');
-    expect(html).toContain('<span class="section-icon">💬</span> Reactions');
+    expect(html).toContain('<h2 class="section-heading">Confidence Breakdown</h2>');
+    expect(html).toContain('<h2 class="section-heading">Suggested Next Steps</h2>');
+    expect(html).toContain('<h2 class="section-heading">Period Comparison</h2>');
+    expect(html).toContain('<h2 class="section-heading">Reactions</h2>');
+    expect(html).not.toContain("section-icon");
+    expect(html).not.toContain("signal-icon");
   });
 
   it("varies the headline label by count", () => {
@@ -310,10 +339,10 @@ describe("renderHTML", () => {
     ).toContain("questions tackled");
   });
 
-  it("shows the report file path in the fun-ending footer", () => {
+  it("shows the stable latest.html path in the fun-ending footer", () => {
     const html = renderHTML(makeReport());
     expect(html).toContain('class="fun-path"');
-    expect(html).toContain("~/.config/dosu-cli/insights/report.html");
+    expect(html).toContain("~/.config/dosu-cli/insights/latest.html");
   });
 
   it("provides hover transitions on suggestion + chart cards", () => {
@@ -344,7 +373,7 @@ describe("renderHTML", () => {
     expect(html).toContain("(+25%)");
   });
 
-  it("omits percent change in headline when prior window is empty", () => {
+  it("replaces headline delta with 'first N days of data' when prior window is empty", () => {
     const html = renderHTML(
       makeReport({
         previous: {
@@ -356,11 +385,65 @@ describe("renderHTML", () => {
           answerRateDelta: null,
           responsesDelta: 100,
           positiveRateDelta: null,
+          hasPriorWindow: false,
         },
       }),
     );
-    // No prior baseline → no percentage
-    expect(html).toMatch(/\+100 vs the prior 30 days/);
+    expect(html).toContain("first 30 days of data");
+    expect(html).not.toMatch(/vs the prior 30 days/);
+    // Delta indicators should be suppressed everywhere (headline + stats row)
+    expect(html).not.toMatch(/▲ \+?100/);
+  });
+
+  it("omits the trend section entirely when prior window is empty", () => {
+    const html = renderHTML(
+      makeReport({
+        previous: { ...makeReport().previous, totalResponses: 0 },
+        derived: {
+          answerRate: 0.8,
+          answerRateDelta: null,
+          responsesDelta: 100,
+          positiveRateDelta: null,
+          hasPriorWindow: false,
+        },
+      }),
+    );
+    expect(html).not.toMatch(/<div class="trend trend-/);
+  });
+
+  it("replaces the comparison table with a 'not enough history' card when prior is empty", () => {
+    const html = renderHTML(
+      makeReport({
+        previous: { ...makeReport().previous, totalResponses: 0 },
+        derived: {
+          answerRate: 0.8,
+          answerRateDelta: null,
+          responsesDelta: 100,
+          positiveRateDelta: null,
+          hasPriorWindow: false,
+        },
+      }),
+    );
+    expect(html).toContain("Period Comparison");
+    expect(html).toContain("Not enough history yet");
+    expect(html).not.toMatch(/<table class="compare-table"/);
+  });
+
+  it("shows em-dash for responses/day and a hint when prior is empty", () => {
+    const html = renderHTML(
+      makeReport({
+        previous: { ...makeReport().previous, totalResponses: 0 },
+        derived: {
+          answerRate: 0.8,
+          answerRateDelta: null,
+          responsesDelta: 100,
+          positiveRateDelta: null,
+          hasPriorWindow: false,
+        },
+      }),
+    );
+    expect(html).toContain("needs 30d of history");
+    expect(html).not.toContain("3.3");
   });
 
   it("renders the scorecard with a letter grade and three mini bars", () => {
@@ -407,6 +490,7 @@ describe("renderHTML", () => {
           answerRateDelta: -0.4,
           responsesDelta: 0,
           positiveRateDelta: -0.5,
+          hasPriorWindow: true,
         },
       }),
     );

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -37,12 +37,16 @@ function makeReport(over: Partial<InsightsReport> = {}): InsightsReport {
       responsesDelta: 20,
       positiveRateDelta: 0.057,
     },
-    narratives: {
-      atAGlance: "You're crushing it this month.",
-      topics: "Mostly questions about deployment and onboarding.",
-      suggestions: "1. Add a runbook.\n2. Tag answers.",
-    },
+    atAGlance: "You're crushing it this month.",
     cheers: ["Big win this week."],
+    investigate: [],
+    suggestions: [
+      {
+        headline: "Audit recent low-confidence answers",
+        detail: "10 answers had low confidence this window.",
+        command: "dosu threads list",
+      },
+    ],
     ...over,
   };
 }
@@ -54,57 +58,16 @@ describe("renderHTML", () => {
     expect(html).toContain("Acme Docs");
   });
 
-  it("renders the at-a-glance narrative when provided", () => {
-    const html = renderHTML(
-      makeReport({ narratives: { atAGlance: "Hello world", topics: null, suggestions: null } }),
-    );
+  it("renders the at-a-glance prose verbatim", () => {
+    const html = renderHTML(makeReport({ atAGlance: "Hello world" }));
     expect(html).toContain("Hello world");
   });
 
-  it("falls back to generated at-a-glance when narrative is null and there are responses", () => {
-    const html = renderHTML(
-      makeReport({ narratives: { atAGlance: null, topics: null, suggestions: null } }),
-    );
-    expect(html).toContain("logged 100 responses");
-    expect(html).toContain("80% answer rate");
-  });
-
-  it("falls back to a welcome at-a-glance when there are no responses", () => {
-    const empty = makeReport({
-      current: {
-        totalResponses: 0,
-        totalWithResponse: 0,
-        byConfidence: { high: 0, medium: 0, low: 0 },
-        reactions: {
-          totalPositive: 0,
-          totalNegative: 0,
-          messagesWithReactions: 0,
-          reactionRate: 0,
-          positiveRate: 0,
-        },
-      },
-      derived: {
-        answerRate: null,
-        answerRateDelta: null,
-        responsesDelta: 0,
-        positiveRateDelta: null,
-      },
-      narratives: { atAGlance: null, topics: null, suggestions: null },
-    });
-    const html = renderHTML(empty);
-    expect(html).toContain("brand new");
-    expect(html).toContain("Day one");
-  });
-
-  it("escapes HTML in deployment name and narratives", () => {
+  it("escapes HTML in deployment name and at-a-glance prose", () => {
     const html = renderHTML(
       makeReport({
         deploymentName: "Pwn <script>alert(1)</script>",
-        narratives: {
-          atAGlance: "Look: <img src=x onerror=alert(1)> & co",
-          topics: null,
-          suggestions: null,
-        },
+        atAGlance: "Look: <img src=x onerror=alert(1)> & co",
       }),
     );
     expect(html).not.toContain("<script>alert(1)</script>");
@@ -113,12 +76,95 @@ describe("renderHTML", () => {
     expect(html).toContain("&amp;");
   });
 
+  it("renders both signal cards when both lists have entries", () => {
+    const html = renderHTML(
+      makeReport({
+        cheers: ["Yay!"],
+        investigate: ["Hmm."],
+      }),
+    );
+    expect(html).toContain('class="signal-card signal-cheers"');
+    expect(html).toContain('class="signal-card signal-investigate"');
+    expect(html).toContain("Yay!");
+    expect(html).toContain("Hmm.");
+  });
+
+  it("omits the cheers card when there are no cheers", () => {
+    const html = renderHTML(makeReport({ cheers: [], investigate: ["Hmm."] }));
+    expect(html).not.toContain('class="signal-card signal-cheers"');
+    expect(html).toContain('class="signal-card signal-investigate"');
+  });
+
+  it("omits the investigate card when there are no investigate items", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain('class="signal-card signal-cheers"');
+    expect(html).not.toContain('class="signal-card signal-investigate"');
+  });
+
+  it("omits the entire signals section when both lists are empty", () => {
+    const html = renderHTML(makeReport({ cheers: [], investigate: [] }));
+    expect(html).not.toContain('class="signals"');
+  });
+
+  it("renders each suggestion as an article with headline, detail, and CTA", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain("Audit recent low-confidence answers");
+    expect(html).toContain("10 answers had low confidence");
+    expect(html).toContain("$ dosu threads list");
+  });
+
+  it("omits the CTA block for suggestions with no command", () => {
+    const html = renderHTML(
+      makeReport({
+        suggestions: [{ headline: "Just FYI", detail: "Nothing to do, just sharing." }],
+      }),
+    );
+    expect(html).toContain("Just FYI");
+    expect(html).not.toContain('class="suggestion-cta"');
+  });
+
+  it("omits the suggestions section entirely when empty", () => {
+    const html = renderHTML(makeReport({ suggestions: [] }));
+    expect(html).not.toContain("Suggested Next Steps");
+  });
+
   it("renders a confidence bar chart with all three levels", () => {
     const html = renderHTML(makeReport());
     expect(html).toContain("High");
     expect(html).toContain("Medium");
     expect(html).toContain("Low");
     expect(html).toContain("Confidence Breakdown");
+  });
+
+  it("color-codes positive deltas as 'up'", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain("delta-up");
+    expect(html).toContain("▲");
+  });
+
+  it("color-codes negative deltas as 'down'", () => {
+    const html = renderHTML(
+      makeReport({
+        derived: {
+          answerRate: 0.6,
+          answerRateDelta: -0.2,
+          responsesDelta: -15,
+          positiveRateDelta: -0.1,
+        },
+      }),
+    );
+    expect(html).toContain("delta-down");
+    expect(html).toContain("▼");
+  });
+
+  it("shows 'no change' when a delta is essentially zero", () => {
+    const html = renderHTML(
+      makeReport({
+        derived: { answerRate: 0.8, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+      }),
+    );
+    expect(html).toContain("no change");
+    expect(html).toContain("delta-flat");
   });
 
   it("shows the trend with a positive arrow when responses are up", () => {
@@ -132,7 +178,12 @@ describe("renderHTML", () => {
     const html = renderHTML(
       makeReport({
         current: { ...makeReport().current, totalResponses: 50 },
-        derived: { answerRate: 0.8, answerRateDelta: 0, responsesDelta: -30, positiveRateDelta: 0 },
+        derived: {
+          answerRate: 0.8,
+          answerRateDelta: 0,
+          responsesDelta: -30,
+          positiveRateDelta: 0,
+        },
       }),
     );
     expect(html).toContain("trend-down");
@@ -150,44 +201,21 @@ describe("renderHTML", () => {
     expect(html).toContain("→");
   });
 
-  it("shows a fallback message when topics narrative is missing", () => {
+  it("uses celebratory flair for high-volume deployments", () => {
     const html = renderHTML(
-      makeReport({ narratives: { atAGlance: "x", topics: null, suggestions: "y" } }),
-    );
-    expect(html).toContain("Not enough signal yet to summarize topics");
-  });
-
-  it("shows a friendly message when suggestions narrative is missing", () => {
-    const html = renderHTML(
-      makeReport({ narratives: { atAGlance: "x", topics: "y", suggestions: null } }),
-    );
-    expect(html).toContain("too busy answering questions");
-  });
-
-  it("renders all cheers as list items", () => {
-    const html = renderHTML(makeReport({ cheers: ["First", "Second", "Third"] }));
-    expect(html).toContain("<li>First</li>");
-    expect(html).toContain("<li>Second</li>");
-    expect(html).toContain("<li>Third</li>");
-  });
-
-  it("uses a celebratory flair for high-volume deployments", () => {
-    const html = renderHTML(
-      makeReport({
-        current: { ...makeReport().current, totalResponses: 1500 },
-      }),
+      makeReport({ current: { ...makeReport().current, totalResponses: 1500 } }),
     );
     expect(html).toContain("1,000 responses");
   });
 
-  it("uses the triple-digits flair when responses are between 100 and 999", () => {
+  it("uses triple-digits flair when responses are 100-999", () => {
     const html = renderHTML(
       makeReport({ current: { ...makeReport().current, totalResponses: 250 } }),
     );
     expect(html).toContain("Triple digits");
   });
 
-  it("uses the chef's-kiss flair when answer rate is at least 95%", () => {
+  it("uses chef's-kiss flair when answer rate is at least 95%", () => {
     const html = renderHTML(
       makeReport({
         current: { ...makeReport().current, totalResponses: 30 },
@@ -197,7 +225,16 @@ describe("renderHTML", () => {
     expect(html).toContain("Almost everything got answered");
   });
 
-  it("uses the default flair when no rule matches", () => {
+  it("uses Day-One flair for empty deployments", () => {
+    const html = renderHTML(
+      makeReport({
+        current: { ...makeReport().current, totalResponses: 0 },
+      }),
+    );
+    expect(html).toContain("Day one");
+  });
+
+  it("uses default flair when no rule matches", () => {
     const html = renderHTML(
       makeReport({
         current: { ...makeReport().current, totalResponses: 30 },
@@ -207,55 +244,30 @@ describe("renderHTML", () => {
     expect(html).toContain("Keep the questions coming");
   });
 
-  it("formats answer-rate delta in percentage points", () => {
-    const html = renderHTML(makeReport());
-    expect(html).toContain("▲ 5 pts");
-  });
-
-  it("renders an em-dash when the answer rate is null", () => {
+  it("escapes HTML in suggestion content", () => {
     const html = renderHTML(
       makeReport({
-        current: {
-          ...makeReport().current,
-          totalResponses: 0,
-          totalWithResponse: 0,
-        },
-        derived: {
-          answerRate: null,
-          answerRateDelta: null,
-          responsesDelta: 0,
-          positiveRateDelta: null,
-        },
+        suggestions: [
+          {
+            headline: "<script>x</script>",
+            detail: "Run <bad>",
+            command: "dosu & co",
+          },
+        ],
       }),
     );
-    expect(html).toContain('class="stat-value">—</div>');
+    expect(html).not.toContain("<script>x</script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("dosu &amp; co");
+  });
+
+  it("includes a dark-mode media query in the inlined CSS", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain("prefers-color-scheme: dark");
   });
 
   it("formats the generated date in long form", () => {
-    const html = renderHTML(makeReport({ generatedAt: "2026-04-16T12:00:00Z" }));
+    const html = renderHTML(makeReport());
     expect(html).toMatch(/Apr 1[56]/);
-  });
-
-  it("shows a 'no change' delta when delta is essentially zero", () => {
-    const html = renderHTML(
-      makeReport({
-        derived: { answerRate: 0.8, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
-      }),
-    );
-    expect(html).toContain("no change");
-  });
-
-  it("formats negative deltas with a down triangle", () => {
-    const html = renderHTML(
-      makeReport({
-        derived: {
-          answerRate: 0.8,
-          answerRateDelta: -0.1,
-          responsesDelta: 0,
-          positiveRateDelta: 0,
-        },
-      }),
-    );
-    expect(html).toContain("▼ 10 pts");
   });
 });

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -6,7 +6,7 @@ function makeReport(over: Partial<InsightsReport> = {}): InsightsReport {
   return {
     generatedAt: "2026-04-16T12:00:00Z",
     windowDays: 30,
-    deploymentName: "Acme Docs",
+    spaceName: "Acme Docs",
     current: {
       totalResponses: 100,
       byConfidence: { high: 50, medium: 20, low: 10 },
@@ -51,7 +51,7 @@ function makeReport(over: Partial<InsightsReport> = {}): InsightsReport {
 }
 
 describe("renderHTML", () => {
-  it("includes the deployment name and a doctype", () => {
+  it("includes the space name and a doctype", () => {
     const html = renderHTML(makeReport());
     expect(html).toMatch(/^<!DOCTYPE html>/);
     expect(html).toContain("Acme Docs");
@@ -62,10 +62,10 @@ describe("renderHTML", () => {
     expect(html).toContain("Hello world");
   });
 
-  it("escapes HTML in deployment name and at-a-glance prose", () => {
+  it("escapes HTML in space name and at-a-glance prose", () => {
     const html = renderHTML(
       makeReport({
-        deploymentName: "Pwn <script>alert(1)</script>",
+        spaceName: "Pwn <script>alert(1)</script>",
         atAGlance: "Look: <img src=x onerror=alert(1)> & co",
       }),
     );
@@ -216,7 +216,7 @@ describe("renderHTML", () => {
     expect(html).toContain("→");
   });
 
-  it("uses celebratory flair for high-volume deployments", () => {
+  it("uses celebratory flair for high-volume spaces", () => {
     const html = renderHTML(
       makeReport({ current: { ...makeReport().current, totalResponses: 1500 } }),
     );
@@ -250,7 +250,7 @@ describe("renderHTML", () => {
     expect(html).toContain("Almost every response landed with high confidence");
   });
 
-  it("uses Day-One flair for empty deployments", () => {
+  it("uses Day-One flair for empty spaces", () => {
     const html = renderHTML(
       makeReport({
         current: { ...makeReport().current, totalResponses: 0 },
@@ -457,7 +457,7 @@ describe("renderHTML", () => {
     expect(html).toContain("Sentiment");
   });
 
-  it("hides the scorecard for empty deployments", () => {
+  it("hides the scorecard for empty spaces", () => {
     const html = renderHTML(
       makeReport({
         current: { ...makeReport().current, totalResponses: 0 },
@@ -466,7 +466,7 @@ describe("renderHTML", () => {
     expect(html).not.toContain('class="scorecard"');
   });
 
-  it("uses a great grade for healthy deployments", () => {
+  it("uses a great grade for healthy spaces", () => {
     const html = renderHTML(makeReport());
     // 80/50/86 → ~72 → B (good tone)
     expect(html).toMatch(/grade-(great|good)/);
@@ -506,7 +506,7 @@ describe("renderHTML", () => {
     expect(html).not.toContain("neutral default");
   });
 
-  it("uses an alarm grade for struggling deployments", () => {
+  it("uses an alarm grade for struggling spaces", () => {
     const html = renderHTML(
       makeReport({
         current: {
@@ -642,32 +642,32 @@ describe("renderHTML", () => {
       return d.toISOString();
     }
 
-    it("uses 'Late … night' for early-morning hours (<5)", () => {
+    it("uses 'Late [day] night' for early-morning hours under 5", () => {
       const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(3) }));
       expect(html).toMatch(
         /Late (Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) night ·/,
       );
     });
 
-    it("uses a morning greeting for hours 5–11", () => {
+    it("uses a morning greeting for hours 5 to 11", () => {
       const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(9) }));
       expect(html).toMatch(/(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) morning ·/);
       expect(html).not.toContain("Late ");
     });
 
-    it("uses an afternoon greeting for hours 12–16", () => {
+    it("uses an afternoon greeting for hours 12 to 16", () => {
       const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(14) }));
       expect(html).toMatch(
         /(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) afternoon ·/,
       );
     });
 
-    it("uses an evening greeting for hours 17–20", () => {
+    it("uses an evening greeting for hours 17 to 20", () => {
       const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(19) }));
       expect(html).toMatch(/(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) evening ·/);
     });
 
-    it("uses a bare '<day> night' greeting for hours 21+", () => {
+    it("uses a bare '[day] night' greeting for hours 21 and up", () => {
       const html = renderHTML(makeReport({ generatedAt: localIsoAtHour(22) }));
       expect(html).toMatch(/(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) night ·/);
       expect(html).not.toMatch(

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -329,14 +329,18 @@ describe("renderHTML", () => {
   });
 
   it("varies the headline label by count", () => {
-    // count=100 → 100 % 4 = 0 → "responses shipped"
+    // count=99 → 99 % 3 = 0 → "responses logged"
+    expect(
+      renderHTML(makeReport({ current: { ...makeReport().current, totalResponses: 99 } })),
+    ).toContain("responses logged");
+    // count=100 → 100 % 3 = 1 → "questions handled"
     expect(
       renderHTML(makeReport({ current: { ...makeReport().current, totalResponses: 100 } })),
-    ).toContain("responses shipped");
-    // count=101 → 1 → "questions tackled"
+    ).toContain("questions handled");
+    // count=101 → 101 % 3 = 2 → "threads fielded"
     expect(
       renderHTML(makeReport({ current: { ...makeReport().current, totalResponses: 101 } })),
-    ).toContain("questions tackled");
+    ).toContain("threads fielded");
   });
 
   it("shows the stable latest.html path in the fun-ending footer", () => {
@@ -361,10 +365,7 @@ describe("renderHTML", () => {
     const html = renderHTML(makeReport());
     expect(html).toContain('class="headline"');
     expect(html).toContain('class="headline-number">100</div>');
-    // The label varies by count (responses shipped / questions tackled / etc.)
-    expect(html).toMatch(
-      /responses (shipped|answered)|questions tackled|answers delivered|moments of help/,
-    );
+    expect(html).toMatch(/responses logged|questions handled|threads fielded/);
   });
 
   it("includes a percent change in the headline when prior > 0", () => {

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -261,9 +261,188 @@ describe("renderHTML", () => {
     expect(html).toContain("dosu &amp; co");
   });
 
-  it("includes a dark-mode media query in the inlined CSS", () => {
+  it("does not include a dark-mode media query (always-light)", () => {
     const html = renderHTML(makeReport());
-    expect(html).toContain("prefers-color-scheme: dark");
+    expect(html).not.toContain("prefers-color-scheme");
+  });
+
+  it("renders the headline metric with the response count", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain('class="headline"');
+    expect(html).toContain('class="headline-number">100</div>');
+    expect(html).toContain("responses answered");
+  });
+
+  it("includes a percent change in the headline when prior > 0", () => {
+    const html = renderHTML(makeReport());
+    // 100 vs 80 → +20 → +25%
+    expect(html).toContain("(+25%)");
+  });
+
+  it("omits percent change in headline when prior window is empty", () => {
+    const html = renderHTML(
+      makeReport({
+        previous: {
+          ...makeReport().previous,
+          totalResponses: 0,
+        },
+        derived: {
+          answerRate: 0.8,
+          answerRateDelta: null,
+          responsesDelta: 100,
+          positiveRateDelta: null,
+        },
+      }),
+    );
+    // No prior baseline → no percentage
+    expect(html).toMatch(/\+100 vs the prior 30 days/);
+  });
+
+  it("renders the scorecard with a letter grade and three mini bars", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain('class="scorecard"');
+    expect(html).toContain("grade-letter");
+    expect(html).toContain("Answer rate");
+    expect(html).toContain("High-confidence");
+    expect(html).toContain("Sentiment");
+  });
+
+  it("hides the scorecard for empty deployments", () => {
+    const html = renderHTML(
+      makeReport({
+        current: { ...makeReport().current, totalResponses: 0, totalWithResponse: 0 },
+      }),
+    );
+    expect(html).not.toContain('class="scorecard"');
+  });
+
+  it("uses a great grade for healthy deployments", () => {
+    const html = renderHTML(makeReport());
+    // 80/50/86 → ~72 → B (good tone)
+    expect(html).toMatch(/grade-(great|good)/);
+  });
+
+  it("uses an alarm grade for struggling deployments", () => {
+    const html = renderHTML(
+      makeReport({
+        current: {
+          totalResponses: 50,
+          totalWithResponse: 15, // 30% answer rate
+          byConfidence: { high: 2, medium: 5, low: 8 },
+          reactions: {
+            totalPositive: 1,
+            totalNegative: 9,
+            messagesWithReactions: 10,
+            reactionRate: 0.2,
+            positiveRate: 0.1,
+          },
+        },
+        derived: {
+          answerRate: 0.3,
+          answerRateDelta: -0.4,
+          responsesDelta: 0,
+          positiveRateDelta: -0.5,
+        },
+      }),
+    );
+    expect(html).toContain("grade-alarm");
+  });
+
+  it("renders a stacked confidence bar with all three segments", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain('class="stacked-bar"');
+    expect(html).toContain("seg-high");
+    expect(html).toContain("seg-med");
+    expect(html).toContain("seg-low");
+    expect(html).toContain("Confidence Breakdown");
+  });
+
+  it("omits the confidence section when there are no answers to bucket", () => {
+    const html = renderHTML(
+      makeReport({
+        current: {
+          ...makeReport().current,
+          totalResponses: 0,
+          totalWithResponse: 0,
+          byConfidence: { high: 0, medium: 0, low: 0 },
+        },
+      }),
+    );
+    expect(html).not.toContain("Confidence Breakdown");
+  });
+
+  it("renders the reactions stacked bar when reactions exist", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toMatch(/<h2[^>]*>Reactions<\/h2>/);
+    expect(html).toContain("positive");
+    expect(html).toContain("negative");
+  });
+
+  it("shows an empty card for reactions when none have been logged", () => {
+    const html = renderHTML(
+      makeReport({
+        current: {
+          ...makeReport().current,
+          reactions: {
+            totalPositive: 0,
+            totalNegative: 0,
+            messagesWithReactions: 0,
+            reactionRate: 0,
+            positiveRate: 0,
+          },
+        },
+      }),
+    );
+    expect(html).toContain("empty-card");
+    expect(html).toContain("No reactions logged yet");
+  });
+
+  it("renders the period-comparison table with current and prior columns", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain('class="compare-table"');
+    expect(html).toContain("This window");
+    expect(html).toContain("Prior window");
+    expect(html).toContain("Responses");
+    expect(html).toContain("Answer rate");
+    expect(html).toContain("Negative reactions");
+  });
+
+  it("color-codes a rising metric as up in the comparison table", () => {
+    const html = renderHTML(makeReport());
+    // Responses 100 vs 80 → +20 (up is good)
+    expect(html).toMatch(/delta-up[^>]*>▲ \+20</);
+  });
+
+  it("color-codes a rising negative-reaction count as down (bad)", () => {
+    const html = renderHTML(
+      makeReport({
+        current: {
+          ...makeReport().current,
+          reactions: {
+            ...makeReport().current.reactions,
+            totalNegative: 12,
+          },
+        },
+        previous: {
+          ...makeReport().previous,
+          reactions: {
+            ...makeReport().previous.reactions,
+            totalNegative: 5,
+          },
+        },
+      }),
+    );
+    // Negative going up is bad → 'down' tone
+    expect(html).toMatch(/delta-down[^>]*>▲ \+7</);
+  });
+
+  it("includes responses-per-day and reactions tally in the stats row", () => {
+    const html = renderHTML(makeReport());
+    // 100 / 30 → 3.3
+    expect(html).toContain("3.3");
+    expect(html).toContain("Responses / day");
+    expect(html).toContain("👍");
+    expect(html).toContain("👎");
   });
 
   it("formats the generated date in long form", () => {

--- a/src/insights/render-html.test.ts
+++ b/src/insights/render-html.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import type { InsightsReport } from "./insights";
+import { renderHTML } from "./render-html";
+
+function makeReport(over: Partial<InsightsReport> = {}): InsightsReport {
+  return {
+    generatedAt: "2026-04-16T12:00:00Z",
+    windowDays: 30,
+    deploymentName: "Acme Docs",
+    current: {
+      totalResponses: 100,
+      totalWithResponse: 80,
+      byConfidence: { high: 50, medium: 20, low: 10 },
+      reactions: {
+        totalPositive: 30,
+        totalNegative: 5,
+        messagesWithReactions: 35,
+        reactionRate: 0.35,
+        positiveRate: 0.857,
+      },
+    },
+    previous: {
+      totalResponses: 80,
+      totalWithResponse: 60,
+      byConfidence: { high: 40, medium: 20, low: 10 },
+      reactions: {
+        totalPositive: 20,
+        totalNegative: 5,
+        messagesWithReactions: 25,
+        reactionRate: 0.31,
+        positiveRate: 0.8,
+      },
+    },
+    derived: {
+      answerRate: 0.8,
+      answerRateDelta: 0.05,
+      responsesDelta: 20,
+      positiveRateDelta: 0.057,
+    },
+    narratives: {
+      atAGlance: "You're crushing it this month.",
+      topics: "Mostly questions about deployment and onboarding.",
+      suggestions: "1. Add a runbook.\n2. Tag answers.",
+    },
+    cheers: ["Big win this week."],
+    ...over,
+  };
+}
+
+describe("renderHTML", () => {
+  it("includes the deployment name and a doctype", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toMatch(/^<!DOCTYPE html>/);
+    expect(html).toContain("Acme Docs");
+  });
+
+  it("renders the at-a-glance narrative when provided", () => {
+    const html = renderHTML(
+      makeReport({ narratives: { atAGlance: "Hello world", topics: null, suggestions: null } }),
+    );
+    expect(html).toContain("Hello world");
+  });
+
+  it("falls back to generated at-a-glance when narrative is null and there are responses", () => {
+    const html = renderHTML(
+      makeReport({ narratives: { atAGlance: null, topics: null, suggestions: null } }),
+    );
+    expect(html).toContain("logged 100 responses");
+    expect(html).toContain("80% answer rate");
+  });
+
+  it("falls back to a welcome at-a-glance when there are no responses", () => {
+    const empty = makeReport({
+      current: {
+        totalResponses: 0,
+        totalWithResponse: 0,
+        byConfidence: { high: 0, medium: 0, low: 0 },
+        reactions: {
+          totalPositive: 0,
+          totalNegative: 0,
+          messagesWithReactions: 0,
+          reactionRate: 0,
+          positiveRate: 0,
+        },
+      },
+      derived: {
+        answerRate: null,
+        answerRateDelta: null,
+        responsesDelta: 0,
+        positiveRateDelta: null,
+      },
+      narratives: { atAGlance: null, topics: null, suggestions: null },
+    });
+    const html = renderHTML(empty);
+    expect(html).toContain("brand new");
+    expect(html).toContain("Day one");
+  });
+
+  it("escapes HTML in deployment name and narratives", () => {
+    const html = renderHTML(
+      makeReport({
+        deploymentName: "Pwn <script>alert(1)</script>",
+        narratives: {
+          atAGlance: "Look: <img src=x onerror=alert(1)> & co",
+          topics: null,
+          suggestions: null,
+        },
+      }),
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&amp;");
+  });
+
+  it("renders a confidence bar chart with all three levels", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain("High");
+    expect(html).toContain("Medium");
+    expect(html).toContain("Low");
+    expect(html).toContain("Confidence Breakdown");
+  });
+
+  it("shows the trend with a positive arrow when responses are up", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain("trend-up");
+    expect(html).toContain("↑");
+    expect(html).toContain("(+20)");
+  });
+
+  it("shows a down arrow when responses dropped", () => {
+    const html = renderHTML(
+      makeReport({
+        current: { ...makeReport().current, totalResponses: 50 },
+        derived: { answerRate: 0.8, answerRateDelta: 0, responsesDelta: -30, positiveRateDelta: 0 },
+      }),
+    );
+    expect(html).toContain("trend-down");
+    expect(html).toContain("↓");
+    expect(html).toContain("(-30)");
+  });
+
+  it("shows a flat arrow when responses match the prior window", () => {
+    const html = renderHTML(
+      makeReport({
+        current: { ...makeReport().current, totalResponses: 80 },
+        derived: { answerRate: 0.8, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+      }),
+    );
+    expect(html).toContain("→");
+  });
+
+  it("shows a fallback message when topics narrative is missing", () => {
+    const html = renderHTML(
+      makeReport({ narratives: { atAGlance: "x", topics: null, suggestions: "y" } }),
+    );
+    expect(html).toContain("Not enough signal yet to summarize topics");
+  });
+
+  it("shows a friendly message when suggestions narrative is missing", () => {
+    const html = renderHTML(
+      makeReport({ narratives: { atAGlance: "x", topics: "y", suggestions: null } }),
+    );
+    expect(html).toContain("too busy answering questions");
+  });
+
+  it("renders all cheers as list items", () => {
+    const html = renderHTML(makeReport({ cheers: ["First", "Second", "Third"] }));
+    expect(html).toContain("<li>First</li>");
+    expect(html).toContain("<li>Second</li>");
+    expect(html).toContain("<li>Third</li>");
+  });
+
+  it("uses a celebratory flair for high-volume deployments", () => {
+    const html = renderHTML(
+      makeReport({
+        current: { ...makeReport().current, totalResponses: 1500 },
+      }),
+    );
+    expect(html).toContain("1,000 responses");
+  });
+
+  it("uses the triple-digits flair when responses are between 100 and 999", () => {
+    const html = renderHTML(
+      makeReport({ current: { ...makeReport().current, totalResponses: 250 } }),
+    );
+    expect(html).toContain("Triple digits");
+  });
+
+  it("uses the chef's-kiss flair when answer rate is at least 95%", () => {
+    const html = renderHTML(
+      makeReport({
+        current: { ...makeReport().current, totalResponses: 30 },
+        derived: { answerRate: 0.97, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+      }),
+    );
+    expect(html).toContain("Almost everything got answered");
+  });
+
+  it("uses the default flair when no rule matches", () => {
+    const html = renderHTML(
+      makeReport({
+        current: { ...makeReport().current, totalResponses: 30 },
+        derived: { answerRate: 0.5, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+      }),
+    );
+    expect(html).toContain("Keep the questions coming");
+  });
+
+  it("formats answer-rate delta in percentage points", () => {
+    const html = renderHTML(makeReport());
+    expect(html).toContain("▲ 5 pts");
+  });
+
+  it("renders an em-dash when the answer rate is null", () => {
+    const html = renderHTML(
+      makeReport({
+        current: {
+          ...makeReport().current,
+          totalResponses: 0,
+          totalWithResponse: 0,
+        },
+        derived: {
+          answerRate: null,
+          answerRateDelta: null,
+          responsesDelta: 0,
+          positiveRateDelta: null,
+        },
+      }),
+    );
+    expect(html).toContain('class="stat-value">—</div>');
+  });
+
+  it("formats the generated date in long form", () => {
+    const html = renderHTML(makeReport({ generatedAt: "2026-04-16T12:00:00Z" }));
+    expect(html).toMatch(/Apr 1[56]/);
+  });
+
+  it("shows a 'no change' delta when delta is essentially zero", () => {
+    const html = renderHTML(
+      makeReport({
+        derived: { answerRate: 0.8, answerRateDelta: 0, responsesDelta: 0, positiveRateDelta: 0 },
+      }),
+    );
+    expect(html).toContain("no change");
+  });
+
+  it("formats negative deltas with a down triangle", () => {
+    const html = renderHTML(
+      makeReport({
+        derived: {
+          answerRate: 0.8,
+          answerRateDelta: -0.1,
+          responsesDelta: 0,
+          positiveRateDelta: 0,
+        },
+      }),
+    );
+    expect(html).toContain("▼ 10 pts");
+  });
+});

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -1,0 +1,267 @@
+/**
+ * Render an InsightsReport as a self-contained HTML file.
+ *
+ * Embeds all CSS inline so the file is portable. No external assets, no JS.
+ * Visually inspired by Claude Code's `/insights` report but only renders
+ * sections we can populate with real data.
+ */
+
+import type { InsightsReport, UsageStats } from "./insights";
+
+export function renderHTML(report: InsightsReport): string {
+  const safeName = escapeHTML(report.deploymentName);
+  const generated = formatDate(report.generatedAt);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Dosu Insights — ${safeName}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>${CSS}</style>
+</head>
+<body>
+  <main class="container">
+    <header class="hero">
+      <div class="brand">DOSU INSIGHTS</div>
+      <h1>${safeName}</h1>
+      <p class="subtitle">Last ${report.windowDays} days · generated ${generated}</p>
+    </header>
+
+    ${renderAtAGlance(report)}
+    ${renderStatsRow(report)}
+    ${renderCheers(report)}
+    ${renderCharts(report.current)}
+    ${renderTopics(report)}
+    ${renderSuggestions(report)}
+    ${renderTrend(report)}
+
+    <footer class="fun-ending">
+      <div class="fun-headline">${pickFlair(report)}</div>
+      <div class="fun-detail">Run <code>dosu insights</code> any time to see what's new. ✨</div>
+    </footer>
+  </main>
+</body>
+</html>`;
+}
+
+function renderAtAGlance(r: InsightsReport): string {
+  const text = r.narratives.atAGlance ?? fallbackAtAGlance(r);
+  return `
+    <section class="at-a-glance">
+      <div class="glance-title">At a Glance</div>
+      <p>${escapeHTML(text)}</p>
+    </section>`;
+}
+
+function renderStatsRow(r: InsightsReport): string {
+  const ar = r.derived.answerRate !== null ? `${(r.derived.answerRate * 100).toFixed(0)}%` : "—";
+  const arDelta = formatDelta(r.derived.answerRateDelta, true);
+  const pr =
+    r.current.reactions.totalPositive + r.current.reactions.totalNegative > 0
+      ? `${(r.current.reactions.positiveRate * 100).toFixed(0)}%`
+      : "—";
+  const prDelta = formatDelta(r.derived.positiveRateDelta, true);
+  const respDelta = formatDelta(
+    r.derived.responsesDelta / Math.max(1, r.previous.totalResponses),
+    true,
+  );
+  return `
+    <section class="stats-row">
+      <div class="stat">
+        <div class="stat-value">${r.current.totalResponses}</div>
+        <div class="stat-label">Responses</div>
+        <div class="stat-delta">${respDelta}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${ar}</div>
+        <div class="stat-label">Answer rate</div>
+        <div class="stat-delta">${arDelta}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${pr}</div>
+        <div class="stat-label">Positive feedback</div>
+        <div class="stat-delta">${prDelta}</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${r.windowDays}</div>
+        <div class="stat-label">Days</div>
+        <div class="stat-delta">&nbsp;</div>
+      </div>
+    </section>`;
+}
+
+function renderCheers(r: InsightsReport): string {
+  const items = r.cheers.map((c) => `<li>${escapeHTML(c)}</li>`).join("");
+  return `
+    <section>
+      <h2>Worth Celebrating</h2>
+      <ul class="cheers">${items}</ul>
+    </section>`;
+}
+
+function renderCharts(stats: UsageStats): string {
+  return `
+    <section class="charts">
+      <div class="chart-card">
+        <div class="chart-title">Confidence Breakdown</div>
+        ${barChart([
+          ["High", stats.byConfidence.high, "#16a34a"],
+          ["Medium", stats.byConfidence.medium, "#eab308"],
+          ["Low", stats.byConfidence.low, "#dc2626"],
+        ])}
+      </div>
+      <div class="chart-card">
+        <div class="chart-title">Reactions</div>
+        ${barChart([
+          ["Positive", stats.reactions.totalPositive, "#16a34a"],
+          ["Negative", stats.reactions.totalNegative, "#dc2626"],
+        ])}
+      </div>
+    </section>`;
+}
+
+function renderTopics(r: InsightsReport): string {
+  const text =
+    r.narratives.topics ??
+    "Not enough signal yet to summarize topics — try again after more questions roll in.";
+  return `
+    <section>
+      <h2>What People Are Asking About</h2>
+      <div class="narrative">${escapeHTML(text)}</div>
+    </section>`;
+}
+
+function renderSuggestions(r: InsightsReport): string {
+  if (!r.narratives.suggestions) {
+    return `
+    <section>
+      <h2>Suggested Next Steps</h2>
+      <div class="narrative muted">No suggestions this round — Dosu was too busy answering questions. 😄</div>
+    </section>`;
+  }
+  // Render as preformatted-ish so numbered lists keep their shape; still escaped.
+  return `
+    <section>
+      <h2>Suggested Next Steps</h2>
+      <div class="narrative suggestions">${escapeHTML(r.narratives.suggestions)}</div>
+    </section>`;
+}
+
+function renderTrend(r: InsightsReport): string {
+  const cur = r.current.totalResponses;
+  const prev = r.previous.totalResponses;
+  const delta = cur - prev;
+  const dir = delta > 0 ? "up" : delta < 0 ? "down" : "flat";
+  const arrow = delta > 0 ? "↑" : delta < 0 ? "↓" : "→";
+  return `
+    <section>
+      <h2>Trend</h2>
+      <div class="trend trend-${dir}">
+        <span class="trend-arrow">${arrow}</span>
+        <span><strong>${cur}</strong> responses this window vs <strong>${prev}</strong> the prior ${r.windowDays} days
+        (${delta >= 0 ? "+" : ""}${delta}).</span>
+      </div>
+    </section>`;
+}
+
+function fallbackAtAGlance(r: InsightsReport): string {
+  if (r.current.totalResponses === 0) {
+    return `Your deployment is brand new and ready to go. The next ${r.windowDays} days will give us something to talk about — let's see what your team asks first.`;
+  }
+  const ar = r.derived.answerRate !== null ? `${(r.derived.answerRate * 100).toFixed(0)}%` : "—";
+  return `In the last ${r.windowDays} days you logged ${r.current.totalResponses} responses with a ${ar} answer rate. Keep the questions coming — every one teaches Dosu more about your team.`;
+}
+
+function pickFlair(r: InsightsReport): string {
+  if (r.current.totalResponses === 0) return "🌱 Day one. Welcome aboard.";
+  if (r.current.totalResponses >= 1000)
+    return "🚀 You crossed 1,000 responses. That's a lot of help shipped.";
+  if (r.current.totalResponses >= 100) return "🎉 Triple digits. Your team is on a roll.";
+  if (r.derived.answerRate !== null && r.derived.answerRate >= 0.95)
+    return "💯 Almost everything got answered. Chef's kiss.";
+  return "👏 Keep the questions coming.";
+}
+
+function barChart(rows: Array<[string, number, string]>): string {
+  const max = Math.max(1, ...rows.map(([, v]) => v));
+  return rows
+    .map(
+      ([label, value, color]) => `
+        <div class="bar-row">
+          <div class="bar-label">${escapeHTML(label)}</div>
+          <div class="bar-track"><div class="bar-fill" style="width:${(value / max) * 100}%;background:${color}"></div></div>
+          <div class="bar-value">${value}</div>
+        </div>`,
+    )
+    .join("");
+}
+
+function formatDelta(delta: number | null, asPercent: boolean): string {
+  if (delta === null || !Number.isFinite(delta)) return "&nbsp;";
+  if (Math.abs(delta) < 0.005 && asPercent) return "no change";
+  if (asPercent) {
+    const pct = (delta * 100).toFixed(0);
+    return delta > 0 ? `▲ ${pct} pts` : `▼ ${Math.abs(Number(pct))} pts`;
+  }
+  return delta > 0 ? `▲ ${delta}` : `▼ ${Math.abs(delta)}`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function escapeHTML(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const CSS = `
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif; background: #f8fafc; color: #334155; line-height: 1.6; padding: 48px 24px; }
+.container { max-width: 820px; margin: 0 auto; }
+.hero { margin-bottom: 32px; }
+.brand { font-size: 11px; letter-spacing: 0.18em; color: #b45309; font-weight: 700; margin-bottom: 8px; }
+h1 { font-size: 32px; font-weight: 700; color: #0f172a; margin-bottom: 4px; }
+h2 { font-size: 18px; font-weight: 600; color: #0f172a; margin-top: 40px; margin-bottom: 12px; }
+.subtitle { color: #64748b; font-size: 14px; }
+.at-a-glance { background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 1px solid #f59e0b; border-radius: 12px; padding: 20px 24px; margin-top: 32px; }
+.glance-title { font-size: 11px; letter-spacing: 0.18em; font-weight: 700; color: #92400e; margin-bottom: 10px; }
+.at-a-glance p { color: #78350f; font-size: 15px; line-height: 1.7; }
+.stats-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin: 24px 0 8px; padding: 20px 0; border-top: 1px solid #e2e8f0; border-bottom: 1px solid #e2e8f0; }
+.stat { text-align: center; }
+.stat-value { font-size: 26px; font-weight: 700; color: #0f172a; }
+.stat-label { font-size: 11px; color: #64748b; text-transform: uppercase; letter-spacing: 0.06em; margin-top: 2px; }
+.stat-delta { font-size: 11px; color: #64748b; margin-top: 4px; }
+.cheers { list-style: none; display: grid; gap: 8px; }
+.cheers li { background: #f0fdf4; border: 1px solid #bbf7d0; color: #166534; border-radius: 8px; padding: 12px 16px; font-size: 14px; }
+.charts { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.chart-card { background: white; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; }
+.chart-title { font-size: 11px; font-weight: 600; color: #64748b; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px; }
+.bar-row { display: flex; align-items: center; margin-bottom: 6px; }
+.bar-label { width: 70px; font-size: 12px; color: #475569; }
+.bar-track { flex: 1; height: 6px; background: #f1f5f9; border-radius: 3px; margin: 0 8px; }
+.bar-fill { height: 100%; border-radius: 3px; }
+.bar-value { width: 36px; font-size: 12px; font-weight: 500; color: #475569; text-align: right; }
+.narrative { background: white; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px 20px; font-size: 14px; line-height: 1.7; color: #475569; white-space: pre-wrap; }
+.narrative.muted { color: #94a3b8; }
+.suggestions { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif; }
+.trend { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 8px; padding: 12px 16px; font-size: 14px; color: #1e40af; display: flex; align-items: center; gap: 12px; }
+.trend-up { background: #f0fdf4; border-color: #bbf7d0; color: #166534; }
+.trend-down { background: #fef2f2; border-color: #fecaca; color: #991b1b; }
+.trend-arrow { font-size: 18px; font-weight: 700; }
+.fun-ending { background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 1px solid #fbbf24; border-radius: 12px; padding: 24px; margin-top: 40px; text-align: center; }
+.fun-headline { font-size: 18px; font-weight: 600; color: #78350f; margin-bottom: 6px; }
+.fun-detail { font-size: 14px; color: #92400e; }
+.fun-detail code { background: rgba(255,255,255,0.7); padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, monospace; font-size: 13px; }
+@media (max-width: 640px) { .stats-row { grid-template-columns: repeat(2, 1fr); } .charts { grid-template-columns: 1fr; } }
+`;

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -1,11 +1,5 @@
-/**
- * Render an InsightsReport as a self-contained HTML file.
- *
- * Embeds all CSS inline so the file is portable. No external assets, no JS.
- * Visually inspired by Claude Code's `/insights` report — gradient panels,
- * card-based content, color-coded deltas, and an action-oriented suggestions
- * grid that calls out the exact `dosu` commands to run next.
- */
+// Render an InsightsReport as a self-contained HTML file. All CSS inline, no
+// JS, no external assets so the file is portable and shareable.
 
 import type { InsightsReport, Suggestion, UsageStats } from "./insights";
 
@@ -47,7 +41,7 @@ export function renderHTML(report: InsightsReport): string {
     <footer class="fun-ending">
       <div class="fun-headline">${pickFlair(report)}</div>
       <div class="fun-detail">Run <code>dosu insights</code> any time to see what's new. ✨</div>
-      <div class="fun-path">~/.config/dosu-cli/insights/report.html</div>
+      <div class="fun-path">~/.config/dosu-cli/insights/latest.html</div>
     </footer>
   </main>
 </body>
@@ -81,13 +75,18 @@ function pickHeadlineLabel(count: number): string {
 
 function renderHeadline(r: InsightsReport): string {
   const cur = r.current.totalResponses;
+  if (!r.derived.hasPriorWindow) {
+    return `
+    <section class="headline">
+      <div class="headline-number">${cur.toLocaleString("en-US")}</div>
+      <div class="headline-label">${pickHeadlineLabel(cur)}</div>
+      <div class="headline-delta delta-flat">first ${r.windowDays} days of data</div>
+    </section>`;
+  }
   const delta = r.derived.responsesDelta;
   const direction = delta > 0 ? "up" : delta < 0 ? "down" : "flat";
   const arrow = delta > 0 ? "▲" : delta < 0 ? "▼" : "→";
-  const pct =
-    r.previous.totalResponses > 0
-      ? ` (${delta >= 0 ? "+" : ""}${Math.round((delta / r.previous.totalResponses) * 100)}%)`
-      : "";
+  const pct = ` (${delta >= 0 ? "+" : ""}${Math.round((delta / r.previous.totalResponses) * 100)}%)`;
   const deltaText =
     delta === 0
       ? "no change vs the prior window"
@@ -167,9 +166,20 @@ function renderStatsRow(r: InsightsReport): string {
       ? `${(r.current.reactions.positiveRate * 100).toFixed(0)}%`
       : "—";
   const prDelta = formatPctDelta(r.derived.positiveRateDelta);
-  const respDelta = formatCountDelta(r.derived.responsesDelta);
+  const respDelta = r.derived.hasPriorWindow
+    ? formatCountDelta(r.derived.responsesDelta)
+    : `<div class="stat-delta">&nbsp;</div>`;
   const perDay = r.current.totalResponses > 0 ? r.current.totalResponses / r.windowDays : 0;
-  const perDayLabel = perDay >= 1 ? perDay.toFixed(1) : perDay > 0 ? perDay.toFixed(2) : "—";
+  const perDayLabel = !r.derived.hasPriorWindow
+    ? "—"
+    : perDay >= 1
+      ? perDay.toFixed(1)
+      : perDay > 0
+        ? perDay.toFixed(2)
+        : "—";
+  const perDayHint = r.derived.hasPriorWindow
+    ? `avg over ${r.windowDays} days`
+    : `needs ${r.windowDays}d of history`;
   const reactionTotal = r.current.reactions.totalPositive + r.current.reactions.totalNegative;
   return `
     <section class="stats-row">
@@ -191,7 +201,7 @@ function renderStatsRow(r: InsightsReport): string {
       <div class="stat">
         <div class="stat-value">${perDayLabel}</div>
         <div class="stat-label">Responses / day</div>
-        <div class="stat-delta">avg over ${r.windowDays} days</div>
+        <div class="stat-delta">${perDayHint}</div>
       </div>
       <div class="stat">
         <div class="stat-value">${reactionTotal}</div>
@@ -213,7 +223,7 @@ function renderSignals(r: InsightsReport): string {
       ${
         r.cheers.length > 0
           ? `<div class="signal-card signal-cheers">
-        <h2><span class="signal-icon">✨</span> Worth Celebrating</h2>
+        <h2>Worth Celebrating</h2>
         <ul>${r.cheers.map((c) => `<li>${escapeHTML(c)}</li>`).join("")}</ul>
       </div>`
           : ""
@@ -221,7 +231,7 @@ function renderSignals(r: InsightsReport): string {
       ${
         r.investigate.length > 0
           ? `<div class="signal-card signal-investigate">
-        <h2><span class="signal-icon">🔎</span> Things to Investigate</h2>
+        <h2>Things to Investigate</h2>
         <ul>${r.investigate.map((c) => `<li>${escapeHTML(c)}</li>`).join("")}</ul>
       </div>`
           : ""
@@ -233,7 +243,7 @@ function renderSuggestions(r: InsightsReport): string {
   if (r.suggestions.length === 0) return "";
   return `
     <section>
-      <h2 class="section-heading"><span class="section-icon">🎯</span> Suggested Next Steps</h2>
+      <h2 class="section-heading">Suggested Next Steps</h2>
       <p class="section-intro">Based on this window's activity. The fastest wins first.</p>
       <div class="suggestions">
         ${r.suggestions.map(renderSuggestionCard).join("")}
@@ -261,7 +271,7 @@ function renderConfidenceBar(stats: UsageStats): string {
   const low = (stats.byConfidence.low / total) * 100;
   return `
     <section>
-      <h2 class="section-heading"><span class="section-icon">📊</span> Confidence Breakdown</h2>
+      <h2 class="section-heading">Confidence Breakdown</h2>
       <p class="section-intro">How sure Dosu was about each answer.</p>
       <div class="stacked-bar-card">
         <div class="stacked-bar">
@@ -283,7 +293,7 @@ function renderReactions(stats: UsageStats): string {
   if (total === 0) {
     return `
     <section>
-      <h2 class="section-heading"><span class="section-icon">💬</span> Reactions</h2>
+      <h2 class="section-heading">Reactions</h2>
       <div class="empty-card">No reactions logged yet — encourage your team to thumbs-up the answers that helped.</div>
     </section>`;
   }
@@ -291,7 +301,7 @@ function renderReactions(stats: UsageStats): string {
   const neg = (stats.reactions.totalNegative / total) * 100;
   return `
     <section>
-      <h2 class="section-heading"><span class="section-icon">💬</span> Reactions</h2>
+      <h2 class="section-heading">Reactions</h2>
       <p class="section-intro">${total} reactions across ${stats.reactions.messagesWithReactions} messages.</p>
       <div class="stacked-bar-card">
         <div class="stacked-bar">
@@ -307,6 +317,13 @@ function renderReactions(stats: UsageStats): string {
 }
 
 function renderComparison(r: InsightsReport): string {
+  if (!r.derived.hasPriorWindow) {
+    return `
+    <section>
+      <h2 class="section-heading">Period Comparison</h2>
+      <div class="empty-card">Not enough history yet — check back after ${r.windowDays} more days for a prior-window comparison.</div>
+    </section>`;
+  }
   const rows: Array<{ label: string; cur: string; prev: string; delta: string; tone: string }> = [
     rowResp("Responses", r.current.totalResponses, r.previous.totalResponses, true),
     rowResp("Answers given", r.current.totalWithResponse, r.previous.totalWithResponse, true),
@@ -334,7 +351,7 @@ function renderComparison(r: InsightsReport): string {
   ];
   return `
     <section>
-      <h2 class="section-heading"><span class="section-icon">📋</span> Period Comparison</h2>
+      <h2 class="section-heading">Period Comparison</h2>
       <p class="section-intro">This window vs the prior ${r.windowDays} days.</p>
       <div class="compare-card">
         <table class="compare-table">
@@ -407,6 +424,7 @@ function rowPct(
 }
 
 function renderTrend(r: InsightsReport): string {
+  if (!r.derived.hasPriorWindow) return "";
   const cur = r.current.totalResponses;
   const prev = r.previous.totalResponses;
   const delta = cur - prev;
@@ -509,7 +527,6 @@ h1 { font-size: 32px; font-weight: 700; color: #0f172a; margin-bottom: 4px; lett
   align-items: center;
   gap: 8px;
 }
-.section-icon { font-size: 18px; }
 .section-intro { color: #64748b; font-size: 13px; margin-bottom: 16px; }
 section { margin-top: 36px; }
 
@@ -645,7 +662,6 @@ section { margin-top: 36px; }
   align-items: center;
   gap: 8px;
 }
-.signal-icon { font-size: 16px; }
 .signal-card ul { list-style: none; display: flex; flex-direction: column; gap: 10px; }
 .signal-card li {
   font-size: 14px;

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -29,11 +29,15 @@ export function renderHTML(report: InsightsReport): string {
       <p class="subtitle">Last ${report.windowDays} days · generated ${generated}</p>
     </header>
 
+    ${renderHeadline(report)}
     ${renderAtAGlance(report)}
+    ${renderScorecard(report)}
     ${renderStatsRow(report)}
     ${renderSignals(report)}
     ${renderSuggestions(report)}
-    ${renderCharts(report.current)}
+    ${renderConfidenceBar(report.current)}
+    ${renderReactions(report.current)}
+    ${renderComparison(report)}
     ${renderTrend(report)}
 
     <footer class="fun-ending">
@@ -45,12 +49,84 @@ export function renderHTML(report: InsightsReport): string {
 </html>`;
 }
 
+function renderHeadline(r: InsightsReport): string {
+  const cur = r.current.totalResponses;
+  const delta = r.derived.responsesDelta;
+  const direction = delta > 0 ? "up" : delta < 0 ? "down" : "flat";
+  const arrow = delta > 0 ? "▲" : delta < 0 ? "▼" : "→";
+  const pct =
+    r.previous.totalResponses > 0
+      ? ` (${delta >= 0 ? "+" : ""}${Math.round((delta / r.previous.totalResponses) * 100)}%)`
+      : "";
+  const deltaText =
+    delta === 0
+      ? "no change vs the prior window"
+      : `${arrow} ${delta >= 0 ? "+" : ""}${delta}${pct} vs the prior ${r.windowDays} days`;
+  return `
+    <section class="headline">
+      <div class="headline-number">${cur.toLocaleString("en-US")}</div>
+      <div class="headline-label">responses answered</div>
+      <div class="headline-delta delta-${direction}">${deltaText}</div>
+    </section>`;
+}
+
 function renderAtAGlance(r: InsightsReport): string {
   return `
     <section class="at-a-glance">
       <div class="glance-title">At a Glance</div>
       <p>${escapeHTML(r.atAGlance)}</p>
     </section>`;
+}
+
+function renderScorecard(r: InsightsReport): string {
+  if (r.current.totalResponses === 0) return "";
+  const answer = r.derived.answerRate ?? 0;
+  const conf =
+    r.current.totalWithResponse > 0 ? r.current.byConfidence.high / r.current.totalWithResponse : 0;
+  const reactionTotal = r.current.reactions.totalPositive + r.current.reactions.totalNegative;
+  const sentiment = reactionTotal > 0 ? r.current.reactions.positiveRate : 0.7; // neutral default
+  const score = Math.round(((answer + conf + sentiment) / 3) * 100);
+  const grade = pickGrade(score);
+
+  return `
+    <section class="scorecard">
+      <div class="scorecard-grade grade-${grade.tone}">
+        <div class="grade-letter">${grade.letter}</div>
+        <div class="grade-label">${grade.label}</div>
+        <div class="grade-score">${score} / 100</div>
+      </div>
+      <div class="scorecard-bars">
+        ${miniBar("Answer rate", answer, "answers reaching the user")}
+        ${miniBar("High-confidence", conf, "of answers Dosu was sure about")}
+        ${miniBar(
+          "Sentiment",
+          sentiment,
+          reactionTotal > 0 ? "of reactions were positive" : "no reactions yet — neutral default",
+        )}
+      </div>
+    </section>`;
+}
+
+function miniBar(label: string, value: number, hint: string): string {
+  const v = Math.max(0, Math.min(1, value));
+  const tone = v >= 0.8 ? "good" : v >= 0.6 ? "ok" : "low";
+  return `
+        <div class="mini">
+          <div class="mini-row">
+            <span class="mini-label">${escapeHTML(label)}</span>
+            <span class="mini-value">${(v * 100).toFixed(0)}%</span>
+          </div>
+          <div class="mini-track"><div class="mini-fill mini-${tone}" style="width:${v * 100}%"></div></div>
+          <div class="mini-hint">${escapeHTML(hint)}</div>
+        </div>`;
+}
+
+function pickGrade(score: number): { letter: string; label: string; tone: string } {
+  if (score >= 90) return { letter: "A+", label: "Outstanding", tone: "great" };
+  if (score >= 80) return { letter: "A", label: "Excellent", tone: "great" };
+  if (score >= 70) return { letter: "B", label: "Healthy", tone: "good" };
+  if (score >= 60) return { letter: "C", label: "Needs attention", tone: "warn" };
+  return { letter: "D", label: "Investigate", tone: "alarm" };
 }
 
 function renderStatsRow(r: InsightsReport): string {
@@ -62,6 +138,9 @@ function renderStatsRow(r: InsightsReport): string {
       : "—";
   const prDelta = formatPctDelta(r.derived.positiveRateDelta);
   const respDelta = formatCountDelta(r.derived.responsesDelta);
+  const perDay = r.current.totalResponses > 0 ? r.current.totalResponses / r.windowDays : 0;
+  const perDayLabel = perDay >= 1 ? perDay.toFixed(1) : perDay > 0 ? perDay.toFixed(2) : "—";
+  const reactionTotal = r.current.reactions.totalPositive + r.current.reactions.totalNegative;
   return `
     <section class="stats-row">
       <div class="stat">
@@ -80,9 +159,19 @@ function renderStatsRow(r: InsightsReport): string {
         ${prDelta}
       </div>
       <div class="stat">
+        <div class="stat-value">${perDayLabel}</div>
+        <div class="stat-label">Responses / day</div>
+        <div class="stat-delta">avg over ${r.windowDays} days</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${reactionTotal}</div>
+        <div class="stat-label">Reactions</div>
+        <div class="stat-delta">${r.current.reactions.totalPositive} 👍 · ${r.current.reactions.totalNegative} 👎</div>
+      </div>
+      <div class="stat">
         <div class="stat-value">${r.windowDays}</div>
-        <div class="stat-label">Days</div>
-        <div class="stat-delta">&nbsp;</div>
+        <div class="stat-label">Window</div>
+        <div class="stat-delta">days</div>
       </div>
     </section>`;
 }
@@ -134,25 +223,157 @@ function renderSuggestionCard(s: Suggestion): string {
     </article>`;
 }
 
-function renderCharts(stats: UsageStats): string {
+function renderConfidenceBar(stats: UsageStats): string {
+  const total = stats.byConfidence.high + stats.byConfidence.medium + stats.byConfidence.low;
+  if (total === 0) return "";
+  const high = (stats.byConfidence.high / total) * 100;
+  const med = (stats.byConfidence.medium / total) * 100;
+  const low = (stats.byConfidence.low / total) * 100;
   return `
-    <section class="charts">
-      <div class="chart-card">
-        <div class="chart-title">Confidence Breakdown</div>
-        ${barChart([
-          ["High", stats.byConfidence.high, "#16a34a"],
-          ["Medium", stats.byConfidence.medium, "#eab308"],
-          ["Low", stats.byConfidence.low, "#dc2626"],
-        ])}
-      </div>
-      <div class="chart-card">
-        <div class="chart-title">Reactions</div>
-        ${barChart([
-          ["Positive", stats.reactions.totalPositive, "#16a34a"],
-          ["Negative", stats.reactions.totalNegative, "#dc2626"],
-        ])}
+    <section>
+      <h2 class="section-heading">Confidence Breakdown</h2>
+      <p class="section-intro">How sure Dosu was about each answer.</p>
+      <div class="stacked-bar-card">
+        <div class="stacked-bar">
+          <div class="stack-seg seg-high" style="width:${high}%" title="High confidence: ${stats.byConfidence.high}"></div>
+          <div class="stack-seg seg-med" style="width:${med}%" title="Medium confidence: ${stats.byConfidence.medium}"></div>
+          <div class="stack-seg seg-low" style="width:${low}%" title="Low confidence: ${stats.byConfidence.low}"></div>
+        </div>
+        <div class="stacked-legend">
+          <div class="legend-item"><span class="legend-swatch swatch-high"></span><strong>${stats.byConfidence.high}</strong> high <span class="legend-pct">${high.toFixed(0)}%</span></div>
+          <div class="legend-item"><span class="legend-swatch swatch-med"></span><strong>${stats.byConfidence.medium}</strong> medium <span class="legend-pct">${med.toFixed(0)}%</span></div>
+          <div class="legend-item"><span class="legend-swatch swatch-low"></span><strong>${stats.byConfidence.low}</strong> low <span class="legend-pct">${low.toFixed(0)}%</span></div>
+        </div>
       </div>
     </section>`;
+}
+
+function renderReactions(stats: UsageStats): string {
+  const total = stats.reactions.totalPositive + stats.reactions.totalNegative;
+  if (total === 0) {
+    return `
+    <section>
+      <h2 class="section-heading">Reactions</h2>
+      <div class="empty-card">No reactions logged yet — encourage your team to thumbs-up the answers that helped.</div>
+    </section>`;
+  }
+  const pos = (stats.reactions.totalPositive / total) * 100;
+  const neg = (stats.reactions.totalNegative / total) * 100;
+  return `
+    <section>
+      <h2 class="section-heading">Reactions</h2>
+      <p class="section-intro">${total} reactions across ${stats.reactions.messagesWithReactions} messages.</p>
+      <div class="stacked-bar-card">
+        <div class="stacked-bar">
+          <div class="stack-seg seg-high" style="width:${pos}%" title="Positive: ${stats.reactions.totalPositive}"></div>
+          <div class="stack-seg seg-low" style="width:${neg}%" title="Negative: ${stats.reactions.totalNegative}"></div>
+        </div>
+        <div class="stacked-legend">
+          <div class="legend-item"><span class="legend-swatch swatch-high"></span><strong>${stats.reactions.totalPositive}</strong> positive <span class="legend-pct">${pos.toFixed(0)}%</span></div>
+          <div class="legend-item"><span class="legend-swatch swatch-low"></span><strong>${stats.reactions.totalNegative}</strong> negative <span class="legend-pct">${neg.toFixed(0)}%</span></div>
+        </div>
+      </div>
+    </section>`;
+}
+
+function renderComparison(r: InsightsReport): string {
+  const rows: Array<{ label: string; cur: string; prev: string; delta: string; tone: string }> = [
+    rowResp("Responses", r.current.totalResponses, r.previous.totalResponses, true),
+    rowResp("Answers given", r.current.totalWithResponse, r.previous.totalWithResponse, true),
+    rowPct(
+      "Answer rate",
+      r.derived.answerRate,
+      r.previous.totalResponses > 0
+        ? r.previous.totalWithResponse / r.previous.totalResponses
+        : null,
+    ),
+    rowResp("High-confidence", r.current.byConfidence.high, r.previous.byConfidence.high, true),
+    rowResp("Low-confidence", r.current.byConfidence.low, r.previous.byConfidence.low, false),
+    rowResp(
+      "Positive reactions",
+      r.current.reactions.totalPositive,
+      r.previous.reactions.totalPositive,
+      true,
+    ),
+    rowResp(
+      "Negative reactions",
+      r.current.reactions.totalNegative,
+      r.previous.reactions.totalNegative,
+      false,
+    ),
+  ];
+  return `
+    <section>
+      <h2 class="section-heading">Period Comparison</h2>
+      <p class="section-intro">This window vs the prior ${r.windowDays} days.</p>
+      <div class="compare-card">
+        <table class="compare-table">
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>This window</th>
+              <th>Prior window</th>
+              <th>Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows
+              .map(
+                (row) => `
+              <tr>
+                <td>${escapeHTML(row.label)}</td>
+                <td class="num">${row.cur}</td>
+                <td class="num prior">${row.prev}</td>
+                <td class="num delta-${row.tone}">${row.delta}</td>
+              </tr>`,
+              )
+              .join("")}
+          </tbody>
+        </table>
+      </div>
+    </section>`;
+}
+
+function rowResp(
+  label: string,
+  cur: number,
+  prev: number,
+  upIsGood: boolean,
+): { label: string; cur: string; prev: string; delta: string; tone: string } {
+  const d = cur - prev;
+  const tone = d === 0 ? "flat" : d > 0 === upIsGood ? "up" : "down";
+  const arrow = d === 0 ? "→" : d > 0 ? "▲" : "▼";
+  const delta = d === 0 ? "no change" : `${arrow} ${d > 0 ? "+" : ""}${d}`;
+  return {
+    label,
+    cur: cur.toLocaleString("en-US"),
+    prev: prev.toLocaleString("en-US"),
+    delta,
+    tone,
+  };
+}
+
+function rowPct(
+  label: string,
+  cur: number | null,
+  prev: number | null,
+): { label: string; cur: string; prev: string; delta: string; tone: string } {
+  const curStr = cur !== null ? `${(cur * 100).toFixed(0)}%` : "—";
+  const prevStr = prev !== null ? `${(prev * 100).toFixed(0)}%` : "—";
+  if (cur === null || prev === null)
+    return { label, cur: curStr, prev: prevStr, delta: "—", tone: "flat" };
+  const d = cur - prev;
+  if (Math.abs(d) < 0.005)
+    return { label, cur: curStr, prev: prevStr, delta: "no change", tone: "flat" };
+  const pct = Math.round(Math.abs(d * 100));
+  const arrow = d > 0 ? "▲" : "▼";
+  return {
+    label,
+    cur: curStr,
+    prev: prevStr,
+    delta: `${arrow} ${pct} pts`,
+    tone: d > 0 ? "up" : "down",
+  };
 }
 
 function renderTrend(r: InsightsReport): string {
@@ -179,20 +400,6 @@ function pickFlair(r: InsightsReport): string {
   if (r.derived.answerRate !== null && r.derived.answerRate >= 0.95)
     return "💯 Almost everything got answered. Chef's kiss.";
   return "👏 Keep the questions coming.";
-}
-
-function barChart(rows: Array<[string, number, string]>): string {
-  const max = Math.max(1, ...rows.map(([, v]) => v));
-  return rows
-    .map(
-      ([label, value, color]) => `
-        <div class="bar-row">
-          <div class="bar-label">${escapeHTML(label)}</div>
-          <div class="bar-track"><div class="bar-fill" style="width:${(value / max) * 100}%;background:${color}"></div></div>
-          <div class="bar-value">${value}</div>
-        </div>`,
-    )
-    .join("");
 }
 
 function formatPctDelta(delta: number | null): string {
@@ -234,13 +441,13 @@ body {
   background: #f8fafc;
   color: #334155;
   line-height: 1.6;
-  padding: 56px 24px;
+  padding: 56px 24px 80px;
   -webkit-font-smoothing: antialiased;
 }
-.container { max-width: 880px; margin: 0 auto; }
+.container { max-width: 920px; margin: 0 auto; }
 
 /* Hero */
-.hero { margin-bottom: 32px; }
+.hero { margin-bottom: 28px; }
 .brand {
   font-size: 11px;
   letter-spacing: 0.18em;
@@ -248,18 +455,48 @@ body {
   font-weight: 700;
   margin-bottom: 8px;
 }
-h1 { font-size: 30px; font-weight: 700; color: #0f172a; margin-bottom: 4px; }
+h1 { font-size: 32px; font-weight: 700; color: #0f172a; margin-bottom: 4px; letter-spacing: -0.01em; }
 .subtitle { color: #64748b; font-size: 14px; }
 .section-heading { font-size: 18px; font-weight: 600; color: #0f172a; margin-bottom: 4px; }
 .section-intro { color: #64748b; font-size: 13px; margin-bottom: 16px; }
+section { margin-top: 36px; }
+
+/* Headline metric */
+.headline {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 32px 24px;
+  text-align: center;
+  margin-top: 16px;
+  box-shadow: 0 1px 3px rgba(15,23,42,0.04);
+}
+.headline-number {
+  font-size: 64px;
+  font-weight: 800;
+  color: #0f172a;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+.headline-label {
+  font-size: 13px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: 10px;
+}
+.headline-delta {
+  font-size: 14px;
+  margin-top: 14px;
+  font-weight: 500;
+}
 
 /* At-a-glance */
 .at-a-glance {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
   border: 1px solid #f59e0b;
-  border-radius: 12px;
-  padding: 22px 26px;
-  margin-top: 8px;
+  border-radius: 14px;
+  padding: 24px 28px;
 }
 .glance-title {
   font-size: 11px;
@@ -270,18 +507,58 @@ h1 { font-size: 30px; font-weight: 700; color: #0f172a; margin-bottom: 4px; }
 }
 .at-a-glance p { color: #78350f; font-size: 15px; line-height: 1.7; }
 
+/* Scorecard */
+.scorecard {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 20px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 1px 3px rgba(15,23,42,0.04);
+}
+.scorecard-grade {
+  border-radius: 12px;
+  padding: 20px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.grade-letter { font-size: 56px; font-weight: 800; line-height: 1; letter-spacing: -0.03em; }
+.grade-label { font-size: 13px; font-weight: 600; margin-top: 8px; text-transform: uppercase; letter-spacing: 0.06em; }
+.grade-score { font-size: 12px; opacity: 0.7; margin-top: 4px; }
+.grade-great { background: #f0fdf4; color: #166534; border: 1px solid #bbf7d0; }
+.grade-good { background: #eff6ff; color: #1e40af; border: 1px solid #bfdbfe; }
+.grade-warn { background: #fffbeb; color: #92400e; border: 1px solid #fde68a; }
+.grade-alarm { background: #fef2f2; color: #991b1b; border: 1px solid #fecaca; }
+.scorecard-bars {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+.mini-row { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
+.mini-label { font-size: 13px; font-weight: 600; color: #334155; }
+.mini-value { font-size: 14px; font-weight: 700; color: #0f172a; font-variant-numeric: tabular-nums; }
+.mini-track { height: 8px; background: #f1f5f9; border-radius: 4px; overflow: hidden; }
+.mini-fill { height: 100%; border-radius: 4px; }
+.mini-good { background: #16a34a; }
+.mini-ok { background: #eab308; }
+.mini-low { background: #dc2626; }
+.mini-hint { font-size: 12px; color: #64748b; margin-top: 4px; }
+
 /* Stats row */
 .stats-row {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin: 32px 0 8px;
-  padding: 20px 0;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 12px;
+  padding: 22px 0;
   border-top: 1px solid #e2e8f0;
   border-bottom: 1px solid #e2e8f0;
 }
 .stat { text-align: center; }
-.stat-value { font-size: 26px; font-weight: 700; color: #0f172a; line-height: 1.1; }
+.stat-value { font-size: 24px; font-weight: 700; color: #0f172a; line-height: 1.1; font-variant-numeric: tabular-nums; }
 .stat-label {
   font-size: 11px;
   color: #64748b;
@@ -294,31 +571,30 @@ h1 { font-size: 30px; font-weight: 700; color: #0f172a; margin-bottom: 4px; }
 .delta-down { color: #dc2626; }
 .delta-flat { color: #94a3b8; }
 
-/* Signals (cheers + investigate side-by-side) */
+/* Signals */
 .signals {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
-  margin-top: 32px;
 }
 .signals:has(.signal-card:only-child) { grid-template-columns: 1fr; }
 .signal-card {
-  border-radius: 10px;
-  padding: 18px 20px;
+  border-radius: 12px;
+  padding: 20px 22px;
   border: 1px solid;
 }
 .signal-card h2 {
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 12px;
+  letter-spacing: 0.08em;
+  margin-bottom: 14px;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 .signal-icon { font-size: 16px; }
-.signal-card ul { list-style: none; display: flex; flex-direction: column; gap: 8px; }
+.signal-card ul { list-style: none; display: flex; flex-direction: column; gap: 10px; }
 .signal-card li {
   font-size: 14px;
   line-height: 1.55;
@@ -332,19 +608,12 @@ h1 { font-size: 30px; font-weight: 700; color: #0f172a; margin-bottom: 4px; }
   font-weight: 700;
   opacity: 0.6;
 }
-.signal-cheers {
-  background: #f0fdf4;
-  border-color: #bbf7d0;
-}
+.signal-cheers { background: #f0fdf4; border-color: #bbf7d0; }
 .signal-cheers h2, .signal-cheers li { color: #166534; }
-.signal-investigate {
-  background: #fef2f2;
-  border-color: #fecaca;
-}
+.signal-investigate { background: #fef2f2; border-color: #fecaca; }
 .signal-investigate h2, .signal-investigate li { color: #991b1b; }
 
 /* Suggestions */
-section { margin-top: 36px; }
 .suggestions {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -353,11 +622,12 @@ section { margin-top: 36px; }
 .suggestion {
   background: white;
   border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 18px 20px;
+  border-radius: 12px;
+  padding: 20px 22px;
   display: flex;
   flex-direction: column;
   gap: 10px;
+  box-shadow: 0 1px 3px rgba(15,23,42,0.04);
 }
 .suggestion h3 { font-size: 15px; font-weight: 600; color: #0f172a; }
 .suggestion p { font-size: 13px; color: #475569; line-height: 1.55; flex: 1; }
@@ -368,42 +638,93 @@ section { margin-top: 36px; }
   color: #e2e8f0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
-  padding: 6px 10px;
+  padding: 6px 12px;
   border-radius: 6px;
-  letter-spacing: 0.01em;
 }
 
-/* Charts */
-.charts {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-.chart-card {
+/* Stacked bars (confidence + reactions) */
+.stacked-bar-card {
   background: white;
   border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 18px;
+  border-radius: 12px;
+  padding: 22px;
+  box-shadow: 0 1px 3px rgba(15,23,42,0.04);
 }
-.chart-title {
+.stacked-bar {
+  display: flex;
+  height: 18px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #f1f5f9;
+  margin-bottom: 16px;
+}
+.stack-seg { height: 100%; transition: width 0.3s ease; }
+.seg-high { background: #16a34a; }
+.seg-med { background: #eab308; }
+.seg-low { background: #dc2626; }
+.stacked-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 13px;
+  color: #475569;
+}
+.legend-item { display: flex; align-items: center; gap: 6px; }
+.legend-swatch { width: 10px; height: 10px; border-radius: 3px; display: inline-block; }
+.swatch-high { background: #16a34a; }
+.swatch-med { background: #eab308; }
+.swatch-low { background: #dc2626; }
+.legend-pct { color: #94a3b8; font-variant-numeric: tabular-nums; }
+.empty-card {
+  background: white;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  padding: 22px;
+  color: #94a3b8;
+  font-size: 14px;
+  text-align: center;
+}
+
+/* Period comparison table */
+.compare-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 8px 4px;
+  box-shadow: 0 1px 3px rgba(15,23,42,0.04);
+  overflow-x: auto;
+}
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.compare-table th {
+  text-align: left;
   font-size: 11px;
-  font-weight: 600;
-  color: #64748b;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  margin-bottom: 12px;
+  color: #64748b;
+  font-weight: 600;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e2e8f0;
 }
-.bar-row { display: flex; align-items: center; margin-bottom: 8px; }
-.bar-row:last-child { margin-bottom: 0; }
-.bar-label { width: 80px; font-size: 12px; color: #475569; }
-.bar-track { flex: 1; height: 8px; background: #f1f5f9; border-radius: 4px; margin: 0 10px; }
-.bar-fill { height: 100%; border-radius: 4px; transition: width 0.3s ease; }
-.bar-value { width: 36px; font-size: 12px; font-weight: 600; color: #475569; text-align: right; }
+.compare-table th.num, .compare-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.compare-table th:nth-child(2), .compare-table td:nth-child(2),
+.compare-table th:nth-child(3), .compare-table td:nth-child(3),
+.compare-table th:nth-child(4), .compare-table td:nth-child(4) { text-align: right; }
+.compare-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #f1f5f9;
+  color: #334155;
+}
+.compare-table tr:last-child td { border-bottom: none; }
+.compare-table td.prior { color: #94a3b8; }
 
 /* Trend */
 .trend {
-  border-radius: 10px;
-  padding: 14px 18px;
+  border-radius: 12px;
+  padding: 16px 20px;
   font-size: 14px;
   display: flex;
   align-items: center;
@@ -419,12 +740,12 @@ section { margin-top: 36px; }
 .fun-ending {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
   border: 1px solid #fbbf24;
-  border-radius: 12px;
-  padding: 26px;
-  margin-top: 40px;
+  border-radius: 14px;
+  padding: 28px;
+  margin-top: 44px;
   text-align: center;
 }
-.fun-headline { font-size: 18px; font-weight: 600; color: #78350f; margin-bottom: 6px; }
+.fun-headline { font-size: 18px; font-weight: 700; color: #78350f; margin-bottom: 6px; }
 .fun-detail { font-size: 14px; color: #92400e; }
 .fun-detail code {
   background: rgba(255,255,255,0.7);
@@ -435,29 +756,16 @@ section { margin-top: 36px; }
 }
 
 /* Responsive */
-@media (max-width: 720px) {
-  body { padding: 32px 16px; }
+@media (max-width: 840px) {
+  .stats-row { grid-template-columns: repeat(3, 1fr); }
+  .scorecard { grid-template-columns: 1fr; }
+}
+@media (max-width: 640px) {
+  body { padding: 32px 16px 60px; }
+  h1 { font-size: 26px; }
+  .headline-number { font-size: 52px; }
   .stats-row { grid-template-columns: repeat(2, 1fr); }
   .signals { grid-template-columns: 1fr; }
   .suggestions { grid-template-columns: 1fr; }
-  .charts { grid-template-columns: 1fr; }
-}
-@media (prefers-color-scheme: dark) {
-  body { background: #0b1220; color: #cbd5e1; }
-  h1, .stat-value, .section-heading { color: #f1f5f9; }
-  .subtitle, .section-intro, .stat-label, .chart-title { color: #94a3b8; }
-  .stats-row { border-color: #1e293b; }
-  .suggestion, .chart-card { background: #111827; border-color: #1e293b; }
-  .suggestion h3 { color: #f1f5f9; }
-  .suggestion p { color: #94a3b8; }
-  .bar-track { background: #1e293b; }
-  .bar-label, .bar-value { color: #cbd5e1; }
-  .signal-cheers { background: rgba(22,163,74,0.08); border-color: rgba(22,163,74,0.35); }
-  .signal-cheers h2, .signal-cheers li { color: #86efac; }
-  .signal-investigate { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.35); }
-  .signal-investigate h2, .signal-investigate li { color: #fca5a5; }
-  .trend-up { background: rgba(22,163,74,0.08); border-color: rgba(22,163,74,0.35); color: #86efac; }
-  .trend-down { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.35); color: #fca5a5; }
-  .trend-flat { background: #111827; border-color: #1e293b; color: #94a3b8; }
 }
 `;

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -234,7 +234,7 @@ function renderSignals(r: InsightsReport): string {
       ${
         r.cheers.length > 0
           ? `<div class="signal-card signal-cheers">
-        <h2>Worth Celebrating</h2>
+        <h2>What's Working</h2>
         <ul>${r.cheers.map((c) => `<li>${escapeHTML(c)}</li>`).join("")}</ul>
       </div>`
           : ""

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -106,12 +106,10 @@ function renderAtAGlance(r: InsightsReport): string {
 
 function renderScorecard(r: InsightsReport): string {
   if (r.current.totalResponses === 0) return "";
-  const answer = r.derived.answerRate ?? 0;
-  const conf =
-    r.current.totalWithResponse > 0 ? r.current.byConfidence.high / r.current.totalWithResponse : 0;
+  const conf = r.derived.highConfidenceRate ?? 0;
   const reactionTotal = r.current.reactions.totalPositive + r.current.reactions.totalNegative;
   const sentiment: number | null = reactionTotal > 0 ? r.current.reactions.positiveRate : null;
-  const signals = sentiment === null ? [answer, conf] : [answer, conf, sentiment];
+  const signals = sentiment === null ? [conf] : [conf, sentiment];
   const score = Math.round((signals.reduce((a, b) => a + b, 0) / signals.length) * 100);
   const grade = pickGrade(score);
 
@@ -123,8 +121,7 @@ function renderScorecard(r: InsightsReport): string {
         <div class="grade-score">${score} / 100</div>
       </div>
       <div class="scorecard-bars">
-        ${miniBar("Answer rate", answer, "answers reaching the user")}
-        ${miniBar("High-confidence", conf, "of answers Dosu was sure about")}
+        ${miniBar("High-confidence", conf, "of responses Dosu was sure about")}
         ${miniBar(
           "Sentiment",
           sentiment,
@@ -170,8 +167,11 @@ function pickGrade(score: number): { letter: string; label: string; tone: string
 }
 
 function renderStatsRow(r: InsightsReport): string {
-  const ar = r.derived.answerRate !== null ? `${(r.derived.answerRate * 100).toFixed(0)}%` : "—";
-  const arDelta = formatPctDelta(r.derived.answerRateDelta);
+  const hc =
+    r.derived.highConfidenceRate !== null
+      ? `${(r.derived.highConfidenceRate * 100).toFixed(0)}%`
+      : "—";
+  const hcDelta = formatPctDelta(r.derived.highConfidenceRateDelta);
   const pr =
     r.current.reactions.totalPositive + r.current.reactions.totalNegative > 0
       ? `${(r.current.reactions.positiveRate * 100).toFixed(0)}%`
@@ -200,9 +200,9 @@ function renderStatsRow(r: InsightsReport): string {
         ${respDelta}
       </div>
       <div class="stat">
-        <div class="stat-value">${ar}</div>
-        <div class="stat-label">Answer rate</div>
-        ${arDelta}
+        <div class="stat-value">${hc}</div>
+        <div class="stat-label">High-confidence</div>
+        ${hcDelta}
       </div>
       <div class="stat">
         <div class="stat-value">${pr}</div>
@@ -337,12 +337,11 @@ function renderComparison(r: InsightsReport): string {
   }
   const rows: Array<{ label: string; cur: string; prev: string; delta: string; tone: string }> = [
     rowResp("Responses", r.current.totalResponses, r.previous.totalResponses, true),
-    rowResp("Answers given", r.current.totalWithResponse, r.previous.totalWithResponse, true),
     rowPct(
-      "Answer rate",
-      r.derived.answerRate,
+      "High-confidence share",
+      r.derived.highConfidenceRate,
       r.previous.totalResponses > 0
-        ? r.previous.totalWithResponse / r.previous.totalResponses
+        ? r.previous.byConfidence.high / r.previous.totalResponses
         : null,
     ),
     rowResp("High-confidence", r.current.byConfidence.high, r.previous.byConfidence.high, true),
@@ -456,8 +455,8 @@ function pickFlair(r: InsightsReport): string {
   if (r.current.totalResponses >= 1000)
     return "🚀 You crossed 1,000 responses. That's a lot of help shipped.";
   if (r.current.totalResponses >= 100) return "🎉 Triple digits. Your team is on a roll.";
-  if (r.derived.answerRate !== null && r.derived.answerRate >= 0.95)
-    return "💯 Almost everything got answered. Chef's kiss.";
+  if (r.derived.highConfidenceRate !== null && r.derived.highConfidenceRate >= 0.9)
+    return "💯 Almost every response landed with high confidence. Chef's kiss.";
   return "👏 Keep the questions coming.";
 }
 

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -80,7 +80,10 @@ function renderHeadline(r: InsightsReport): string {
   const delta = r.derived.responsesDelta;
   const direction = delta > 0 ? "up" : delta < 0 ? "down" : "flat";
   const arrow = delta > 0 ? "▲" : delta < 0 ? "▼" : "→";
-  const pct = ` (${delta >= 0 ? "+" : ""}${Math.round((delta / r.previous.totalResponses) * 100)}%)`;
+  const pct =
+    r.previous.totalResponses > 0
+      ? ` (${delta >= 0 ? "+" : ""}${Math.round((delta / r.previous.totalResponses) * 100)}%)`
+      : "";
   const deltaText =
     delta === 0
       ? "no change vs the prior window"
@@ -107,8 +110,9 @@ function renderScorecard(r: InsightsReport): string {
   const conf =
     r.current.totalWithResponse > 0 ? r.current.byConfidence.high / r.current.totalWithResponse : 0;
   const reactionTotal = r.current.reactions.totalPositive + r.current.reactions.totalNegative;
-  const sentiment = reactionTotal > 0 ? r.current.reactions.positiveRate : 0.7; // neutral default
-  const score = Math.round(((answer + conf + sentiment) / 3) * 100);
+  const sentiment: number | null = reactionTotal > 0 ? r.current.reactions.positiveRate : null;
+  const signals = sentiment === null ? [answer, conf] : [answer, conf, sentiment];
+  const score = Math.round((signals.reduce((a, b) => a + b, 0) / signals.length) * 100);
   const grade = pickGrade(score);
 
   return `
@@ -124,13 +128,26 @@ function renderScorecard(r: InsightsReport): string {
         ${miniBar(
           "Sentiment",
           sentiment,
-          reactionTotal > 0 ? "of reactions were positive" : "no reactions yet — neutral default",
+          sentiment === null
+            ? "no reactions yet — excluded from grade"
+            : "of reactions were positive",
         )}
       </div>
     </section>`;
 }
 
-function miniBar(label: string, value: number, hint: string): string {
+function miniBar(label: string, value: number | null, hint: string): string {
+  if (value === null) {
+    return `
+        <div class="mini">
+          <div class="mini-row">
+            <span class="mini-label">${escapeHTML(label)}</span>
+            <span class="mini-value">—</span>
+          </div>
+          <div class="mini-track"><div class="mini-fill mini-ok" style="width:0%"></div></div>
+          <div class="mini-hint">${escapeHTML(hint)}</div>
+        </div>`;
+  }
   const v = Math.max(0, Math.min(1, value));
   const tone = v >= 0.8 ? "good" : v >= 0.6 ? "ok" : "low";
   return `

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -62,14 +62,8 @@ function pickGreeting(iso: string): string {
 
 function pickHeadlineLabel(count: number): string {
   if (count === 0) return "responses to come";
-  if (count === 1) return "response shipped";
-  // Deterministic but varied — picks based on count so the same window always renders the same word
-  const variants = [
-    "responses shipped",
-    "questions tackled",
-    "answers delivered",
-    "moments of help",
-  ];
+  if (count === 1) return "response logged";
+  const variants = ["responses logged", "questions handled", "threads fielded"];
   return variants[count % variants.length];
 }
 

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -13,6 +13,8 @@ export function renderHTML(report: InsightsReport): string {
   const safeName = escapeHTML(report.deploymentName);
   const generated = formatDate(report.generatedAt);
 
+  const greeting = pickGreeting(report.generatedAt);
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -24,9 +26,11 @@ export function renderHTML(report: InsightsReport): string {
 <body>
   <main class="container">
     <header class="hero">
-      <div class="brand">DOSU INSIGHTS</div>
+      <div class="brand">
+        <span class="prompt">❯</span> dosu insights<span class="cursor">▌</span>
+      </div>
       <h1>${safeName}</h1>
-      <p class="subtitle">Last ${report.windowDays} days · generated ${generated}</p>
+      <p class="subtitle">${greeting} · last ${report.windowDays} days · generated ${generated}</p>
     </header>
 
     ${renderHeadline(report)}
@@ -43,10 +47,36 @@ export function renderHTML(report: InsightsReport): string {
     <footer class="fun-ending">
       <div class="fun-headline">${pickFlair(report)}</div>
       <div class="fun-detail">Run <code>dosu insights</code> any time to see what's new. ✨</div>
+      <div class="fun-path">~/.config/dosu-cli/insights/report.html</div>
     </footer>
   </main>
 </body>
 </html>`;
+}
+
+function pickGreeting(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "Snapshot";
+  const hour = d.getHours();
+  const day = d.toLocaleDateString("en-US", { weekday: "long" });
+  if (hour < 5) return `Late ${day} night`;
+  if (hour < 12) return `${day} morning`;
+  if (hour < 17) return `${day} afternoon`;
+  if (hour < 21) return `${day} evening`;
+  return `${day} night`;
+}
+
+function pickHeadlineLabel(count: number): string {
+  if (count === 0) return "responses to come";
+  if (count === 1) return "response shipped";
+  // Deterministic but varied — picks based on count so the same window always renders the same word
+  const variants = [
+    "responses shipped",
+    "questions tackled",
+    "answers delivered",
+    "moments of help",
+  ];
+  return variants[count % variants.length];
 }
 
 function renderHeadline(r: InsightsReport): string {
@@ -65,7 +95,7 @@ function renderHeadline(r: InsightsReport): string {
   return `
     <section class="headline">
       <div class="headline-number">${cur.toLocaleString("en-US")}</div>
-      <div class="headline-label">responses answered</div>
+      <div class="headline-label">${pickHeadlineLabel(cur)}</div>
       <div class="headline-delta delta-${direction}">${deltaText}</div>
     </section>`;
 }
@@ -203,7 +233,7 @@ function renderSuggestions(r: InsightsReport): string {
   if (r.suggestions.length === 0) return "";
   return `
     <section>
-      <h2 class="section-heading">Suggested Next Steps</h2>
+      <h2 class="section-heading"><span class="section-icon">🎯</span> Suggested Next Steps</h2>
       <p class="section-intro">Based on this window's activity. The fastest wins first.</p>
       <div class="suggestions">
         ${r.suggestions.map(renderSuggestionCard).join("")}
@@ -213,7 +243,7 @@ function renderSuggestions(r: InsightsReport): string {
 
 function renderSuggestionCard(s: Suggestion): string {
   const cmd = s.command
-    ? `<div class="suggestion-cta"><code>$ ${escapeHTML(s.command)}</code></div>`
+    ? `<div class="suggestion-cta"><code><span class="cta-prompt">❯</span> ${escapeHTML(s.command)}</code></div>`
     : "";
   return `
     <article class="suggestion">
@@ -231,7 +261,7 @@ function renderConfidenceBar(stats: UsageStats): string {
   const low = (stats.byConfidence.low / total) * 100;
   return `
     <section>
-      <h2 class="section-heading">Confidence Breakdown</h2>
+      <h2 class="section-heading"><span class="section-icon">📊</span> Confidence Breakdown</h2>
       <p class="section-intro">How sure Dosu was about each answer.</p>
       <div class="stacked-bar-card">
         <div class="stacked-bar">
@@ -253,7 +283,7 @@ function renderReactions(stats: UsageStats): string {
   if (total === 0) {
     return `
     <section>
-      <h2 class="section-heading">Reactions</h2>
+      <h2 class="section-heading"><span class="section-icon">💬</span> Reactions</h2>
       <div class="empty-card">No reactions logged yet — encourage your team to thumbs-up the answers that helped.</div>
     </section>`;
   }
@@ -261,7 +291,7 @@ function renderReactions(stats: UsageStats): string {
   const neg = (stats.reactions.totalNegative / total) * 100;
   return `
     <section>
-      <h2 class="section-heading">Reactions</h2>
+      <h2 class="section-heading"><span class="section-icon">💬</span> Reactions</h2>
       <p class="section-intro">${total} reactions across ${stats.reactions.messagesWithReactions} messages.</p>
       <div class="stacked-bar-card">
         <div class="stacked-bar">
@@ -304,7 +334,7 @@ function renderComparison(r: InsightsReport): string {
   ];
   return `
     <section>
-      <h2 class="section-heading">Period Comparison</h2>
+      <h2 class="section-heading"><span class="section-icon">📋</span> Period Comparison</h2>
       <p class="section-intro">This window vs the prior ${r.windowDays} days.</p>
       <div class="compare-card">
         <table class="compare-table">
@@ -438,7 +468,9 @@ const CSS = `
 * { box-sizing: border-box; margin: 0; padding: 0; }
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
-  background: #f8fafc;
+  background:
+    radial-gradient(ellipse 900px 360px at 50% -120px, rgba(251, 191, 36, 0.18), transparent 70%),
+    #f8fafc;
   color: #334155;
   line-height: 1.6;
   padding: 56px 24px 80px;
@@ -449,15 +481,35 @@ body {
 /* Hero */
 .hero { margin-bottom: 28px; }
 .brand {
-  font-size: 11px;
-  letter-spacing: 0.18em;
-  color: #b45309;
-  font-weight: 700;
-  margin-bottom: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  color: #92400e;
+  font-weight: 600;
+  margin-bottom: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
+.brand .prompt { color: #f59e0b; font-weight: 700; }
+.brand .cursor {
+  display: inline-block;
+  margin-left: 2px;
+  color: #f59e0b;
+  animation: blink 1.1s steps(2) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
 h1 { font-size: 32px; font-weight: 700; color: #0f172a; margin-bottom: 4px; letter-spacing: -0.01em; }
 .subtitle { color: #64748b; font-size: 14px; }
-.section-heading { font-size: 18px; font-weight: 600; color: #0f172a; margin-bottom: 4px; }
+.section-heading {
+  font-size: 18px;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.section-icon { font-size: 18px; }
 .section-intro { color: #64748b; font-size: 13px; margin-bottom: 16px; }
 section { margin-top: 36px; }
 
@@ -628,6 +680,12 @@ section { margin-top: 36px; }
   flex-direction: column;
   gap: 10px;
   box-shadow: 0 1px 3px rgba(15,23,42,0.04);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.suggestion:hover {
+  transform: translateY(-2px);
+  border-color: #fcd34d;
+  box-shadow: 0 6px 18px rgba(245, 158, 11, 0.12);
 }
 .suggestion h3 { font-size: 15px; font-weight: 600; color: #0f172a; }
 .suggestion p { font-size: 13px; color: #475569; line-height: 1.55; flex: 1; }
@@ -641,6 +699,7 @@ section { margin-top: 36px; }
   padding: 6px 12px;
   border-radius: 6px;
 }
+.cta-prompt { color: #fbbf24; font-weight: 700; margin-right: 4px; }
 
 /* Stacked bars (confidence + reactions) */
 .stacked-bar-card {
@@ -649,6 +708,12 @@ section { margin-top: 36px; }
   border-radius: 12px;
   padding: 22px;
   box-shadow: 0 1px 3px rgba(15,23,42,0.04);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.stacked-bar-card:hover {
+  transform: translateY(-2px);
+  border-color: #fcd34d;
+  box-shadow: 0 6px 18px rgba(245, 158, 11, 0.12);
 }
 .stacked-bar {
   display: flex;
@@ -693,6 +758,12 @@ section { margin-top: 36px; }
   padding: 8px 4px;
   box-shadow: 0 1px 3px rgba(15,23,42,0.04);
   overflow-x: auto;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.compare-card:hover {
+  transform: translateY(-2px);
+  border-color: #fcd34d;
+  box-shadow: 0 6px 18px rgba(245, 158, 11, 0.12);
 }
 .compare-table {
   width: 100%;
@@ -753,6 +824,34 @@ section { margin-top: 36px; }
   border-radius: 4px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 13px;
+}
+.fun-path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: #b45309;
+  margin-top: 14px;
+  opacity: 0.7;
+}
+.headline {
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.headline:hover {
+  border-color: #fcd34d;
+  box-shadow: 0 6px 18px rgba(245, 158, 11, 0.12);
+}
+.scorecard {
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.scorecard:hover {
+  border-color: #fcd34d;
+  box-shadow: 0 6px 18px rgba(245, 158, 11, 0.12);
+}
+@media (prefers-reduced-motion: reduce) {
+  .brand .cursor { animation: none; }
+  .suggestion, .stacked-bar-card, .compare-card, .headline, .scorecard {
+    transition: none;
+  }
+  .suggestion:hover, .stacked-bar-card:hover, .compare-card:hover { transform: none; }
 }
 
 /* Responsive */

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -2,11 +2,12 @@
  * Render an InsightsReport as a self-contained HTML file.
  *
  * Embeds all CSS inline so the file is portable. No external assets, no JS.
- * Visually inspired by Claude Code's `/insights` report but only renders
- * sections we can populate with real data.
+ * Visually inspired by Claude Code's `/insights` report — gradient panels,
+ * card-based content, color-coded deltas, and an action-oriented suggestions
+ * grid that calls out the exact `dosu` commands to run next.
  */
 
-import type { InsightsReport, UsageStats } from "./insights";
+import type { InsightsReport, Suggestion, UsageStats } from "./insights";
 
 export function renderHTML(report: InsightsReport): string {
   const safeName = escapeHTML(report.deploymentName);
@@ -30,10 +31,9 @@ export function renderHTML(report: InsightsReport): string {
 
     ${renderAtAGlance(report)}
     ${renderStatsRow(report)}
-    ${renderCheers(report)}
-    ${renderCharts(report.current)}
-    ${renderTopics(report)}
+    ${renderSignals(report)}
     ${renderSuggestions(report)}
+    ${renderCharts(report.current)}
     ${renderTrend(report)}
 
     <footer class="fun-ending">
@@ -46,42 +46,38 @@ export function renderHTML(report: InsightsReport): string {
 }
 
 function renderAtAGlance(r: InsightsReport): string {
-  const text = r.narratives.atAGlance ?? fallbackAtAGlance(r);
   return `
     <section class="at-a-glance">
       <div class="glance-title">At a Glance</div>
-      <p>${escapeHTML(text)}</p>
+      <p>${escapeHTML(r.atAGlance)}</p>
     </section>`;
 }
 
 function renderStatsRow(r: InsightsReport): string {
   const ar = r.derived.answerRate !== null ? `${(r.derived.answerRate * 100).toFixed(0)}%` : "—";
-  const arDelta = formatDelta(r.derived.answerRateDelta, true);
+  const arDelta = formatPctDelta(r.derived.answerRateDelta);
   const pr =
     r.current.reactions.totalPositive + r.current.reactions.totalNegative > 0
       ? `${(r.current.reactions.positiveRate * 100).toFixed(0)}%`
       : "—";
-  const prDelta = formatDelta(r.derived.positiveRateDelta, true);
-  const respDelta = formatDelta(
-    r.derived.responsesDelta / Math.max(1, r.previous.totalResponses),
-    true,
-  );
+  const prDelta = formatPctDelta(r.derived.positiveRateDelta);
+  const respDelta = formatCountDelta(r.derived.responsesDelta);
   return `
     <section class="stats-row">
       <div class="stat">
         <div class="stat-value">${r.current.totalResponses}</div>
         <div class="stat-label">Responses</div>
-        <div class="stat-delta">${respDelta}</div>
+        ${respDelta}
       </div>
       <div class="stat">
         <div class="stat-value">${ar}</div>
         <div class="stat-label">Answer rate</div>
-        <div class="stat-delta">${arDelta}</div>
+        ${arDelta}
       </div>
       <div class="stat">
         <div class="stat-value">${pr}</div>
         <div class="stat-label">Positive feedback</div>
-        <div class="stat-delta">${prDelta}</div>
+        ${prDelta}
       </div>
       <div class="stat">
         <div class="stat-value">${r.windowDays}</div>
@@ -91,13 +87,51 @@ function renderStatsRow(r: InsightsReport): string {
     </section>`;
 }
 
-function renderCheers(r: InsightsReport): string {
-  const items = r.cheers.map((c) => `<li>${escapeHTML(c)}</li>`).join("");
+function renderSignals(r: InsightsReport): string {
+  if (r.cheers.length === 0 && r.investigate.length === 0) return "";
+  return `
+    <section class="signals">
+      ${
+        r.cheers.length > 0
+          ? `<div class="signal-card signal-cheers">
+        <h2><span class="signal-icon">✨</span> Worth Celebrating</h2>
+        <ul>${r.cheers.map((c) => `<li>${escapeHTML(c)}</li>`).join("")}</ul>
+      </div>`
+          : ""
+      }
+      ${
+        r.investigate.length > 0
+          ? `<div class="signal-card signal-investigate">
+        <h2><span class="signal-icon">🔎</span> Things to Investigate</h2>
+        <ul>${r.investigate.map((c) => `<li>${escapeHTML(c)}</li>`).join("")}</ul>
+      </div>`
+          : ""
+      }
+    </section>`;
+}
+
+function renderSuggestions(r: InsightsReport): string {
+  if (r.suggestions.length === 0) return "";
   return `
     <section>
-      <h2>Worth Celebrating</h2>
-      <ul class="cheers">${items}</ul>
+      <h2 class="section-heading">Suggested Next Steps</h2>
+      <p class="section-intro">Based on this window's activity. The fastest wins first.</p>
+      <div class="suggestions">
+        ${r.suggestions.map(renderSuggestionCard).join("")}
+      </div>
     </section>`;
+}
+
+function renderSuggestionCard(s: Suggestion): string {
+  const cmd = s.command
+    ? `<div class="suggestion-cta"><code>$ ${escapeHTML(s.command)}</code></div>`
+    : "";
+  return `
+    <article class="suggestion">
+      <h3>${escapeHTML(s.headline)}</h3>
+      <p>${escapeHTML(s.detail)}</p>
+      ${cmd}
+    </article>`;
 }
 
 function renderCharts(stats: UsageStats): string {
@@ -121,33 +155,6 @@ function renderCharts(stats: UsageStats): string {
     </section>`;
 }
 
-function renderTopics(r: InsightsReport): string {
-  const text =
-    r.narratives.topics ??
-    "Not enough signal yet to summarize topics — try again after more questions roll in.";
-  return `
-    <section>
-      <h2>What People Are Asking About</h2>
-      <div class="narrative">${escapeHTML(text)}</div>
-    </section>`;
-}
-
-function renderSuggestions(r: InsightsReport): string {
-  if (!r.narratives.suggestions) {
-    return `
-    <section>
-      <h2>Suggested Next Steps</h2>
-      <div class="narrative muted">No suggestions this round — Dosu was too busy answering questions. 😄</div>
-    </section>`;
-  }
-  // Render as preformatted-ish so numbered lists keep their shape; still escaped.
-  return `
-    <section>
-      <h2>Suggested Next Steps</h2>
-      <div class="narrative suggestions">${escapeHTML(r.narratives.suggestions)}</div>
-    </section>`;
-}
-
 function renderTrend(r: InsightsReport): string {
   const cur = r.current.totalResponses;
   const prev = r.previous.totalResponses;
@@ -156,21 +163,12 @@ function renderTrend(r: InsightsReport): string {
   const arrow = delta > 0 ? "↑" : delta < 0 ? "↓" : "→";
   return `
     <section>
-      <h2>Trend</h2>
       <div class="trend trend-${dir}">
         <span class="trend-arrow">${arrow}</span>
         <span><strong>${cur}</strong> responses this window vs <strong>${prev}</strong> the prior ${r.windowDays} days
         (${delta >= 0 ? "+" : ""}${delta}).</span>
       </div>
     </section>`;
-}
-
-function fallbackAtAGlance(r: InsightsReport): string {
-  if (r.current.totalResponses === 0) {
-    return `Your deployment is brand new and ready to go. The next ${r.windowDays} days will give us something to talk about — let's see what your team asks first.`;
-  }
-  const ar = r.derived.answerRate !== null ? `${(r.derived.answerRate * 100).toFixed(0)}%` : "—";
-  return `In the last ${r.windowDays} days you logged ${r.current.totalResponses} responses with a ${ar} answer rate. Keep the questions coming — every one teaches Dosu more about your team.`;
 }
 
 function pickFlair(r: InsightsReport): string {
@@ -197,14 +195,18 @@ function barChart(rows: Array<[string, number, string]>): string {
     .join("");
 }
 
-function formatDelta(delta: number | null, asPercent: boolean): string {
-  if (delta === null || !Number.isFinite(delta)) return "&nbsp;";
-  if (Math.abs(delta) < 0.005 && asPercent) return "no change";
-  if (asPercent) {
-    const pct = (delta * 100).toFixed(0);
-    return delta > 0 ? `▲ ${pct} pts` : `▼ ${Math.abs(Number(pct))} pts`;
-  }
-  return delta > 0 ? `▲ ${delta}` : `▼ ${Math.abs(delta)}`;
+function formatPctDelta(delta: number | null): string {
+  if (delta === null || !Number.isFinite(delta)) return `<div class="stat-delta">&nbsp;</div>`;
+  if (Math.abs(delta) < 0.005) return `<div class="stat-delta delta-flat">no change</div>`;
+  const pct = Math.round(Math.abs(delta * 100));
+  if (delta > 0) return `<div class="stat-delta delta-up">▲ ${pct} pts</div>`;
+  return `<div class="stat-delta delta-down">▼ ${pct} pts</div>`;
+}
+
+function formatCountDelta(delta: number): string {
+  if (delta === 0) return `<div class="stat-delta delta-flat">no change</div>`;
+  if (delta > 0) return `<div class="stat-delta delta-up">▲ ${delta}</div>`;
+  return `<div class="stat-delta delta-down">▼ ${Math.abs(delta)}</div>`;
 }
 
 function formatDate(iso: string): string {
@@ -227,41 +229,235 @@ function escapeHTML(s: string): string {
 
 const CSS = `
 * { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif; background: #f8fafc; color: #334155; line-height: 1.6; padding: 48px 24px; }
-.container { max-width: 820px; margin: 0 auto; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+  background: #f8fafc;
+  color: #334155;
+  line-height: 1.6;
+  padding: 56px 24px;
+  -webkit-font-smoothing: antialiased;
+}
+.container { max-width: 880px; margin: 0 auto; }
+
+/* Hero */
 .hero { margin-bottom: 32px; }
-.brand { font-size: 11px; letter-spacing: 0.18em; color: #b45309; font-weight: 700; margin-bottom: 8px; }
-h1 { font-size: 32px; font-weight: 700; color: #0f172a; margin-bottom: 4px; }
-h2 { font-size: 18px; font-weight: 600; color: #0f172a; margin-top: 40px; margin-bottom: 12px; }
+.brand {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: #b45309;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+h1 { font-size: 30px; font-weight: 700; color: #0f172a; margin-bottom: 4px; }
 .subtitle { color: #64748b; font-size: 14px; }
-.at-a-glance { background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 1px solid #f59e0b; border-radius: 12px; padding: 20px 24px; margin-top: 32px; }
-.glance-title { font-size: 11px; letter-spacing: 0.18em; font-weight: 700; color: #92400e; margin-bottom: 10px; }
+.section-heading { font-size: 18px; font-weight: 600; color: #0f172a; margin-bottom: 4px; }
+.section-intro { color: #64748b; font-size: 13px; margin-bottom: 16px; }
+
+/* At-a-glance */
+.at-a-glance {
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  border: 1px solid #f59e0b;
+  border-radius: 12px;
+  padding: 22px 26px;
+  margin-top: 8px;
+}
+.glance-title {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  color: #92400e;
+  margin-bottom: 10px;
+}
 .at-a-glance p { color: #78350f; font-size: 15px; line-height: 1.7; }
-.stats-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin: 24px 0 8px; padding: 20px 0; border-top: 1px solid #e2e8f0; border-bottom: 1px solid #e2e8f0; }
+
+/* Stats row */
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin: 32px 0 8px;
+  padding: 20px 0;
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 1px solid #e2e8f0;
+}
 .stat { text-align: center; }
-.stat-value { font-size: 26px; font-weight: 700; color: #0f172a; }
-.stat-label { font-size: 11px; color: #64748b; text-transform: uppercase; letter-spacing: 0.06em; margin-top: 2px; }
-.stat-delta { font-size: 11px; color: #64748b; margin-top: 4px; }
-.cheers { list-style: none; display: grid; gap: 8px; }
-.cheers li { background: #f0fdf4; border: 1px solid #bbf7d0; color: #166534; border-radius: 8px; padding: 12px 16px; font-size: 14px; }
-.charts { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-.chart-card { background: white; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; }
-.chart-title { font-size: 11px; font-weight: 600; color: #64748b; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px; }
-.bar-row { display: flex; align-items: center; margin-bottom: 6px; }
-.bar-label { width: 70px; font-size: 12px; color: #475569; }
-.bar-track { flex: 1; height: 6px; background: #f1f5f9; border-radius: 3px; margin: 0 8px; }
-.bar-fill { height: 100%; border-radius: 3px; }
-.bar-value { width: 36px; font-size: 12px; font-weight: 500; color: #475569; text-align: right; }
-.narrative { background: white; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px 20px; font-size: 14px; line-height: 1.7; color: #475569; white-space: pre-wrap; }
-.narrative.muted { color: #94a3b8; }
-.suggestions { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif; }
-.trend { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 8px; padding: 12px 16px; font-size: 14px; color: #1e40af; display: flex; align-items: center; gap: 12px; }
+.stat-value { font-size: 26px; font-weight: 700; color: #0f172a; line-height: 1.1; }
+.stat-label {
+  font-size: 11px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-top: 6px;
+}
+.stat-delta { font-size: 11px; color: #64748b; margin-top: 6px; font-weight: 500; }
+.delta-up { color: #16a34a; }
+.delta-down { color: #dc2626; }
+.delta-flat { color: #94a3b8; }
+
+/* Signals (cheers + investigate side-by-side) */
+.signals {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 32px;
+}
+.signals:has(.signal-card:only-child) { grid-template-columns: 1fr; }
+.signal-card {
+  border-radius: 10px;
+  padding: 18px 20px;
+  border: 1px solid;
+}
+.signal-card h2 {
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.signal-icon { font-size: 16px; }
+.signal-card ul { list-style: none; display: flex; flex-direction: column; gap: 8px; }
+.signal-card li {
+  font-size: 14px;
+  line-height: 1.55;
+  padding-left: 16px;
+  position: relative;
+}
+.signal-card li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  font-weight: 700;
+  opacity: 0.6;
+}
+.signal-cheers {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+.signal-cheers h2, .signal-cheers li { color: #166534; }
+.signal-investigate {
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+.signal-investigate h2, .signal-investigate li { color: #991b1b; }
+
+/* Suggestions */
+section { margin-top: 36px; }
+.suggestions {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+.suggestion {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.suggestion h3 { font-size: 15px; font-weight: 600; color: #0f172a; }
+.suggestion p { font-size: 13px; color: #475569; line-height: 1.55; flex: 1; }
+.suggestion-cta { margin-top: 4px; }
+.suggestion-cta code {
+  display: inline-block;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  letter-spacing: 0.01em;
+}
+
+/* Charts */
+.charts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.chart-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 18px;
+}
+.chart-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 12px;
+}
+.bar-row { display: flex; align-items: center; margin-bottom: 8px; }
+.bar-row:last-child { margin-bottom: 0; }
+.bar-label { width: 80px; font-size: 12px; color: #475569; }
+.bar-track { flex: 1; height: 8px; background: #f1f5f9; border-radius: 4px; margin: 0 10px; }
+.bar-fill { height: 100%; border-radius: 4px; transition: width 0.3s ease; }
+.bar-value { width: 36px; font-size: 12px; font-weight: 600; color: #475569; text-align: right; }
+
+/* Trend */
+.trend {
+  border-radius: 10px;
+  padding: 14px 18px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 1px solid;
+}
 .trend-up { background: #f0fdf4; border-color: #bbf7d0; color: #166534; }
 .trend-down { background: #fef2f2; border-color: #fecaca; color: #991b1b; }
-.trend-arrow { font-size: 18px; font-weight: 700; }
-.fun-ending { background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 1px solid #fbbf24; border-radius: 12px; padding: 24px; margin-top: 40px; text-align: center; }
+.trend-flat { background: #f1f5f9; border-color: #cbd5e1; color: #475569; }
+.trend-arrow { font-size: 22px; font-weight: 700; line-height: 1; }
+
+/* Fun ending */
+.fun-ending {
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  border: 1px solid #fbbf24;
+  border-radius: 12px;
+  padding: 26px;
+  margin-top: 40px;
+  text-align: center;
+}
 .fun-headline { font-size: 18px; font-weight: 600; color: #78350f; margin-bottom: 6px; }
 .fun-detail { font-size: 14px; color: #92400e; }
-.fun-detail code { background: rgba(255,255,255,0.7); padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, monospace; font-size: 13px; }
-@media (max-width: 640px) { .stats-row { grid-template-columns: repeat(2, 1fr); } .charts { grid-template-columns: 1fr; } }
+.fun-detail code {
+  background: rgba(255,255,255,0.7);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+}
+
+/* Responsive */
+@media (max-width: 720px) {
+  body { padding: 32px 16px; }
+  .stats-row { grid-template-columns: repeat(2, 1fr); }
+  .signals { grid-template-columns: 1fr; }
+  .suggestions { grid-template-columns: 1fr; }
+  .charts { grid-template-columns: 1fr; }
+}
+@media (prefers-color-scheme: dark) {
+  body { background: #0b1220; color: #cbd5e1; }
+  h1, .stat-value, .section-heading { color: #f1f5f9; }
+  .subtitle, .section-intro, .stat-label, .chart-title { color: #94a3b8; }
+  .stats-row { border-color: #1e293b; }
+  .suggestion, .chart-card { background: #111827; border-color: #1e293b; }
+  .suggestion h3 { color: #f1f5f9; }
+  .suggestion p { color: #94a3b8; }
+  .bar-track { background: #1e293b; }
+  .bar-label, .bar-value { color: #cbd5e1; }
+  .signal-cheers { background: rgba(22,163,74,0.08); border-color: rgba(22,163,74,0.35); }
+  .signal-cheers h2, .signal-cheers li { color: #86efac; }
+  .signal-investigate { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.35); }
+  .signal-investigate h2, .signal-investigate li { color: #fca5a5; }
+  .trend-up { background: rgba(22,163,74,0.08); border-color: rgba(22,163,74,0.35); color: #86efac; }
+  .trend-down { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.35); color: #fca5a5; }
+  .trend-flat { background: #111827; border-color: #1e293b; color: #94a3b8; }
+}
 `;

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -4,7 +4,7 @@
 import type { InsightsReport, Suggestion, UsageStats } from "./insights";
 
 export function renderHTML(report: InsightsReport): string {
-  const safeName = escapeHTML(report.deploymentName);
+  const safeName = escapeHTML(report.spaceName);
   const generated = formatDate(report.generatedAt);
 
   const greeting = pickGreeting(report.generatedAt);

--- a/src/insights/render-html.ts
+++ b/src/insights/render-html.ts
@@ -13,7 +13,7 @@ export function renderHTML(report: InsightsReport): string {
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Dosu Insights — ${safeName}</title>
+<title>Dosu Insights · ${safeName}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>${CSS}</style>
 </head>
@@ -126,7 +126,7 @@ function renderScorecard(r: InsightsReport): string {
           "Sentiment",
           sentiment,
           sentiment === null
-            ? "no reactions yet — excluded from grade"
+            ? "no reactions yet, excluded from grade"
             : "of reactions were positive",
         )}
       </div>
@@ -139,7 +139,7 @@ function miniBar(label: string, value: number | null, hint: string): string {
         <div class="mini">
           <div class="mini-row">
             <span class="mini-label">${escapeHTML(label)}</span>
-            <span class="mini-value">—</span>
+            <span class="mini-value">n/a</span>
           </div>
           <div class="mini-track"><div class="mini-fill mini-ok" style="width:0%"></div></div>
           <div class="mini-hint">${escapeHTML(hint)}</div>
@@ -170,24 +170,24 @@ function renderStatsRow(r: InsightsReport): string {
   const hc =
     r.derived.highConfidenceRate !== null
       ? `${(r.derived.highConfidenceRate * 100).toFixed(0)}%`
-      : "—";
+      : "n/a";
   const hcDelta = formatPctDelta(r.derived.highConfidenceRateDelta);
   const pr =
     r.current.reactions.totalPositive + r.current.reactions.totalNegative > 0
       ? `${(r.current.reactions.positiveRate * 100).toFixed(0)}%`
-      : "—";
+      : "n/a";
   const prDelta = formatPctDelta(r.derived.positiveRateDelta);
   const respDelta = r.derived.hasPriorWindow
     ? formatCountDelta(r.derived.responsesDelta)
     : `<div class="stat-delta">&nbsp;</div>`;
   const perDay = r.current.totalResponses > 0 ? r.current.totalResponses / r.windowDays : 0;
   const perDayLabel = !r.derived.hasPriorWindow
-    ? "—"
+    ? "n/a"
     : perDay >= 1
       ? perDay.toFixed(1)
       : perDay > 0
         ? perDay.toFixed(2)
-        : "—";
+        : "n/a";
   const perDayHint = r.derived.hasPriorWindow
     ? `avg over ${r.windowDays} days`
     : `needs ${r.windowDays}d of history`;
@@ -305,7 +305,7 @@ function renderReactions(stats: UsageStats): string {
     return `
     <section>
       <h2 class="section-heading">Reactions</h2>
-      <div class="empty-card">No reactions logged yet — encourage your team to thumbs-up the answers that helped.</div>
+      <div class="empty-card">No reactions logged yet. Encourage your team to thumbs-up the answers that helped.</div>
     </section>`;
   }
   const pos = (stats.reactions.totalPositive / total) * 100;
@@ -332,7 +332,7 @@ function renderComparison(r: InsightsReport): string {
     return `
     <section>
       <h2 class="section-heading">Period Comparison</h2>
-      <div class="empty-card">Not enough history yet — check back after ${r.windowDays} more days for a prior-window comparison.</div>
+      <div class="empty-card">Not enough history yet. Check back after ${r.windowDays} more days for a prior-window comparison.</div>
     </section>`;
   }
   const rows: Array<{ label: string; cur: string; prev: string; delta: string; tone: string }> = [
@@ -415,10 +415,10 @@ function rowPct(
   cur: number | null,
   prev: number | null,
 ): { label: string; cur: string; prev: string; delta: string; tone: string } {
-  const curStr = cur !== null ? `${(cur * 100).toFixed(0)}%` : "—";
-  const prevStr = prev !== null ? `${(prev * 100).toFixed(0)}%` : "—";
+  const curStr = cur !== null ? `${(cur * 100).toFixed(0)}%` : "n/a";
+  const prevStr = prev !== null ? `${(prev * 100).toFixed(0)}%` : "n/a";
   if (cur === null || prev === null)
-    return { label, cur: curStr, prev: prevStr, delta: "—", tone: "flat" };
+    return { label, cur: curStr, prev: prevStr, delta: "n/a", tone: "flat" };
   const d = cur - prev;
   if (Math.abs(d) < 0.005)
     return { label, cur: curStr, prev: prevStr, delta: "no change", tone: "flat" };

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -34,6 +34,10 @@ vi.mock("../setup/flow", () => ({
   runSetup: vi.fn(),
 }));
 
+vi.mock("../commands/insights", () => ({
+  executeInsights: vi.fn(),
+}));
+
 vi.mock("picocolors", () => ({
   default: {
     magenta: (s: string) => s,
@@ -48,6 +52,7 @@ vi.mock("picocolors", () => ({
 import * as p from "@clack/prompts";
 import { startOAuthFlow } from "../auth/flow";
 import { Client } from "../client/client";
+import { executeInsights } from "../commands/insights";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
 import { runSetup } from "../setup/flow";
@@ -59,6 +64,7 @@ const mockIsCancel = vi.mocked(p.isCancel);
 const mockOutro = vi.mocked(p.outro);
 const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
 const mockRunSetup = vi.mocked(runSetup);
+const mockExecuteInsights = vi.mocked(executeInsights);
 
 // ---------------------------------------------------------------------------
 // Temp directory setup — real config on disk
@@ -356,6 +362,43 @@ describe("runTUI", () => {
     expect(ondisk.expires_at).toBe(0);
     expect(ondisk.mode).toBeUndefined();
     expect(p.log.success).toHaveBeenCalledWith("Credentials cleared.");
+  });
+
+  it("includes 'View Insights' in the menu when fully configured", async () => {
+    writeRealConfig(
+      makeCfg({ access_token: "tok", space_id: "sp", deployment_id: "d", api_key: "k" }),
+    );
+    mockIsCancel.mockReturnValue(false);
+    mockSelect.mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    const opts = mockSelect.mock.calls[0]?.[0]?.options as Array<{ value: string }>;
+    expect(opts.map((o) => o.value)).toContain("insights");
+  });
+
+  it("omits 'View Insights' when the deployment isn't configured yet", async () => {
+    writeRealConfig(makeCfg({ access_token: "tok" }));
+    mockIsCancel.mockReturnValue(false);
+    mockSelect.mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    const opts = mockSelect.mock.calls[0]?.[0]?.options as Array<{ value: string }>;
+    expect(opts.map((o) => o.value)).not.toContain("insights");
+  });
+
+  it("calls executeInsights when 'insights' is selected", async () => {
+    writeRealConfig(
+      makeCfg({ access_token: "tok", space_id: "sp", deployment_id: "d", api_key: "k" }),
+    );
+    mockIsCancel.mockReturnValue(false);
+    mockExecuteInsights.mockResolvedValueOnce(undefined);
+    mockSelect.mockResolvedValueOnce("insights").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockExecuteInsights).toHaveBeenCalledTimes(1);
   });
 
   it("setup action calls runSetup and reloads config", async () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -41,7 +41,7 @@ export async function runTUI(): Promise<void> {
       options.push({
         label: "View Insights",
         value: "insights",
-        hint: "Open a fun report of your deployment's activity",
+        hint: "Open a fun report of your space's activity",
       });
     }
     options.push(

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -7,6 +7,7 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { Client } from "../client/client";
+import { executeInsights } from "../commands/insights";
 import { isAuthenticated, loadConfig, saveConfig } from "../config/config";
 import { runSetup } from "../setup/flow";
 
@@ -28,22 +29,34 @@ export async function runTUI(): Promise<void> {
 
   // Main menu
   while (true) {
+    const insightsReady = Boolean(cfg.space_id && cfg.deployment_id && cfg.api_key);
+    const options: Array<{ label: string; value: string; hint?: string }> = [
+      {
+        label: "Setup",
+        value: "setup",
+        hint: "Configure MCP for your AI tools",
+      },
+    ];
+    if (insightsReady) {
+      options.push({
+        label: "View Insights",
+        value: "insights",
+        hint: "Open a fun report of your deployment's activity",
+      });
+    }
+    options.push(
+      {
+        label: "Authenticate",
+        value: "auth",
+        hint: isAuthenticated(cfg) ? "Re-authenticate" : undefined,
+      },
+      { label: "Clear Credentials", value: "logout" },
+      { label: "Exit", value: "exit" },
+    );
+
     const action = await p.select({
       message: "What would you like to do?",
-      options: [
-        {
-          label: "Setup",
-          value: "setup",
-          hint: "Configure MCP for your AI tools",
-        },
-        {
-          label: "Authenticate",
-          value: "auth",
-          hint: isAuthenticated(cfg) ? "Re-authenticate" : undefined,
-        },
-        { label: "Clear Credentials", value: "logout" },
-        { label: "Exit", value: "exit" },
-      ],
+      options,
     });
 
     if (p.isCancel(action) || action === "exit") {
@@ -58,6 +71,9 @@ export async function runTUI(): Promise<void> {
         await runSetup();
         // Reload config after setup (it may have changed deployment, api_key, etc.)
         Object.assign(cfg, loadConfig());
+        break;
+      case "insights":
+        await executeInsights(cfg);
         break;
       case "logout":
         handleLogout(cfg);


### PR DESCRIPTION
Closes ENG-118

## Summary
- New `dosu insights` command. Generates a self-contained HTML report (scorecard, stats row, confidence breakdown, reactions, period comparison, LLM-written At-a-Glance, cheers/investigate signals, suggested next steps) and opens it in the browser. Writes both a timestamped snapshot and a stable `latest.html` in `~/.config/dosu-cli/insights/`, pruned to the 20 most recent.
- **Drop Answer Rate (the last commit):** the Apr 10 backend migration filtered usage-stats to `POST_SUCCESSFUL`/`PREVIEW_ONLY` rows, which made `totalWithResponse / totalResponses` ≈ 100% by construction. A tautology flagged and replaced (scorecard, stats row, comparison table, at-a-glance prompt, cheers/investigate, flair, `dosu analytics` output) with **High-Confidence Share** (`byConfidence.high / totalResponses`). Same shape, genuinely variable, ties the visible headline to a signal users can move.
- Handles new spaces (no prior window) without rendering misleading `vs prior` deltas; renders an A, B, C, or D letter grade scorecard; keeps prior report history across runs.
- **Review-round polish (most recent 5 commits):** drops unused `totalWithResponse` field; swaps "deployment" to "space" in user-facing copy; adds progress feedback for the 90s narrative call; hoists the `open` mock to avoid load-order races in tests; guards `readdirSync` in `pruneOldReports` against `ENOTDIR`/`EACCES`.

## Test plan
- [x] `bun run typecheck`: clean
- [x] `bun run test`: 828/828 passing
- [x] `bun run check`: Biome clean
- [x] Live render with realistic numbers (573 vs 319 responses, 72% high-confidence, 87% positive) verified: Grade A (80/100), zero occurrences of "Answer rate", High-confidence surfaces in scorecard/stats row/comparison table
- [x] Reviewer walkthrough: see the "What to eyeball in 5 minutes" comment below.
