### PR TITLE
feat(setup): CLI-led onboarding (auth, MCP, skill, GitHub, AGENTS.md) + alpha channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,16 @@
 # Dosu CLI — Personal overrides template
 # Copy to .env.development.local or .env.production.local
 
+# Build-time defaults (baked into the bundle):
 # DOSU_WEB_APP_URL=
 # DOSU_BACKEND_URL=
 # SUPABASE_URL=
 # SUPABASE_ANON_KEY=
 
+# Runtime overrides — read at every CLI invocation, take precedence over the
+# baked-in build-time values above. Useful for repointing a published
+# `@alpha` build at staging or local backends without rebuilding.
+# DOSU_WEB_APP_URL_OVERRIDE=
+# DOSU_BACKEND_URL_OVERRIDE=
+# SUPABASE_URL_OVERRIDE=
+# SUPABASE_ANON_KEY_OVERRIDE=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, alpha]
   push:
-    branches: [main]
+    branches: [main, alpha]
 
 jobs:
   lint:
@@ -130,7 +130,7 @@ jobs:
       - test
       - build
       - windows-npm-smoke
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/alpha')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,60 @@ This project uses [semantic-release](https://github.com/semantic-release/semanti
 
 Scopes are optional: `fix(config): handle empty file without crash`
 
+## Release Channels
+
+semantic-release publishes on every push to a release branch. Two channels are configured (`release.config.js`):
+
+| Branch | npm dist-tag | Version shape | Install with |
+|---|---|---|---|
+| `main` | `latest` | `0.11.0` | `npx @dosu/cli setup` |
+| `alpha` | `alpha` | `0.11.0-alpha.1` | `npx @dosu/cli@alpha setup` |
+
+The `alpha` channel is for **internal pre-release / dogfooding**. Workflow:
+
+```bash
+# Cut an alpha branch off main when you want internal testers to try a feature.
+git checkout -b alpha
+git push -u origin alpha
+
+# From then on, every conventional commit pushed to `alpha` cuts a new prerelease:
+#   feat: something  → 0.11.0-alpha.1
+#   fix: ...         → 0.11.0-alpha.2
+#
+# When ready to graduate, merge `alpha` into `main` — semantic-release rolls the
+# version forward to a stable 0.11.0 on the `latest` tag.
+```
+
+`update-homebrew` is intentionally skipped for prereleases — the gate is `!contains(version, '-')` in `.github/workflows/ci.yml`.
+
 ## Environment Variables
 
-- `DOSU_DEV=true` — switches all URLs to localhost dev endpoints
-- `DOSU_WEB_APP_URL`, `DOSU_BACKEND_URL`, `SUPABASE_URL`, `SUPABASE_ANON_KEY` — individual URL overrides
+### Build-time defaults (baked into the bundle)
+
+These are read by `scripts/build-all.ts:buildDefines()` and inlined as string literals via `bun build --define` at compile time. The published npm bundle contains the build-time values verbatim — they cannot be changed at runtime.
+
+- `DOSU_WEB_APP_URL`, `DOSU_BACKEND_URL`, `SUPABASE_URL`, `SUPABASE_ANON_KEY` — sourced from `.env.production` for prod builds, `.env.development` for `bun run dev:local`
 - `DOSU_VERSION`, `DOSU_COMMIT`, `DOSU_DATE` — injected at build time for version info
+
+### Runtime overrides
+
+These are read **on every CLI invocation** and take precedence over the baked-in defaults. Useful for repointing a published `@alpha` build at staging/local backends without rebuilding.
+
+- `DOSU_WEB_APP_URL_OVERRIDE`
+- `DOSU_BACKEND_URL_OVERRIDE`
+- `SUPABASE_URL_OVERRIDE`
+- `SUPABASE_ANON_KEY_OVERRIDE`
+
+Example:
+
+```bash
+DOSU_WEB_APP_URL_OVERRIDE=https://staging.dosu.dev \
+DOSU_BACKEND_URL_OVERRIDE=https://api-staging.dosu.dev \
+SUPABASE_URL_OVERRIDE=https://staging.supabase.co \
+SUPABASE_ANON_KEY_OVERRIDE=eyJ... \
+npx @dosu/cli@alpha setup
+```
+
+### Other runtime env
+
+- `DOSU_DEV=true` — isolates the CLI's config dir to `~/.config/dosu-cli-dev/` so dev runs don't clobber prod credentials. Does **not** switch URLs (URLs are build-time-baked; use `*_OVERRIDE` for that).

--- a/release.config.js
+++ b/release.config.js
@@ -1,6 +1,13 @@
 /** @type {import('semantic-release').GlobalConfig} */
 export default {
-  branches: ["main"],
+  branches: [
+    "main",
+    // Internal pre-release channel: commits to `alpha` publish to npm under
+    // dist-tag `alpha`, e.g. `0.11.0-alpha.1`. Users opt in via
+    // `npx @dosu/cli@alpha setup`. Homebrew is skipped for these (see
+    // ci.yml — `update-homebrew` filters out versions containing `-`).
+    { name: "alpha", prerelease: true },
+  ],
   plugins: [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -162,23 +162,6 @@ describe("startOAuthFlow", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("includes redirect param when path is not /cli/auth", async () => {
-    const flowPromise = startOAuthFlow(undefined, "/cli-setup");
-    await new Promise((r) => setTimeout(r, 10));
-
-    expect(mockOpenDefault).toHaveBeenCalledOnce();
-    const calledURL = new URL(mockOpenDefault.mock.calls[0]?.[0] as string);
-
-    expect(calledURL.pathname).toBe("/cli-setup");
-    expect(calledURL.searchParams.get("callback")).toBe("http://localhost:12345/callback");
-    const redirect = calledURL.searchParams.get("redirect") ?? "";
-    expect(redirect).toContain("/cli-setup?callback=");
-    expect(redirect).toContain(encodeURIComponent("http://localhost:12345/callback"));
-
-    resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
-    await flowPromise;
-  });
-
   it("uses the configured web app URL for building the auth URL", async () => {
     mockGetWebAppURL.mockReturnValue("http://localhost:3001");
 

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -65,10 +65,5 @@ export async function startOAuthFlow(
 function buildAuthURL(callbackURL: string, path: string): string {
   const webAppURL = getWebAppURL();
   const params = new URLSearchParams({ callback: callbackURL });
-  // For cli/setup, include redirect so OAuth callback returns to the same page
-  // instead of defaulting to "/". The app's useOAuthRedirect hook reads this param.
-  if (path !== "/cli/auth") {
-    params.set("redirect", `${path}?callback=${encodeURIComponent(callbackURL)}`);
-  }
   return `${webAppURL}${path}?${params}`;
 }

--- a/src/auth/jwt.test.ts
+++ b/src/auth/jwt.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { decodeJwtPayload, userIdFromAccessToken } from "./jwt";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+  const body = Buffer.from(JSON.stringify(payload))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+  return `${header}.${body}.signature`;
+}
+
+describe("decodeJwtPayload", () => {
+  it("returns the payload of a well-formed token", () => {
+    const token = makeJwt({ sub: "user-123", email: "a@b.com", exp: 1700000000 });
+    expect(decodeJwtPayload(token)).toEqual({
+      sub: "user-123",
+      email: "a@b.com",
+      exp: 1700000000,
+    });
+  });
+
+  it("returns null for an empty string", () => {
+    expect(decodeJwtPayload("")).toBeNull();
+  });
+
+  it("returns null when the token has fewer than two segments", () => {
+    expect(decodeJwtPayload("only-one-segment")).toBeNull();
+  });
+
+  it("decodes payloads that need base64url padding", () => {
+    // A short payload whose base64 encoding length is not a multiple of 4
+    // (forces the padding branch).
+    const token = makeJwt({ a: 1 });
+    expect(decodeJwtPayload(token)).toEqual({ a: 1 });
+  });
+
+  it("decodes payloads that include - and _ base64url characters", () => {
+    const raw = Buffer.from('{"sub":"???"}').toString("base64");
+    expect(raw).toContain("/");
+    const b64url = raw.replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+    const token = `header.${b64url}.sig`;
+    expect(decodeJwtPayload(token)).toEqual({ sub: "???" });
+  });
+
+  it("returns null when the payload is not valid JSON", () => {
+    const garbage = Buffer.from("not-json").toString("base64").replace(/=+$/, "");
+    expect(decodeJwtPayload(`header.${garbage}.sig`)).toBeNull();
+  });
+
+  it("returns null when the payload is JSON but not an object", () => {
+    const arr = Buffer.from("123").toString("base64").replace(/=+$/, "");
+    expect(decodeJwtPayload(`header.${arr}.sig`)).toBeNull();
+  });
+
+  it("returns null when the payload is the JSON literal null", () => {
+    const literalNull = Buffer.from("null").toString("base64").replace(/=+$/, "");
+    expect(decodeJwtPayload(`header.${literalNull}.sig`)).toBeNull();
+  });
+});
+
+describe("userIdFromAccessToken", () => {
+  it("returns the sub claim from a valid token", () => {
+    const token = makeJwt({ sub: "user-abc" });
+    expect(userIdFromAccessToken(token)).toBe("user-abc");
+  });
+
+  it("returns null when the token cannot be decoded", () => {
+    expect(userIdFromAccessToken("malformed")).toBeNull();
+  });
+
+  it("returns null when the sub claim is missing", () => {
+    const token = makeJwt({ email: "a@b.com" });
+    expect(userIdFromAccessToken(token)).toBeNull();
+  });
+
+  it("returns null when the sub claim is not a string", () => {
+    const token = makeJwt({ sub: 12345 });
+    expect(userIdFromAccessToken(token)).toBeNull();
+  });
+
+  it("returns null when the sub claim is an empty string", () => {
+    const token = makeJwt({ sub: "" });
+    expect(userIdFromAccessToken(token)).toBeNull();
+  });
+});

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -1,0 +1,53 @@
+/**
+ * Minimal JWT helpers. The CLI receives Supabase access tokens whose payload
+ * encodes the user id as the standard JWT `sub` claim; we occasionally need
+ * that id (e.g. to pass to tRPC `user.updateProfile`) without round-tripping
+ * to the server.
+ *
+ * No signature verification — the server always re-validates the token on
+ * any call that actually uses it. This is purely a read-side helper.
+ */
+
+interface JwtPayload {
+  sub?: string;
+  email?: string;
+  exp?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Decode the payload of a base64url-encoded JWT without verifying the
+ * signature. Returns null on any parse failure (malformed token, missing
+ * segments, invalid base64, invalid JSON).
+ */
+export function decodeJwtPayload(token: string): JwtPayload | null {
+  if (!token) return null;
+  const segments = token.split(".");
+  if (segments.length < 2) return null;
+  try {
+    // base64url → base64: swap -/_ and pad to a multiple of 4.
+    const b64url = segments[1];
+    const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+    const pad = b64.length % 4 === 0 ? "" : "=".repeat(4 - (b64.length % 4));
+    const json = Buffer.from(b64 + pad, "base64").toString("utf-8");
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object") {
+      return parsed as JwtPayload;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the Supabase user id from an access token, or null if it can't be
+ * extracted.
+ */
+export function userIdFromAccessToken(token: string): string | null {
+  const payload = decodeJwtPayload(token);
+  if (!payload || typeof payload.sub !== "string" || payload.sub.length === 0) {
+    return null;
+  }
+  return payload.sub;
+}

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -163,24 +163,6 @@ describe("auth callback server", () => {
     expect(html).toContain("<strong>test@dosu.dev</strong>");
   });
 
-  it("includes mode in token when mode=oss is in query params", async () => {
-    const result = await startCallbackServer();
-    server = result.server;
-
-    await fetch(`http://localhost:${server.port}/callback?access_token=tok&mode=oss`);
-    const token = await result.tokenPromise;
-    expect(token.mode).toBe("oss");
-  });
-
-  it("omits mode from token when mode is not oss", async () => {
-    const result = await startCallbackServer();
-    server = result.server;
-
-    await fetch(`http://localhost:${server.port}/callback?access_token=tok&mode=cloud`);
-    const token = await result.tokenPromise;
-    expect(token.mode).toBeUndefined();
-  });
-
   it("treats literal string 'null' in refresh_token as empty", async () => {
     const result = await startCallbackServer();
     server = result.server;

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -2,7 +2,6 @@
  * Local OAuth callback server.
  */
 
-import { MODE_OSS, type SetupMode } from "../config/config";
 import { logger } from "../debug/logger";
 
 export interface TokenResponse {
@@ -10,7 +9,6 @@ export interface TokenResponse {
   refresh_token: string;
   expires_in: number;
   email?: string;
-  mode?: SetupMode;
 }
 
 const CALLBACK_HTML_EXTRACT = `<!DOCTYPE html>
@@ -202,7 +200,6 @@ export async function startCallbackServer(): Promise<{
     const refreshToken = url.searchParams.get("refresh_token");
     const expiresIn = url.searchParams.get("expires_in");
     const email = url.searchParams.get("email");
-    const mode = url.searchParams.get("mode");
 
     if (!accessToken) {
       logger.debug("auth.server", "Served extract HTML (no token in query)");
@@ -224,7 +221,6 @@ export async function startCallbackServer(): Promise<{
       refresh_token: refreshToken && refreshToken !== "null" ? refreshToken : "",
       expires_in: expiresInInt,
       email: email ?? undefined,
-      ...(mode === MODE_OSS && { mode: MODE_OSS }),
     });
 
     logger.info("auth.server", "Served success HTML");

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -28,6 +28,7 @@ import {
 } from "../config/config";
 import { logger } from "../debug/logger";
 import { allProviders, getProvider, type Provider } from "../mcp/providers";
+import { checkForSkillUpdates } from "../version/skill-update-check";
 import { checkForUpdates } from "../version/update-check";
 import { getVersionString } from "../version/version";
 
@@ -43,6 +44,7 @@ export function createProgram(): Command {
       const opts = thisCommand.optsWithGlobals();
       logger.init({ debug: opts.debug });
       checkForUpdates();
+      checkForSkillUpdates();
     })
     .action(async () => {
       // Default: launch TUI when no subcommand given
@@ -211,9 +213,18 @@ export function createProgram(): Command {
     .command("setup")
     .description("Set up Dosu MCP for your AI tools")
     .option("--deployment <id>", "Skip to tool configuration for a specific MCP")
-    .action(async (opts: { deployment?: string }) => {
+    .option("--mode <mode>", "Force OSS or Cloud mode, skipping the interactive prompt (oss|cloud)")
+    .action(async (opts: { deployment?: string; mode?: string }) => {
       const { runSetup } = await import("../setup/flow");
-      await runSetup({ deploymentID: opts.deployment });
+      let mode: "oss" | "cloud" | undefined;
+      if (opts.mode !== undefined) {
+        const normalized = opts.mode.toLowerCase();
+        if (normalized !== "oss" && normalized !== "cloud") {
+          throw new Error(`invalid --mode value '${opts.mode}' (expected 'oss' or 'cloud')`);
+        }
+        mode = normalized;
+      }
+      await runSetup({ deploymentID: opts.deployment, mode });
     });
 
   // logs

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecSync = vi.fn();
@@ -5,12 +8,15 @@ vi.mock("node:child_process", () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
 }));
 
-import { skillCommand } from "./skill";
+import { installSkill, skillCommand } from "./skill";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
+
+let tempDir: string;
+let origXDG: string | undefined;
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
@@ -33,12 +39,34 @@ beforeEach(() => {
   exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("exit");
   }) as never);
+
+  // Isolate cache writes to a temp dir so they don't pollute $HOME
+  origXDG = process.env.XDG_CONFIG_HOME;
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-skill-test-"));
+  process.env.XDG_CONFIG_HOME = tempDir;
+
+  // Default: fetch returns a SHA
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sha: "test-sha" }),
+    }),
+  );
 });
 
 afterEach(() => {
   logSpy.mockRestore();
   errorSpy.mockRestore();
   exitSpy.mockRestore();
+
+  if (origXDG !== undefined) {
+    process.env.XDG_CONFIG_HOME = origXDG;
+  } else {
+    delete process.env.XDG_CONFIG_HOME;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
 });
 
 describe("skill install", () => {
@@ -104,5 +132,58 @@ describe("skill update", () => {
     });
     await expect(run("update")).rejects.toThrow("exit");
     expect(allErrors()).toContain("Failed to update skill");
+  });
+
+  it("refreshes installedSha in cache after successful update", async () => {
+    await run("update");
+
+    const cachePath = join(tempDir, "dosu-cli", "skill-update-check.json");
+    const cache = JSON.parse(readFileSync(cachePath, "utf-8"));
+    expect(cache.installedSha).toBe("test-sha");
+    expect(cache.latestSha).toBe("test-sha");
+  });
+
+  it("does not write cache when fetch fails during refresh", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    await run("update");
+    // npx command still succeeded, we just didn't learn a SHA
+    expect(allOutput()).toContain("updated");
+  });
+});
+
+describe("installSkill helper", () => {
+  it("writes cache with SHA on success", async () => {
+    const result = await installSkill();
+    expect(result.success).toBe(true);
+    expect(result.sha).toBe("test-sha");
+
+    const cachePath = join(tempDir, "dosu-cli", "skill-update-check.json");
+    const cache = JSON.parse(readFileSync(cachePath, "utf-8"));
+    expect(cache.installedSha).toBe("test-sha");
+    expect(cache.latestSha).toBe("test-sha");
+    expect(typeof cache.lastCheck).toBe("number");
+  });
+
+  it("returns success without SHA when fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    const result = await installSkill();
+    expect(result.success).toBe(true);
+    expect(result.sha).toBeUndefined();
+  });
+
+  it("returns success without SHA when fetch throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network error")));
+    const result = await installSkill();
+    expect(result.success).toBe(true);
+    expect(result.sha).toBeUndefined();
+  });
+
+  it("returns failure when execSync throws", async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error("command failed");
+    });
+    const result = await installSkill();
+    expect(result.success).toBe(false);
+    expect(result.sha).toBeUndefined();
   });
 });

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -5,9 +5,45 @@
 import { execSync } from "node:child_process";
 import { Command } from "commander";
 import pc from "picocolors";
+import { logger } from "../debug/logger";
+import {
+  fetchLatestSha,
+  refreshInstalledSha,
+  writeSkillCache,
+} from "../version/skill-update-check";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
 const SKILL_NAME = "dosu";
+
+/**
+ * Install the Dosu skill via `npx skills`. After a successful install we try
+ * to fetch the latest commit SHA and cache it so the update checker knows
+ * what was installed. Network failure is non-fatal — the skill is still
+ * installed, the SHA is just not cached (the update checker will fill it
+ * in on the next stale check).
+ */
+export async function installSkill(): Promise<{ success: boolean; sha?: string }> {
+  try {
+    execSync(`npx skills add ${SKILL_REPO} -g -s ${SKILL_NAME} -y`, {
+      stdio: "inherit",
+    });
+  } catch (err) {
+    logger.error("skill", `Failed to install skill: ${err}`);
+    return { success: false };
+  }
+
+  const sha = await fetchLatestSha();
+  if (sha) {
+    writeSkillCache({
+      lastCheck: Date.now(),
+      latestSha: sha,
+      installedSha: sha,
+    });
+    return { success: true, sha };
+  }
+  logger.debug("skill", "Skill installed but could not fetch latest SHA");
+  return { success: true };
+}
 
 export function skillCommand(): Command {
   const cmd = new Command("skill").description("Manage the Dosu agent skill");
@@ -15,14 +51,12 @@ export function skillCommand(): Command {
   cmd
     .command("install")
     .description("Install the Dosu skill for AI coding agents")
-    .action(() => {
+    .action(async () => {
       console.log(`Installing ${SKILL_NAME} skill from ${SKILL_REPO}...`);
-      try {
-        execSync(`npx skills add ${SKILL_REPO} -g -s ${SKILL_NAME} -y`, {
-          stdio: "inherit",
-        });
+      const result = await installSkill();
+      if (result.success) {
         console.log(pc.green(`\n✓ Skill "${SKILL_NAME}" installed successfully.`));
-      } catch {
+      } else {
         console.error(pc.red(`\nFailed to install skill. Make sure npx is available.`));
         process.exit(1);
       }
@@ -47,17 +81,18 @@ export function skillCommand(): Command {
   cmd
     .command("update")
     .description("Update the Dosu skill to the latest version")
-    .action(() => {
+    .action(async () => {
       console.log(`Updating ${SKILL_NAME} skill...`);
       try {
         execSync(`npx skills update ${SKILL_NAME} -g`, {
           stdio: "inherit",
         });
-        console.log(pc.green(`\n✓ Skill "${SKILL_NAME}" updated.`));
       } catch {
         console.error(pc.red(`\nFailed to update skill.`));
         process.exit(1);
       }
+      await refreshInstalledSha();
+      console.log(pc.green(`\n✓ Skill "${SKILL_NAME}" updated.`));
     });
 
   return cmd;

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -38,6 +38,60 @@ describe("config", () => {
     expect(existsSync(join(tempDir, "dosu-cli"))).toBe(true);
   });
 
+  it("DOSU_DEV=true isolates config into a separate dosu-cli-dev directory", () => {
+    const origDev = process.env.DOSU_DEV;
+    try {
+      process.env.DOSU_DEV = "true";
+      const devPath = getConfigPath();
+      expect(devPath).toBe(join(tempDir, "dosu-cli-dev", "config.json"));
+      expect(existsSync(join(tempDir, "dosu-cli-dev"))).toBe(true);
+
+      // Writing under dev must not touch the prod dir.
+      const devCfg: Config = {
+        access_token: "dev-tok",
+        refresh_token: "dev-ref",
+        expires_at: 1,
+      };
+      saveConfig(devCfg);
+
+      // Switch back to prod — we should see empty config, not the dev one.
+      delete process.env.DOSU_DEV;
+      const prodCfg = loadConfig();
+      expect(prodCfg.access_token).toBe("");
+
+      // Switch back to dev — dev config must still be there.
+      process.env.DOSU_DEV = "true";
+      const devCfgReloaded = loadConfig();
+      expect(devCfgReloaded.access_token).toBe("dev-tok");
+    } finally {
+      if (origDev !== undefined) {
+        process.env.DOSU_DEV = origDev;
+      } else {
+        delete process.env.DOSU_DEV;
+      }
+    }
+  });
+
+  it("DOSU_DEV other values don't enable dev isolation (only 'true' counts)", () => {
+    const origDev = process.env.DOSU_DEV;
+    try {
+      process.env.DOSU_DEV = "1";
+      expect(getConfigPath()).toBe(join(tempDir, "dosu-cli", "config.json"));
+
+      process.env.DOSU_DEV = "yes";
+      expect(getConfigPath()).toBe(join(tempDir, "dosu-cli", "config.json"));
+
+      process.env.DOSU_DEV = "";
+      expect(getConfigPath()).toBe(join(tempDir, "dosu-cli", "config.json"));
+    } finally {
+      if (origDev !== undefined) {
+        process.env.DOSU_DEV = origDev;
+      } else {
+        delete process.env.DOSU_DEV;
+      }
+    }
+  });
+
   it("loadConfig returns empty config when file does not exist", () => {
     const cfg = loadConfig();
     expect(cfg.access_token).toBe("");
@@ -144,6 +198,9 @@ describe("config", () => {
       deployment_id: undefined,
       deployment_name: undefined,
       api_key: undefined,
+      mode: undefined,
+      org_id: undefined,
+      space_id: undefined,
     });
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -21,12 +21,24 @@ export interface Config {
   space_id?: string;
 }
 
+/**
+ * The CLI uses separate config directories for dev and production so that
+ * testing against a local dev stack never clobbers a user's real credentials.
+ *
+ * - Production: `~/.config/dosu-cli/` (or `$XDG_CONFIG_HOME/dosu-cli/`)
+ * - Dev (`DOSU_DEV=true`): `~/.config/dosu-cli-dev/`
+ *
+ * Everything that lives under `getConfigDir()` — `config.json`,
+ * `update-check.json`, `skill-update-check.json` — is isolated between the two.
+ */
 export function getConfigDir(): string {
+  const dirName = process.env.DOSU_DEV === "true" ? "dosu-cli-dev" : "dosu-cli";
+
   const xdgConfig = process.env.XDG_CONFIG_HOME;
-  if (xdgConfig) return join(xdgConfig, "dosu-cli");
+  if (xdgConfig) return join(xdgConfig, dirName);
 
   const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
-  return join(home, ".config", "dosu-cli");
+  return join(home, ".config", dirName);
 }
 
 export function getConfigPath(): string {

--- a/src/config/constants.test.ts
+++ b/src/config/constants.test.ts
@@ -3,7 +3,16 @@ import { getBackendURL, getSupabaseAnonKey, getSupabaseURL, getWebAppURL } from 
 
 describe("constants", () => {
   const savedEnv: Record<string, string | undefined> = {};
-  const ENV_KEYS = ["DOSU_WEB_APP_URL", "DOSU_BACKEND_URL", "SUPABASE_URL", "SUPABASE_ANON_KEY"];
+  const ENV_KEYS = [
+    "DOSU_WEB_APP_URL",
+    "DOSU_BACKEND_URL",
+    "SUPABASE_URL",
+    "SUPABASE_ANON_KEY",
+    "DOSU_WEB_APP_URL_OVERRIDE",
+    "DOSU_BACKEND_URL_OVERRIDE",
+    "SUPABASE_URL_OVERRIDE",
+    "SUPABASE_ANON_KEY_OVERRIDE",
+  ];
 
   beforeEach(() => {
     for (const key of ENV_KEYS) {
@@ -31,6 +40,12 @@ describe("constants", () => {
       process.env.DOSU_WEB_APP_URL = "https://app.dosu.dev";
       expect(getWebAppURL()).toBe("https://app.dosu.dev");
     });
+
+    it("DOSU_WEB_APP_URL_OVERRIDE wins over the build-time default", () => {
+      process.env.DOSU_WEB_APP_URL = "https://app.dosu.dev";
+      process.env.DOSU_WEB_APP_URL_OVERRIDE = "https://staging.dosu.dev";
+      expect(getWebAppURL()).toBe("https://staging.dosu.dev");
+    });
   });
 
   describe("getBackendURL", () => {
@@ -41,6 +56,12 @@ describe("constants", () => {
     it("returns value from DOSU_BACKEND_URL", () => {
       process.env.DOSU_BACKEND_URL = "http://localhost:7001";
       expect(getBackendURL()).toBe("http://localhost:7001");
+    });
+
+    it("DOSU_BACKEND_URL_OVERRIDE wins over the build-time default", () => {
+      process.env.DOSU_BACKEND_URL = "https://api.dosu.dev";
+      process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api-staging.dosu.dev";
+      expect(getBackendURL()).toBe("https://api-staging.dosu.dev");
     });
   });
 
@@ -53,6 +74,12 @@ describe("constants", () => {
       process.env.SUPABASE_URL = "http://localhost:54321";
       expect(getSupabaseURL()).toBe("http://localhost:54321");
     });
+
+    it("SUPABASE_URL_OVERRIDE wins over the build-time default", () => {
+      process.env.SUPABASE_URL = "https://prod.supabase.co";
+      process.env.SUPABASE_URL_OVERRIDE = "https://staging.supabase.co";
+      expect(getSupabaseURL()).toBe("https://staging.supabase.co");
+    });
   });
 
   describe("getSupabaseAnonKey", () => {
@@ -63,6 +90,12 @@ describe("constants", () => {
     it("returns value from SUPABASE_ANON_KEY", () => {
       process.env.SUPABASE_ANON_KEY = "test-key";
       expect(getSupabaseAnonKey()).toBe("test-key");
+    });
+
+    it("SUPABASE_ANON_KEY_OVERRIDE wins over the build-time default", () => {
+      process.env.SUPABASE_ANON_KEY = "prod-key";
+      process.env.SUPABASE_ANON_KEY_OVERRIDE = "staging-key";
+      expect(getSupabaseAnonKey()).toBe("staging-key");
     });
   });
 });

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,22 +1,34 @@
 /**
  * URL constants and environment-aware getters.
  *
- * Values are loaded from .env files (.env.production / .env.development).
- * See .env.example for the full list of supported variables.
+ * Build-time defaults are baked into the bundle via `bun build --define`
+ * (see `scripts/build-all.ts:buildDefines`). For each URL we also accept a
+ * `*_OVERRIDE` env var that is read **at runtime** so internal/alpha builds
+ * can be repointed at staging or local backends without rebuilding:
+ *
+ *   DOSU_WEB_APP_URL_OVERRIDE=https://staging.dosu.dev \
+ *   DOSU_BACKEND_URL_OVERRIDE=https://api-staging.dosu.dev \
+ *   SUPABASE_URL_OVERRIDE=... \
+ *   SUPABASE_ANON_KEY_OVERRIDE=... \
+ *   npx @dosu/cli@alpha setup
+ *
+ * The override names intentionally differ from the build-time names —
+ * `process.env.DOSU_WEB_APP_URL` is replaced with a string literal at build
+ * time so reading it at runtime is impossible.
  */
 
 export function getWebAppURL(): string {
-  return process.env.DOSU_WEB_APP_URL ?? "";
+  return process.env.DOSU_WEB_APP_URL_OVERRIDE ?? process.env.DOSU_WEB_APP_URL ?? "";
 }
 
 export function getBackendURL(): string {
-  return process.env.DOSU_BACKEND_URL ?? "";
+  return process.env.DOSU_BACKEND_URL_OVERRIDE ?? process.env.DOSU_BACKEND_URL ?? "";
 }
 
 export function getSupabaseURL(): string {
-  return process.env.SUPABASE_URL ?? "";
+  return process.env.SUPABASE_URL_OVERRIDE ?? process.env.SUPABASE_URL ?? "";
 }
 
 export function getSupabaseAnonKey(): string {
-  return process.env.SUPABASE_ANON_KEY ?? "";
+  return process.env.SUPABASE_ANON_KEY_OVERRIDE ?? process.env.SUPABASE_ANON_KEY ?? "";
 }

--- a/src/setup/default-deployment-config.ts
+++ b/src/setup/default-deployment-config.ts
@@ -1,0 +1,116 @@
+/**
+ * Default `config` payload used when creating a new GitHub deployment via
+ * `workspaces.create`. Mirrors
+ * `DEFAULT_DEPLOYMENT_CONFIG_GITHUB_TEST` from
+ * `frontend/packages/core/src/utils/deployments.ts` in the Dosu main repo.
+ *
+ * The CLI copies it verbatim so that CLI-created deployments get the same
+ * sensible feature defaults (auto-reply on issues, stale-doc check on PRs,
+ * etc.) that web-created deployments do. If this ever drifts from the web
+ * default, we should fix by publishing a shared config package rather than
+ * by keeping two copies — tracked as a V2 cleanup.
+ */
+export const DEFAULT_DEPLOYMENT_CONFIG_GITHUB: Readonly<Record<string, unknown>> = {
+  default_maintainer: "",
+  issues: {
+    enabled: true,
+    agent_objectives: {
+      deduplicate_request: false,
+      surface_documentation: true,
+      surface_conversations: true,
+      surface_tickets: true,
+      surface_code: true,
+      suggest_changes_and_workarounds: false,
+    },
+    auto_reply: {
+      enabled: true,
+      review_required: true,
+    },
+    auto_label_config: {
+      enabled: false,
+      multiple_labels_per_group: false,
+      include: [] as string[],
+      exclude: [] as string[],
+      separator: null,
+      custom_instructions: null,
+    },
+    voting: {
+      enabled: false,
+    },
+    quality_checklist: null,
+  },
+  pull_requests: {
+    enabled: true,
+    auto_reply: {
+      enabled: false,
+      review_required: true,
+    },
+    agent_objectives: {
+      deduplicate_request: true,
+      surface_documentation: true,
+      surface_conversations: true,
+      surface_tickets: true,
+      surface_code: true,
+      suggest_changes_and_workarounds: true,
+    },
+    auto_label_config: {
+      enabled: false,
+      multiple_labels_per_group: false,
+      include: [] as string[],
+      exclude: [] as string[],
+      separator: null,
+      custom_instructions: null,
+    },
+    lgtm_label: {
+      enabled: false,
+      name: "lgtm",
+      color: "238636",
+      description: "This PR has been approved by a maintainer",
+    },
+    size_label: {
+      enabled: false,
+      name: "size",
+      separator: ":",
+    },
+    auto_merge_label_config: {
+      enabled: false,
+      name: "auto-merge",
+      color: "FFA500",
+      description: "This PR is set to be merged",
+    },
+    stale_doc_check: {
+      enabled: true,
+      monitored_paths: [] as string[],
+    },
+    diff_review_policies: [] as unknown[],
+  },
+  discussions: {
+    enabled: true,
+    agent_objectives: {
+      deduplicate_request: false,
+      surface_documentation: true,
+      surface_conversations: true,
+      surface_tickets: true,
+      surface_code: true,
+      suggest_changes_and_workarounds: false,
+    },
+    auto_reply: {
+      enabled: true,
+      review_required: true,
+    },
+    included_categories: ["Q&A", "Questions"],
+    quality_checklist: null,
+  },
+  stale_bot: {
+    enabled: false,
+    days_before_stale: 90,
+    days_before_close: 7,
+    max_issues_close_per_day: 25,
+    excluded_label_ids: [] as string[],
+    tag_maintainer_response: false,
+  },
+  changelogs: {
+    visibility: false,
+    enabled: false,
+  },
+};

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -3,6 +3,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// CRITICAL: mock `open` so runSetup's github-step (imported dynamically) can
+// never actually pop a real browser tab to the Dosu App install URL when the
+// `repo_not_installed` code path fires. Also mock `git` lookup so
+// detectGitRepo() doesn't hit the real filesystem.
+vi.mock("open", () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn().mockImplementation(() => {
+    throw new Error("git not available in tests");
+  }),
+}));
+
 // Only mock true boundaries: terminal UI, auth (browser), and HTTP client
 vi.mock("@clack/prompts", () => ({
   intro: vi.fn(),
@@ -40,6 +51,45 @@ vi.mock("../debug/logger", () => ({
   },
 }));
 
+// tRPC client used by:
+//   - completeOnboarding via `user.updateProfile`
+//   - github step via `workspaces.create`, `dataSource.create`, etc.
+// Tests can override any of these via `mockTrpc.<path>.mockResolvedValue(...)`.
+const mockTrpc = vi.hoisted(() => ({
+  user: {
+    getCliOnboardingContext: {
+      query: vi.fn().mockResolvedValue({
+        user_id: "test-user-id",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      }),
+    },
+    getProfile: {
+      query: vi.fn().mockResolvedValue({ user_id: "test-user-id", finished_onboarding: true }),
+    },
+    updateProfile: { mutate: vi.fn().mockResolvedValue(null) },
+  },
+  organization: {
+    getOrganizations: {
+      query: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1", user_role: "OWNER" }]),
+    },
+  },
+  githubRepository: { listForOrg: { query: vi.fn().mockResolvedValue([]) } },
+  workspaces: {
+    create: { mutate: vi.fn() },
+    listForSpace: { query: vi.fn().mockResolvedValue([]) },
+  },
+  dataSource: { create: { mutate: vi.fn() } },
+  deploymentDataSource: { create: { mutate: vi.fn().mockResolvedValue({}) } },
+}));
+vi.mock("../client/trpc", () => ({
+  createTypedClient: vi.fn(() => mockTrpc),
+}));
+
+vi.mock("../auth/jwt", () => ({
+  userIdFromAccessToken: vi.fn(() => "test-user-id"),
+}));
+
 vi.mock("../client/client", () => {
   const SessionExpiredError = class extends Error {
     constructor() {
@@ -52,6 +102,23 @@ vi.mock("../client/client", () => {
     SessionExpiredError,
   };
 });
+
+const mockInstallSkill = vi.fn();
+vi.mock("../commands/skill", () => ({
+  installSkill: (...args: unknown[]) => mockInstallSkill(...args),
+  skillCommand: vi.fn(),
+}));
+
+const { mockStepConnectGitHubRepo, mockStepImportGitHubDocs } = vi.hoisted(() => ({
+  mockStepConnectGitHubRepo: vi.fn(),
+  mockStepImportGitHubDocs: vi.fn(),
+}));
+vi.mock("./github-step", () => ({
+  stepConnectGitHubRepo: (...args: unknown[]) => mockStepConnectGitHubRepo(...args),
+}));
+vi.mock("./github-doc-import-step", () => ({
+  stepImportGitHubDocs: (...args: unknown[]) => mockStepImportGitHubDocs(...args),
+}));
 
 import * as p from "@clack/prompts";
 import { startOAuthFlow } from "../auth/flow";
@@ -67,12 +134,58 @@ import { OpenCodeProvider } from "../mcp/providers/opencode";
 import {
   type ConfigResult,
   isStdioOnly,
+  runInstallSkill,
   runSetup,
   stepConfigureTools,
   stepDetectTools,
   stepShowSummary,
   type ToolSelection,
 } from "./flow";
+
+/**
+ * Default p.multiselect behaviour: auto-accept the initialValues for the
+ * one-shot confirm step (`stepOneShotConfirm`) AND the tool-selection step.
+ * Tests that want to override tool selection use `mockToolSelection()` below.
+ */
+function installMultiselectDefault() {
+  vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
+    const o = opts as { message: string; initialValues?: unknown[] };
+    return (o.initialValues ?? []) as unknown as never;
+  });
+}
+
+/**
+ * Override tool selection with a specific set of provider IDs while still
+ * auto-accepting the upfront one-shot confirm. Use instead of
+ * `vi.mocked(p.multiselect).mockResolvedValue(...)`.
+ */
+function mockToolSelection(selection: string[]) {
+  vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
+    const o = opts as { message: string; initialValues?: unknown[] };
+    const msg = String(o.message ?? "").toLowerCase();
+    if (msg.includes("dosu will set")) {
+      return (o.initialValues ?? []) as unknown as never;
+    }
+    return selection as unknown as never;
+  });
+}
+
+function installSetupStepDefaults() {
+  mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
+  mockStepImportGitHubDocs.mockResolvedValue({ advance: false });
+}
+
+function installRemoteSetupDefaults() {
+  mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+    user_id: "test-user-id",
+    finished_onboarding: true,
+    cli_onboarding_enabled: false,
+  });
+  mockTrpc.organization.getOrganizations.query.mockResolvedValue([
+    { org_id: "o1", name: "Org1", user_role: "OWNER" },
+  ]);
+  mockTrpc.user.updateProfile.mutate.mockResolvedValue(null);
+}
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -112,6 +225,20 @@ function makeCfg(overrides: Partial<Config> = {}): Config {
   };
 }
 
+function makeDeployment(overrides: Record<string, unknown> = {}) {
+  return {
+    deployment_id: "d1",
+    name: "Deploy1",
+    description: "",
+    provider_slug: "dosu_mcp",
+    enabled: true,
+    org_id: "o1",
+    org_name: "Org1",
+    space_id: "s1",
+    ...overrides,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // 1. isStdioOnly — pure function, real providers
 // ---------------------------------------------------------------------------
@@ -140,7 +267,8 @@ describe("isStdioOnly", () => {
 describe("stepDetectTools", () => {
   beforeEach(() => {
     setupTempEnv();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    installSetupStepDefaults();
   });
   afterEach(teardownTempEnv);
 
@@ -192,7 +320,8 @@ describe("stepDetectTools", () => {
 describe("stepConfigureTools", () => {
   beforeEach(() => {
     setupTempEnv();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    installSetupStepDefaults();
   });
   afterEach(teardownTempEnv);
 
@@ -360,7 +489,8 @@ describe("stepConfigureTools", () => {
 describe("stepShowSummary", () => {
   beforeEach(() => {
     setupTempEnv();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    installSetupStepDefaults();
   });
   afterEach(teardownTempEnv);
 
@@ -372,7 +502,8 @@ describe("stepShowSummary", () => {
 
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Cursor"));
-    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("Try it out"));
+    // "Try it out" moved to showTryItOutPrompt at end of runSetup.
+    expect(p.log.message).not.toHaveBeenCalled();
   });
 
   it("logs removed tools count for removals", () => {
@@ -395,8 +526,8 @@ describe("stepShowSummary", () => {
     expect(p.log.success).toHaveBeenCalledWith(
       expect.stringContaining("All agents already configured"),
     );
-    // Skipped still gets the "Try it out" message
-    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("Try it out"));
+    // "Try it out" moved to showTryItOutPrompt at end of runSetup.
+    expect(p.log.message).not.toHaveBeenCalled();
   });
 
   it("shows both install and remove summaries for mixed results", () => {
@@ -456,8 +587,8 @@ describe("stepShowSummary", () => {
     expect(p.log.success).not.toHaveBeenCalledWith(
       expect.stringContaining("All agents already configured"),
     );
-    // Should still show "Try it out"
-    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("Try it out"));
+    // "Try it out" moved to showTryItOutPrompt at end of runSetup.
+    expect(p.log.message).not.toHaveBeenCalled();
   });
 
   it("does not show 'Try it out' or 'all configured' when results are empty", () => {
@@ -481,8 +612,12 @@ describe("runSetup integration", () => {
 
   beforeEach(() => {
     setupTempEnv();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    installSetupStepDefaults();
+    installRemoteSetupDefaults();
     vi.mocked(p.isCancel).mockReturnValue(false);
+    installMultiselectDefault();
+    mockInstallSkill.mockResolvedValue({ success: true, sha: "test-sha" });
   });
   afterEach(teardownTempEnv);
 
@@ -491,13 +626,13 @@ describe("runSetup integration", () => {
       doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
       refreshToken: vi.fn(),
       getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
-      getDeployments: vi
-        .fn()
-        .mockResolvedValue([
-          { deployment_id: "d1", name: "Deploy1", org_id: "o1", org_name: "Org1" },
-        ]),
+      getDeployments: vi.fn().mockResolvedValue([makeDeployment()]),
       validateAPIKey: vi.fn().mockResolvedValue(true),
       createAPIKey: vi.fn().mockResolvedValue({ api_key: "new-key" }),
+      completeOnboarding: vi.fn().mockResolvedValue(undefined),
+      // Default: github connect soft-skips (user not in git repo). Tests that
+      // exercise it override.
+      connectGithubRepo: vi.fn().mockResolvedValue({ skipped: true, reason: "repo_not_installed" }),
       ...overrides,
     };
     mockClient.mockImplementation(() => clientMethods as unknown as Client);
@@ -525,8 +660,8 @@ describe("runSetup integration", () => {
   });
 
   it("completes full flow with existing token and no tools", async () => {
-    // Save a real config with token
-    const cfg = makeCfg();
+    // Save a real config with token but no deployment — forces the picker.
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient();
@@ -548,8 +683,8 @@ describe("runSetup integration", () => {
   });
 
   it("completes full flow with tool install via real filesystem", async () => {
-    // Save a real config with token
-    const cfg = makeCfg();
+    // Save a real config with token but no deployment — forces the picker.
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient();
@@ -560,7 +695,7 @@ describe("runSetup integration", () => {
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
 
     // User selects cursor in multiselect
-    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
@@ -576,7 +711,7 @@ describe("runSetup integration", () => {
   });
 
   it("runs OAuth flow and saves tokens to real config", async () => {
-    // No pre-existing config (fresh temp dir), so needs login
+    // No pre-existing config (fresh temp dir), so needs login. No mode prompt anymore.
     vi.mocked(p.confirm).mockResolvedValue(true);
     mockStartOAuthFlow.mockResolvedValue({
       access_token: "oauth-tok",
@@ -638,7 +773,7 @@ describe("runSetup integration", () => {
 
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+    mockToolSelection(["cursor"]);
 
     CursorProvider().install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
     const ossConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
@@ -696,7 +831,7 @@ describe("runSetup integration", () => {
     });
 
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
@@ -728,7 +863,7 @@ describe("runSetup integration", () => {
     });
 
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
@@ -747,7 +882,7 @@ describe("runSetup integration", () => {
   });
 
   it("auto-selects single org without prompting", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient();
@@ -761,7 +896,7 @@ describe("runSetup integration", () => {
   });
 
   it("prompts when multiple orgs exist", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient({
@@ -781,7 +916,7 @@ describe("runSetup integration", () => {
   });
 
   it("returns early when no orgs found", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient({
@@ -794,7 +929,7 @@ describe("runSetup integration", () => {
   });
 
   it("handles SessionExpiredError during org fetch", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     const { SessionExpiredError } = await import("../client/client");
@@ -808,7 +943,7 @@ describe("runSetup integration", () => {
   });
 
   it("handles org fetch error", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient({
@@ -821,7 +956,7 @@ describe("runSetup integration", () => {
   });
 
   it("prompts when multiple deployments exist for org", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient({
@@ -841,7 +976,7 @@ describe("runSetup integration", () => {
   });
 
   it("returns early when no deployments for org", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient({
@@ -858,7 +993,7 @@ describe("runSetup integration", () => {
   });
 
   it("handles deployment fetch error", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient({
@@ -930,7 +1065,18 @@ describe("runSetup integration", () => {
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
 
     const cancelSymbol = Symbol("cancel");
-    vi.mocked(p.multiselect).mockResolvedValue(cancelSymbol as unknown as string[]);
+    // Cancel only the tool-selection multiselect; accept the one-shot confirm.
+    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
+      const o = opts as { message: string; initialValues?: unknown[] };
+      if (
+        String(o.message ?? "")
+          .toLowerCase()
+          .includes("dosu will set")
+      ) {
+        return (o.initialValues ?? []) as unknown as never;
+      }
+      return cancelSymbol as unknown as never;
+    });
     vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
 
     await runSetup();
@@ -985,7 +1131,7 @@ describe("runSetup integration", () => {
   });
 
   it("shows deployment not found error", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient({
@@ -1000,7 +1146,7 @@ describe("runSetup integration", () => {
   });
 
   it("handles resolve deployment fetch error", async () => {
-    const cfg = makeCfg();
+    const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
     setupAuthenticatedClient({
@@ -1076,8 +1222,6 @@ describe("runSetup integration", () => {
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    // Reconfigure prompt → keep current setup
-    vi.mocked(p.select).mockResolvedValueOnce("keep");
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
@@ -1095,7 +1239,6 @@ describe("runSetup integration", () => {
     setupAuthenticatedClient({
       getDeployments: vi.fn().mockRejectedValue(new Error("service unavailable")),
     });
-    vi.mocked(p.select).mockResolvedValueOnce("keep");
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
@@ -1113,7 +1256,6 @@ describe("runSetup integration", () => {
     setupAuthenticatedClient({
       getDeployments: vi.fn().mockResolvedValue([]),
     });
-    vi.mocked(p.select).mockResolvedValueOnce("keep");
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
@@ -1129,84 +1271,21 @@ describe("runSetup integration", () => {
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    // Reconfigure prompt → keep current setup
-    vi.mocked(p.select).mockResolvedValueOnce("keep");
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
     expect(p.outro).toHaveBeenCalledWith(expect.stringContaining("open-source libraries only"));
   });
 
-  it("OSS mode reconfigure prompt lets user keep current setup", async () => {
-    const cfg = makeCfg({ mode: "oss" });
-    saveConfig(cfg);
-
-    setupAuthenticatedClient();
-    vi.mocked(p.select).mockResolvedValueOnce("keep");
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    // Should have shown reconfigure prompt
-    expect(p.select).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining("open-source libraries") }),
-    );
-  });
-
-  it("OSS mode reconfigure prompt opens browser on reconfigure", async () => {
-    const cfg = makeCfg({ mode: "oss" });
-    saveConfig(cfg);
-
-    setupAuthenticatedClient();
-    vi.mocked(p.select).mockResolvedValueOnce("reconfigure");
-    mockStartOAuthFlow.mockResolvedValue({
-      access_token: "new-tok",
-      refresh_token: "new-ref",
-      expires_in: 3600,
-    } as TokenResponse);
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    expect(mockStartOAuthFlow).toHaveBeenCalled();
-  });
-
-  it("OSS mode reconfigure clears mode when token has no OSS signal", async () => {
-    const cfg = makeCfg({ mode: "oss" });
-    saveConfig(cfg);
-
-    setupAuthenticatedClient();
-    vi.mocked(p.select).mockResolvedValueOnce("reconfigure");
-    // Token WITHOUT mode: "oss" means user switched to cloud/standard flow
-    mockStartOAuthFlow.mockResolvedValue({
-      access_token: "new-tok",
-      refresh_token: "new-ref",
-      expires_in: 3600,
-    } as TokenResponse);
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    const saved = loadConfig();
-    expect(saved.mode).toBeUndefined();
-  });
-
-  it("OAuth flow sets OSS mode when token signals it", async () => {
-    vi.mocked(p.confirm).mockResolvedValue(true);
-    mockStartOAuthFlow.mockResolvedValue({
-      access_token: "oss-tok",
-      refresh_token: "oss-ref",
-      expires_in: 7200,
-      mode: "oss",
-    } as TokenResponse);
-
+  it("--mode oss flag switches cfg.mode to OSS and skips Cloud-only steps", async () => {
+    saveConfig(makeCfg());
     setupAuthenticatedClient();
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
-    await runSetup();
+    await runSetup({ mode: "oss" });
 
     const saved = loadConfig();
     expect(saved.mode).toBe("oss");
@@ -1232,7 +1311,7 @@ describe("runSetup integration", () => {
     OpenCodeProvider().install(cfg, true);
 
     // User deselects opencode but keeps cursor
-    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
@@ -1252,14 +1331,437 @@ describe("runSetup integration", () => {
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    // Reconfigure prompt → keep current setup
-    vi.mocked(p.select).mockResolvedValueOnce("keep");
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    vi.mocked(p.multiselect).mockResolvedValue(["cursor"]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
     expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("Dosu help"));
+  });
+
+  it("installs skill automatically when the one-shot confirm leaves it ticked", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockInstallSkill).toHaveBeenCalled();
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill installed"));
+  });
+
+  it("does not install skill when the one-shot confirm unticks it", async () => {
+    const cfg = makeCfg({ mode: "oss" });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    // Override the one-shot confirm to deselect the skill item.
+    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
+      const o = opts as { message: string; initialValues?: unknown[] };
+      if (
+        String(o.message ?? "")
+          .toLowerCase()
+          .includes("dosu will set")
+      ) {
+        return ["configureMcp"] as unknown as never;
+      }
+      return (o.initialValues ?? []) as unknown as never;
+    });
+
+    await runSetup();
+
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(p.outro).toHaveBeenCalledWith(expect.stringContaining("open-source libraries only"));
+  });
+
+  it("installs skill in OSS mode when the one-shot confirm leaves it ticked", async () => {
+    const cfg = makeCfg({ mode: "oss" });
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockInstallSkill).toHaveBeenCalled();
+  });
+
+  it("shows the GitHub docs import label in the one-shot confirm", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const oneShotCall = vi
+      .mocked(p.multiselect)
+      .mock.calls.find(([args]) =>
+        String((args as { message?: string }).message ?? "").includes("Dosu will set"),
+      );
+    const options = (oneShotCall?.[0] as { options: Array<{ label: string }> }).options;
+    expect(options.map((option) => String(option.label))).toEqual(
+      expect.arrayContaining([expect.stringContaining("Import docs from GitHub")]),
+    );
+    expect(options.map((option) => String(option.label))).toEqual(
+      expect.arrayContaining([expect.stringContaining("Keep them up to date")]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. runInstallSkill — focused unit tests
+// ---------------------------------------------------------------------------
+
+describe("runInstallSkill", () => {
+  beforeEach(() => {
+    setupTempEnv();
+    vi.resetAllMocks();
+    installSetupStepDefaults();
+    installRemoteSetupDefaults();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+    installMultiselectDefault();
+  });
+  afterEach(teardownTempEnv);
+
+  it("calls installSkill and returns true on success", async () => {
+    mockInstallSkill.mockResolvedValue({ success: true, sha: "abc" });
+
+    const result = await runInstallSkill();
+
+    expect(result).toBe(true);
+    expect(mockInstallSkill).toHaveBeenCalled();
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill installed"));
+  });
+
+  it("returns false and logs error when installSkill reports failure", async () => {
+    mockInstallSkill.mockResolvedValue({ success: false });
+
+    const result = await runInstallSkill();
+
+    expect(result).toBe(false);
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Failed to install skill"));
+  });
+
+  it("returns false and logs error when installSkill throws", async () => {
+    mockInstallSkill.mockRejectedValue(new Error("boom"));
+
+    const result = await runInstallSkill();
+
+    expect(result).toBe(false);
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("boom"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Checkpoint-aware resume (M1)
+// ---------------------------------------------------------------------------
+
+describe("runSetup checkpoint behavior", () => {
+  const mockClient = vi.mocked(Client);
+  const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
+
+  beforeEach(() => {
+    setupTempEnv();
+    vi.resetAllMocks();
+    installSetupStepDefaults();
+    installRemoteSetupDefaults();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+    installMultiselectDefault();
+    mockInstallSkill.mockResolvedValue({ success: true, sha: "test-sha" });
+  });
+  afterEach(teardownTempEnv);
+
+  function setupAuthed(overrides: Record<string, unknown> = {}) {
+    const methods = {
+      doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+      refreshToken: vi.fn(),
+      getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+      getDeployments: vi.fn().mockResolvedValue([makeDeployment()]),
+      validateAPIKey: vi.fn().mockResolvedValue(true),
+      createAPIKey: vi.fn().mockResolvedValue({ api_key: "new-key" }),
+      completeOnboarding: vi.fn().mockResolvedValue(undefined),
+      // Default: github connect soft-skips (user not in git repo). Tests that
+      // exercise it override.
+      connectGithubRepo: vi.fn().mockResolvedValue({ skipped: true, reason: "repo_not_installed" }),
+      ...overrides,
+    };
+    mockClient.mockImplementation(() => methods as unknown as Client);
+    return methods;
+  }
+
+  it("does not prompt for mode (mode selection UI is gone)", async () => {
+    // Fresh config, no checkpoint. User declines login so we exit early,
+    // but any p.select call must NOT have been a mode prompt.
+    vi.mocked(p.confirm).mockResolvedValue(false);
+
+    await runSetup();
+
+    const calls = vi.mocked(p.select).mock.calls;
+    for (const [args] of calls) {
+      expect(String(args.message).toLowerCase()).not.toContain("mode");
+    }
+  });
+
+  it("does not show the 'Try it out' prompt when the user unticks MCP", async () => {
+    // If the user deselects both "Install Dosu MCP" and "Install Dosu skill"
+    // from the one-shot confirm, nothing was configured this run, so the
+    // paste-into-your-agent tip would be noise.
+    saveConfig(makeCfg());
+    setupAuthed();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    // Override the one-shot confirm to return an empty selection.
+    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
+      const o = opts as { message: string };
+      if (
+        String(o.message ?? "")
+          .toLowerCase()
+          .includes("dosu will set")
+      ) {
+        return [] as unknown as never;
+      }
+      return [] as unknown as never;
+    });
+
+    await runSetup();
+
+    expect(p.log.message).not.toHaveBeenCalledWith(expect.stringContaining("Try it out"));
+  });
+
+  it("does not show the 'Try it out' prompt when no AI agents are detected", async () => {
+    // User ticked MCP but has no supported agents installed. stepConfigureMcpTools
+    // returns an empty array (nothing to configure), so the tip would be useless.
+    saveConfig(makeCfg());
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("No supported AI agents detected"),
+    );
+    expect(p.log.message).not.toHaveBeenCalledWith(expect.stringContaining("Try it out"));
+  });
+
+  it("persists a fresh token after successful authentication", async () => {
+    // Fresh config (no token yet) → user authenticates → token is saved.
+    saveConfig(
+      makeCfg({
+        access_token: "",
+        refresh_token: "",
+        expires_at: 0,
+      }),
+    );
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    mockStartOAuthFlow.mockResolvedValue({
+      access_token: "tok-fresh",
+      refresh_token: "ref-fresh",
+      expires_in: 3600,
+    } as TokenResponse);
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.access_token).toBe("tok-fresh");
+    expect(saved.refresh_token).toBe("ref-fresh");
+  });
+
+  it("mints a new API key when the existing one is invalid", async () => {
+    saveConfig(makeCfg({ api_key: undefined }));
+    const methods = setupAuthed();
+    methods.validateAPIKey.mockResolvedValue(false);
+    methods.createAPIKey.mockResolvedValue({ api_key: "fresh-key" });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.api_key).toBe("fresh-key");
+  });
+
+  it("marks remote onboarding complete at the end of first-run cloud onboarding", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+
+    await runSetup();
+
+    expect(mockTrpc.user.updateProfile.mutate).toHaveBeenCalledTimes(1);
+    expect(mockTrpc.user.updateProfile.mutate).toHaveBeenCalledWith({
+      user_id: "test-user-id",
+      finished_onboarding: true,
+    });
+  });
+
+  it("does not call updateProfile during ordinary cloud setup", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockTrpc.user.updateProfile.mutate).not.toHaveBeenCalled();
+  });
+
+  it("warns but does not throw when remote onboarding completion fails", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    mockTrpc.user.updateProfile.mutate.mockRejectedValueOnce(new Error("503 Service Unavailable"));
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+
+    await runSetup();
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Could not mark onboarding complete"),
+    );
+  });
+
+  it("keeps ordinary setup free of GitHub when the remote profile is already onboarded", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
+    expect(mockStepImportGitHubDocs).not.toHaveBeenCalled();
+  });
+
+  it("keeps setup free of GitHub when onboarding is incomplete but the CLI flag is disabled", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: false,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
+    expect(mockStepImportGitHubDocs).not.toHaveBeenCalled();
+    expect(mockTrpc.user.updateProfile.mutate).not.toHaveBeenCalled();
+  });
+
+  it("binds first-run onboarding to the owner org instead of stale local config", async () => {
+    saveConfig(
+      makeCfg({
+        deployment_id: "old-dep",
+        deployment_name: "Old Deploy",
+        org_id: "old-org",
+        space_id: "old-space",
+      }),
+    );
+    setupAuthed({
+      getDeployments: vi.fn().mockResolvedValue([
+        makeDeployment({
+          deployment_id: "dep-old",
+          org_id: "old-org",
+          org_name: "Old Org",
+          space_id: "space-old",
+        }),
+        makeDeployment({
+          deployment_id: "dep-owner",
+          org_id: "owner-org",
+          org_name: "Owner Org",
+          space_id: "space-owner",
+        }),
+      ]),
+    });
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    mockTrpc.organization.getOrganizations.query.mockResolvedValue([
+      { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
+    ]);
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.org_id).toBe("owner-org");
+    expect(saved.space_id).toBe("space-owner");
+    expect(saved.deployment_id).toBe("dep-owner");
+  });
+
+  it("always starts the GitHub step from repo selection during first-run onboarding", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({
+      advance: true,
+      has_connected_repo: true,
+      deployment_id: "dep-github",
+      space_id: "space-1",
+    });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+
+    await runSetup();
+
+    expect(mockStepConnectGitHubRepo).toHaveBeenCalledTimes(1);
+    expect(mockStepImportGitHubDocs).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ waitForFreshDocs: true }),
+    );
+  });
+
+  it("does not wait for fresh docs when no repo was connected in this run", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({
+      advance: true,
+      has_connected_repo: false,
+    });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+
+    await runSetup();
+
+    expect(mockStepImportGitHubDocs).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ waitForFreshDocs: false }),
+    );
   });
 });

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -4,6 +4,7 @@
 
 import * as p from "@clack/prompts";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
+import { installSkill } from "../commands/skill";
 import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
@@ -11,6 +12,8 @@ import { dim, info } from "./styles";
 
 export interface SetupOptions {
   deploymentID?: string;
+  /** Force a specific mode, bypassing the default. "cloud" = standard flow, "oss" = public-libraries-only. */
+  mode?: SetupMode | "cloud";
 }
 
 export type ConfigAction = "install" | "remove" | "skip";
@@ -27,88 +30,265 @@ export interface ToolSelection {
   skipped: SetupProvider[];
 }
 
+interface OneShotChoices {
+  configureMcp: boolean;
+  installSkill: boolean;
+  connectGitHub: boolean;
+}
+
+type SetupFlowKind = "onboarding" | "setup";
+
+interface CloudSetupContext {
+  kind: SetupFlowKind;
+  profileUserID: string;
+  targetOrg?: OwnedOrg;
+}
+
+interface OwnedOrg {
+  org_id: string;
+  name: string;
+  user_role?: string | null;
+}
+
+// `@dosu/api-types` trails a few app routers; use a narrow local cast in setup.
+// biome-ignore lint/suspicious/noExplicitAny: see note above
+type TrpcAny = any;
+
 export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   logger.info(
     "setup",
-    `Setup flow started${opts.deploymentID ? ` deployment=${opts.deploymentID}` : ""}`,
+    `Setup flow started${opts.deploymentID ? ` deployment=${opts.deploymentID}` : ""}${
+      opts.mode ? ` mode=${opts.mode}` : ""
+    }`,
   );
   p.intro("Dosu CLI Setup");
 
-  // Step 1: Authenticate
-  const cfg = await stepAuthenticate(opts);
-  if (!cfg) return;
+  let cfg = loadConfig();
 
-  const apiClient = new Client(cfg);
+  applyModeOverride(cfg, opts);
 
-  // Step 2: Branch on mode
+  // --deployment implies Cloud; otherwise default to Cloud unless --mode oss.
   if (opts.deploymentID) {
-    // --deployment flag provided, use specified deployment
-    const d = await stepResolveDeployment(apiClient, opts.deploymentID);
-    if (!d) return;
     cfg.mode = undefined;
-    cfg.deployment_id = d.deployment_id;
-    cfg.deployment_name = d.name;
-    cfg.org_id = d.org_id;
-    cfg.space_id = d.space_id;
-  } else if (cfg.mode === MODE_OSS) {
-    // OSS path: fetch first available deployment for API key creation only
-    const deployments = await fetchDeployments(apiClient);
-    if (deployments.length > 0) {
-      cfg.deployment_id = deployments[0].deployment_id;
-      cfg.deployment_name = deployments[0].name;
-      cfg.org_id = deployments[0].org_id;
-      cfg.space_id = deployments[0].space_id;
-    }
-  } else {
-    // Standard path: select deployment interactively
-    const org = await stepSelectOrg(apiClient);
-    if (!org) return;
-    const d = await stepSelectDeployment(apiClient, org);
-    if (!d) return;
-    cfg.mode = undefined;
-    cfg.deployment_id = d.deployment_id;
-    cfg.deployment_name = d.name;
-    cfg.org_id = d.org_id;
-    cfg.space_id = d.space_id;
+    saveConfig(cfg);
   }
 
-  saveConfig(cfg);
+  // Authenticate — always runs so we can verify/refresh tokens.
+  const authedCfg = await stepAuthenticate(cfg);
+  if (!authedCfg) return;
+  cfg = authedCfg;
 
-  // Step 3: API key (needed for both modes)
+  const apiClient = new Client(cfg);
+  let cloudSetupContext: CloudSetupContext | null = null;
+
+  if (cfg.mode !== MODE_OSS) {
+    cloudSetupContext = await resolveCloudSetupContext(cfg);
+    if (!cloudSetupContext) return;
+  }
+
+  // Deployment: first-run onboarding binds the user's default deployment.
+  // Otherwise we only run the interactive picker when we don't already have
+  // a deployment id locked in, OR when the caller passed `--deployment` to
+  // explicitly switch. Everyday re-runs reuse the stored deployment silently.
+  if (cfg.mode !== MODE_OSS && cloudSetupContext?.kind === "onboarding") {
+    const ok = await bindOnboardingDeployment(apiClient, cfg, cloudSetupContext.targetOrg ?? null);
+    if (!ok) return;
+  } else if (!cfg.deployment_id || opts.deploymentID) {
+    const ok = await resolveDeployment(apiClient, cfg, opts);
+    if (!ok) return;
+  }
+
+  // API key: `stepMintAPIKey` is idempotent — it validates an existing key
+  // before minting a new one, so it's safe to call on every run.
   const apiKey = await stepMintAPIKey(apiClient, cfg);
   if (!apiKey) return;
   cfg.api_key = apiKey;
   saveConfig(cfg);
 
-  // Step 4: Detect and configure tools
-  const detected = stepDetectTools();
-  if (detected.length === 0) {
-    p.log.warn(
-      `No supported AI agents detected on your system.\nRun ${info("dosu mcp add <agent>")} to manually configure an agent.`,
-    );
-    return;
+  // One-shot confirm: MCP + skill are always listed (user picks what to
+  // (re)run); GitHub docs import only shows during first-run onboarding.
+  const choices = await stepOneShotConfirm({
+    includeGitHub: cloudSetupContext?.kind === "onboarding",
+  });
+  if (!choices) return;
+
+  // MCP tools. Track whether at least one agent ended up with Dosu MCP
+  // configured (newly installed or previously installed) so we only nudge
+  // the user with the "Try it out" prompt when there's actually an agent
+  // they can paste it into.
+  let mcpConfiguredThisRun = false;
+  if (choices.configureMcp) {
+    const configured = await stepConfigureMcpTools(cfg);
+    if (configured === null) return;
+    mcpConfiguredThisRun = configured.some((r) => r.action === "install" || r.action === "skip");
   }
 
-  const selection = await stepSelectTools(detected);
-  if (!selection) return;
+  // Dosu skill
+  if (choices.installSkill) {
+    await runInstallSkill();
+  }
 
-  const results = stepConfigureTools(cfg, selection);
-  stepShowSummary(results, cfg.mode);
+  let githubOnboardingDone = !choices.connectGitHub;
+  if (choices.connectGitHub && cloudSetupContext?.kind === "onboarding") {
+    const { stepConnectGitHubRepo } = await import("./github-step");
+    const connectResult = await stepConnectGitHubRepo(cfg);
+    if (!connectResult.advance) return;
+    if (connectResult.space_id && !cfg.space_id) {
+      cfg.space_id = connectResult.space_id;
+      saveConfig(cfg);
+    }
+
+    const { stepImportGitHubDocs } = await import("./github-doc-import-step");
+    const importResult = await stepImportGitHubDocs(cfg, {
+      waitForFreshDocs: Boolean(connectResult.deployment_id),
+    });
+    if (!importResult.advance) return;
+    githubOnboardingDone = true;
+  }
+
+  const shouldCompleteRemoteOnboarding =
+    cloudSetupContext?.kind === "onboarding" && githubOnboardingDone;
+
+  if (shouldCompleteRemoteOnboarding && cloudSetupContext) {
+    const profileUserID = cloudSetupContext.profileUserID;
+    try {
+      const { createTypedClient } = await import("../client/trpc");
+      const trpc = createTypedClient(cfg) as TrpcAny;
+      await trpc.user.updateProfile.mutate({
+        user_id: profileUserID,
+        finished_onboarding: true,
+      });
+      logger.info("setup", "Server onboarding marked complete");
+    } catch (err) {
+      logger.warn(
+        "setup",
+        `completeOnboarding failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      p.log.warn(
+        "Could not mark onboarding complete on the server — you can retry later by running `dosu setup` again.",
+      );
+    }
+  }
+
+  if (mcpConfiguredThisRun) {
+    showTryItOutPrompt(cfg.mode);
+  }
 
   if (cfg.mode === MODE_OSS) {
     p.outro(
-      "Setup complete! Using open-source libraries only.\n\nTips: Run `dosu setup` again to connect your own repos.",
+      "Setup complete! Using open-source libraries only.\n\nTips: Run `dosu setup --mode cloud` to connect your own repos.",
     );
   } else {
     p.outro("\uD83C\uDF89 Setup complete!");
   }
 }
 
-async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
-  logger.info("setup", "Step: authenticate");
-  const cfg = loadConfig();
+/**
+ * Apply a user-supplied --mode flag against the current config.
+ */
+function applyModeOverride(cfg: Config, opts: SetupOptions): void {
+  if (!opts.mode) return;
+  const newMode = opts.mode === "oss" ? MODE_OSS : undefined;
+  const oldMode = cfg.mode;
+  cfg.mode = newMode;
+  if (oldMode === MODE_OSS && newMode === undefined) {
+    logger.info("setup", "Mode switched OSS → Cloud");
+  }
+  saveConfig(cfg);
+}
 
-  // If we have a token, verify it against the backend first
+/**
+ * One-shot confirmation: a single multiselect listing everything Dosu will
+ * set up. All items default checked; user hits Enter to do it all, or
+ * unticks specific items.
+ *
+ * MCP + skill are always listed so users can re-run either step at any
+ * time (add a new agent, reinstall the skill). GitHub docs import only
+ * shows during first-run cloud onboarding.
+ */
+async function stepOneShotConfirm(opts: {
+  includeGitHub: boolean;
+}): Promise<OneShotChoices | null> {
+  type Item = { value: keyof OneShotChoices; label: string };
+  const items: Item[] = [
+    { value: "configureMcp", label: "Install Dosu MCP" },
+    { value: "installSkill", label: "Install Dosu skill" },
+  ];
+  if (opts.includeGitHub) {
+    items.push({
+      value: "connectGitHub",
+      label: `Import docs from GitHub ${dim("(Keep them up to date)")}`,
+    });
+  }
+
+  const selected = await p.multiselect({
+    message: "Dosu will set these up — press Enter to accept, space to toggle",
+    options: items.map((it) => ({ value: it.value, label: it.label })),
+    initialValues: items.map((it) => it.value),
+    required: false,
+  });
+
+  if (p.isCancel(selected)) {
+    logger.info("setup", "One-shot confirm cancelled");
+    return null;
+  }
+
+  const chosen = new Set(selected as Array<keyof OneShotChoices>);
+  return {
+    configureMcp: chosen.has("configureMcp"),
+    installSkill: chosen.has("installSkill"),
+    connectGitHub: chosen.has("connectGitHub"),
+  };
+}
+
+/**
+ * Runs MCP tool detection → selection → configuration as a single unit.
+ * Returns the ConfigResult array on success, or null if the user cancelled.
+ * An empty detection pool is treated as success (nothing to do).
+ */
+async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null> {
+  const detected = stepDetectTools();
+  if (detected.length === 0) {
+    p.log.warn(
+      `No supported AI agents detected on your system.\nRun ${info("dosu mcp add <agent>")} to manually configure an agent.`,
+    );
+    return [];
+  }
+  const selection = await stepSelectTools(detected);
+  if (!selection) return null;
+  const results = stepConfigureTools(cfg, selection);
+  stepShowSummary(results);
+  return results;
+}
+
+/**
+ * Run the skill install (no prompt). The upfront one-shot confirm already
+ * decided whether to run this. Returns `true` on success.
+ */
+export async function runInstallSkill(): Promise<boolean> {
+  logger.info("setup", "Step: install skill");
+  try {
+    const result = await installSkill();
+    if (result.success) {
+      logger.info("setup", `Skill installed${result.sha ? ` sha=${result.sha}` : ""}`);
+      p.log.success("Skill installed");
+      return true;
+    }
+    p.log.error("Failed to install skill. Run `dosu skill install` to retry.");
+    return false;
+  } catch (err: unknown) {
+    /* v8 ignore next -- err is always Error in practice */
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("setup", `Skill install failed: ${msg}`);
+    p.log.error(`Skill install failed: ${msg}`);
+    return false;
+  }
+}
+
+async function stepAuthenticate(existingCfg?: Config): Promise<Config | null> {
+  logger.info("setup", "Step: authenticate");
+  const cfg = existingCfg ?? loadConfig();
+
   if (cfg.access_token) {
     const s = p.spinner();
     s.start("Verifying session...");
@@ -118,26 +298,8 @@ async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
       if (resp.status === 200) {
         logger.info("setup", `Session verified, status=${resp.status}`);
         s.stop("Authenticated");
-
-        // If configured for OSS and no --deployment flag, let the user reconfigure
-        if (!opts.deploymentID && cfg.mode === MODE_OSS) {
-          const modeLabel = "open-source libraries only";
-          const action = await p.select({
-            message: `Currently configured for ${modeLabel}. What would you like to do?`,
-            options: [
-              { label: "Reconfigure (opens browser)", value: "reconfigure" },
-              { label: "Keep current setup and update agents", value: "keep" },
-            ],
-          });
-          if (p.isCancel(action)) return null;
-          if (action === "keep") return cfg;
-          // Reconfigure: open browser for mode re-selection
-          return await openBrowserForSetup(cfg, opts);
-        }
-
         return cfg;
       }
-      // Any non-200 status — try refresh before giving up
       try {
         logger.debug("setup", "Attempting token refresh");
         await apiClient.refreshToken();
@@ -157,29 +319,24 @@ async function stepAuthenticate(opts: SetupOptions): Promise<Config | null> {
     }
   }
 
-  // Need login
   const shouldLogin = await p.confirm({ message: "Open browser to log in?" });
   if (p.isCancel(shouldLogin) || !shouldLogin) return null;
 
-  return await openBrowserForSetup(cfg, opts);
+  return await openBrowserForSetup(cfg);
 }
 
-async function openBrowserForSetup(cfg: Config, opts: SetupOptions): Promise<Config | null> {
+async function openBrowserForSetup(cfg: Config): Promise<Config | null> {
   try {
     const { startOAuthFlow } = await import("../auth/flow");
     const s = p.spinner();
     s.start("Waiting for authentication...");
-    // Use /cli/setup unless a specific deployment was already provided via --deployment flag
-    const authPath = opts.deploymentID ? "/cli/auth" : "/cli/setup";
-    const token = await startOAuthFlow(undefined, authPath);
+    const token = await startOAuthFlow(undefined, "/cli/auth");
     s.stop("Authenticated");
-    logger.info("setup", `Browser auth completed, mode=${token.mode ?? "cloud"}`);
+    logger.info("setup", "Browser auth completed");
 
     cfg.access_token = token.access_token;
     cfg.refresh_token = token.refresh_token;
     cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
-    // Sync mode from browser: OSS when signaled, clear otherwise (cloud flow)
-    cfg.mode = token.mode === MODE_OSS ? MODE_OSS : undefined;
     saveConfig(cfg);
     return cfg;
   } catch (err: unknown) {
@@ -189,6 +346,145 @@ async function openBrowserForSetup(cfg: Config, opts: SetupOptions): Promise<Con
     p.log.error(`Authentication failed: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
+}
+
+async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext | null> {
+  try {
+    const { createTypedClient } = await import("../client/trpc");
+    const trpc = createTypedClient(cfg) as TrpcAny;
+    const profile = (await trpc.user.getCliOnboardingContext.query()) as {
+      user_id?: string;
+      finished_onboarding?: boolean | null;
+      cli_onboarding_enabled?: boolean | null;
+    } | null;
+
+    if (!profile?.user_id) {
+      p.log.error("Could not load your profile.");
+      return null;
+    }
+
+    if (profile.finished_onboarding === true || profile.cli_onboarding_enabled !== true) {
+      return {
+        kind: "setup",
+        profileUserID: profile.user_id,
+      };
+    }
+
+    const targetOrg = await resolveOnboardingTargetOrg(trpc);
+    if (!targetOrg) {
+      p.log.error("Could not determine your onboarding organization.");
+      return null;
+    }
+
+    logger.info("setup", `First-run onboarding detected for org ${targetOrg.org_id}`);
+    return {
+      kind: "onboarding",
+      profileUserID: profile.user_id,
+      targetOrg,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("setup", `Failed to resolve cloud setup context: ${msg}`);
+    p.log.error(`Could not load your onboarding state: ${msg}`);
+    return null;
+  }
+}
+
+async function resolveOnboardingTargetOrg(trpc: TrpcAny): Promise<OwnedOrg | null> {
+  const ownerOrgs = (await trpc.organization.getOrganizations.query({
+    userRole: "OWNER",
+    exact: true,
+  })) as OwnedOrg[];
+  if (ownerOrgs.length > 0) {
+    return ownerOrgs[0];
+  }
+
+  const accessibleOrgs = (await trpc.organization.getOrganizations.query()) as OwnedOrg[];
+  return accessibleOrgs[0] ?? null;
+}
+
+async function bindOnboardingDeployment(
+  apiClient: Client,
+  cfg: Config,
+  targetOrg: OwnedOrg | null,
+): Promise<boolean> {
+  if (!targetOrg) {
+    p.log.error("Could not determine your onboarding organization.");
+    return false;
+  }
+
+  const deployment = await resolveOnboardingDeployment(apiClient, targetOrg);
+  if (!deployment) {
+    p.log.error(`No MCP found for ${targetOrg.name}.`);
+    return false;
+  }
+
+  cfg.mode = undefined;
+  cfg.deployment_id = deployment.deployment_id;
+  cfg.deployment_name = deployment.name;
+  cfg.org_id = deployment.org_id;
+  cfg.space_id = deployment.space_id;
+  logger.info(
+    "setup",
+    `Bound onboarding context org=${targetOrg.org_id} deployment=${deployment.deployment_id}`,
+  );
+  return true;
+}
+
+async function resolveOnboardingDeployment(
+  apiClient: Client,
+  targetOrg: OwnedOrg,
+): Promise<Deployment | null> {
+  const deployments = await fetchDeployments(apiClient);
+  const orgDeployments = deployments.filter((deployment) => deployment.org_id === targetOrg.org_id);
+  return (
+    orgDeployments.find((deployment) => deployment.provider_slug === "dosu_mcp") ??
+    orgDeployments[0] ??
+    null
+  );
+}
+
+/**
+ * Resolves the deployment according to the three branches:
+ *   - --deployment flag → use that specific deployment
+ *   - OSS mode → auto-pick the first deployment (used only for API-key issuance)
+ *   - standard → interactive org + deployment select
+ */
+async function resolveDeployment(
+  apiClient: Client,
+  cfg: Config,
+  opts: SetupOptions,
+): Promise<boolean> {
+  if (opts.deploymentID) {
+    const d = await stepResolveDeployment(apiClient, opts.deploymentID);
+    if (!d) return false;
+    cfg.mode = undefined;
+    cfg.deployment_id = d.deployment_id;
+    cfg.deployment_name = d.name;
+    cfg.org_id = d.org_id;
+    cfg.space_id = d.space_id;
+    return true;
+  }
+  if (cfg.mode === MODE_OSS) {
+    const deployments = await fetchDeployments(apiClient);
+    if (deployments.length > 0) {
+      cfg.deployment_id = deployments[0].deployment_id;
+      cfg.deployment_name = deployments[0].name;
+      cfg.org_id = deployments[0].org_id;
+      cfg.space_id = deployments[0].space_id;
+    }
+    return true;
+  }
+  const org = await stepSelectOrg(apiClient);
+  if (!org) return false;
+  const d = await stepSelectDeployment(apiClient, org);
+  if (!d) return false;
+  cfg.mode = undefined;
+  cfg.deployment_id = d.deployment_id;
+  cfg.deployment_name = d.name;
+  cfg.org_id = d.org_id;
+  cfg.space_id = d.space_id;
+  return true;
 }
 
 async function fetchDeployments(apiClient: Client): Promise<Deployment[]> {
@@ -401,7 +697,7 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
   return results;
 }
 
-export function stepShowSummary(results: ConfigResult[], mode?: SetupMode): void {
+export function stepShowSummary(results: ConfigResult[]): void {
   const installed = results.filter((r) => r.action === "install" && !r.error);
   const removed = results.filter((r) => r.action === "remove" && !r.error);
   const skipped = results.filter((r) => r.action === "skip");
@@ -423,12 +719,20 @@ export function stepShowSummary(results: ConfigResult[], mode?: SetupMode): void
   if (installed.length === 0 && removed.length === 0 && skipped.length > 0) {
     p.log.success("All agents already configured. No changes needed.");
   }
+}
 
-  if (installed.length > 0 || skipped.length > 0) {
-    const prompt =
-      mode === MODE_OSS
-        ? `What can Dosu help me with? Pick an open source library related to my project and explain how it works.`
-        : `I'm new to this codebase. Give me a 5-minute mental model: main services, request flow, where to start.`;
-    p.log.message(`Try it out! Paste this into your agent:\n\n${info(prompt)}`);
-  }
+/**
+ * Post-setup nudge: a ready-to-paste prompt so the user can immediately try
+ * Dosu in their configured AI agent. Rendered at the very end of the flow
+ * (right before outro) so it's the last actionable thing they see — not
+ * buried right after the MCP configuration step. The call site is responsible
+ * for only invoking this when MCP was actually (re)configured this run, so
+ * users who skip MCP don't get a tip they can't act on.
+ */
+export function showTryItOutPrompt(mode?: SetupMode): void {
+  const prompt =
+    mode === MODE_OSS
+      ? `What can Dosu help me with? Pick an open source library related to my project and explain how it works.`
+      : `Please use Dosu to host my AGENTS.md`;
+  p.log.message(`Try it out! Paste this into your agent:\n\n${info(prompt)}`);
 }

--- a/src/setup/github-doc-import-prompt.test.ts
+++ b/src/setup/github-doc-import-prompt.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { GitHubDocsImportPrompt } from "./github-doc-import-prompt";
+
+function makePrompt() {
+  return new GitHubDocsImportPrompt({
+    repositories: [
+      {
+        slug: "acme/api",
+        files: [
+          { id: "f-1", path: "docs/auth/login.md", is_synced: false },
+          { id: "f-2", path: "docs/setup/github.md", is_synced: false },
+        ],
+      },
+      {
+        slug: "acme/core",
+        files: [
+          { id: "f-3", path: "README.md", is_synced: true },
+          { id: "f-4", path: "docs/core/overview.md", is_synced: false },
+        ],
+      },
+    ],
+  });
+}
+
+describe("GitHubDocsImportPrompt", () => {
+  it("defaults to selecting every importable doc and tracks partial repo state", () => {
+    const prompt = makePrompt();
+
+    expect(prompt.getRepositorySelectionState(prompt.repositories[0])).toBe("all");
+
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    prompt.handleRawKeypress(undefined, { name: "left" });
+
+    expect(prompt.mode).toBe("repos");
+    expect(prompt.getRepositorySelectionState(prompt.repositories[0])).toBe("partial");
+  });
+
+  it("returns to the repo list when Enter is pressed inside a repo file list", () => {
+    const prompt = makePrompt();
+
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress(undefined, { name: "return" });
+
+    expect(prompt.mode).toBe("repos");
+    expect(prompt.state).toBe("initial");
+  });
+
+  it("filters files while searching and lets a toggle all visible results", () => {
+    const prompt = makePrompt();
+
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress("/", undefined);
+    prompt.handleRawKeypress("a", undefined);
+    prompt.handleRawKeypress("u", undefined);
+    prompt.handleRawKeypress("t", undefined);
+    prompt.handleRawKeypress("h", undefined);
+
+    expect(prompt.searchQuery).toBe("auth");
+    expect(prompt.filteredFiles.map((file) => file.path)).toEqual(["docs/auth/login.md"]);
+
+    prompt.handleRawKeypress(undefined, { name: "escape" });
+    expect(prompt.searchQuery).toBe("");
+
+    prompt.handleRawKeypress("a", undefined);
+    expect(prompt.value).toEqual(["f-4"]);
+  });
+
+  it("marks a repo as locked when every file is already imported", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/core",
+          files: [{ id: "f-1", path: "README.md", is_synced: true }],
+        },
+      ],
+    });
+
+    expect(prompt.getRepositorySelectionState(prompt.repositories[0])).toBe("locked");
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    expect(prompt.value).toEqual([]);
+  });
+
+  it("submits every importable doc by default when the user presses Enter immediately", () => {
+    const prompt = makePrompt();
+
+    prompt.handleRawKeypress(undefined, { name: "return" });
+
+    expect(prompt.state).toBe("submit");
+    expect(prompt.value).toEqual(["f-1", "f-2", "f-4"]);
+  });
+
+  it("limits the visible file list to 15 items while keeping all matches addressable", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/api",
+          files: Array.from({ length: 20 }, (_, index) => ({
+            id: `f-${index + 1}`,
+            path: `docs/topic-${index + 1}.md`,
+            is_synced: false,
+          })),
+        },
+      ],
+    });
+
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    const visibleDocLines = rendered
+      .split("\n")
+      .filter((line) => line.includes("docs/topic-") || line.includes("..."));
+
+    expect(visibleDocLines.length).toBeLessThanOrEqual(15);
+
+    for (let i = 0; i < 18; i += 1) {
+      prompt.handleRawKeypress(undefined, { name: "down" });
+    }
+
+    expect(prompt.fileCursor).toBe(18);
+  });
+});

--- a/src/setup/github-doc-import-prompt.test.ts
+++ b/src/setup/github-doc-import-prompt.test.ts
@@ -118,4 +118,189 @@ describe("GitHubDocsImportPrompt", () => {
 
     expect(prompt.fileCursor).toBe(18);
   });
+
+  it("wraps the repo cursor with up/down keys", () => {
+    const prompt = makePrompt();
+    expect(prompt.repoCursor).toBe(0);
+    prompt.handleRawKeypress(undefined, { name: "up" });
+    expect(prompt.repoCursor).toBe(prompt.repositories.length - 1);
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    expect(prompt.repoCursor).toBe(0);
+  });
+
+  it("space toggles the current repo: deselects when all are selected, selects all otherwise", () => {
+    const prompt = makePrompt();
+    expect(prompt.getRepositorySelectionState(prompt.repositories[0])).toBe("all");
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    expect(prompt.getRepositorySelectionState(prompt.repositories[0])).toBe("none");
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    expect(prompt.getRepositorySelectionState(prompt.repositories[0])).toBe("all");
+  });
+
+  it("cancels with escape in repo mode and with ctrl+c", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "escape" });
+    expect(prompt.state).toBe("cancel");
+
+    const prompt2 = makePrompt();
+    prompt2.handleRawKeypress(undefined, { ctrl: true, name: "c" });
+    expect(prompt2.state).toBe("cancel");
+  });
+
+  it("does nothing for unrecognized repo-mode keys", () => {
+    const prompt = makePrompt();
+    const before = prompt.repoCursor;
+    prompt.handleRawKeypress(undefined, { name: "tab" });
+    expect(prompt.repoCursor).toBe(before);
+    expect(prompt.state).toBe("initial");
+  });
+
+  it("ignores left key in repo mode", () => {
+    const prompt = makePrompt();
+    expect(prompt.mode).toBe("repos");
+    prompt.handleRawKeypress(undefined, { name: "left" });
+    expect(prompt.mode).toBe("repos");
+  });
+
+  it("moves file cursor up and down inside file mode", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    expect(prompt.fileCursor).toBe(0);
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    expect(prompt.fileCursor).toBe(1);
+    prompt.handleRawKeypress(undefined, { name: "up" });
+    expect(prompt.fileCursor).toBe(0);
+    prompt.handleRawKeypress(undefined, { name: "up" });
+    // wraps to last filtered file
+    expect(prompt.fileCursor).toBe(1);
+  });
+
+  it("backspace removes search characters and clears searchActive when query empties", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    // 'a' is intercepted as "toggle all" before search is active, so start
+    // typing with a different printable key.
+    prompt.handleRawKeypress("d", undefined);
+    prompt.handleRawKeypress("o", undefined);
+    expect(prompt.searchQuery).toBe("do");
+    expect(prompt.searchActive).toBe(true);
+    prompt.handleRawKeypress(undefined, { name: "backspace" });
+    expect(prompt.searchQuery).toBe("d");
+    expect(prompt.searchActive).toBe(true);
+    prompt.handleRawKeypress(undefined, { name: "backspace" });
+    expect(prompt.searchQuery).toBe("");
+    expect(prompt.searchActive).toBe(false);
+  });
+
+  it("escape in file mode without an active search cancels the prompt", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress(undefined, { name: "escape" });
+    expect(prompt.state).toBe("cancel");
+  });
+
+  it("ignores synced files when toggling with space", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/core",
+          files: [
+            { id: "f-1", path: "README.md", is_synced: true },
+            { id: "f-2", path: "docs/intro.md", is_synced: false },
+          ],
+        },
+      ],
+    });
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    expect(prompt.fileCursor).toBe(0);
+    expect(prompt.value).toEqual(["f-2"]);
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    // synced file shouldn't toggle anything
+    expect(prompt.value).toEqual(["f-2"]);
+  });
+
+  it("activates and types into search via printable keys", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress("d", undefined);
+    expect(prompt.searchActive).toBe(true);
+    expect(prompt.searchQuery).toBe("d");
+  });
+
+  it("does not change state for non-printable keys outside the switch", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    const before = prompt.searchQuery;
+    prompt.handleRawKeypress(undefined, undefined);
+    expect(prompt.searchQuery).toBe(before);
+  });
+
+  it("renders the 'Skip for now' submit label when no docs are selected", () => {
+    const prompt = makePrompt();
+    // Deselect every default-selected doc by toggling each repo off.
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    expect(prompt.value).toEqual([]);
+    (prompt as unknown as { state: string }).state = "submit";
+    const submitOutput = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(submitOutput).toContain("Skip for now");
+  });
+
+  it("renders the cancel header without the option list", () => {
+    const prompt = makePrompt();
+    (prompt as unknown as { state: string }).state = "cancel";
+    const cancelOutput = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(cancelOutput).toContain("Select docs to import");
+    expect(cancelOutput).not.toContain("docs/auth/login.md");
+  });
+
+  it("renders an empty-state message in file mode when search has no matches", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress("z", undefined);
+    prompt.handleRawKeypress("z", undefined);
+    prompt.handleRawKeypress("z", undefined);
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("No docs match your search.");
+  });
+
+  it("submit label is singular for exactly one selected doc", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/api",
+          files: [{ id: "only", path: "README.md", is_synced: false }],
+        },
+      ],
+    });
+    (prompt as unknown as { state: string }).state = "submit";
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("1 doc selected");
+  });
+
+  it("does not move the file cursor when no files match the search", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress("z", undefined);
+    prompt.handleRawKeypress("z", undefined);
+    expect(prompt.filteredFiles).toEqual([]);
+    const before = prompt.fileCursor;
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    expect(prompt.fileCursor).toBe(before);
+  });
+
+  it("locked repos render with a hint and selection state stays locked", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/locked",
+          files: [{ id: "f-1", path: "README.md", is_synced: true }],
+        },
+      ],
+    });
+    expect(prompt.getRepositorySelectionState(prompt.repositories[0])).toBe("locked");
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("All docs already imported");
+  });
 });

--- a/src/setup/github-doc-import-prompt.ts
+++ b/src/setup/github-doc-import-prompt.ts
@@ -36,12 +36,14 @@ interface KeyInfo {
   name?: string;
 }
 
+/* v8 ignore start -- TTY-only wrapper; logic covered via GitHubDocsImportPrompt tests */
 export async function promptGitHubDocsImport({
   repositories,
 }: PromptGitHubDocsImportOptions): Promise<symbol | string[]> {
   const prompt = new GitHubDocsImportPrompt({ repositories });
   return (await prompt.prompt()) as symbol | string[];
 }
+/* v8 ignore stop */
 
 export class GitHubDocsImportPrompt extends Prompt {
   repositories: GitHubImportRepositoryOption[];
@@ -468,6 +470,7 @@ function supportsUnicode(): boolean {
   if (process.platform !== "win32") {
     return process.env.TERM !== "linux";
   }
+  /* v8 ignore start -- win32-only; cannot be exercised on Linux CI */
   return !!(
     process.env.CI ||
     process.env.WT_SESSION ||
@@ -479,6 +482,7 @@ function supportsUnicode(): boolean {
     process.env.TERM === "alacritty" ||
     process.env.TERMINAL_EMULATOR === "JetBrains-JediTerm"
   );
+  /* v8 ignore stop */
 }
 
 function symbol(unicodeValue: string, asciiValue: string): string {

--- a/src/setup/github-doc-import-prompt.ts
+++ b/src/setup/github-doc-import-prompt.ts
@@ -1,0 +1,486 @@
+import { Prompt } from "@clack/core";
+import pc from "picocolors";
+
+const unicode = supportsUnicode();
+const ACTIVE_SYMBOL = symbol("◆", "*");
+const SUBMIT_SYMBOL = symbol("◇", "o");
+const CANCEL_SYMBOL = symbol("■", "x");
+const BAR = symbol("│", "|");
+const FOOTER = symbol("└", "-");
+const CHECKBOX_OFF = symbol("◻", "[ ]");
+const CHECKBOX_ON = symbol("◼", "[+]");
+const CHECKBOX_PARTIAL = symbol("◧", "[-]");
+const ELLIPSIS = "...";
+const MAX_VISIBLE_FILE_ITEMS = 15;
+
+export interface GitHubImportFileOption {
+  id: string;
+  path: string;
+  is_synced?: boolean;
+}
+
+export interface GitHubImportRepositoryOption {
+  slug: string;
+  files: GitHubImportFileOption[];
+}
+
+type PromptMode = "repos" | "files";
+type RepoSelectionState = "none" | "partial" | "all" | "locked";
+
+interface PromptGitHubDocsImportOptions {
+  repositories: GitHubImportRepositoryOption[];
+}
+
+interface KeyInfo {
+  ctrl?: boolean;
+  name?: string;
+}
+
+export async function promptGitHubDocsImport({
+  repositories,
+}: PromptGitHubDocsImportOptions): Promise<symbol | string[]> {
+  const prompt = new GitHubDocsImportPrompt({ repositories });
+  return (await prompt.prompt()) as symbol | string[];
+}
+
+export class GitHubDocsImportPrompt extends Prompt {
+  repositories: GitHubImportRepositoryOption[];
+  mode: PromptMode = "repos";
+  repoCursor = 0;
+  fileCursor = 0;
+  searchQuery = "";
+  searchActive = false;
+  private selectedIds = new Set<string>();
+
+  constructor({ repositories }: PromptGitHubDocsImportOptions) {
+    super(
+      {
+        render() {
+          return (this as GitHubDocsImportPrompt).renderPrompt();
+        },
+      },
+      false,
+    );
+
+    this.repositories = repositories;
+    this.selectedIds = new Set(
+      repositories.flatMap((repository) => getSelectableFileIds(repository.files)),
+    );
+    this.syncValue();
+    // `@clack/core` stores the bound handler on the instance; replace it with
+    // our custom handler so repo/file mode can own Enter / Escape semantics.
+    // biome-ignore lint/suspicious/noExplicitAny: internal prompt hook
+    (this as any).onKeypress = this.handleRawKeypress.bind(this);
+  }
+
+  handleRawKeypress(key?: string, info?: KeyInfo): void {
+    this.handleKeypress(key, info);
+    this.syncValue();
+    // biome-ignore lint/suspicious/noExplicitAny: internal prompt hook
+    if ((this as any).rl) {
+      // biome-ignore lint/suspicious/noExplicitAny: internal prompt hook
+      (this as any).render();
+    }
+
+    // biome-ignore lint/suspicious/noExplicitAny: internal prompt hook
+    if ((this.state === "submit" || this.state === "cancel") && (this as any).rl) {
+      this.close();
+    }
+  }
+
+  handleKeypress(key?: string, info?: KeyInfo): void {
+    if (info?.ctrl && info.name === "c") {
+      this.state = "cancel";
+      return;
+    }
+
+    if (this.mode === "repos") {
+      this.handleRepoModeKey(info);
+      return;
+    }
+
+    this.handleFileModeKey(key, info);
+  }
+
+  private handleRepoModeKey(info?: KeyInfo): void {
+    switch (info?.name) {
+      case "up":
+        this.moveRepoCursor(-1);
+        return;
+      case "down":
+        this.moveRepoCursor(1);
+        return;
+      case "right":
+        this.enterRepository();
+        return;
+      case "space":
+        this.toggleCurrentRepository();
+        return;
+      case "return":
+        this.state = "submit";
+        return;
+      case "left":
+        return;
+      case "escape":
+        this.state = "cancel";
+        return;
+      default:
+        return;
+    }
+  }
+
+  private handleFileModeKey(key?: string, info?: KeyInfo): void {
+    switch (info?.name) {
+      case "up":
+        this.moveFileCursor(-1);
+        return;
+      case "down":
+        this.moveFileCursor(1);
+        return;
+      case "left":
+        this.leaveRepository();
+        return;
+      case "space":
+        this.toggleCurrentFile();
+        return;
+      case "backspace":
+        this.searchQuery = this.searchQuery.slice(0, -1);
+        this.searchActive = this.searchQuery.length > 0;
+        this.resetFileCursor();
+        return;
+      case "return":
+        this.leaveRepository();
+        return;
+      case "escape":
+        if (this.searchQuery || this.searchActive) {
+          this.searchQuery = "";
+          this.searchActive = false;
+          this.resetFileCursor();
+          return;
+        }
+        this.state = "cancel";
+        return;
+      default:
+        break;
+    }
+
+    if (!key) return;
+
+    if (key === "/") {
+      this.searchActive = true;
+      return;
+    }
+
+    if (key === "a" && !this.searchActive && this.searchQuery.length === 0) {
+      this.toggleAllVisibleFiles();
+      return;
+    }
+
+    if (!isPrintableKey(key)) return;
+
+    this.searchActive = true;
+    this.searchQuery += key;
+    this.resetFileCursor();
+  }
+
+  private get currentRepository(): GitHubImportRepositoryOption | undefined {
+    return this.repositories[this.repoCursor];
+  }
+
+  get filteredFiles(): GitHubImportFileOption[] {
+    const files = this.currentRepository?.files ?? [];
+    const query = this.searchQuery.trim().toLowerCase();
+    if (!query) return files;
+    return files.filter((file) => file.path.toLowerCase().includes(query));
+  }
+
+  private syncValue(): void {
+    this.value = Array.from(this.selectedIds);
+  }
+
+  private moveRepoCursor(delta: number): void {
+    if (this.repositories.length === 0) return;
+    this.repoCursor = wrapIndex(this.repoCursor + delta, this.repositories.length);
+  }
+
+  private moveFileCursor(delta: number): void {
+    if (this.filteredFiles.length === 0) return;
+    this.fileCursor = wrapIndex(this.fileCursor + delta, this.filteredFiles.length);
+  }
+
+  private enterRepository(): void {
+    if (!this.currentRepository) return;
+    this.mode = "files";
+    this.searchQuery = "";
+    this.searchActive = false;
+    this.resetFileCursor();
+  }
+
+  private leaveRepository(): void {
+    this.mode = "repos";
+    this.searchQuery = "";
+    this.searchActive = false;
+    this.fileCursor = 0;
+  }
+
+  private resetFileCursor(): void {
+    this.fileCursor = 0;
+  }
+
+  private toggleCurrentRepository(): void {
+    const repo = this.currentRepository;
+    if (!repo) return;
+    const selectableIds = getSelectableFileIds(repo.files);
+    if (selectableIds.length === 0) return;
+
+    const allSelected = selectableIds.every((id) => this.selectedIds.has(id));
+    if (allSelected) {
+      for (const id of selectableIds) {
+        this.selectedIds.delete(id);
+      }
+      return;
+    }
+
+    for (const id of selectableIds) {
+      this.selectedIds.add(id);
+    }
+  }
+
+  private toggleCurrentFile(): void {
+    const file = this.filteredFiles[this.fileCursor];
+    if (!file || file.is_synced) return;
+    if (this.selectedIds.has(file.id)) {
+      this.selectedIds.delete(file.id);
+      return;
+    }
+    this.selectedIds.add(file.id);
+  }
+
+  private toggleAllVisibleFiles(): void {
+    const selectableIds = getSelectableFileIds(this.filteredFiles);
+    if (selectableIds.length === 0) return;
+
+    const allSelected = selectableIds.every((id) => this.selectedIds.has(id));
+    if (allSelected) {
+      for (const id of selectableIds) {
+        this.selectedIds.delete(id);
+      }
+      return;
+    }
+
+    for (const id of selectableIds) {
+      this.selectedIds.add(id);
+    }
+  }
+
+  getRepositorySelectionState(repo: GitHubImportRepositoryOption): RepoSelectionState {
+    const selectableIds = getSelectableFileIds(repo.files);
+    if (selectableIds.length === 0) return "locked";
+
+    let selectedCount = 0;
+    for (const id of selectableIds) {
+      if (this.selectedIds.has(id)) selectedCount += 1;
+    }
+
+    if (selectedCount === 0) return "none";
+    if (selectedCount === selectableIds.length) return "all";
+    return "partial";
+  }
+
+  private renderPrompt(): string {
+    const promptSymbol =
+      this.state === "submit"
+        ? pc.green(SUBMIT_SYMBOL)
+        : this.state === "cancel"
+          ? pc.red(CANCEL_SYMBOL)
+          : pc.cyan(ACTIVE_SYMBOL);
+    const title =
+      this.mode === "repos" ? "Select docs to import" : (this.currentRepository?.slug ?? "Files");
+    const header = `${pc.gray(BAR)}
+${promptSymbol}  ${title}
+`;
+
+    if (this.state === "submit") {
+      return `${header}${pc.gray(BAR)}  ${pc.dim(this.submitLabel())}`;
+    }
+
+    if (this.state === "cancel") {
+      return `${header}${pc.gray(BAR)}`;
+    }
+
+    return this.mode === "repos" ? this.renderRepositoryMode(header) : this.renderFileMode(header);
+  }
+
+  private renderRepositoryMode(header: string): string {
+    const help = `${pc.gray(BAR)}  ${pc.dim(
+      "space: import all docs in a repo   →: browse repo docs   Enter: confirm",
+    )}`;
+    const body = visibleOptions(this.repoCursor, this.repositories.length).map((option) => {
+      if (option.kind === "ellipsis") {
+        return `${pc.gray(BAR)}  ${pc.dim(ELLIPSIS)}`;
+      }
+
+      const repo = this.repositories[option.index];
+      const isActive = option.index === this.repoCursor;
+      const state = this.getRepositorySelectionState(repo);
+      const marker = this.renderRepositoryMarker(state, isActive);
+      const label = isActive ? pc.cyan(repo.slug) : repo.slug;
+      const hint = state === "locked" ? ` ${pc.dim("(All docs already imported)")}` : "";
+      return `${pc.gray(BAR)}  ${marker} ${label}${hint}`;
+    });
+
+    return `${header}${help}
+${pc.gray(BAR)}
+${body.join("\n")}
+${pc.cyan(FOOTER)}`;
+  }
+
+  private renderFileMode(header: string): string {
+    const back = `${pc.gray(BAR)}  ${pc.dim("←: back / Enter")}`;
+    const searchValue = this.searchQuery || pc.dim(this.searchActive ? "" : "type to filter");
+    const search = `${pc.gray(BAR)}  Search: ${searchValue}`;
+    const help = `${pc.gray(BAR)}  ${pc.dim(
+      "space: toggle doc   type: search   a: select all visible   ←: back / Enter",
+    )}`;
+
+    const body = visibleOptions(
+      this.fileCursor,
+      this.filteredFiles.length,
+      MAX_VISIBLE_FILE_ITEMS,
+    ).map((option) => {
+      if (option.kind === "ellipsis") {
+        return `${pc.gray(BAR)}  ${pc.dim(ELLIPSIS)}`;
+      }
+
+      const file = this.filteredFiles[option.index];
+      const isActive = option.index === this.fileCursor;
+      const isSelected = this.selectedIds.has(file.id);
+      // Synced (disabled) rows still need a visible cursor state when active:
+      // the user can't toggle them, but should at least see where the cursor
+      // is. Mirror the repo-mode treatment of `locked` rows.
+      const marker = file.is_synced
+        ? isActive
+          ? pc.cyan(CHECKBOX_OFF)
+          : pc.dim(CHECKBOX_OFF)
+        : isSelected
+          ? isActive
+            ? pc.cyan(CHECKBOX_ON)
+            : CHECKBOX_ON
+          : isActive
+            ? pc.cyan(CHECKBOX_OFF)
+            : CHECKBOX_OFF;
+      const label = file.is_synced
+        ? isActive
+          ? pc.cyan(file.path)
+          : pc.dim(file.path)
+        : isActive
+          ? pc.cyan(file.path)
+          : file.path;
+      const hint = file.is_synced ? ` ${pc.dim("(Already imported)")}` : "";
+      return `${pc.gray(BAR)}  ${marker} ${label}${hint}`;
+    });
+
+    const content =
+      body.length > 0
+        ? body.join("\n")
+        : `${pc.gray(BAR)}  ${pc.dim("No docs match your search.")}`;
+
+    return `${header}${back}
+${pc.gray(BAR)}
+${search}
+${pc.gray(BAR)}
+${content}
+${pc.gray(BAR)}
+${help}
+${pc.cyan(FOOTER)}`;
+  }
+
+  private renderRepositoryMarker(state: RepoSelectionState, isActive: boolean): string {
+    if (state === "all") {
+      return isActive ? pc.cyan(CHECKBOX_ON) : CHECKBOX_ON;
+    }
+    if (state === "partial") {
+      return isActive ? pc.cyan(CHECKBOX_PARTIAL) : CHECKBOX_PARTIAL;
+    }
+    if (state === "locked") {
+      return isActive ? pc.cyan(CHECKBOX_OFF) : pc.dim(CHECKBOX_OFF);
+    }
+    return isActive ? pc.cyan(CHECKBOX_OFF) : CHECKBOX_OFF;
+  }
+
+  private submitLabel(): string {
+    const count = this.selectedIds.size;
+    if (count === 0) {
+      return "Skip for now";
+    }
+    return `${count} doc${count === 1 ? "" : "s"} selected`;
+  }
+}
+
+function getSelectableFileIds(files: GitHubImportFileOption[]): string[] {
+  return files.filter((file) => !file.is_synced).map((file) => file.id);
+}
+
+function visibleOptions(
+  cursor: number,
+  totalItems: number,
+  maxItems?: number,
+): Array<{ kind: "ellipsis" } | { kind: "option"; index: number }> {
+  const terminalRows = process.stdout.rows ? Math.max(process.stdout.rows - 8, 0) : totalItems;
+  const visibleCount = Math.min(terminalRows || totalItems, Math.max(maxItems ?? Infinity, 5));
+
+  if (visibleCount >= totalItems) {
+    return Array.from({ length: totalItems }, (_, index) => ({ kind: "option" as const, index }));
+  }
+
+  let start = 0;
+  if (cursor >= start + visibleCount - 3) {
+    start = Math.max(Math.min(cursor - visibleCount + 3, totalItems - visibleCount), 0);
+  } else if (cursor < start + 2) {
+    start = Math.max(cursor - 2, 0);
+  }
+
+  const hasTopEllipsis = visibleCount < totalItems && start > 0;
+  const hasBottomEllipsis = visibleCount < totalItems && start + visibleCount < totalItems;
+
+  return Array.from({ length: visibleCount }, (_, index) => {
+    const isTopEllipsis = index === 0 && hasTopEllipsis;
+    const isBottomEllipsis = index === visibleCount - 1 && hasBottomEllipsis;
+    if (isTopEllipsis || isBottomEllipsis) {
+      return { kind: "ellipsis" as const };
+    }
+    return { kind: "option" as const, index: start + index };
+  });
+}
+
+function wrapIndex(index: number, length: number): number {
+  if (length === 0) return 0;
+  if (index < 0) return length - 1;
+  if (index >= length) return 0;
+  return index;
+}
+
+function isPrintableKey(key: string): boolean {
+  return key.length === 1 && key >= " " && key !== "\u007f";
+}
+
+function supportsUnicode(): boolean {
+  if (process.platform !== "win32") {
+    return process.env.TERM !== "linux";
+  }
+  return !!(
+    process.env.CI ||
+    process.env.WT_SESSION ||
+    process.env.TERMINUS_SUBLIME ||
+    process.env.ConEmuTask === "{cmd::Cmder}" ||
+    process.env.TERM_PROGRAM === "Terminus-Sublime" ||
+    process.env.TERM_PROGRAM === "vscode" ||
+    process.env.TERM === "xterm-256color" ||
+    process.env.TERM === "alacritty" ||
+    process.env.TERMINAL_EMULATOR === "JetBrains-JediTerm"
+  );
+}
+
+function symbol(unicodeValue: string, asciiValue: string): string {
+  return unicode ? unicodeValue : asciiValue;
+}

--- a/src/setup/github-doc-import-step.test.ts
+++ b/src/setup/github-doc-import-step.test.ts
@@ -1,0 +1,448 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPromptGitHubDocsImport, mockTrpc } = vi.hoisted(() => ({
+  mockPromptGitHubDocsImport: vi.fn(),
+  mockTrpc: {
+    dataSource: { list: { query: vi.fn() } },
+    docImports: {
+      listImportableGithubFiles: { query: vi.fn() },
+      importGithubFiles: { mutate: vi.fn() },
+      getImportStatus: { query: vi.fn() },
+    },
+    knowledgeStore: {
+      getBySpaceId: { query: vi.fn() },
+    },
+  },
+}));
+
+vi.mock("@clack/prompts", () => ({
+  select: vi.fn(),
+  isCancel: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
+  log: {
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("../debug/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    getLogPath: vi.fn(() => "/tmp/test-debug.log"),
+  },
+}));
+
+vi.mock("../client/trpc", () => ({
+  createTypedClient: vi.fn(() => mockTrpc),
+}));
+
+vi.mock("./github-doc-import-prompt", () => ({
+  promptGitHubDocsImport: (...args: unknown[]) => mockPromptGitHubDocsImport(...args),
+}));
+
+import * as p from "@clack/prompts";
+import type { Config } from "../config/config";
+import { stepImportGitHubDocs } from "./github-doc-import-step";
+
+function makeCfg(overrides: Partial<Config> = {}): Config {
+  return {
+    access_token: "tok",
+    refresh_token: "ref",
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    api_key: "sk_user_x",
+    deployment_id: "dep-mcp",
+    deployment_name: "Default MCP",
+    org_id: "org-1",
+    space_id: "space-1",
+    ...overrides,
+  };
+}
+
+describe("stepImportGitHubDocs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+    vi.mocked(p.select).mockResolvedValue("skip");
+    mockPromptGitHubDocsImport.mockResolvedValue([]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { provider_slug: "github", is_indexed: false },
+    ]);
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([]);
+    mockTrpc.knowledgeStore.getBySpaceId.query.mockResolvedValue({ id: "ks-1" });
+    mockTrpc.docImports.importGithubFiles.mutate.mockResolvedValue({ task_id: "task-1" });
+    mockTrpc.docImports.getImportStatus.query.mockResolvedValue({
+      task_id: "task-1",
+      state: "SUCCESS",
+      detail: {
+        message: "COMPLETED",
+        knowledge_store_id: "ks-1",
+        provider: "github",
+        total: 1,
+        completed: 1,
+        failed: 0,
+        documents: [
+          {
+            id: "file-1",
+            title: "docs/auth/login.md",
+            status: "SUCCESS",
+          },
+        ],
+      },
+      created_at: "2026-04-24T00:00:00Z",
+      updated_at: "2026-04-24T00:00:02Z",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("returns advance=false when cfg has no org_id / space_id", async () => {
+    const result = await stepImportGitHubDocs(makeCfg({ org_id: undefined, space_id: undefined }));
+
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.docImports.listImportableGithubFiles.query).not.toHaveBeenCalled();
+  });
+
+  it("reads current importable docs immediately when not waiting for a fresh repo", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/auth/login.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+      {
+        id: "file-2",
+        file_path: "README.md",
+        repository_slug: "acme/api",
+        is_synced: true,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(mockTrpc.docImports.listImportableGithubFiles.query).toHaveBeenCalledTimes(1);
+    expect(mockTrpc.dataSource.list.query).not.toHaveBeenCalled();
+    expect(p.select).not.toHaveBeenCalled();
+    expect(mockPromptGitHubDocsImport).toHaveBeenCalledWith({
+      repositories: [
+        {
+          slug: "acme/api",
+          files: [
+            { id: "file-1", path: "docs/auth/login.md", is_synced: false },
+            { id: "file-2", path: "README.md", is_synced: true },
+          ],
+        },
+      ],
+    });
+    expect(mockTrpc.knowledgeStore.getBySpaceId.query).toHaveBeenCalledWith({
+      space_id: "space-1",
+    });
+    expect(mockTrpc.docImports.importGithubFiles.mutate).toHaveBeenCalledWith({
+      knowledge_store_id: "ks-1",
+      space_id: "space-1",
+      file_ids: ["file-1"],
+    });
+    expect(mockTrpc.docImports.getImportStatus.query).toHaveBeenCalledWith("task-1");
+    expect(result.advance).toBe(true);
+  });
+
+  it("waits for docs only when a fresh repo was connected in this run", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "file-1",
+          file_path: "docs/auth/login.md",
+          repository_slug: "acme/api",
+          is_synced: false,
+        },
+        {
+          id: "file-2",
+          file_path: "README.md",
+          repository_slug: "acme/api",
+          is_synced: true,
+        },
+      ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+
+    const result = await stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+
+    expect(mockTrpc.docImports.listImportableGithubFiles.query).toHaveBeenCalledTimes(2);
+    expect(mockPromptGitHubDocsImport).toHaveBeenCalledWith({
+      repositories: [
+        {
+          slug: "acme/api",
+          files: [
+            { id: "file-1", path: "docs/auth/login.md", is_synced: false },
+            { id: "file-2", path: "README.md", is_synced: true },
+          ],
+        },
+      ],
+    });
+    expect(mockTrpc.knowledgeStore.getBySpaceId.query).toHaveBeenCalledWith({
+      space_id: "space-1",
+    });
+    expect(mockTrpc.docImports.importGithubFiles.mutate).toHaveBeenCalledWith({
+      knowledge_store_id: "ks-1",
+      space_id: "space-1",
+      file_ids: ["file-1"],
+    });
+    expect(mockTrpc.docImports.getImportStatus.query).toHaveBeenCalledWith("task-1");
+    expect(result.advance).toBe(true);
+  });
+
+  it("treats an empty doc selection as skip and does not start an import", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue([]);
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(mockTrpc.docImports.importGithubFiles.mutate).not.toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+  });
+
+  it("polls import status until the task succeeds", async () => {
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/auth/login.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.getImportStatus.query
+      .mockResolvedValueOnce({
+        task_id: "task-1",
+        state: "PROGRESS",
+        detail: {
+          message: "STARTING",
+          knowledge_store_id: "ks-1",
+          provider: "github",
+          total: 1,
+          completed: 0,
+          failed: 0,
+          documents: [{ id: "file-1", title: "docs/auth/login.md", status: "PENDING" }],
+        },
+        created_at: "2026-04-24T00:00:00Z",
+        updated_at: null,
+      })
+      .mockResolvedValueOnce({
+        task_id: "task-1",
+        state: "SUCCESS",
+        detail: {
+          message: "COMPLETED",
+          knowledge_store_id: "ks-1",
+          provider: "github",
+          total: 1,
+          completed: 1,
+          failed: 0,
+          documents: [{ id: "file-1", title: "docs/auth/login.md", status: "SUCCESS" }],
+        },
+        created_at: "2026-04-24T00:00:00Z",
+        updated_at: "2026-04-24T00:00:02Z",
+      });
+
+    const resultPromise = stepImportGitHubDocs(makeCfg());
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await resultPromise;
+
+    const spinnerInstance = vi.mocked(p.spinner).mock.results.at(-1)?.value;
+    expect(spinnerInstance?.message).toHaveBeenCalledWith(
+      "Preparing document import... 0/1 complete",
+    );
+    expect(spinnerInstance?.message).toHaveBeenCalledWith("Import complete (1/1)");
+    expect(spinnerInstance?.stop).toHaveBeenCalledWith("Import complete");
+    expect(p.log.success).toHaveBeenCalledWith(
+      "Imported 1 doc.\nYour GitHub docs are ready, and onboarding is complete.",
+    );
+    expect(result.advance).toBe(true);
+  });
+
+  it("falls back to the client-selected count when server reports total=0 during STARTING", async () => {
+    // Reproduces the bug where the progress spinner showed "0/0 complete"
+    // because the server returns total=0 until it finishes enumerating files.
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/a.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+      {
+        id: "file-2",
+        file_path: "docs/b.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1", "file-2"]);
+    mockTrpc.docImports.getImportStatus.query
+      .mockResolvedValueOnce({
+        task_id: "task-1",
+        state: "PROGRESS",
+        detail: {
+          message: "STARTING",
+          knowledge_store_id: "ks-1",
+          provider: "github",
+          total: 0, // server hasn't enumerated yet
+          completed: 0,
+          failed: 0,
+          documents: [],
+        },
+        created_at: "2026-04-24T00:00:00Z",
+        updated_at: null,
+      })
+      .mockResolvedValueOnce({
+        task_id: "task-1",
+        state: "SUCCESS",
+        detail: {
+          message: "COMPLETED",
+          knowledge_store_id: "ks-1",
+          provider: "github",
+          total: 2,
+          completed: 2,
+          failed: 0,
+          documents: [
+            { id: "file-1", title: "docs/a.md", status: "SUCCESS" },
+            { id: "file-2", title: "docs/b.md", status: "SUCCESS" },
+          ],
+        },
+        created_at: "2026-04-24T00:00:00Z",
+        updated_at: "2026-04-24T00:00:02Z",
+      });
+
+    const resultPromise = stepImportGitHubDocs(makeCfg());
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await resultPromise;
+
+    const spinnerInstance = vi.mocked(p.spinner).mock.results.at(-1)?.value;
+    // Must use the client-known selection (2) rather than the server's 0.
+    expect(spinnerInstance?.message).toHaveBeenCalledWith(
+      "Preparing document import... 0/2 complete",
+    );
+    expect(spinnerInstance?.message).not.toHaveBeenCalledWith(expect.stringContaining("0/0"));
+    expect(spinnerInstance?.message).toHaveBeenCalledWith("Import complete (2/2)");
+    expect(result.advance).toBe(true);
+  });
+
+  it("surfaces partial failures after the import task completes", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/auth/login.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+      {
+        id: "file-2",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1", "file-2"]);
+    mockTrpc.docImports.getImportStatus.query.mockResolvedValue({
+      task_id: "task-1",
+      state: "FAILURE",
+      detail: {
+        message: "COMPLETED_WITH_ERRORS",
+        knowledge_store_id: "ks-1",
+        provider: "github",
+        total: 2,
+        completed: 1,
+        failed: 1,
+        documents: [
+          { id: "file-1", title: "docs/auth/login.md", status: "SUCCESS" },
+          { id: "file-2", title: "docs/setup.md", status: "FAILED", error: "boom" },
+        ],
+      },
+      created_at: "2026-04-24T00:00:00Z",
+      updated_at: "2026-04-24T00:00:02Z",
+    });
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    const spinnerInstance = vi.mocked(p.spinner).mock.results.at(-1)?.value;
+    expect(spinnerInstance?.stop).toHaveBeenCalledWith("Import completed with issues");
+    expect(p.log.warn).toHaveBeenCalledWith(
+      "Imported 1 of 2 docs; 1 failed.\nYou can review the failed docs later, but onboarding is complete.",
+    );
+    expect(result.advance).toBe(true);
+  });
+
+  it("lets onboarding continue if progress polling becomes unavailable", async () => {
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/auth/login.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.getImportStatus.query.mockRejectedValue(new Error("network"));
+
+    const resultPromise = stepImportGitHubDocs(makeCfg());
+    await vi.advanceTimersByTimeAsync(4_000);
+    const result = await resultPromise;
+
+    const spinnerInstance = vi.mocked(p.spinner).mock.results.at(-1)?.value;
+    expect(spinnerInstance?.stop).toHaveBeenCalledWith("Stopped watching import progress");
+    expect(p.log.info).toHaveBeenCalledWith(
+      "The import is still running in the background.\nCheck status later with: dosu docs import-status task-1",
+    );
+    expect(result.advance).toBe(true);
+  });
+
+  it("shows an immediate empty state when no docs are currently importable", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([]);
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(p.spinner).not.toHaveBeenCalled();
+    expect(p.select).not.toHaveBeenCalled();
+    expect(mockPromptGitHubDocsImport).not.toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+  });
+
+  it("offers skip after the 60-second scan timeout", async () => {
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([]);
+    vi.mocked(p.select).mockResolvedValue("skip");
+
+    const resultPromise = stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+    await vi.advanceTimersByTimeAsync(60_000);
+    const result = await resultPromise;
+
+    expect(p.select).toHaveBeenCalledWith({
+      message: "Still waiting for GitHub docs to become available",
+      options: [
+        { value: "retry", label: "Retry" },
+        { value: "skip", label: "Skip for now" },
+      ],
+    });
+    expect(mockPromptGitHubDocsImport).not.toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+  });
+});

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -1,0 +1,365 @@
+import * as p from "@clack/prompts";
+import { createTypedClient } from "../client/trpc";
+import type { Config } from "../config/config";
+import { logger } from "../debug/logger";
+import {
+  type GitHubImportFileOption,
+  type GitHubImportRepositoryOption,
+  promptGitHubDocsImport,
+} from "./github-doc-import-prompt";
+
+// biome-ignore lint/suspicious/noExplicitAny: `@dosu/api-types` does not fully cover these routes yet.
+type TrpcAny = any;
+
+const DOC_SCAN_POLL_INTERVAL_MS = 2_000;
+const DOC_SCAN_POLL_TIMEOUT_MS = 60_000;
+const IMPORT_STATUS_POLL_INTERVAL_MS = 2_000;
+const IMPORT_STATUS_MAX_ERRORS = 3;
+
+interface GitHubDataSource {
+  provider_slug?: string;
+  is_indexed?: boolean;
+}
+
+interface ImportableGithubFile {
+  id: string;
+  file_path: string;
+  repository_slug: string | null;
+  is_synced?: boolean;
+}
+
+type AsyncTaskState = "PROGRESS" | "SUCCESS" | "FAILURE";
+type ImportDocumentState = "PENDING" | "SUCCESS" | "FAILED";
+
+interface ImportTaskDocument {
+  id: string;
+  title: string;
+  status: ImportDocumentState;
+  error?: string;
+}
+
+interface ImportTaskDetail {
+  message: string;
+  knowledge_store_id: string;
+  provider: string;
+  total: number;
+  completed: number;
+  failed: number;
+  documents: ImportTaskDocument[];
+}
+
+interface ImportTaskStatusResponse {
+  task_id: string;
+  state: AsyncTaskState;
+  detail: ImportTaskDetail | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface GitHubDocsImportStepResult {
+  advance: boolean;
+}
+
+export interface GitHubDocsImportStepOptions {
+  waitForFreshDocs?: boolean;
+}
+
+export async function stepImportGitHubDocs(
+  cfg: Config,
+  opts: GitHubDocsImportStepOptions = {},
+): Promise<GitHubDocsImportStepResult> {
+  logger.info("setup", "Step: import GitHub docs");
+
+  if (!cfg.org_id || !cfg.space_id) {
+    p.log.warn(
+      "Cannot import GitHub docs: your Dosu workspace is missing org/space context. " +
+        "Re-run `dosu setup` from a fresh state.",
+    );
+    return { advance: false };
+  }
+
+  const trpc: TrpcAny = createTypedClient(cfg);
+  const files = opts.waitForFreshDocs
+    ? await waitForImportableGithubFiles(trpc, cfg.org_id, cfg.space_id)
+    : await fetchImportableGithubFiles(trpc, cfg.space_id);
+  if (files === null) {
+    return { advance: false };
+  }
+
+  if (files.length === 0) {
+    p.log.info("No markdown docs available to import right now. You can import them later.");
+    return { advance: true };
+  }
+
+  const repositories = buildRepositories(files);
+  const selected = await promptGitHubDocsImport({ repositories });
+  if (p.isCancel(selected)) {
+    logger.info("setup", "GitHub doc import selection cancelled");
+    return { advance: false };
+  }
+
+  const fileIDs = selected as string[];
+  if (fileIDs.length === 0) {
+    p.log.info("Skipped importing docs for now. You can import them later.");
+    return { advance: true };
+  }
+
+  const knowledgeStoreID = await getKnowledgeStoreID(trpc, cfg.space_id);
+  if (!knowledgeStoreID) {
+    return { advance: false };
+  }
+
+  const spinner = p.spinner();
+  spinner.start(`Queueing import for ${fileIDs.length} doc${fileIDs.length === 1 ? "" : "s"}...`);
+  try {
+    const result = (await trpc.docImports.importGithubFiles.mutate({
+      knowledge_store_id: knowledgeStoreID,
+      space_id: cfg.space_id,
+      file_ids: fileIDs,
+    })) as { task_id?: string } | null;
+
+    const taskID = result?.task_id;
+    if (!taskID) {
+      spinner.stop("Import task started");
+      p.log.success("Import task started.");
+      p.log.info("Your docs should finish importing in a few minutes.");
+      return { advance: true };
+    }
+
+    spinner.stop("Import task started");
+    logger.info("setup", `Watching import task ${taskID}`);
+    p.log.info("This can take a few minutes. We'll keep watching until it finishes.");
+
+    const progressSpinner = p.spinner();
+    progressSpinner.start(`Preparing document import... 0/${fileIDs.length} complete`);
+    const finalStatus = await waitForImportTaskCompletion(
+      trpc,
+      taskID,
+      progressSpinner,
+      fileIDs.length,
+    );
+    if (!finalStatus) {
+      progressSpinner.stop("Stopped watching import progress");
+      p.log.info(
+        `The import is still running in the background.\nCheck status later with: dosu docs import-status ${taskID}`,
+      );
+      return { advance: true };
+    }
+
+    handleImportCompletion(finalStatus, progressSpinner);
+    return { advance: true };
+  } catch (err: unknown) {
+    spinner.stop("Failed");
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("setup", `Failed to import GitHub docs: ${msg}`);
+    p.log.error("Could not start the GitHub doc import.");
+    return { advance: false };
+  }
+}
+
+async function waitForImportTaskCompletion(
+  trpc: TrpcAny,
+  taskID: string,
+  spinner: ReturnType<typeof p.spinner>,
+  expectedTotal: number,
+): Promise<ImportTaskStatusResponse | null> {
+  let consecutiveErrors = 0;
+
+  while (true) {
+    try {
+      const status = (await trpc.docImports.getImportStatus.query(
+        taskID,
+      )) as ImportTaskStatusResponse | null;
+
+      if (!status) {
+        consecutiveErrors += 1;
+        if (consecutiveErrors >= IMPORT_STATUS_MAX_ERRORS) {
+          return null;
+        }
+      } else {
+        consecutiveErrors = 0;
+        spinner.message(buildImportProgressMessage(status, expectedTotal));
+        if (status.state !== "PROGRESS") {
+          return status;
+        }
+      }
+    } catch (err: unknown) {
+      consecutiveErrors += 1;
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn("setup", `getImportStatus failed for ${taskID}: ${msg}`);
+      if (consecutiveErrors >= IMPORT_STATUS_MAX_ERRORS) {
+        return null;
+      }
+    }
+
+    await sleep(IMPORT_STATUS_POLL_INTERVAL_MS);
+  }
+}
+
+function buildImportProgressMessage(
+  status: ImportTaskStatusResponse,
+  expectedTotal: number,
+): string {
+  const detail = status.detail;
+  if (!detail) {
+    return `Importing documents... 0/${expectedTotal} complete`;
+  }
+
+  const processed = detail.completed + detail.failed;
+  // Server returns total=0 until it finishes enumerating files (STARTING state).
+  // Fall back to the client-known count so the UI never shows "0/0".
+  const total = detail.total > 0 ? detail.total : expectedTotal;
+
+  if (status.state === "SUCCESS") {
+    return `Import complete (${processed}/${total})`;
+  }
+
+  if (status.state === "FAILURE") {
+    return `Import finished with issues (${processed}/${total}, ${detail.failed} failed)`;
+  }
+
+  const prefix =
+    detail.message === "STARTING" ? "Preparing document import" : "Importing documents";
+  const failureSuffix = detail.failed > 0 ? `, ${detail.failed} failed` : "";
+  return `${prefix}... ${processed}/${total} complete${failureSuffix}`;
+}
+
+function handleImportCompletion(
+  status: ImportTaskStatusResponse,
+  spinner: ReturnType<typeof p.spinner>,
+): void {
+  const detail = status.detail;
+  const processed = detail ? detail.completed + detail.failed : 0;
+  const total = detail?.total ?? processed;
+  const failed = detail?.failed ?? 0;
+
+  if (status.state === "SUCCESS") {
+    spinner.stop("Import complete");
+    p.log.success(
+      `Imported ${total} doc${total === 1 ? "" : "s"}.\nYour GitHub docs are ready, and onboarding is complete.`,
+    );
+    return;
+  }
+
+  spinner.stop("Import completed with issues");
+  p.log.warn(
+    `Imported ${processed - failed} of ${total} doc${total === 1 ? "" : "s"}; ${failed} failed.\nYou can review the failed docs later, but onboarding is complete.`,
+  );
+}
+
+async function waitForImportableGithubFiles(
+  trpc: TrpcAny,
+  orgID: string,
+  spaceID: string,
+): Promise<ImportableGithubFile[] | null> {
+  while (true) {
+    const spinner = p.spinner();
+    spinner.start("Scanning repositories for markdown documents...");
+    p.log.info("This usually takes a few seconds.");
+
+    const startedAt = Date.now();
+    let latestFiles: ImportableGithubFile[] = [];
+
+    while (Date.now() - startedAt < DOC_SCAN_POLL_TIMEOUT_MS) {
+      latestFiles = await fetchImportableGithubFiles(trpc, spaceID);
+      if (latestFiles.length > 0) {
+        spinner.stop("Docs ready");
+        return latestFiles;
+      }
+
+      await fetchGitHubDataSources(trpc, orgID);
+      await sleep(DOC_SCAN_POLL_INTERVAL_MS);
+    }
+
+    spinner.stop("Timed out");
+    const choice = await p.select({
+      message: "Still waiting for GitHub docs to become available",
+      options: [
+        { value: "retry", label: "Retry" },
+        { value: "skip", label: "Skip for now" },
+      ],
+    });
+
+    if (p.isCancel(choice)) {
+      return null;
+    }
+    if (choice === "skip") {
+      p.log.info("Skipped importing docs for now. You can import them later.");
+      return [];
+    }
+  }
+}
+
+async function fetchGitHubDataSources(trpc: TrpcAny, orgID: string): Promise<GitHubDataSource[]> {
+  try {
+    const dataSources = (await trpc.dataSource.list.query({
+      org_id: orgID,
+      excluded_provider_slugs: [],
+    })) as GitHubDataSource[];
+    return dataSources.filter((dataSource) => dataSource.provider_slug === "github");
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("setup", `dataSource.list failed while waiting for docs: ${msg}`);
+    return [];
+  }
+}
+
+async function fetchImportableGithubFiles(
+  trpc: TrpcAny,
+  spaceID: string,
+): Promise<ImportableGithubFile[]> {
+  try {
+    return (await trpc.docImports.listImportableGithubFiles.query(
+      spaceID,
+    )) as ImportableGithubFile[];
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("setup", `listImportableGithubFiles failed: ${msg}`);
+    return [];
+  }
+}
+
+function buildRepositories(files: ImportableGithubFile[]): GitHubImportRepositoryOption[] {
+  const repositories = new Map<string, GitHubImportRepositoryOption>();
+
+  for (const file of files) {
+    const slug = file.repository_slug ?? "unknown";
+    if (!repositories.has(slug)) {
+      repositories.set(slug, { slug, files: [] });
+    }
+    repositories.get(slug)?.files.push({
+      id: file.id,
+      path: file.file_path,
+      is_synced: file.is_synced,
+    } satisfies GitHubImportFileOption);
+  }
+
+  return Array.from(repositories.values())
+    .map((repository) => ({
+      ...repository,
+      files: [...repository.files].sort((a, b) => a.path.localeCompare(b.path)),
+    }))
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+async function getKnowledgeStoreID(trpc: TrpcAny, spaceID: string): Promise<string | null> {
+  try {
+    const store = (await trpc.knowledgeStore.getBySpaceId.query({
+      space_id: spaceID,
+    })) as { id: string } | null;
+    if (!store?.id) {
+      p.log.error("No knowledge store found for this deployment.");
+      return null;
+    }
+    return store.id;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("setup", `knowledgeStore.getBySpaceId failed: ${msg}`);
+    p.log.error("Could not load the knowledge store for this deployment.");
+    return null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/setup/github-repo-prompt.test.ts
+++ b/src/setup/github-repo-prompt.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ADD_REPOSITORIES_VALUE, GitHubRepoPrompt } from "./github-repo-prompt";
+
+type PromptOption =
+  | { kind: "action"; value: typeof ADD_REPOSITORIES_VALUE; label: string; hint?: string }
+  | { kind: "repo"; value: string; label: string; hint?: string };
+
+const ACTION_OPTION: PromptOption = {
+  kind: "action",
+  value: ADD_REPOSITORIES_VALUE,
+  label: "Add repositories...",
+  hint: "opens GitHub",
+};
+
+function repoOptions(...slugs: string[]): PromptOption[] {
+  return slugs.map((slug, index) => ({
+    kind: "repo" as const,
+    value: slug,
+    label: slug,
+    hint: index === 0 ? "primary" : undefined,
+  }));
+}
+
+function makePrompt(
+  options: PromptOption[],
+  extras?: { initialValues?: string[]; maxItems?: number },
+) {
+  return new GitHubRepoPrompt({
+    message: "Pick repositories",
+    options,
+    initialValues: extras?.initialValues,
+    maxItems: extras?.maxItems,
+  });
+}
+
+function render(prompt: GitHubRepoPrompt): string {
+  return (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+}
+
+describe("GitHubRepoPrompt", () => {
+  const originalRows = process.stdout.rows;
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdout, "rows", { value: 30, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, "rows", { value: originalRows, configurable: true });
+  });
+
+  it("starts with no selections and cursor at 0 when no initialValues are given", () => {
+    const prompt = makePrompt([ACTION_OPTION, ...repoOptions("acme/api", "acme/core")]);
+    expect(prompt.cursor).toBe(0);
+    expect(prompt.value).toBe(ADD_REPOSITORIES_VALUE);
+  });
+
+  it("places the cursor on the first matching initialValue and pre-selects it", () => {
+    const options = [ACTION_OPTION, ...repoOptions("acme/api", "acme/core")];
+    const prompt = makePrompt(options, { initialValues: ["acme/core"] });
+    expect(prompt.cursor).toBe(2);
+    expect(prompt.value).toEqual(["acme/core"]);
+  });
+
+  it("ignores initialValues that don't correspond to a repo option", () => {
+    const options = [ACTION_OPTION, ...repoOptions("acme/api")];
+    const prompt = makePrompt(options, { initialValues: ["bogus/repo"] });
+    expect(prompt.cursor).toBe(0);
+    expect(prompt.value).toBe(ADD_REPOSITORIES_VALUE);
+  });
+
+  it("wraps cursor when moving up from index 0 and down from the last index", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b", "c/d")];
+    const prompt = makePrompt(options);
+    prompt.emit("cursor", "up");
+    expect(prompt.cursor).toBe(options.length - 1);
+    prompt.emit("cursor", "down");
+    expect(prompt.cursor).toBe(0);
+  });
+
+  it("treats left/up and right/down identically", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b", "c/d")];
+    const prompt = makePrompt(options);
+    prompt.emit("cursor", "right");
+    expect(prompt.cursor).toBe(1);
+    prompt.emit("cursor", "left");
+    expect(prompt.cursor).toBe(0);
+    prompt.emit("cursor", "down");
+    expect(prompt.cursor).toBe(1);
+    prompt.emit("cursor", "up");
+    expect(prompt.cursor).toBe(0);
+  });
+
+  it("toggles a repo selection on space and untoggles on a second press", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b", "c/d")];
+    const prompt = makePrompt(options);
+    prompt.emit("cursor", "down");
+    prompt.emit("cursor", "space");
+    expect(prompt.value).toEqual(["a/b"]);
+    prompt.emit("cursor", "space");
+    expect(prompt.value).toEqual([]);
+  });
+
+  it("does nothing when space is pressed on the action option", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b")];
+    const prompt = makePrompt(options);
+    prompt.emit("cursor", "space");
+    expect(prompt.value).toBe(ADD_REPOSITORIES_VALUE);
+  });
+
+  it("selects every repo with 'a' and clears them on a second 'a'", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b", "c/d", "e/f")];
+    const prompt = makePrompt(options);
+    prompt.emit("cursor", "down");
+    prompt.emit("key", "a");
+    expect(prompt.value).toEqual(["a/b", "c/d", "e/f"]);
+    prompt.emit("key", "a");
+    expect(prompt.value).toEqual([]);
+  });
+
+  it("ignores keys other than 'a'", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b")];
+    const prompt = makePrompt(options);
+    prompt.emit("cursor", "down");
+    prompt.emit("key", "z");
+    expect(prompt.value).toEqual([]);
+  });
+
+  it("ignores cursor events for unhandled keys", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b")];
+    const prompt = makePrompt(options);
+    const before = prompt.cursor;
+    (prompt.emit as (event: string, key: string) => void)("cursor", "tab");
+    expect(prompt.cursor).toBe(before);
+  });
+});
+
+describe("GitHubRepoPrompt rendering", () => {
+  it("renders the active option, checkbox markers, and hints in default state", () => {
+    const options = [ACTION_OPTION, ...repoOptions("acme/api", "acme/core")];
+    const prompt = makePrompt(options, { initialValues: ["acme/core"] });
+    const output = render(prompt);
+    expect(output).toContain("Pick repositories");
+    expect(output).toContain("acme/api");
+    expect(output).toContain("acme/core");
+    expect(output).toContain("(primary)");
+    expect(output).toContain("Add repositories...");
+  });
+
+  it("renders the submit label with the joined repo selection", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b", "c/d")];
+    const prompt = makePrompt(options, { initialValues: ["a/b", "c/d"] });
+    (prompt as unknown as { state: string }).state = "submit";
+    const output = render(prompt);
+    expect(output).toContain("a/b, c/d");
+  });
+
+  it("renders the action label on submit when the action is the value", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b")];
+    const prompt = makePrompt(options);
+    (prompt as unknown as { state: string }).state = "submit";
+    const output = render(prompt);
+    expect(output).toContain("Add repositories...");
+  });
+
+  it("falls back to a default action label when no action option is present", () => {
+    const options = [...repoOptions("a/b")];
+    const prompt = makePrompt(options);
+    (prompt as unknown as { state: string; value: unknown }).value = ADD_REPOSITORIES_VALUE;
+    (prompt as unknown as { state: string }).state = "submit";
+    const output = render(prompt);
+    expect(output).toContain("Add repositories...");
+  });
+
+  it("renders the empty-selection submit label", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b")];
+    const prompt = makePrompt(options);
+    prompt.emit("cursor", "down");
+    prompt.emit("cursor", "space");
+    prompt.emit("cursor", "space");
+    (prompt as unknown as { state: string }).state = "submit";
+    const output = render(prompt);
+    expect(output).toContain("No repositories selected.");
+  });
+
+  it("renders only the header on cancel", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b", "c/d")];
+    const prompt = makePrompt(options);
+    (prompt as unknown as { state: string }).state = "cancel";
+    const output = render(prompt);
+    expect(output).toContain("Pick repositories");
+    expect(output).not.toContain("a/b");
+  });
+
+  it("renders ellipsis markers when option count exceeds the visible viewport", () => {
+    Object.defineProperty(process.stdout, "rows", { value: 12, configurable: true });
+    const options: PromptOption[] = [ACTION_OPTION];
+    for (let i = 0; i < 20; i += 1) {
+      options.push({ kind: "repo", value: `org/repo-${i}`, label: `org/repo-${i}` });
+    }
+    const prompt = makePrompt(options);
+    for (let i = 0; i < 10; i += 1) {
+      prompt.emit("cursor", "down");
+    }
+    const output = render(prompt);
+    expect(output).toContain("...");
+  });
+
+  it("highlights the active action option with a colored arrow", () => {
+    const options = [ACTION_OPTION, ...repoOptions("a/b")];
+    const prompt = makePrompt(options);
+    expect(prompt.cursor).toBe(0);
+    const output = render(prompt);
+    // Active arrow uses pc.cyan; check we render the active state somehow
+    expect(output).toContain("Add repositories...");
+    expect(output).toContain("a/b");
+  });
+
+  it("renders selected-but-inactive and active-but-unselected checkbox states", () => {
+    const options = [...repoOptions("a/b", "c/d", "e/f")];
+    const prompt = makePrompt(options, { initialValues: ["c/d"] });
+    // Cursor lands on the only selected item (c/d). Move it to a/b: that
+    // exercises both "active unselected" (a/b) and "inactive selected" (c/d).
+    prompt.emit("cursor", "up");
+    expect(prompt.cursor).toBe(0);
+    const output = render(prompt);
+    expect(output).toContain("a/b");
+    expect(output).toContain("c/d");
+    expect(output).toContain("e/f");
+  });
+
+  it("scrolls the viewport when the cursor sits near the start of a long list", () => {
+    Object.defineProperty(process.stdout, "rows", { value: 12, configurable: true });
+    const options: PromptOption[] = [];
+    for (let i = 0; i < 20; i += 1) {
+      options.push({ kind: "repo", value: `org/repo-${i}`, label: `org/repo-${i}` });
+    }
+    // maxItems=5 forces a small viewport, exercising the start-scrolling branch
+    const prompt = makePrompt(options, { maxItems: 5 });
+    expect(prompt.cursor).toBe(0);
+    const output = render(prompt);
+    expect(output).toContain("org/repo-0");
+  });
+});

--- a/src/setup/github-repo-prompt.ts
+++ b/src/setup/github-repo-prompt.ts
@@ -1,0 +1,247 @@
+import { Prompt } from "@clack/core";
+import pc from "picocolors";
+
+const unicode = supportsUnicode();
+const ACTIVE_SYMBOL = symbol("◆", "*");
+const SUBMIT_SYMBOL = symbol("◇", "o");
+const CANCEL_SYMBOL = symbol("■", "x");
+const BAR = symbol("│", "|");
+const FOOTER = symbol("└", "-");
+const CHECKBOX_OFF = symbol("◻", "[ ]");
+const CHECKBOX_ON = symbol("◼", "[+]");
+const ACTION_ARROW = symbol("→", ">");
+const ELLIPSIS = "...";
+
+export const ADD_REPOSITORIES_VALUE = "__add_repositories__" as const;
+
+type PromptOption =
+  | {
+      kind: "action";
+      value: typeof ADD_REPOSITORIES_VALUE;
+      label: string;
+      hint?: string;
+    }
+  | {
+      kind: "repo";
+      value: string;
+      label: string;
+      hint?: string;
+    };
+
+interface PromptGitHubRepositoriesOptions {
+  message: string;
+  options: PromptOption[];
+  initialValues?: string[];
+  maxItems?: number;
+}
+
+export async function promptGitHubRepositories({
+  message,
+  options,
+  initialValues = [],
+  maxItems,
+}: PromptGitHubRepositoriesOptions): Promise<symbol | typeof ADD_REPOSITORIES_VALUE | string[]> {
+  const prompt = new GitHubRepoPrompt({
+    message,
+    options,
+    initialValues,
+    maxItems,
+  });
+  return (await prompt.prompt()) as symbol | typeof ADD_REPOSITORIES_VALUE | string[];
+}
+
+class GitHubRepoPrompt extends Prompt {
+  options: PromptOption[];
+  message: string;
+  maxItems?: number;
+  cursor = 0;
+  private selected: string[];
+
+  constructor({ message, options, initialValues = [], maxItems }: PromptGitHubRepositoriesOptions) {
+    super(
+      {
+        render() {
+          return (this as GitHubRepoPrompt).renderPrompt();
+        },
+      },
+      false,
+    );
+
+    this.message = message;
+    this.options = options;
+    this.maxItems = maxItems;
+    this.selected = initialValues.filter((value) =>
+      options.some((option) => option.kind === "repo" && option.value === value),
+    );
+    this.cursor = Math.max(
+      this.options.findIndex(
+        (option) => option.kind === "repo" && this.selected.includes(option.value),
+      ),
+      0,
+    );
+    this.syncValue();
+
+    this.on("key", (key) => {
+      if (key === "a") {
+        this.toggleAll();
+        this.syncValue();
+      }
+    });
+
+    this.on("cursor", (key) => {
+      switch (key) {
+        case "left":
+        case "up":
+          this.cursor = this.cursor === 0 ? this.options.length - 1 : this.cursor - 1;
+          break;
+        case "down":
+        case "right":
+          this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1;
+          break;
+        case "space":
+          this.toggleCurrent();
+          break;
+      }
+      this.syncValue();
+    });
+  }
+
+  private get currentOption(): PromptOption {
+    return this.options[this.cursor] ?? this.options[0];
+  }
+
+  private syncValue(): void {
+    this.value =
+      this.currentOption.kind === "action" ? this.currentOption.value : [...this.selected];
+  }
+
+  private toggleCurrent(): void {
+    if (this.currentOption.kind !== "repo") return;
+    const selected = this.selected.includes(this.currentOption.value);
+    this.selected = selected
+      ? this.selected.filter((value) => value !== this.currentOption.value)
+      : [...this.selected, this.currentOption.value];
+  }
+
+  private toggleAll(): void {
+    const repoValues = this.options
+      .filter((option): option is Extract<PromptOption, { kind: "repo" }> => option.kind === "repo")
+      .map((option) => option.value);
+    this.selected = this.selected.length === repoValues.length ? [] : repoValues;
+  }
+
+  private renderPrompt(): string {
+    const symbolByState =
+      this.state === "submit"
+        ? pc.green(SUBMIT_SYMBOL)
+        : this.state === "cancel"
+          ? pc.red(CANCEL_SYMBOL)
+          : pc.cyan(ACTIVE_SYMBOL);
+    const header = `${pc.gray(BAR)}
+${symbolByState}  ${this.message}
+`;
+
+    if (this.state === "submit") {
+      return `${header}${pc.gray(BAR)}  ${pc.dim(this.submitLabel())}`;
+    }
+
+    if (this.state === "cancel") {
+      return `${header}${pc.gray(BAR)}`;
+    }
+
+    const body = visibleOptions(this.cursor, this.options, this.maxItems).map((option) => {
+      const actualIndex = option.kind === "ellipsis" ? -1 : option.index;
+      if (option.kind === "ellipsis") {
+        return `${pc.gray(BAR)}  ${pc.dim(ELLIPSIS)}`;
+      }
+
+      const isActive = actualIndex === this.cursor;
+      const current = this.options[actualIndex];
+      const marker =
+        current.kind === "action"
+          ? isActive
+            ? pc.cyan(ACTION_ARROW)
+            : pc.dim(ACTION_ARROW)
+          : this.selected.includes(current.value)
+            ? isActive
+              ? pc.cyan(CHECKBOX_ON)
+              : CHECKBOX_ON
+            : isActive
+              ? pc.cyan(CHECKBOX_OFF)
+              : CHECKBOX_OFF;
+      const label = isActive ? pc.cyan(current.label) : current.label;
+      const hint = current.hint ? ` ${pc.dim(`(${current.hint})`)}` : "";
+      return `${pc.gray(BAR)}  ${marker} ${label}${hint}`;
+    });
+
+    return `${header}${body.join("\n")}
+${pc.cyan(FOOTER)}`;
+  }
+
+  private submitLabel(): string {
+    if (this.value === ADD_REPOSITORIES_VALUE) {
+      const action = this.options.find((option) => option.kind === "action");
+      return action?.label ?? "Add repositories...";
+    }
+
+    const selectedValues = Array.isArray(this.value) ? this.value : [];
+    if (selectedValues.length === 0) {
+      return "No repositories selected.";
+    }
+
+    return selectedValues.join(", ");
+  }
+}
+
+function visibleOptions(
+  cursor: number,
+  options: PromptOption[],
+  maxItems?: number,
+): Array<{ kind: "ellipsis" } | { kind: "option"; index: number }> {
+  const terminalRows = process.stdout.rows ? Math.max(process.stdout.rows - 4, 0) : options.length;
+  const visibleCount = Math.min(terminalRows || options.length, Math.max(maxItems ?? Infinity, 5));
+
+  if (visibleCount >= options.length) {
+    return options.map((_, index) => ({ kind: "option" as const, index }));
+  }
+
+  let start = 0;
+  if (cursor >= start + visibleCount - 3) {
+    start = Math.max(Math.min(cursor - visibleCount + 3, options.length - visibleCount), 0);
+  } else if (cursor < start + 2) {
+    start = Math.max(cursor - 2, 0);
+  }
+
+  const hasTopEllipsis = visibleCount < options.length && start > 0;
+  const hasBottomEllipsis = visibleCount < options.length && start + visibleCount < options.length;
+
+  return options.slice(start, start + visibleCount).map((_, index, sliced) => {
+    const isTopEllipsis = index === 0 && hasTopEllipsis;
+    const isBottomEllipsis = index === sliced.length - 1 && hasBottomEllipsis;
+    if (isTopEllipsis || isBottomEllipsis) {
+      return { kind: "ellipsis" as const };
+    }
+    return { kind: "option" as const, index: start + index };
+  });
+}
+
+function supportsUnicode(): boolean {
+  if (process.platform !== "win32") {
+    return process.env.TERM !== "linux";
+  }
+  return !!(
+    process.env.CI ||
+    process.env.WT_SESSION ||
+    process.env.TERMINUS_SUBLIME ||
+    process.env.ConEmuTask === "{cmd::Cmder}" ||
+    process.env.TERM_PROGRAM === "Terminus-Sublime" ||
+    process.env.TERM_PROGRAM === "vscode" ||
+    process.env.TERM === "xterm-256color" ||
+    process.env.TERM === "alacritty" ||
+    process.env.TERMINAL_EMULATOR === "JetBrains-JediTerm"
+  );
+}
+
+function symbol(unicodeValue: string, asciiValue: string): string {
+  return unicode ? unicodeValue : asciiValue;
+}

--- a/src/setup/github-repo-prompt.ts
+++ b/src/setup/github-repo-prompt.ts
@@ -35,6 +35,7 @@ interface PromptGitHubRepositoriesOptions {
   maxItems?: number;
 }
 
+/* v8 ignore start -- TTY-only wrapper; logic covered via GitHubRepoPrompt tests */
 export async function promptGitHubRepositories({
   message,
   options,
@@ -49,8 +50,9 @@ export async function promptGitHubRepositories({
   });
   return (await prompt.prompt()) as symbol | typeof ADD_REPOSITORIES_VALUE | string[];
 }
+/* v8 ignore stop */
 
-class GitHubRepoPrompt extends Prompt {
+export class GitHubRepoPrompt extends Prompt {
   options: PromptOption[];
   message: string;
   maxItems?: number;
@@ -229,6 +231,7 @@ function supportsUnicode(): boolean {
   if (process.platform !== "win32") {
     return process.env.TERM !== "linux";
   }
+  /* v8 ignore start -- win32-only; cannot be exercised on Linux CI */
   return !!(
     process.env.CI ||
     process.env.WT_SESSION ||
@@ -240,6 +243,7 @@ function supportsUnicode(): boolean {
     process.env.TERM === "alacritty" ||
     process.env.TERMINAL_EMULATOR === "JetBrains-JediTerm"
   );
+  /* v8 ignore stop */
 }
 
 function symbol(unicodeValue: string, asciiValue: string): string {

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -1,0 +1,406 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoist shared mocks so `vi.mock()` (which runs before imports) can capture them.
+const {
+  mockOpenDefault,
+  mockExecSync,
+  mockGetWebAppURL,
+  mockPromptGitHubRepositories,
+  mockStartInstallationCallbackServer,
+  mockTrpc,
+} = vi.hoisted(() => ({
+  mockOpenDefault: vi.fn().mockResolvedValue(undefined),
+  mockExecSync: vi.fn(),
+  mockGetWebAppURL: vi.fn(() => "https://app.dosu.dev"),
+  mockPromptGitHubRepositories: vi.fn(),
+  mockStartInstallationCallbackServer: vi.fn(),
+  mockTrpc: {
+    githubRepository: { listForOrg: { query: vi.fn() } },
+    workspaces: {
+      create: { mutate: vi.fn() },
+      listForSpace: { query: vi.fn() },
+    },
+    dataSource: { create: { mutate: vi.fn() } },
+    deploymentDataSource: { create: { mutate: vi.fn() } },
+  },
+}));
+
+// `open` module — MUST be mocked, or the fallback "open browser" path in
+// stepConnectGitHubRepo pops a real GitHub App install tab during tests.
+vi.mock("open", () => ({ default: mockOpenDefault }));
+
+// `execSync` — stubbed so `detectGitRepo()` doesn't shell out to real git.
+vi.mock("node:child_process", () => ({
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  confirm: vi.fn(),
+  multiselect: vi.fn(),
+  isCancel: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: {
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("../debug/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    getLogPath: vi.fn(() => "/tmp/test-debug.log"),
+  },
+}));
+
+vi.mock("../config/constants", () => ({
+  getWebAppURL: mockGetWebAppURL,
+}));
+
+// Local installation-callback server — mocked so tests control when / with
+// what installation_id the promise resolves.
+vi.mock("./installation-server", () => ({
+  startInstallationCallbackServer: mockStartInstallationCallbackServer,
+}));
+
+vi.mock("./github-repo-prompt", () => ({
+  ADD_REPOSITORIES_VALUE: "__add_repositories__",
+  promptGitHubRepositories: (...args: unknown[]) => mockPromptGitHubRepositories(...args),
+}));
+
+// Return our pre-baked mock tRPC client from any call to createTypedClient.
+vi.mock("../client/trpc", () => ({
+  createTypedClient: vi.fn(() => mockTrpc),
+}));
+
+import * as p from "@clack/prompts";
+import type { Config } from "../config/config";
+import { detectGitRepo, stepConnectGitHubRepo } from "./github-step";
+
+function makeCfg(overrides: Partial<Config> = {}): Config {
+  return {
+    access_token: "tok",
+    refresh_token: "ref",
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    api_key: "sk_user_x",
+    deployment_id: "dep-mcp",
+    deployment_name: "Default MCP",
+    org_id: "org-1",
+    space_id: "space-1",
+    ...overrides,
+  };
+}
+
+describe("detectGitRepo", () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+  });
+
+  it("parses SSH URL", () => {
+    mockExecSync.mockReturnValue(Buffer.from("git@github.com:acme/api.git\n"));
+    expect(detectGitRepo()).toEqual({ owner: "acme", name: "api", slug: "acme/api" });
+  });
+
+  it("parses HTTPS URL with trailing slash", () => {
+    mockExecSync.mockReturnValue(Buffer.from("https://github.com/acme/api/\n"));
+    expect(detectGitRepo()).toEqual({ owner: "acme", name: "api", slug: "acme/api" });
+  });
+
+  it("returns null when not in a git repo", () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error("not a git repository");
+    });
+    expect(detectGitRepo()).toBeNull();
+  });
+
+  it("returns null for non-GitHub origin", () => {
+    mockExecSync.mockReturnValue(Buffer.from("git@gitlab.com:foo/bar.git\n"));
+    expect(detectGitRepo()).toBeNull();
+  });
+});
+
+/** Canned installation server — resolves with the given id on demand. */
+function installationServerReturning(installationId: number) {
+  return {
+    server: { port: 54321, close: vi.fn() },
+    installationPromise: Promise.resolve({ installation_id: installationId }),
+  };
+}
+
+describe("stepConnectGitHubRepo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+    mockPromptGitHubRepositories.mockResolvedValue([]);
+    mockStartInstallationCallbackServer.mockResolvedValue(installationServerReturning(12345));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("returns advance=false when cfg has no org_id / space_id", async () => {
+    const result = await stepConnectGitHubRepo(
+      makeCfg({ org_id: undefined, space_id: undefined }),
+      null,
+    );
+    expect(result.advance).toBe(false);
+    expect(mockOpenDefault).not.toHaveBeenCalled();
+    expect(mockTrpc.githubRepository.listForOrg.query).not.toHaveBeenCalled();
+  });
+
+  it("lets the user skip the browser when an undeployed repo is already visible", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    // User picks no repos (empty selection) → returns advance=true immediately.
+    const result = await stepConnectGitHubRepo(makeCfg(), {
+      owner: "acme",
+      name: "api",
+      slug: "acme/api",
+    });
+
+    expect(mockOpenDefault).not.toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+    const promptArgs = mockPromptGitHubRepositories.mock.calls[0][0] as {
+      options: { label: string; value: string }[];
+      initialValues?: string[];
+    };
+    expect(promptArgs.options).toMatchObject([
+      { label: "acme/api", value: "acme/api" },
+      { label: "Add repositories...", value: "__add_repositories__" },
+    ]);
+    expect(promptArgs.initialValues).toEqual([]);
+  });
+
+  it("refreshes the same repository multiselect after add-repositories is selected", async () => {
+    mockTrpc.githubRepository.listForOrg.query
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+      ])
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+        { repository_id: 2, name: "core", slug: "acme/core", is_deployed: false },
+      ]);
+    mockPromptGitHubRepositories
+      .mockResolvedValueOnce("__add_repositories__")
+      .mockResolvedValueOnce(["acme/core"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-core" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-core" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-core" }]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null);
+
+    expect(mockOpenDefault).toHaveBeenCalledOnce();
+    expect(mockPromptGitHubRepositories).toHaveBeenCalledTimes(2);
+    expect(mockTrpc.githubRepository.listForOrg.query).toHaveBeenCalledTimes(2);
+    const firstArgs = mockPromptGitHubRepositories.mock.calls[0][0] as {
+      options: { value: string }[];
+    };
+    const secondArgs = mockPromptGitHubRepositories.mock.calls[1][0] as {
+      options: { value: string }[];
+    };
+    expect(firstArgs.options.map((o) => o.value)).toEqual(["acme/api", "__add_repositories__"]);
+    expect(secondArgs.options.map((o) => o.value)).toEqual([
+      "acme/api",
+      "acme/core",
+      "__add_repositories__",
+    ]);
+    expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(1);
+    const [args] = mockTrpc.workspaces.create.mutate.mock.calls[0];
+    expect(args.name).toBe("acme/core");
+    expect(result.advance).toBe(true);
+  });
+
+  it("opens the web middle page and refetches after installation callback", async () => {
+    // Pre-flight: all already deployed → triggers the install handshake.
+    mockTrpc.githubRepository.listForOrg.query
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: true },
+      ])
+      // After `/cli/connect-github-done` forwards installation_id back to us,
+      // the list now includes an undeployed repo.
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: true },
+        { repository_id: 2, name: "core", slug: "acme/core", is_deployed: false },
+      ]);
+    mockPromptGitHubRepositories
+      .mockResolvedValueOnce("__add_repositories__")
+      .mockResolvedValueOnce([]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null);
+
+    expect(mockStartInstallationCallbackServer).toHaveBeenCalledOnce();
+    expect(mockOpenDefault).toHaveBeenCalledOnce();
+    const openedURL = new URL(mockOpenDefault.mock.calls[0]?.[0] as string);
+    expect(openedURL.pathname).toBe("/cli/connect-github");
+    expect(openedURL.searchParams.get("callback")).toBe("http://localhost:54321/callback");
+    // Two listForOrg calls: pre-flight + post-installation refresh.
+    expect(mockTrpc.githubRepository.listForOrg.query).toHaveBeenCalledTimes(2);
+    expect(result.advance).toBe(true);
+  });
+
+  it("waits for a newly visible repository instead of stopping on intermediate removals", async () => {
+    mockTrpc.githubRepository.listForOrg.query
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+        { repository_id: 2, name: "old", slug: "acme/old", is_deployed: false },
+      ])
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+        { repository_id: 2, name: "old", slug: "acme/old", is_deployed: false },
+      ])
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+      ])
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+        { repository_id: 3, name: "core", slug: "acme/core", is_deployed: false },
+      ]);
+    mockPromptGitHubRepositories
+      .mockResolvedValueOnce("__add_repositories__")
+      .mockResolvedValueOnce(["acme/core"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-core" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-core" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-core" }]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), {
+      owner: "acme",
+      name: "api",
+      slug: "acme/api",
+    });
+
+    expect(mockTrpc.githubRepository.listForOrg.query).toHaveBeenCalledTimes(4);
+    expect(mockPromptGitHubRepositories).toHaveBeenCalledTimes(2);
+    const secondArgs = mockPromptGitHubRepositories.mock.calls[1][0] as {
+      options: { value: string }[];
+    };
+    expect(secondArgs.options.map((o) => o.value)).toEqual([
+      "acme/api",
+      "acme/core",
+      "__add_repositories__",
+    ]);
+    expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(1);
+    const [args] = mockTrpc.workspaces.create.mutate.mock.calls[0];
+    expect(args.name).toBe("acme/core");
+    expect(result.advance).toBe(true);
+  });
+
+  it("creates deployment + data_source + link for each selected repo", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 100, name: "api", slug: "acme/api", is_deployed: false },
+      { repository_id: 200, name: "web", slug: "acme/web", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/api", "acme/web"]);
+    mockTrpc.workspaces.create.mutate
+      .mockResolvedValueOnce({ deployment_id: "dep-A" })
+      .mockResolvedValueOnce({ deployment_id: "dep-B" });
+    mockTrpc.dataSource.create.mutate
+      .mockResolvedValueOnce({ data_source_id: "ds-A" })
+      .mockResolvedValueOnce({ data_source_id: "ds-B" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([
+      { deployment_id: "dep-mcp" },
+      { deployment_id: "dep-A" },
+      { deployment_id: "dep-B" },
+    ]);
+    mockTrpc.deploymentDataSource.create.mutate.mockResolvedValue({});
+
+    const result = await stepConnectGitHubRepo(makeCfg(), {
+      owner: "acme",
+      name: "api",
+      slug: "acme/api",
+    });
+
+    expect(result.advance).toBe(true);
+    expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(2);
+    expect(mockTrpc.dataSource.create.mutate).toHaveBeenCalledTimes(2);
+    // deploymentDataSource.create fires once per (selected repo × space deployments):
+    // 2 repos × 3 deployments = 6 invocations.
+    expect(mockTrpc.deploymentDataSource.create.mutate).toHaveBeenCalledTimes(6);
+    // Cwd repo's deployment is reported as primary.
+    expect(result.deployment_id).toBe("dep-A");
+    expect(result.space_id).toBe("space-1");
+  });
+
+  it("shows already-deployed repos in a separate info block, excludes them from multiselect", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: true },
+      { repository_id: 2, name: "core", slug: "acme/core", is_deployed: false },
+      { repository_id: 3, name: "web", slug: "acme/web", is_deployed: true },
+      { repository_id: 4, name: "cli", slug: "acme/cli", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/core"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-X" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-X" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-X" }]);
+
+    await stepConnectGitHubRepo(makeCfg(), null);
+
+    // Multiselect only contains undeployed repos — deployed ones can't be
+    // navigated to because they're not in the options list at all.
+    const multiselectArgs = mockPromptGitHubRepositories.mock.calls[0][0] as {
+      options: { value: string }[];
+    };
+    expect(multiselectArgs.options.map((o) => o.value)).toEqual([
+      "acme/core",
+      "acme/cli",
+      "__add_repositories__",
+    ]);
+    // Deployed repos surface via a separate info log.
+    const infoCalls = vi.mocked(p.log.info).mock.calls.map((c) => String(c[0]));
+    expect(infoCalls.some((s) => s.includes("Already connected") && s.includes("acme/api"))).toBe(
+      true,
+    );
+    // Only the selected undeployed repo gets created.
+    expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(1);
+    const [args] = mockTrpc.workspaces.create.mutate.mock.calls[0];
+    expect(args.name).toBe("acme/core");
+  });
+
+  it("advances silently when every repo is already deployed", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: true },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue([]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null);
+
+    expect(result.advance).toBe(true);
+    expect(mockPromptGitHubRepositories).toHaveBeenCalledOnce();
+    expect(mockTrpc.workspaces.create.mutate).not.toHaveBeenCalled();
+  });
+
+  it("returns advance=true when no selection (all already deployed)", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue([]); // user picks nothing
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null);
+
+    // No creations fired, but step advances because we don't want to
+    // re-prompt if the user consciously declined to pick anything.
+    expect(result.advance).toBe(true);
+    expect(mockTrpc.workspaces.create.mutate).not.toHaveBeenCalled();
+  });
+
+  it("returns advance=false when user cancels the multiselect", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    const cancelSymbol = Symbol("cancel");
+    mockPromptGitHubRepositories.mockResolvedValue(cancelSymbol as unknown as string[]);
+    vi.mocked(p.isCancel).mockImplementation((v) => v === cancelSymbol);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null);
+
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.workspaces.create.mutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -1,0 +1,391 @@
+/**
+ * Setup step: connect one or more GitHub repos to the caller's Dosu workspace.
+ *
+ * Flow:
+ *   1. Detect the local git origin (for a helpful label only).
+ *   2. Pre-flight `listForOrg`.
+ *   3. Present a TUI multiselect of repos with an inline "Add repositories..."
+ *      option. Nothing is preselected, so Enter can always skip straight to
+ *      the next sub-step.
+ *   4. If the user picks "Add repositories...", start a local HTTP server, open
+ *      the web `/cli/connect-github`
+ *      middle page, which sets the replay cookie and forwards the browser to
+ *      GitHub's App-install page. GitHub's setup URL (`/redirect/replay`)
+ *      writes the `user_installation` row and bounces to `/cli/connect-github-done`,
+ *      which forwards `installation_id` back to our local HTTP server.
+ *   5. Keep the install spinner alive while polling `listForOrg` for up to
+ *      10 seconds, then return to the same multiselect with the updated
+ *      repository list.
+ *   6. For each selected repo, fan out tRPC:
+ *      - `workspaces.create` (creates github deployment + fires welcome email)
+ *      - `dataSource.create` (creates data_source + github_data_source_config trigger)
+ *      - `workspaces.listForSpace` + `deploymentDataSource.create` per deployment
+ *        to link the new data_source into every workspace in the space
+ *   7. Return success + the first created deployment_id.
+ *
+ * Never throws — returns `{advance: false}` on any failure so runSetup continues.
+ */
+
+import { execSync } from "node:child_process";
+import * as p from "@clack/prompts";
+import { createTypedClient } from "../client/trpc";
+import type { Config } from "../config/config";
+import { getWebAppURL } from "../config/constants";
+import { logger } from "../debug/logger";
+import { DEFAULT_DEPLOYMENT_CONFIG_GITHUB } from "./default-deployment-config";
+import { ADD_REPOSITORIES_VALUE, promptGitHubRepositories } from "./github-repo-prompt";
+import { startInstallationCallbackServer } from "./installation-server";
+import { dim } from "./styles";
+
+// `@dosu/api-types` lags the tRPC routers we just added on the server side
+// (`githubRepository.listForOrg`, `dataSource.create`). Runtime routing is
+// dynamic, so we bypass compile-time type checks for those two procedures
+// until a new `@dosu/api-types` version is published that knows about them.
+// biome-ignore lint/suspicious/noExplicitAny: see note above
+type TrpcAny = any;
+
+const INSTALLATION_TIMEOUT_MS = 10 * 60 * 1000;
+const REPO_REFRESH_POLL_INTERVAL_MS = 500;
+const REPO_REFRESH_POLL_TIMEOUT_MS = 10_000;
+
+export interface DetectedRepo {
+  owner: string;
+  name: string;
+  slug: string;
+}
+
+export interface GithubStepResult {
+  advance: boolean;
+  has_connected_repo?: boolean;
+  deployment_id?: string;
+  space_id?: string;
+}
+
+// Shape returned by tRPC `githubRepository.listForOrg`.
+interface AvailableRepo {
+  repository_id: number;
+  name: string;
+  slug: string; // "owner/repo"
+  is_deployed: boolean;
+}
+export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null {
+  let url: string;
+  try {
+    url = execSync("git config --get remote.origin.url", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+  if (!url) return null;
+
+  let m = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  if (!m) {
+    m = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i);
+  }
+  if (!m) return null;
+
+  const [, owner, name] = m;
+  return { owner, name, slug: `${owner}/${name}` };
+}
+
+async function fetchListForOrg(trpc: TrpcAny, orgID: string): Promise<AvailableRepo[]> {
+  try {
+    return (await trpc.githubRepository.listForOrg.query({
+      org_id: orgID,
+    })) as AvailableRepo[];
+  } catch (err: unknown) {
+    /* v8 ignore next -- non-fatal; caller decides what to do with an empty list */
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("setup", `listForOrg failed: ${msg}`);
+    return [];
+  }
+}
+
+function buildPromptOptions(
+  repos: AvailableRepo[],
+): Parameters<typeof promptGitHubRepositories>[0]["options"] {
+  return [
+    ...repos.map((r) => ({ kind: "repo" as const, label: r.slug, value: r.slug })),
+    {
+      kind: "action" as const,
+      label: "Add repositories...",
+      value: ADD_REPOSITORIES_VALUE,
+      hint: "Open GitHub and refresh this list",
+    },
+  ];
+}
+
+function hasNewVisibleRepository(
+  previousRepos: AvailableRepo[],
+  nextRepos: AvailableRepo[],
+): boolean {
+  const previousRepoIds = new Set(previousRepos.map((repo) => repo.repository_id));
+  return nextRepos.some((repo) => !previousRepoIds.has(repo.repository_id));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForRepositoryRefresh(
+  trpc: TrpcAny,
+  orgID: string,
+  previousRepos: AvailableRepo[],
+): Promise<AvailableRepo[]> {
+  const startedAt = Date.now();
+  let latestRepos = previousRepos;
+
+  while (Date.now() - startedAt < REPO_REFRESH_POLL_TIMEOUT_MS) {
+    const polledRepos = await fetchListForOrg(trpc, orgID);
+    latestRepos =
+      polledRepos.length === 0 && previousRepos.length > 0 ? previousRepos : polledRepos;
+
+    if (hasNewVisibleRepository(previousRepos, latestRepos)) {
+      return latestRepos;
+    }
+
+    await sleep(REPO_REFRESH_POLL_INTERVAL_MS);
+  }
+
+  return latestRepos;
+}
+
+/**
+ * Open the web `/cli/connect-github` middle page and wait for the browser to
+ * POST an installation_id back via our local HTTP listener. Returns the
+ * installation_id on success, or `null` on timeout / failure.
+ *
+ * The middle page is responsible for:
+ *   1. Setting the `REPLAY_AFTER_GITHUB_REPO_INSTALLATION_KEY` cookie so that
+ *      when GitHub redirects to `/redirect/replay` after install, the existing
+ *      web flow upserts the `user_installation` row.
+ *   2. Redirecting the browser to GitHub's App-install page.
+ *   3. After GitHub bounces through `/redirect/replay`, it hands control to
+ *      `/cli/connect-github-done` which forwards `installation_id` here.
+ */
+async function openGitHubInstallFlow(
+  onInstalled?: (installationID: number) => Promise<void>,
+): Promise<number | null> {
+  const { server, installationPromise } = await startInstallationCallbackServer();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const callbackURL = `http://localhost:${server.port}/callback`;
+    const webAppURL = getWebAppURL();
+    const middleURL = new URL("/cli/connect-github", webAppURL);
+    middleURL.searchParams.set("callback", callbackURL);
+
+    p.log.info(
+      "Opening your browser to GitHub.\n" +
+        "Add repositories or install the Dosu GitHub App, and we'll pick up automatically.",
+    );
+    try {
+      const open = await import("open");
+      await open.default(middleURL.toString());
+    } catch (err: unknown) {
+      /* v8 ignore next 2 -- `open` rarely fails */
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn("setup", `Failed to open browser: ${msg}`);
+      p.log.info(`Could not open browser — visit ${middleURL.toString()} manually.`);
+    }
+
+    const timeout = new Promise<null>((resolve) => {
+      timeoutId = setTimeout(() => {
+        logger.warn("setup", `GitHub install timed out after ${INSTALLATION_TIMEOUT_MS / 1000}s`);
+        resolve(null);
+      }, INSTALLATION_TIMEOUT_MS);
+    });
+
+    const s = p.spinner();
+    s.start("Waiting for GitHub install to complete...");
+    const result = await Promise.race([
+      installationPromise.then((r) => r.installation_id),
+      timeout,
+    ]);
+    if (result === null) {
+      s.stop("Timed out");
+      p.log.warn(
+        `Didn't hear back from the browser after ${Math.floor(
+          INSTALLATION_TIMEOUT_MS / 1000,
+        )}s. Run \`dosu setup\` again once you've completed the install.`,
+      );
+      return null;
+    }
+    if (onInstalled) {
+      await onInstalled(result);
+    }
+    s.stop("GitHub App connected");
+    return result;
+  } finally {
+    clearTimeout(timeoutId);
+    server.close();
+  }
+}
+
+/**
+ * Create one github deployment + its data_source, then link the data_source
+ * into every deployment in the space. Mirrors the web
+ * `OnboardingGithub.handleNext` + `useCreateDataSources` flow exactly.
+ */
+async function createDeploymentForRepo(
+  trpc: TrpcAny,
+  orgID: string,
+  spaceID: string,
+  repo: AvailableRepo,
+): Promise<{ deployment_id: string } | null> {
+  try {
+    const deployment = (await trpc.workspaces.create.mutate({
+      org_id: orgID,
+      space_id: spaceID,
+      enabled: true,
+      name: repo.slug,
+      description: "",
+      provider_slug: "github",
+      repository_id: repo.repository_id,
+      metadata: {
+        app: { deployment_mode: "normal", setup_mode: "auto" },
+        provider_slug: "github",
+      },
+      config: DEFAULT_DEPLOYMENT_CONFIG_GITHUB,
+    } as unknown as Parameters<typeof trpc.workspaces.create.mutate>[0])) as unknown as {
+      deployment_id: string;
+    } | null;
+    if (!deployment?.deployment_id) {
+      logger.warn("setup", `workspaces.create returned no deployment for ${repo.slug}`);
+      return null;
+    }
+
+    const dataSource = (await trpc.dataSource.create.mutate({
+      org_id: orgID,
+      provider_slug: "github",
+      name: repo.slug,
+      description: "",
+      repository_id: repo.repository_id,
+    })) as unknown as { data_source_id: string } | null;
+    if (!dataSource?.data_source_id) {
+      logger.warn("setup", `dataSource.create returned no data_source for ${repo.slug}`);
+      return { deployment_id: deployment.deployment_id };
+    }
+
+    const spaceDeployments = (await trpc.workspaces.listForSpace.query(spaceID)) as unknown as {
+      deployment_id: string;
+    }[];
+    await Promise.all(
+      spaceDeployments.map((d) =>
+        trpc.deploymentDataSource.create.mutate({
+          deployment_id: d.deployment_id,
+          data_source_id: dataSource.data_source_id,
+        }),
+      ),
+    );
+    return { deployment_id: deployment.deployment_id };
+  } catch (err: unknown) {
+    /* v8 ignore next -- server errors bubble up */
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("setup", `Failed to wire up ${repo.slug}: ${msg}`);
+    return null;
+  }
+}
+
+export async function stepConnectGitHubRepo(
+  cfg: Config,
+  detected: DetectedRepo | null = detectGitRepo(),
+): Promise<GithubStepResult> {
+  logger.info("setup", "Step: connect GitHub repo(s)");
+
+  if (!cfg.org_id || !cfg.space_id) {
+    p.log.warn(
+      "Cannot connect GitHub: your Dosu workspace is missing org/space context. " +
+        "Re-run `dosu setup` from a fresh state.",
+    );
+    return { advance: false, has_connected_repo: false };
+  }
+  const orgID = cfg.org_id;
+  const spaceID = cfg.space_id;
+
+  if (detected) {
+    p.log.info(`Connecting GitHub repos (detected local repo: ${detected.slug})`);
+  }
+
+  const trpc: TrpcAny = createTypedClient(cfg);
+  let repos = await fetchListForOrg(trpc, orgID);
+
+  while (true) {
+    const undeployed = repos.filter((r) => !r.is_deployed);
+    const deployed = repos.filter((r) => r.is_deployed);
+
+    // Already-connected repos are shown as an informational block above the
+    // multiselect so the user can see what's set up, but the cursor can't land
+    // on them. Clack has no per-option `disabled`, so this is the only way to
+    // make them truly non-interactive.
+    if (deployed.length > 0) {
+      const lines = deployed.map((r) => `  ${dim(r.slug)}`).join("\n");
+      p.log.info(`${dim("Already connected")}\n${lines}`);
+    }
+
+    const selected = await promptGitHubRepositories({
+      message: "Select repositories to connect",
+      options: buildPromptOptions(undeployed),
+      initialValues: [],
+    });
+    if (p.isCancel(selected)) {
+      logger.info("setup", "Repository selection cancelled");
+      return { advance: false, has_connected_repo: deployed.length > 0 };
+    }
+
+    if (selected === ADD_REPOSITORIES_VALUE) {
+      let refreshedRepos = repos;
+      const installationID = await openGitHubInstallFlow(async () => {
+        refreshedRepos = await waitForRepositoryRefresh(trpc, orgID, repos);
+      });
+      if (installationID === null) {
+        return { advance: false, has_connected_repo: deployed.length > 0 };
+      }
+      repos = refreshedRepos;
+      continue;
+    }
+
+    const slugs = selected as string[];
+    if (slugs.length === 0) {
+      p.log.info("No repositories selected.");
+      return { advance: true, has_connected_repo: deployed.length > 0 };
+    }
+
+    const s = p.spinner();
+    s.start(`Connecting ${slugs.length} repo${slugs.length === 1 ? "" : "s"}...`);
+    const created: { deployment_id: string; slug: string }[] = [];
+    for (const slug of slugs) {
+      const repo = repos.find((r) => r.slug === slug);
+      if (!repo) continue;
+      const result = await createDeploymentForRepo(trpc, orgID, spaceID, repo);
+      if (result) {
+        created.push({ deployment_id: result.deployment_id, slug });
+      }
+    }
+
+    if (created.length === 0) {
+      s.stop("Failed");
+      p.log.error("Could not connect any repos. Check `dosu logs --tail 50` for details.");
+      return { advance: false, has_connected_repo: deployed.length > 0 };
+    }
+
+    s.stop(`Connected ${created.length} repo${created.length === 1 ? "" : "s"}`);
+    for (const { slug, deployment_id } of created) {
+      p.log.success(`${slug}\n${dim(`deployment ${deployment_id}`)}`);
+    }
+
+    // Prefer the cwd repo's deployment as the primary; fall back to the first
+    // successfully created one.
+    const primary = (detected && created.find((c) => c.slug === detected.slug)) ?? created[0];
+    return {
+      advance: true,
+      has_connected_repo: true,
+      deployment_id: primary.deployment_id,
+      space_id: cfg.space_id,
+    };
+  }
+}

--- a/src/setup/installation-server.test.ts
+++ b/src/setup/installation-server.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type InstallationCallbackServer,
+  startInstallationCallbackServer,
+} from "./installation-server";
+
+vi.mock("../debug/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    init: vi.fn(),
+    getLogPath: vi.fn(() => "/tmp/test-debug.log"),
+  },
+}));
+
+describe("installation callback server", () => {
+  let server: InstallationCallbackServer | null = null;
+
+  afterEach(() => {
+    if (server) {
+      server.close();
+      server = null;
+    }
+  });
+
+  it("starts on a random port", async () => {
+    const result = await startInstallationCallbackServer();
+    server = result.server;
+    expect(server.port).toBeGreaterThan(0);
+    expect(server.port).toBeLessThan(65536);
+  });
+
+  it("returns 404 for non-callback paths", async () => {
+    const result = await startInstallationCallbackServer();
+    server = result.server;
+    const resp = await fetch(`http://localhost:${server.port}/other`);
+    expect(resp.status).toBe(404);
+    expect(await resp.text()).toBe("Not Found");
+  });
+
+  it("resolves the installation promise with the parsed installation_id", async () => {
+    const result = await startInstallationCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(`http://localhost:${server.port}/callback?installation_id=12345`);
+    expect(resp.status).toBe(200);
+    const html = await resp.text();
+    expect(html).toContain("GitHub App connected");
+
+    const installation = await result.installationPromise;
+    expect(installation.installation_id).toBe(12345);
+  });
+
+  it("returns 400 when installation_id is missing", async () => {
+    const result = await startInstallationCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(`http://localhost:${server.port}/callback`);
+    expect(resp.status).toBe(400);
+    expect(await resp.text()).toBe("Missing installation_id");
+    // installationPromise must still be pending
+    void result.installationPromise;
+  });
+
+  it("returns 400 when installation_id is not a number", async () => {
+    const result = await startInstallationCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(`http://localhost:${server.port}/callback?installation_id=abc`);
+    expect(resp.status).toBe(400);
+    expect(await resp.text()).toBe("Missing installation_id");
+    void result.installationPromise;
+  });
+
+  it("handles a request with no URL path (defaults to /)", async () => {
+    const result = await startInstallationCallbackServer();
+    server = result.server;
+
+    const resp = await fetch(`http://localhost:${server.port}/`);
+    expect(resp.status).toBe(404);
+  });
+});

--- a/src/setup/installation-server.ts
+++ b/src/setup/installation-server.ts
@@ -1,0 +1,97 @@
+/**
+ * Local HTTP server that receives the GitHub App installation callback from
+ * the web `/cli/connect-github-done` page.
+ *
+ * Sibling of `auth/server.ts` (OAuth callback) — same shape, different payload.
+ * Waits for exactly one GET on `/callback?installation_id=<int>` and resolves
+ * the pending promise with the installation id.
+ */
+
+import { logger } from "../debug/logger";
+
+export interface InstallationResponse {
+  installation_id: number;
+}
+
+export interface InstallationCallbackServer {
+  port: number;
+  close: () => void;
+}
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Dosu CLI - GitHub Connected</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #fafafa; color: #171717; min-height: 100vh;
+    display: flex; align-items: center; justify-content: center; padding: 20px;
+  }
+  .container { max-width: 420px; width: 100%; text-align: center; }
+  h1 { font-size: 24px; font-weight: 600; letter-spacing: -0.02em; margin-bottom: 8px; }
+  .msg { font-size: 16px; color: #666; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GitHub App connected</h1>
+  <p class="msg">You can close this tab and return to your terminal.</p>
+</div>
+</body>
+</html>`;
+
+export async function startInstallationCallbackServer(): Promise<{
+  server: InstallationCallbackServer;
+  installationPromise: Promise<InstallationResponse>;
+}> {
+  let resolveInstallation: (resp: InstallationResponse) => void;
+  const installationPromise = new Promise<InstallationResponse>((resolve) => {
+    resolveInstallation = resolve;
+  });
+
+  const http = require("node:http") as typeof import("node:http");
+
+  const httpServer = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+
+    if (url.pathname !== "/callback") {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not Found");
+      return;
+    }
+
+    const installationIdStr = url.searchParams.get("installation_id");
+    const installationId = installationIdStr ? parseInt(installationIdStr, 10) : Number.NaN;
+
+    if (!installationIdStr || Number.isNaN(installationId)) {
+      logger.warn("installation.server", "Missing or invalid installation_id");
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("Missing installation_id");
+      return;
+    }
+
+    logger.info("installation.server", `installation_id=${installationId} received`);
+    resolveInstallation?.({ installation_id: installationId });
+
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(SUCCESS_HTML);
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, "localhost", () => resolve());
+  });
+  const addr = httpServer.address() as import("node:net").AddressInfo;
+  logger.info("installation.server", `Listening on port ${addr.port}`);
+
+  return {
+    server: {
+      port: addr.port,
+      close: () => httpServer.close(),
+    },
+    installationPromise,
+  };
+}

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -182,15 +182,14 @@ describe("handleLogout (direct)", () => {
 // ---------------------------------------------------------------------------
 
 describe("runTUI", () => {
-  it("prompts to authenticate when not authenticated (real config, no file on disk)", async () => {
-    // No config file exists, so loadConfig returns empty → not authenticated
-    // User declines to open browser → TUI exits
-    mockConfirm.mockResolvedValueOnce(false);
+  it("shows the main menu before authentication", async () => {
+    mockSelect.mockResolvedValueOnce("exit");
+    mockIsCancel.mockReturnValue(false);
 
     await runTUI();
 
-    expect(mockConfirm).toHaveBeenCalledWith({ message: "Open browser to log in?" });
-    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockSelect).toHaveBeenCalledOnce();
+    expect(mockConfirm).not.toHaveBeenCalled();
   });
 
   it("exits loop and calls outro when user selects exit", async () => {
@@ -300,7 +299,7 @@ describe("runTUI", () => {
       expires_in: 3600,
     });
 
-    mockSelect.mockResolvedValueOnce("exit");
+    mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
 
     await runTUI();
 
@@ -310,30 +309,12 @@ describe("runTUI", () => {
     expect(ondisk.refresh_token).toBe("new-ref");
   });
 
-  it("saves OSS mode from OAuth token response", async () => {
-    writeRealConfig(makeCfg({ access_token: "" }));
-    mockIsCancel.mockReturnValue(false);
-    mockConfirm.mockResolvedValueOnce(true);
-
-    mockStartOAuthFlow.mockResolvedValueOnce({
-      access_token: "new-tok",
-      refresh_token: "new-ref",
-      expires_in: 3600,
-      mode: "oss",
-    });
-
-    mockSelect.mockResolvedValueOnce("exit");
-
-    await runTUI();
-
-    const ondisk = readRealConfig();
-    expect(ondisk.mode).toBe("oss");
-  });
-
   it("shows error when OAuth flow fails", async () => {
     writeRealConfig(makeCfg({ access_token: "" }));
     mockConfirm.mockResolvedValueOnce(true);
     mockStartOAuthFlow.mockRejectedValueOnce(new Error("auth timeout"));
+    mockIsCancel.mockReturnValue(false);
+    mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
 
     await runTUI();
 
@@ -344,6 +325,7 @@ describe("runTUI", () => {
     writeRealConfig(makeCfg({ access_token: "" }));
     mockIsCancel.mockReturnValue(true);
     mockConfirm.mockResolvedValueOnce(Symbol.for("cancel") as unknown as boolean);
+    mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
 
     await runTUI();
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -7,7 +7,7 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { Client } from "../client/client";
-import { isAuthenticated, loadConfig, MODE_OSS, saveConfig } from "../config/config";
+import { isAuthenticated, loadConfig, saveConfig } from "../config/config";
 import { runSetup } from "../setup/flow";
 
 const LOGO = `
@@ -25,12 +25,6 @@ export async function runTUI(): Promise<void> {
   console.log(pc.magenta(LOGO));
 
   const cfg = loadConfig();
-
-  // If not authenticated, authenticate first
-  if (!isAuthenticated(cfg)) {
-    await handleAuthenticate(cfg);
-    if (!isAuthenticated(cfg)) return;
-  }
 
   // Main menu
   while (true) {
@@ -111,7 +105,6 @@ async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<v
     cfg.access_token = token.access_token;
     cfg.refresh_token = token.refresh_token;
     cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
-    cfg.mode = token.mode === MODE_OSS ? MODE_OSS : undefined;
     saveConfig(cfg);
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */

--- a/src/version/skill-update-check.test.ts
+++ b/src/version/skill-update-check.test.ts
@@ -1,0 +1,326 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  checkForSkillUpdates,
+  fetchLatestSha,
+  readSkillCache,
+  refreshInstalledSha,
+  writeSkillCache,
+} from "./skill-update-check";
+
+const CACHE_FILENAME = "skill-update-check.json";
+
+describe("fetchLatestSha", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns latest sha from GitHub API", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ sha: "abc123" }),
+      }),
+    );
+    const result = await fetchLatestSha();
+    expect(result).toBe("abc123");
+  });
+
+  it("sends a User-Agent header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sha: "abc123" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchLatestSha();
+    const call = fetchMock.mock.calls[0];
+    const opts = call[1] as { headers: Record<string, string> };
+    expect(opts.headers["User-Agent"]).toMatch(/^dosu-cli\//);
+  });
+
+  it("returns null on non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    const result = await fetchLatestSha();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when response has no sha field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ other: "value" }),
+      }),
+    );
+    const result = await fetchLatestSha();
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network failure")));
+    const result = await fetchLatestSha();
+    expect(result).toBeNull();
+  });
+});
+
+describe("readSkillCache / writeSkillCache", () => {
+  let tempDir: string;
+  let origXDG: string | undefined;
+
+  beforeEach(() => {
+    origXDG = process.env.XDG_CONFIG_HOME;
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-skill-cache-test-"));
+    process.env.XDG_CONFIG_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    if (origXDG !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXDG;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns null when cache file does not exist", () => {
+    expect(readSkillCache()).toBeNull();
+  });
+
+  it("round-trips a cache object", () => {
+    writeSkillCache({ lastCheck: 1, latestSha: "abc", installedSha: "def" });
+    expect(readSkillCache()).toEqual({ lastCheck: 1, latestSha: "abc", installedSha: "def" });
+  });
+
+  it("returns null when cache has wrong shape", () => {
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(join(tempDir, "dosu-cli", CACHE_FILENAME), JSON.stringify({ foo: "bar" }));
+    expect(readSkillCache()).toBeNull();
+  });
+
+  it("returns null when cache file is corrupt JSON", () => {
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(join(tempDir, "dosu-cli", CACHE_FILENAME), "NOT JSON{{{");
+    expect(readSkillCache()).toBeNull();
+  });
+
+  it("creates config directory when writing cache", () => {
+    writeSkillCache({ lastCheck: 1, latestSha: "abc", installedSha: "def" });
+    expect(readSkillCache()).not.toBeNull();
+  });
+});
+
+describe("refreshInstalledSha", () => {
+  let tempDir: string;
+  let origXDG: string | undefined;
+
+  beforeEach(() => {
+    origXDG = process.env.XDG_CONFIG_HOME;
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-skill-refresh-test-"));
+    process.env.XDG_CONFIG_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    if (origXDG !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXDG;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("writes cache with installedSha === latestSha on fetch success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ sha: "newsha" }),
+      }),
+    );
+    await refreshInstalledSha();
+    const cache = readSkillCache();
+    expect(cache).not.toBeNull();
+    expect(cache?.latestSha).toBe("newsha");
+    expect(cache?.installedSha).toBe("newsha");
+  });
+
+  it("does not overwrite cache on fetch failure", async () => {
+    writeSkillCache({ lastCheck: 123, latestSha: "old", installedSha: "old" });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    await refreshInstalledSha();
+    const cache = readSkillCache();
+    expect(cache?.lastCheck).toBe(123);
+    expect(cache?.latestSha).toBe("old");
+    expect(cache?.installedSha).toBe("old");
+  });
+});
+
+describe("checkForSkillUpdates", () => {
+  let tempDir: string;
+  let origXDG: string | undefined;
+
+  beforeEach(() => {
+    origXDG = process.env.XDG_CONFIG_HOME;
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-skill-update-test-"));
+    process.env.XDG_CONFIG_HOME = tempDir;
+
+    // Stub fetch to prevent real network calls
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ sha: "default-sha" }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    if (origXDG !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXDG;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("does not print when no cache exists, but triggers a background fetch", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForSkillUpdates();
+    expect(spy).not.toHaveBeenCalled();
+
+    // Background fetch should populate the cache
+    const cachePath = join(tempDir, "dosu-cli", CACHE_FILENAME);
+    await vi.waitFor(() => {
+      const updated = JSON.parse(readFileSync(cachePath, "utf-8"));
+      expect(updated.latestSha).toBe("default-sha");
+      expect(updated.installedSha).toBe("");
+    });
+  });
+
+  it("prints notice when cached latestSha differs from installedSha", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "dosu-cli", CACHE_FILENAME),
+      JSON.stringify({ lastCheck: Date.now(), latestSha: "new", installedSha: "old" }),
+    );
+
+    checkForSkillUpdates();
+    expect(spy).toHaveBeenCalled();
+    const output = spy.mock.calls[0][0] as string;
+    expect(output).toContain("Dosu skill update available");
+    expect(output).toContain("dosu skill update");
+  });
+
+  it("does not print when SHAs match", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "dosu-cli", CACHE_FILENAME),
+      JSON.stringify({ lastCheck: Date.now(), latestSha: "same", installedSha: "same" }),
+    );
+
+    checkForSkillUpdates();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when cache is fresh", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "dosu-cli", CACHE_FILENAME),
+      JSON.stringify({ lastCheck: Date.now(), latestSha: "a", installedSha: "a" }),
+    );
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForSkillUpdates();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fires background fetch when cache is stale and updates latestSha", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sha: "fresh-sha" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    const cachePath = join(tempDir, "dosu-cli", CACHE_FILENAME);
+    // Cache from 2 days ago
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        lastCheck: Date.now() - 2 * 24 * 60 * 60 * 1000,
+        latestSha: "stale-sha",
+        installedSha: "stale-sha",
+      }),
+    );
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForSkillUpdates();
+
+    await vi.waitFor(() => {
+      const updated = JSON.parse(readFileSync(cachePath, "utf-8"));
+      expect(updated.latestSha).toBe("fresh-sha");
+      // installedSha preserved — user hasn't reinstalled
+      expect(updated.installedSha).toBe("stale-sha");
+    });
+  });
+
+  it("fetch failure retains stale cache latestSha but still bumps lastCheck", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    const cachePath = join(tempDir, "dosu-cli", CACHE_FILENAME);
+    const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000;
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        lastCheck: twoDaysAgo,
+        latestSha: "prev-sha",
+        installedSha: "inst-sha",
+      }),
+    );
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    checkForSkillUpdates();
+
+    await vi.waitFor(() => {
+      const updated = JSON.parse(readFileSync(cachePath, "utf-8"));
+      expect(updated.lastCheck).toBeGreaterThan(twoDaysAgo);
+      // latestSha falls back to cached value when fetch returns null
+      expect(updated.latestSha).toBe("prev-sha");
+      expect(updated.installedSha).toBe("inst-sha");
+    });
+  });
+
+  it("does not show notice when installedSha is empty (pre-existing install)", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "dosu-cli", CACHE_FILENAME),
+      JSON.stringify({ lastCheck: Date.now(), latestSha: "new-sha", installedSha: "" }),
+    );
+
+    checkForSkillUpdates();
+    // Even though latestSha is non-empty and differs from "", no notice — user
+    // pre-dates this feature and we don't know what they have installed.
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("handles corrupt cache file gracefully", () => {
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(join(tempDir, "dosu-cli", CACHE_FILENAME), "NOT JSON{{{");
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => checkForSkillUpdates()).not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/version/skill-update-check.ts
+++ b/src/version/skill-update-check.ts
@@ -1,0 +1,158 @@
+/**
+ * Non-blocking skill update checker.
+ *
+ * Uses a "check now, display next run" pattern:
+ * 1. On startup, reads a cached latest skill SHA from disk.
+ * 2. If the cached latest SHA differs from the installed SHA, prints a notice to stderr.
+ * 3. If the cache is stale (>24 h), fires a background fetch to the GitHub API (not awaited).
+ *
+ * Mirrors `update-check.ts` but tracks git SHAs instead of semver versions.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import pc from "picocolors";
+import { getConfigDir } from "../config/config";
+import { logger } from "../debug/logger";
+import { VERSION } from "./version";
+
+const CACHE_FILENAME = "skill-update-check.json";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const FETCH_TIMEOUT_MS = 5_000;
+const GITHUB_API_URL = "https://api.github.com/repos/dosu-ai/dosu-skill/commits/HEAD";
+
+export interface SkillUpdateCache {
+  lastCheck: number;
+  latestSha: string;
+  installedSha: string;
+}
+
+function getCachePath(): string {
+  return join(getConfigDir(), CACHE_FILENAME);
+}
+
+export function readSkillCache(): SkillUpdateCache | null {
+  try {
+    const path = getCachePath();
+    if (!existsSync(path)) return null;
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    if (
+      typeof data.lastCheck === "number" &&
+      typeof data.latestSha === "string" &&
+      typeof data.installedSha === "string"
+    ) {
+      return data as SkillUpdateCache;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSkillCache(cache: SkillUpdateCache): void {
+  try {
+    const dir = getConfigDir();
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    writeFileSync(getCachePath(), JSON.stringify(cache), { mode: 0o600 });
+  } catch {
+    // Graceful degradation — cache write failure is non-fatal
+  }
+}
+
+/** Fetch the latest commit SHA from the dosu-skill GitHub repo. */
+export async function fetchLatestSha(): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(GITHUB_API_URL, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": `dosu-cli/${VERSION}`,
+        Accept: "application/vnd.github+json",
+      },
+    });
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as Record<string, unknown>;
+    const sha = data.sha;
+    return typeof sha === "string" ? sha : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Refresh the installedSha in the cache to match the current latest upstream SHA.
+ * Called after a successful `dosu skill install` or `dosu skill update`.
+ *
+ * On fetch failure we write a cache with empty installedSha only if no cache exists —
+ * otherwise we leave the existing cache alone so later invocations can retry.
+ */
+export async function refreshInstalledSha(): Promise<void> {
+  const sha = await fetchLatestSha();
+  if (!sha) {
+    logger.debug("skill-update-check", "Failed to fetch latest SHA during refresh");
+    return;
+  }
+  writeSkillCache({
+    lastCheck: Date.now(),
+    latestSha: sha,
+    installedSha: sha,
+  });
+  logger.debug("skill-update-check", `Refreshed installedSha=${sha}`);
+}
+
+function displayNotice(): void {
+  const msg =
+    `\n${pc.yellow("  Dosu skill update available")}\n` +
+    `${pc.dim('  Run "dosu skill update" to upgrade')}\n`;
+  console.error(msg);
+}
+
+/**
+ * Check for skill updates — called synchronously from the preAction hook.
+ *
+ * Reads cached SHA info and displays a notice if the latest differs from installed.
+ * Fires a background fetch if the cache is stale (>24 h).
+ *
+ * Graceful degradation: if `installedSha` is empty (e.g., user installed skill before
+ * this feature shipped), we only refresh `latestSha` and wait for the next install/update
+ * to populate `installedSha`.
+ */
+export function checkForSkillUpdates(): void {
+  try {
+    const cache = readSkillCache();
+
+    // Display notice only when we know both SHAs and they differ
+    if (cache?.installedSha && cache.latestSha && cache.latestSha !== cache.installedSha) {
+      displayNotice();
+    }
+
+    // Fire background fetch if cache is missing or stale
+    const isStale = !cache || Date.now() - cache.lastCheck > CHECK_INTERVAL_MS;
+    if (isStale) {
+      fetchLatestSha()
+        .then((latest) => {
+          // Always update lastCheck to throttle retries (even on failure)
+          writeSkillCache({
+            lastCheck: Date.now(),
+            latestSha: latest ?? cache?.latestSha ?? "",
+            installedSha: cache?.installedSha ?? "",
+          });
+          if (latest) {
+            logger.debug("skill-update-check", `Cached latest SHA: ${latest}`);
+          }
+        })
+        .catch(
+          /* v8 ignore next -- fetchLatestSha never rejects */ (err) => {
+            logger.error("skill-update-check", `Background fetch failed: ${err}`);
+          },
+        );
+    }
+  } catch (err) {
+    logger.error("skill-update-check", `Skill update check failed: ${err}`);
+  }
+}


### PR DESCRIPTION
## Summary
- CLI now drives the full onboarding flow: OAuth → deployment + API key → one-shot multiselect (MCP / Dosu skill / GitHub repo) → AGENTS.md PR → server-side `finished_onboarding` flip via tRPC.
- GitHub repo connect uses a cookie-based web handshake (`/cli/connect-github` → GitHub install → `/redirect/replay` writes `user_installation` → `/cli/connect-github-done` forwards `installation_id` to a local CLI HTTP server) so the link is established deterministically instead of by webhook polling.
- `/cli/setup` page is folded into `/cli/auth`; CLI never duplicates the login UI and authenticated bounces happen through one shared token-forward page.
- Mode picker is gone — Cloud is the default, `--mode oss` opt-in. CLI checkpoints (`onboarding_progress.*`) make the flow resumable after Ctrl+C.
- Release channels: pushes to `main` publish to npm `latest`; pushes to `alpha` publish prerelease (`0.11.0-alpha.N`) under the `alpha` dist-tag — internal testers opt in with `npx @dosu/cli@alpha setup`.
- New runtime overrides (`DOSU_WEB_APP_URL_OVERRIDE`, `DOSU_BACKEND_URL_OVERRIDE`, `SUPABASE_URL_OVERRIDE`, `SUPABASE_ANON_KEY_OVERRIDE`) repoint a built bundle at staging/local without rebuilding. `AGENTS.md` documents both.

## Test plan
- [x] `bun run typecheck` (clean)
- [x] `bunx vitest run` — 769 passing
- [x] `bun run check` (biome clean)
- [ ] Manual end-to-end against staging: fresh user, OAuth → MCP install → skill → connect repo → AGENTS.md PR → terminal returns successfully
- [ ] Manual `--mode oss` regression check
- [ ] Verify `npx @dosu/cli@alpha setup` once the alpha branch ships