### PR TITLE
fix: rename user-facing "tool" to "agent" and "deployment" to "MCP"

### DIFF
--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -195,8 +195,8 @@ describe("CLI actions", () => {
       await run("status");
 
       expect(logSpy).toHaveBeenCalledWith("Status: Logged in");
-      expect(logSpy).toHaveBeenCalledWith("Deployment: My App");
-      expect(logSpy).toHaveBeenCalledWith("Deployment ID: dep_123");
+      expect(logSpy).toHaveBeenCalledWith("MCP: My App");
+      expect(logSpy).toHaveBeenCalledWith("MCP ID: dep_123");
     });
 
     it("shows not-logged-in with empty config", async () => {
@@ -225,8 +225,8 @@ describe("CLI actions", () => {
 
       await run("status");
 
-      expect(logSpy).toHaveBeenCalledWith("Deployment: None selected");
-      expect(logSpy).toHaveBeenCalledWith("Run 'dosu' to open the TUI and select a deployment.");
+      expect(logSpy).toHaveBeenCalledWith("MCP: None selected");
+      expect(logSpy).toHaveBeenCalledWith("Run 'dosu' to open the TUI and select an MCP.");
     });
 
     it("shows OSS mode without requiring a deployment", async () => {
@@ -239,7 +239,7 @@ describe("CLI actions", () => {
       await run("status");
 
       expect(logSpy).toHaveBeenCalledWith("Mode: OSS");
-      expect(logSpy).toHaveBeenCalledWith("Deployment: Public libraries only");
+      expect(logSpy).toHaveBeenCalledWith("MCP: Public libraries only");
     });
   });
 
@@ -276,7 +276,7 @@ describe("CLI actions", () => {
         }
       }
 
-      expect(output).toContain("Use 'dosu mcp add <tool>' to add Dosu MCP to a tool.");
+      expect(output).toContain("Use 'dosu mcp add <agent>' to add Dosu MCP to a tool.");
     });
   });
 
@@ -327,7 +327,7 @@ describe("CLI actions", () => {
       cfg.deployment_id = undefined;
       saveConfig(cfg);
 
-      await expect(run("mcp", "add", "cursor")).rejects.toThrow("no deployment selected");
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow("no MCP selected");
     });
 
     it("supports OSS mode without a selected deployment", async () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -100,7 +100,7 @@ export function createProgram(): Command {
   // status
   program
     .command("status")
-    .description("Show current authentication and deployment status")
+    .description("Show current authentication and MCP status")
     .action(() => {
       const cfg = loadConfig();
       if (!isAuthenticated(cfg)) {
@@ -116,13 +116,13 @@ export function createProgram(): Command {
       }
       if (cfg.mode === MODE_OSS) {
         console.log("Mode: OSS");
-        console.log("Deployment: Public libraries only");
+        console.log("MCP: Public libraries only");
       } else if (cfg.deployment_id) {
-        console.log(`Deployment: ${cfg.deployment_name}`);
-        console.log(`Deployment ID: ${cfg.deployment_id}`);
+        console.log(`MCP: ${cfg.deployment_name}`);
+        console.log(`MCP ID: ${cfg.deployment_id}`);
       } else {
-        console.log("Deployment: None selected");
-        console.log("Run 'dosu' to open the TUI and select a deployment.");
+        console.log("MCP: None selected");
+        console.log("Run 'dosu' to open the TUI and select an MCP.");
       }
     });
 
@@ -130,7 +130,7 @@ export function createProgram(): Command {
   const mcp = program.command("mcp").description("Manage MCP server integrations");
 
   mcp
-    .command("add <tool>")
+    .command("add <agent>")
     .description("Add Dosu MCP to an AI tool")
     .option("-g, --global", "Add globally (all projects) instead of project-local", false)
     .action((toolId: string, opts: { global: boolean }) => {
@@ -150,7 +150,7 @@ export function createProgram(): Command {
       }
       if (cfg.mode !== MODE_OSS && !cfg.deployment_id) {
         throw new Error(
-          "no deployment selected. Run 'dosu' to open the TUI and select a deployment",
+          "no MCP selected. Run 'dosu' to open the TUI and select an MCP",
         );
       }
 
@@ -189,7 +189,7 @@ export function createProgram(): Command {
         if (p.id() === "manual") scope = "";
         console.log(`  ${p.id().padEnd(10)} ${p.name()} ${scope}`);
       }
-      console.log("\nUse 'dosu mcp add <tool>' to add Dosu MCP to a tool.");
+      console.log("\nUse 'dosu mcp add <agent>' to add Dosu MCP to a tool.");
     });
 
   // Agent-facing commands
@@ -212,7 +212,7 @@ export function createProgram(): Command {
   program
     .command("setup")
     .description("Set up Dosu MCP for your AI tools")
-    .option("--deployment <id>", "Skip to tool configuration for a specific deployment")
+    .option("--deployment <id>", "Skip to tool configuration for a specific MCP")
     .action(async (opts: { deployment?: string }) => {
       const { runSetup } = await import("../setup/flow");
       await runSetup({ deploymentID: opts.deployment });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -149,9 +149,7 @@ export function createProgram(): Command {
         throw new Error("session expired. Run 'dosu login' to re-authenticate");
       }
       if (cfg.mode !== MODE_OSS && !cfg.deployment_id) {
-        throw new Error(
-          "no MCP selected. Run 'dosu' to open the TUI and select an MCP",
-        );
+        throw new Error("no MCP selected. Run 'dosu' to open the TUI and select an MCP");
       }
 
       if (provider.id() === "manual") {

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -370,7 +370,7 @@ describe("stepShowSummary", () => {
 
     stepShowSummary(results);
 
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 tool"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Cursor"));
     expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("Try it out"));
   });
@@ -381,7 +381,7 @@ describe("stepShowSummary", () => {
 
     stepShowSummary(results);
 
-    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 tool"));
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 agent"));
     // No "Try it out" when only removals
     expect(p.log.message).not.toHaveBeenCalled();
   });
@@ -393,7 +393,7 @@ describe("stepShowSummary", () => {
     stepShowSummary(results);
 
     expect(p.log.success).toHaveBeenCalledWith(
-      expect.stringContaining("All tools already configured"),
+      expect.stringContaining("All agents already configured"),
     );
     // Skipped still gets the "Try it out" message
     expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("Try it out"));
@@ -409,8 +409,8 @@ describe("stepShowSummary", () => {
 
     stepShowSummary(results);
 
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 tool"));
-    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 tool"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 agent"));
   });
 
   it("does not count errored results in install summary", () => {
@@ -424,7 +424,7 @@ describe("stepShowSummary", () => {
     stepShowSummary(results);
 
     // Only 1 successful install
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 tool"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
   });
 
   it("does not show 'Try it out' when only removals and no skips", () => {
@@ -437,7 +437,7 @@ describe("stepShowSummary", () => {
 
     stepShowSummary(results);
 
-    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 2 tool"));
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 2 agent"));
     expect(p.log.message).not.toHaveBeenCalled();
   });
 
@@ -452,9 +452,9 @@ describe("stepShowSummary", () => {
     stepShowSummary(results);
 
     // Should show install summary, NOT "all configured"
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 tool"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
     expect(p.log.success).not.toHaveBeenCalledWith(
-      expect.stringContaining("All tools already configured"),
+      expect.stringContaining("All agents already configured"),
     );
     // Should still show "Try it out"
     expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("Try it out"));
@@ -538,7 +538,7 @@ describe("runSetup integration", () => {
 
     // Should warn about no tools
     expect(p.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("No supported AI tools detected"),
+      expect.stringContaining("No supported AI agents detected"),
     );
 
     // Config should have been saved with deployment info
@@ -572,7 +572,7 @@ describe("runSetup integration", () => {
     expect(cursorConfig.mcpServers.dosu.url).toContain("d1");
 
     // Verify summary was shown
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 tool"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
   });
 
   it("runs OAuth flow and saves tokens to real config", async () => {
@@ -854,7 +854,7 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No deployments found"));
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No MCPs found"));
   });
 
   it("handles deployment fetch error", async () => {
@@ -996,7 +996,7 @@ describe("runSetup integration", () => {
 
     await runSetup({ deploymentID: "nonexistent" });
 
-    expect(p.log.error).toHaveBeenCalledWith("Deployment nonexistent not found");
+    expect(p.log.error).toHaveBeenCalledWith("MCP nonexistent not found");
   });
 
   it("handles resolve deployment fetch error", async () => {
@@ -1100,7 +1100,7 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(p.log.error).toHaveBeenCalledWith("No deployment available for API key creation");
+    expect(p.log.error).toHaveBeenCalledWith("No MCP available for API key creation");
     const saved = loadConfig();
     expect(saved.deployment_id).toBeUndefined();
     expect(p.outro).not.toHaveBeenCalled();
@@ -1118,7 +1118,7 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(p.log.error).toHaveBeenCalledWith("No deployment available for API key creation");
+    expect(p.log.error).toHaveBeenCalledWith("No MCP available for API key creation");
     const saved = loadConfig();
     expect(saved.deployment_id).toBeUndefined();
     expect(p.outro).not.toHaveBeenCalled();
@@ -1244,7 +1244,7 @@ describe("runSetup integration", () => {
     const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
     expect(cursorConfig.mcpServers?.dosu).toBeDefined();
 
-    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 tool"));
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 agent"));
   });
 
   it("OSS mode stepShowSummary uses OSS-specific prompt", async () => {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -84,7 +84,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   const detected = stepDetectTools();
   if (detected.length === 0) {
     p.log.warn(
-      `No supported AI tools detected on your system.\nRun ${info("dosu mcp add <tool>")} to manually configure a tool.`,
+      `No supported AI agents detected on your system.\nRun ${info("dosu mcp add <agent>")} to manually configure an agent.`,
     );
     return;
   }
@@ -126,7 +126,7 @@ async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
             message: `Currently configured for ${modeLabel}. What would you like to do?`,
             options: [
               { label: "Reconfigure (opens browser)", value: "reconfigure" },
-              { label: "Keep current setup and update tools", value: "keep" },
+              { label: "Keep current setup and update agents", value: "keep" },
             ],
           });
           if (p.isCancel(action)) return null;
@@ -238,16 +238,16 @@ async function stepResolveDeployment(apiClient: Client, id: string): Promise<Dep
     const d = deployments.find((d) => d.deployment_id === id);
     if (!d) {
       logger.warn("setup", `Deployment ${id} not found`);
-      p.log.error(`Deployment ${id} not found`);
+      p.log.error(`MCP ${id} not found`);
       return null;
     }
     logger.info("setup", `Resolved deployment: ${d.name}`);
-    p.log.success(`Using deployment\n${dim(d.name)}`);
+    p.log.success(`Using MCP\n${dim(d.name)}`);
     return d;
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
     p.log.error(
-      `Failed to resolve deployment: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to resolve MCP: ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;
   }
@@ -259,12 +259,12 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
     const deployments = allDeployments.filter((d) => d.org_id === org.org_id);
 
     if (deployments.length === 0) {
-      p.log.error(`No deployments found for ${org.name}`);
+      p.log.error(`No MCPs found for ${org.name}`);
       return null;
     }
     if (deployments.length === 1) {
       logger.info("setup", `Selected deployment: ${deployments[0].name} (auto, only one)`);
-      p.log.success(`Using deployment\n${dim(deployments[0].name)}`);
+      p.log.success(`Using MCP\n${dim(deployments[0].name)}`);
       return deployments[0];
     }
     const selected = await p.select({
@@ -277,14 +277,14 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
     return d;
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
-    p.log.error(`Deployment selection failed: ${err instanceof Error ? err.message : String(err)}`);
+    p.log.error(`MCP selection failed: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }
 
 async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | null> {
   if (!cfg.deployment_id) {
-    p.log.error("No deployment available for API key creation");
+    p.log.error("No MCP available for API key creation");
     return null;
   }
 
@@ -338,7 +338,7 @@ async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection
   const preselected = detected.filter((p) => configuredMap.get(p.id())).map((p) => p.id());
 
   const selected = await p.multiselect({
-    message: "Select tools to configure or update",
+    message: "Select agents to configure or update",
     options,
     initialValues: preselected,
   });
@@ -412,18 +412,18 @@ export function stepShowSummary(results: ConfigResult[], mode?: SetupMode): void
     const lines = installed
       .map((r) => `+ ${r.provider.name()}\n  ${dim(r.provider.globalConfigPath())}`)
       .join("\n");
-    p.log.success(`Configured ${installed.length} tool(s):\n${lines}`);
+    p.log.success(`Configured ${installed.length} agent(s):\n${lines}`);
   }
 
   if (removed.length > 0) {
     const lines = removed
       .map((r) => `- ${r.provider.name()}\n  ${dim(r.provider.globalConfigPath())}`)
       .join("\n");
-    p.log.info(`Removed from ${removed.length} tool(s):\n${lines}`);
+    p.log.info(`Removed from ${removed.length} agent(s):\n${lines}`);
   }
 
   if (installed.length === 0 && removed.length === 0 && skipped.length > 0) {
-    p.log.success("All tools already configured. No changes needed.");
+    p.log.success("All agents already configured. No changes needed.");
   }
 
   if (installed.length > 0 || skipped.length > 0) {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -246,9 +246,7 @@ async function stepResolveDeployment(apiClient: Client, id: string): Promise<Dep
     return d;
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
-    p.log.error(
-      `Failed to resolve MCP: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    p.log.error(`Failed to resolve MCP: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Renames user-visible copy in the CLI status command, setup flow, and error messages to say "MCP" instead of "deployment".
- Renames "tool" to "agent" across setup summary text (e.g. "Configured 1 agent(s)", "Select agents to configure or update").
- Renames the `dosu mcp add <tool>` positional argument to `<agent>` to match.
- Internal identifiers (config fields like `deployment_id`, API paths like `/v1/mcp/deployments`, type names, function names) are unchanged. The `--deployment <id>` setup flag is preserved for CLI backwards-compatibility; only its description was updated.

## Test plan
- [x] `bun run test` passes (updated assertions in `cli-actions.test.ts` and `flow.test.ts`)
- [x] `dosu status` prints "MCP:" / "MCP ID:" instead of "Deployment:" / "Deployment ID:"
- [x] `dosu mcp add <agent>` help shows `<agent>` in usage
- [x] `dosu setup` interactive messages say "Using MCP" / "No MCPs found for ..." / "Select agents to configure or update"
- [x] `dosu setup --deployment <id>` flag still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)