### PR TITLE
fix(setup): exit doc-scan early when repos are indexed but empty

### DIFF
--- a/src/setup/github-doc-import-step.test.ts
+++ b/src/setup/github-doc-import-step.test.ts
@@ -201,6 +201,23 @@ describe("stepImportGitHubDocs", () => {
     expect(result.advance).toBe(true);
   });
 
+  it("returns immediately when every github data source is indexed but the repos contain no markdown", async () => {
+    // Repo legitimately has no .md files (e.g. an asset repo). Backend has
+    // already finished indexing — listImportableGithubFiles returns []
+    // forever. We must not wait out the 60s timeout in that case.
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { provider_slug: "github", is_indexed: true },
+    ]);
+
+    const result = await stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+
+    expect(result.advance).toBe(true);
+    // We don't ask the user anything when we can prove there's nothing to scan.
+    expect(p.select).not.toHaveBeenCalled();
+    expect(mockTrpc.docImports.importGithubFiles.mutate).not.toHaveBeenCalled();
+  });
+
   it("treats an empty doc selection as skip and does not start an import", async () => {
     mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
       {

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -267,7 +267,15 @@ async function waitForImportableGithubFiles(
         return latestFiles;
       }
 
-      await fetchGitHubDataSources(trpc, orgID);
+      // Distinguish "still indexing" from "indexed but empty". If every
+      // GitHub data source in the org is fully indexed and we still have no
+      // files, the repos legitimately contain no markdown — exit immediately
+      // instead of waiting out the timeout.
+      const dataSources = await fetchGitHubDataSources(trpc, orgID);
+      if (dataSources.length > 0 && dataSources.every((ds) => ds.is_indexed === true)) {
+        spinner.stop("No markdown docs found");
+        return [];
+      }
       await sleep(DOC_SCAN_POLL_INTERVAL_MS);
     }
 


### PR DESCRIPTION
## Summary
- `waitForImportableGithubFiles` now uses `dataSource.list`'s `is_indexed` flag to distinguish "still indexing" from "indexed but empty", so asset-only repos (no markdown) skip the full 60s timeout + retry/skip prompt.
- Polling exits immediately with an empty result and a "No markdown docs found" spinner message when every connected GitHub data source reports `is_indexed === true`.
- The "still indexing" path is unchanged: `is_indexed=false` keeps polling until files appear or the timeout fires.

## Test plan
- [x] `bunx vitest run` — 826 passing (new test: `returns immediately when every github data source is indexed but the repos contain no markdown`)
- [x] `bun run typecheck` clean
- [x] `bun run check` clean
- [ ] Re-run alpha against a markdown-less repo (e.g. `dosu-ai/assets`) — confirm no 60s wait + no manual skip prompt