### PR TITLE
fix(setup): sync GitHub data sources

### DIFF
--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -20,7 +20,7 @@ const {
       create: { mutate: vi.fn() },
       listForSpace: { query: vi.fn() },
     },
-    dataSource: { create: { mutate: vi.fn() } },
+    dataSource: { create: { mutate: vi.fn() }, syncDataSource: { mutate: vi.fn() } },
     deploymentDataSource: { create: { mutate: vi.fn() } },
   },
 }));
@@ -320,6 +320,11 @@ describe("stepConnectGitHubRepo", () => {
     expect(result.advance).toBe(true);
     expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(2);
     expect(mockTrpc.dataSource.create.mutate).toHaveBeenCalledTimes(2);
+    // syncDataSource fires once per created data source so the backend
+    // enqueues `sync_data_source` and clones the repo.
+    expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledTimes(2);
+    expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledWith("ds-A");
+    expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledWith("ds-B");
     // deploymentDataSource.create fires once per (selected repo × space deployments):
     // 2 repos × 3 deployments = 6 invocations.
     expect(mockTrpc.deploymentDataSource.create.mutate).toHaveBeenCalledTimes(6);

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -271,6 +271,8 @@ async function createDeploymentForRepo(
       return { deployment_id: deployment.deployment_id };
     }
 
+    await trpc.dataSource.syncDataSource.mutate(dataSource.data_source_id);
+
     const spaceDeployments = (await trpc.workspaces.listForSpace.query(spaceID)) as unknown as {
       deployment_id: string;
     }[];


### PR DESCRIPTION
Calls syncDataSource after creating each GitHub data source during setup so the backend enqueues repository sync work before deployment wiring continues. Updates the GitHub setup test mock and assertions to verify one sync call per created data source.\n\nTested with: bunx vitest run src/setup/github-step.test.ts