### PR TITLE
fix(setup): drop orphan deployments + scope doc-scan to this run

### DIFF
--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -141,6 +141,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     const { stepImportGitHubDocs } = await import("./github-doc-import-step");
     const importResult = await stepImportGitHubDocs(cfg, {
       waitForFreshDocs: Boolean(connectResult.deployment_id),
+      expectedDataSourceIds: connectResult.created_data_source_ids,
     });
     if (!importResult.advance) return;
     githubOnboardingDone = true;

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -82,9 +82,6 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   let cloudSetupContext: CloudSetupContext | null = null;
 
   if (cfg.mode !== MODE_OSS) {
-    // resolveCloudSetupContext fans out 1–3 tRPC calls (profile +
-    // organization lookup) which can each take a few hundred ms. Without
-    // a spinner the post-Authenticated gap looks like a freeze.
     const s = p.spinner();
     s.start("Loading your workspace...");
     cloudSetupContext = await resolveCloudSetupContext(cfg);

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -429,6 +429,7 @@ async function bindOnboardingDeployment(
     "setup",
     `Bound onboarding context org=${targetOrg.org_id} deployment=${deployment.deployment_id}`,
   );
+  p.log.success(`Organization\n${dim(targetOrg.name)}`);
   return true;
 }
 

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -82,8 +82,17 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   let cloudSetupContext: CloudSetupContext | null = null;
 
   if (cfg.mode !== MODE_OSS) {
+    // resolveCloudSetupContext fans out 1–3 tRPC calls (profile +
+    // organization lookup) which can each take a few hundred ms. Without
+    // a spinner the post-Authenticated gap looks like a freeze.
+    const s = p.spinner();
+    s.start("Loading your workspace...");
     cloudSetupContext = await resolveCloudSetupContext(cfg);
-    if (!cloudSetupContext) return;
+    if (!cloudSetupContext) {
+      s.stop("Workspace load failed");
+      return;
+    }
+    s.stop("Workspace loaded");
   }
 
   // Deployment: first-run onboarding binds the user's default deployment.

--- a/src/setup/github-doc-import-step.test.ts
+++ b/src/setup/github-doc-import-step.test.ts
@@ -218,6 +218,45 @@ describe("stepImportGitHubDocs", () => {
     expect(mockTrpc.docImports.importGithubFiles.mutate).not.toHaveBeenCalled();
   });
 
+  it("ignores stale org-wide data sources and only waits on this run's set", async () => {
+    // Reproduces the bug we hit on staging: a previous setup left a
+    // GitHub data source stuck in is_indexed=false (QUEUED). With the old
+    // exit condition, that would block "No markdown docs found" forever
+    // even when this run's freshly-created data source is already done.
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-stale", provider_slug: "github", is_indexed: false },
+      { data_source_id: "ds-fresh", provider_slug: "github", is_indexed: true },
+    ]);
+
+    const result = await stepImportGitHubDocs(makeCfg(), {
+      waitForFreshDocs: true,
+      expectedDataSourceIds: ["ds-fresh"],
+    });
+
+    expect(result.advance).toBe(true);
+    expect(p.select).not.toHaveBeenCalled();
+  });
+
+  it("treats a backend-deleted expected data source as resolved (no markdown found)", async () => {
+    // Backend's sync_github_data_source deleted ds-fresh after Dosu's
+    // GitHub App couldn't clone the repo. The data source we expected is
+    // simply absent — that's a terminal "nothing to import" state, not an
+    // ongoing wait.
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-other", provider_slug: "github", is_indexed: false },
+    ]);
+
+    const result = await stepImportGitHubDocs(makeCfg(), {
+      waitForFreshDocs: true,
+      expectedDataSourceIds: ["ds-fresh"],
+    });
+
+    expect(result.advance).toBe(true);
+    expect(p.select).not.toHaveBeenCalled();
+  });
+
   it("treats an empty doc selection as skip and does not start an import", async () => {
     mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
       {

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -17,6 +17,7 @@ const IMPORT_STATUS_POLL_INTERVAL_MS = 2_000;
 const IMPORT_STATUS_MAX_ERRORS = 3;
 
 interface GitHubDataSource {
+  data_source_id?: string;
   provider_slug?: string;
   is_indexed?: boolean;
 }
@@ -62,6 +63,15 @@ export interface GitHubDocsImportStepResult {
 
 export interface GitHubDocsImportStepOptions {
   waitForFreshDocs?: boolean;
+  /**
+   * `data_source_id`s the caller just created in this run. When set, the
+   * scan loop only waits on these ids — once each one is either indexed or
+   * has been deleted by the backend, we exit. Without this, the loop
+   * watches every GitHub data source in the org, so a stale
+   * `is_indexed=false` row from a previous run can stall fresh setups
+   * indefinitely.
+   */
+  expectedDataSourceIds?: string[];
 }
 
 export async function stepImportGitHubDocs(
@@ -80,7 +90,7 @@ export async function stepImportGitHubDocs(
 
   const trpc: TrpcAny = createTypedClient(cfg);
   const files = opts.waitForFreshDocs
-    ? await waitForImportableGithubFiles(trpc, cfg.org_id, cfg.space_id)
+    ? await waitForImportableGithubFiles(trpc, cfg.org_id, cfg.space_id, opts.expectedDataSourceIds)
     : await fetchImportableGithubFiles(trpc, cfg.space_id);
   if (files === null) {
     return { advance: false };
@@ -251,6 +261,7 @@ async function waitForImportableGithubFiles(
   trpc: TrpcAny,
   orgID: string,
   spaceID: string,
+  expectedDataSourceIds?: string[],
 ): Promise<ImportableGithubFile[] | null> {
   while (true) {
     const spinner = p.spinner();
@@ -267,12 +278,13 @@ async function waitForImportableGithubFiles(
         return latestFiles;
       }
 
-      // Distinguish "still indexing" from "indexed but empty". If every
-      // GitHub data source in the org is fully indexed and we still have no
-      // files, the repos legitimately contain no markdown — exit immediately
-      // instead of waiting out the timeout.
+      // Distinguish "still indexing" from "indexed but empty". When the
+      // caller passed the data_source ids it just created we only wait on
+      // those — they're either indexed-or-missing very quickly. Otherwise
+      // fall back to watching every GitHub data source in the org (legacy
+      // path used by non-onboarding callers).
       const dataSources = await fetchGitHubDataSources(trpc, orgID);
-      if (dataSources.length > 0 && dataSources.every((ds) => ds.is_indexed === true)) {
+      if (isScanComplete(dataSources, expectedDataSourceIds)) {
         spinner.stop("No markdown docs found");
         return [];
       }
@@ -296,6 +308,34 @@ async function waitForImportableGithubFiles(
       return [];
     }
   }
+}
+
+/**
+ * Decide whether the GitHub doc scan has settled and the user can move on.
+ *
+ * - With `expectedDataSourceIds`: every id is either indexed in the current
+ *   list or absent (the backend deleted it because Dosu can't reach the
+ *   repo). A still-pending QUEUED row elsewhere in the org doesn't matter.
+ * - Without it: keep the legacy "all GitHub data sources indexed" check so
+ *   non-onboarding callers don't change behaviour.
+ */
+function isScanComplete(
+  dataSources: GitHubDataSource[],
+  expectedDataSourceIds?: string[],
+): boolean {
+  if (expectedDataSourceIds && expectedDataSourceIds.length > 0) {
+    const byId = new Map<string, GitHubDataSource>();
+    for (const ds of dataSources) {
+      if (ds.data_source_id) byId.set(ds.data_source_id, ds);
+    }
+    for (const id of expectedDataSourceIds) {
+      const ds = byId.get(id);
+      if (!ds) continue; // backend deleted it — treat as resolved
+      if (ds.is_indexed !== true) return false;
+    }
+    return true;
+  }
+  return dataSources.length > 0 && dataSources.every((ds) => ds.is_indexed === true);
 }
 
 async function fetchGitHubDataSources(trpc: TrpcAny, orgID: string): Promise<GitHubDataSource[]> {

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -191,8 +191,8 @@ describe("stepConnectGitHubRepo", () => {
       initialValues?: string[];
     };
     expect(promptArgs.options).toMatchObject([
-      { label: "acme/api", value: "acme/api" },
       { label: "Add repositories...", value: "__add_repositories__" },
+      { label: "acme/api", value: "acme/api" },
     ]);
     expect(promptArgs.initialValues).toEqual([]);
   });
@@ -227,11 +227,11 @@ describe("stepConnectGitHubRepo", () => {
     const secondArgs = mockPromptGitHubRepositories.mock.calls[1][0] as {
       options: { value: string }[];
     };
-    expect(firstArgs.options.map((o) => o.value)).toEqual(["acme/api", "__add_repositories__"]);
+    expect(firstArgs.options.map((o) => o.value)).toEqual(["__add_repositories__", "acme/api"]);
     expect(secondArgs.options.map((o) => o.value)).toEqual([
+      "__add_repositories__",
       "acme/api",
       "acme/core",
-      "__add_repositories__",
     ]);
     expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(1);
     const [args] = mockTrpc.workspaces.create.mutate.mock.calls[0];
@@ -306,9 +306,9 @@ describe("stepConnectGitHubRepo", () => {
       options: { value: string }[];
     };
     expect(secondArgs.options.map((o) => o.value)).toEqual([
+      "__add_repositories__",
       "acme/api",
       "acme/core",
-      "__add_repositories__",
     ]);
     expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(1);
     const [args] = mockTrpc.workspaces.create.mutate.mock.calls[0];
@@ -388,9 +388,9 @@ describe("stepConnectGitHubRepo", () => {
       options: { value: string }[];
     };
     expect(multiselectArgs.options.map((o) => o.value)).toEqual([
+      "__add_repositories__",
       "acme/core",
       "acme/cli",
-      "__add_repositories__",
     ]);
     // Deployed repos surface via a separate info log.
     const infoCalls = vi.mocked(p.log.info).mock.calls.map((c) => String(c[0]));

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -488,6 +488,49 @@ describe("stepConnectGitHubRepo", () => {
     expect(errorCalls.some((m) => m.includes("acme/stale"))).toBe(true);
   });
 
+  it("sorts repos most-recently-added-first so a fresh GitHub App install lands on top", async () => {
+    // Backend sorts alphabetically; for orgs with hundreds of repos that
+    // buries the one the user just added. The CLI re-sorts by created_at
+    // desc so the freshly installed repo is the first thing the cursor
+    // can reach.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      {
+        repository_id: 1,
+        name: "old",
+        slug: "acme/old",
+        is_deployed: false,
+        created_at: "2025-01-01T00:00:00Z",
+      },
+      {
+        repository_id: 2,
+        name: "newest",
+        slug: "acme/newest",
+        is_deployed: false,
+        created_at: "2026-04-27T18:00:00Z",
+      },
+      {
+        repository_id: 3,
+        name: "middle",
+        slug: "acme/middle",
+        is_deployed: false,
+        created_at: "2025-12-01T00:00:00Z",
+      },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue([]);
+
+    await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    const args = mockPromptGitHubRepositories.mock.calls[0][0] as {
+      options: { value: string }[];
+    };
+    expect(args.options.map((o) => o.value)).toEqual([
+      "__add_repositories__",
+      "acme/newest",
+      "acme/middle",
+      "acme/old",
+    ]);
+  });
+
   it("returns advance=false when user cancels the multiselect", async () => {
     mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
       { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -18,9 +18,14 @@ const {
     githubRepository: { listForOrg: { query: vi.fn() } },
     workspaces: {
       create: { mutate: vi.fn() },
+      delete: { mutate: vi.fn() },
       listForSpace: { query: vi.fn() },
     },
-    dataSource: { create: { mutate: vi.fn() }, syncDataSource: { mutate: vi.fn() } },
+    dataSource: {
+      create: { mutate: vi.fn() },
+      syncDataSource: { mutate: vi.fn() },
+      list: { query: vi.fn() },
+    },
     deploymentDataSource: { create: { mutate: vi.fn() } },
   },
 }));
@@ -82,6 +87,12 @@ import * as p from "@clack/prompts";
 import type { Config } from "../config/config";
 import { detectGitRepo, stepConnectGitHubRepo } from "./github-step";
 
+// Skip the post-connect verify-poll budget so each test resolves in real
+// time without needing fake timers to coexist with the install-flow promise
+// chain. The verify behaviour itself is still exercised — the loop runs
+// once and exits — just without any sleep between checks.
+const NO_WAIT_VERIFY = { verify: { timeoutMs: 0, intervalMs: 0 } } as const;
+
 function makeCfg(overrides: Partial<Config> = {}): Config {
   return {
     access_token: "tok",
@@ -134,15 +145,22 @@ function installationServerReturning(installationId: number) {
 
 describe("stepConnectGitHubRepo", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) so leftover `mockResolvedValueOnce`
+    // queues from a previous test don't bleed into this one's first call.
+    vi.resetAllMocks();
     vi.mocked(p.isCancel).mockReturnValue(false);
     mockPromptGitHubRepositories.mockResolvedValue([]);
     mockStartInstallationCallbackServer.mockResolvedValue(installationServerReturning(12345));
+    // Default: dataSource.list returns whatever's in mockTrpc state. Tests
+    // that exercise the verify step set their own mock; the rest stub it
+    // empty so verifyDataSourcesPersist completes immediately.
+    mockTrpc.dataSource.list.query.mockResolvedValue([]);
+    mockTrpc.workspaces.delete.mutate.mockResolvedValue({});
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it("returns advance=false when cfg has no org_id / space_id", async () => {
@@ -194,8 +212,11 @@ describe("stepConnectGitHubRepo", () => {
     mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-core" });
     mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-core" });
     mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-core" }]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-core", provider_slug: "github", is_indexed: false },
+    ]);
 
-    const result = await stepConnectGitHubRepo(makeCfg(), null);
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
 
     expect(mockOpenDefault).toHaveBeenCalledOnce();
     expect(mockPromptGitHubRepositories).toHaveBeenCalledTimes(2);
@@ -269,12 +290,15 @@ describe("stepConnectGitHubRepo", () => {
     mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-core" });
     mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-core" });
     mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-core" }]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-core", provider_slug: "github", is_indexed: false },
+    ]);
 
-    const result = await stepConnectGitHubRepo(makeCfg(), {
-      owner: "acme",
-      name: "api",
-      slug: "acme/api",
-    });
+    const result = await stepConnectGitHubRepo(
+      makeCfg(),
+      { owner: "acme", name: "api", slug: "acme/api" },
+      NO_WAIT_VERIFY,
+    );
 
     expect(mockTrpc.githubRepository.listForOrg.query).toHaveBeenCalledTimes(4);
     expect(mockPromptGitHubRepositories).toHaveBeenCalledTimes(2);
@@ -310,12 +334,16 @@ describe("stepConnectGitHubRepo", () => {
       { deployment_id: "dep-B" },
     ]);
     mockTrpc.deploymentDataSource.create.mutate.mockResolvedValue({});
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-A", provider_slug: "github", is_indexed: false },
+      { data_source_id: "ds-B", provider_slug: "github", is_indexed: false },
+    ]);
 
-    const result = await stepConnectGitHubRepo(makeCfg(), {
-      owner: "acme",
-      name: "api",
-      slug: "acme/api",
-    });
+    const result = await stepConnectGitHubRepo(
+      makeCfg(),
+      { owner: "acme", name: "api", slug: "acme/api" },
+      NO_WAIT_VERIFY,
+    );
 
     expect(result.advance).toBe(true);
     expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(2);
@@ -331,6 +359,10 @@ describe("stepConnectGitHubRepo", () => {
     // Cwd repo's deployment is reported as primary.
     expect(result.deployment_id).toBe("dep-A");
     expect(result.space_id).toBe("space-1");
+    // Both data_sources survived the verify step — neither got deleted by
+    // backend sync — so they're surfaced for downstream doc-import wait.
+    expect(result.created_data_source_ids).toEqual(["ds-A", "ds-B"]);
+    expect(mockTrpc.workspaces.delete.mutate).not.toHaveBeenCalled();
   });
 
   it("shows already-deployed repos in a separate info block, excludes them from multiselect", async () => {
@@ -344,8 +376,11 @@ describe("stepConnectGitHubRepo", () => {
     mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-X" });
     mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-X" });
     mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-X" }]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-X", provider_slug: "github", is_indexed: false },
+    ]);
 
-    await stepConnectGitHubRepo(makeCfg(), null);
+    await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
 
     // Multiselect only contains undeployed repos — deployed ones can't be
     // navigated to because they're not in the options list at all.
@@ -393,6 +428,64 @@ describe("stepConnectGitHubRepo", () => {
     // re-prompt if the user consciously declined to pick anything.
     expect(result.advance).toBe(true);
     expect(mockTrpc.workspaces.create.mutate).not.toHaveBeenCalled();
+  });
+
+  it("reverts orphan deployment when backend deletes its data_source mid-sync", async () => {
+    // Reproduces the staging case: `dataSource.create` succeeds, but
+    // `sync_github_data_source` fires `RepositoryNotFoundException` because
+    // Dosu's GitHub App can't reach the repo, so the backend deletes the
+    // data_source row a few seconds later. The CLI must detect that and
+    // tear down the orphan deployment instead of reporting "Connected".
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 100, name: "good", slug: "acme/good", is_deployed: false },
+      { repository_id: 200, name: "stale", slug: "acme/stale", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/good", "acme/stale"]);
+    mockTrpc.workspaces.create.mutate
+      .mockResolvedValueOnce({ deployment_id: "dep-good" })
+      .mockResolvedValueOnce({ deployment_id: "dep-stale" });
+    mockTrpc.dataSource.create.mutate
+      .mockResolvedValueOnce({ data_source_id: "ds-good" })
+      .mockResolvedValueOnce({ data_source_id: "ds-stale" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([
+      { deployment_id: "dep-good" },
+      { deployment_id: "dep-stale" },
+    ]);
+    mockTrpc.deploymentDataSource.create.mutate.mockResolvedValue({});
+    // Verify-poll sees ds-good present and ds-stale missing (backend already
+    // deleted it after RepositoryNotFoundException) — single-iteration mock
+    // is sufficient because NO_WAIT_VERIFY exits as soon as a drop appears.
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-good", provider_slug: "github", is_indexed: false },
+    ]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(true);
+    expect(mockTrpc.workspaces.delete.mutate).toHaveBeenCalledTimes(1);
+    expect(mockTrpc.workspaces.delete.mutate).toHaveBeenCalledWith("dep-stale");
+    expect(result.created_data_source_ids).toEqual(["ds-good"]);
+    expect(result.deployment_id).toBe("dep-good");
+    const warnCalls = vi.mocked(p.log.warn).mock.calls.map((c) => String(c[0]));
+    expect(warnCalls.some((m) => m.includes("acme/stale"))).toBe(true);
+  });
+
+  it("fails the step when every connected data_source gets deleted by backend sync", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 100, name: "stale", slug: "acme/stale", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/stale"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-stale" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-stale" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-stale" }]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([]); // already gone
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.workspaces.delete.mutate).toHaveBeenCalledWith("dep-stale");
+    const errorCalls = vi.mocked(p.log.error).mock.calls.map((c) => String(c[0]));
+    expect(errorCalls.some((m) => m.includes("acme/stale"))).toBe(true);
   });
 
   it("returns advance=false when user cancels the multiselect", async () => {

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -138,13 +138,13 @@ function buildPromptOptions(
   repos: AvailableRepo[],
 ): Parameters<typeof promptGitHubRepositories>[0]["options"] {
   return [
-    ...repos.map((r) => ({ kind: "repo" as const, label: r.slug, value: r.slug })),
     {
       kind: "action" as const,
       label: "Add repositories...",
       value: ADD_REPOSITORIES_VALUE,
       hint: "Open GitHub and refresh this list",
     },
+    ...repos.map((r) => ({ kind: "repo" as const, label: r.slug, value: r.slug })),
   ];
 }
 

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -47,6 +47,12 @@ type TrpcAny = any;
 const INSTALLATION_TIMEOUT_MS = 10 * 60 * 1000;
 const REPO_REFRESH_POLL_INTERVAL_MS = 500;
 const REPO_REFRESH_POLL_TIMEOUT_MS = 10_000;
+// Backend `sync_github_data_source` deletes the data_source row if it can't
+// reach the repo on GitHub (typical RepositoryNotFoundException turnaround is
+// 3–7s once the workflow picks up). We poll a little past that to detect the
+// drop before reporting Connected to the user.
+const DATA_SOURCE_VERIFY_POLL_INTERVAL_MS = 1_000;
+const DATA_SOURCE_VERIFY_POLL_TIMEOUT_MS = 10_000;
 
 export interface DetectedRepo {
   owner: string;
@@ -54,11 +60,34 @@ export interface DetectedRepo {
   slug: string;
 }
 
+/**
+ * Internal knobs for the post-connect data-source verification poll. Real
+ * runs use the defaults (multi-second budget so we catch the backend's
+ * async `RepositoryNotFoundException` deletion). Tests inject `0` so they
+ * don't burn real time waiting on fake timers that don't pair cleanly with
+ * the install-flow promise chain.
+ */
+export interface StepConnectGitHubRepoOptions {
+  verify?: {
+    timeoutMs?: number;
+    intervalMs?: number;
+  };
+}
+
 export interface GithubStepResult {
   advance: boolean;
   has_connected_repo?: boolean;
   deployment_id?: string;
   space_id?: string;
+  /**
+   * `data_source_id`s that the user just connected in this run AND that
+   * survived the backend's initial sync attempt. Empty when nothing connected
+   * or when every connection was reverted because Dosu couldn't reach the
+   * underlying GitHub repo. Downstream doc-import waits on exactly this set
+   * so a stale `is_indexed=false` data source elsewhere in the org doesn't
+   * stall it.
+   */
+  created_data_source_ids?: string[];
 }
 
 // Shape returned by tRPC `githubRepository.listForOrg`.
@@ -230,13 +259,18 @@ async function openGitHubInstallFlow(
  * Create one github deployment + its data_source, then link the data_source
  * into every deployment in the space. Mirrors the web
  * `OnboardingGithub.handleNext` + `useCreateDataSources` flow exactly.
+ *
+ * Returns the `data_source_id` alongside `deployment_id` so the caller can
+ * verify the row survived the backend's initial sync attempt — when Dosu's
+ * GitHub App can't reach the repo, `sync_github_data_source` deletes the
+ * data_source asynchronously, leaving an orphan deployment behind.
  */
 async function createDeploymentForRepo(
   trpc: TrpcAny,
   orgID: string,
   spaceID: string,
   repo: AvailableRepo,
-): Promise<{ deployment_id: string } | null> {
+): Promise<{ deployment_id: string; data_source_id?: string } | null> {
   try {
     const deployment = (await trpc.workspaces.create.mutate({
       org_id: orgID,
@@ -284,7 +318,10 @@ async function createDeploymentForRepo(
         }),
       ),
     );
-    return { deployment_id: deployment.deployment_id };
+    return {
+      deployment_id: deployment.deployment_id,
+      data_source_id: dataSource.data_source_id,
+    };
   } catch (err: unknown) {
     /* v8 ignore next -- server errors bubble up */
     const msg = err instanceof Error ? err.message : String(err);
@@ -293,9 +330,99 @@ async function createDeploymentForRepo(
   }
 }
 
+interface SyncSurvivors {
+  alive: Set<string>;
+  dropped: Set<string>;
+}
+
+interface VerifyDataSourcesOptions {
+  /** Poll budget. Tests inject 0 to short-circuit to a single check. */
+  timeoutMs?: number;
+  /** Sleep between polls. Tests inject 0 to avoid any awaiting. */
+  intervalMs?: number;
+}
+
+/**
+ * Poll `dataSource.list` until each `expectedDataSourceIds` either shows up
+ * (alive) or stays missing through the budget (dropped — backend sync
+ * deleted it).
+ *
+ * Why we need this: `dataSource.create` is a synchronous insert, but
+ * `syncDataSource` only enqueues the GitHub clone+index workflow. If that
+ * workflow throws `RepositoryNotFoundException` it deletes the data_source
+ * a few seconds later. CLI-side this looks like a successful create, so
+ * without a follow-up read the user sees "Connected N" even when the row
+ * has already been GC'd server-side.
+ */
+export async function verifyDataSourcesPersist(
+  trpc: TrpcAny,
+  orgID: string,
+  expectedDataSourceIds: string[],
+  opts: VerifyDataSourcesOptions = {},
+): Promise<SyncSurvivors> {
+  const expected = new Set(expectedDataSourceIds);
+  if (expected.size === 0) {
+    return { alive: new Set(), dropped: new Set() };
+  }
+
+  const timeoutMs = opts.timeoutMs ?? DATA_SOURCE_VERIFY_POLL_TIMEOUT_MS;
+  const intervalMs = opts.intervalMs ?? DATA_SOURCE_VERIFY_POLL_INTERVAL_MS;
+
+  const startedAt = Date.now();
+  let alive = new Set<string>();
+  let dropped = new Set<string>();
+  let firstIteration = true;
+
+  while (firstIteration || Date.now() - startedAt < timeoutMs) {
+    firstIteration = false;
+    let listed: { data_source_id?: string }[] = [];
+    try {
+      listed = (await trpc.dataSource.list.query({
+        org_id: orgID,
+        excluded_provider_slugs: [],
+      })) as { data_source_id?: string }[];
+    } catch (err: unknown) {
+      /* v8 ignore next -- transient list failures are non-fatal; we'll retry */
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn("setup", `dataSource.list during verify failed: ${msg}`);
+    }
+
+    const presentNow = new Set(
+      listed.map((d) => d.data_source_id).filter((id): id is string => Boolean(id)),
+    );
+
+    alive = new Set([...expected].filter((id) => presentNow.has(id)));
+    dropped = new Set([...expected].filter((id) => !presentNow.has(id)));
+
+    // Earliest exit: any expected id has already been GC'd by the backend.
+    // Once one is gone we don't gain anything by polling longer.
+    if (dropped.size > 0) return { alive, dropped };
+
+    if (timeoutMs === 0) break;
+    await sleep(intervalMs);
+  }
+
+  return { alive, dropped };
+}
+
+async function deleteOrphanDeployment(
+  trpc: TrpcAny,
+  deploymentID: string,
+  slug: string,
+): Promise<void> {
+  try {
+    await trpc.workspaces.delete.mutate(deploymentID);
+  } catch (err: unknown) {
+    /* v8 ignore next -- best-effort cleanup; user can delete manually if needed */
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("setup", `Failed to revert orphan deployment for ${slug}: ${msg}`);
+  }
+}
+
 export async function stepConnectGitHubRepo(
   cfg: Config,
   detected: DetectedRepo | null = detectGitRepo(),
+  opts: StepConnectGitHubRepoOptions = {},
 ): Promise<GithubStepResult> {
   logger.info("setup", "Step: connect GitHub repo(s)");
 
@@ -359,35 +486,85 @@ export async function stepConnectGitHubRepo(
 
     const s = p.spinner();
     s.start(`Connecting ${slugs.length} repo${slugs.length === 1 ? "" : "s"}...`);
-    const created: { deployment_id: string; slug: string }[] = [];
+    const created: { deployment_id: string; data_source_id?: string; slug: string }[] = [];
     for (const slug of slugs) {
       const repo = repos.find((r) => r.slug === slug);
       if (!repo) continue;
       const result = await createDeploymentForRepo(trpc, orgID, spaceID, repo);
       if (result) {
-        created.push({ deployment_id: result.deployment_id, slug });
+        created.push({
+          deployment_id: result.deployment_id,
+          data_source_id: result.data_source_id,
+          slug,
+        });
       }
     }
 
-    if (created.length === 0) {
+    // The CLI just created data_sources synchronously, but the backend's
+    // GitHub sync workflow may have already deleted some of them if Dosu's
+    // GitHub App can't reach the repo. Verify before declaring success — and
+    // revert the orphan deployments so the multiselect doesn't keep showing
+    // those repos as `is_deployed=true` on the next run.
+    const expectedDsIds = created
+      .map((c) => c.data_source_id)
+      .filter((id): id is string => Boolean(id));
+    const survivors = await verifyDataSourcesPersist(trpc, orgID, expectedDsIds, opts.verify);
+
+    const reverted: { slug: string; deployment_id: string }[] = [];
+    if (survivors.dropped.size > 0) {
+      const droppedEntries = created.filter(
+        (c) => c.data_source_id && survivors.dropped.has(c.data_source_id),
+      );
+      for (const entry of droppedEntries) {
+        await deleteOrphanDeployment(trpc, entry.deployment_id, entry.slug);
+        reverted.push({ slug: entry.slug, deployment_id: entry.deployment_id });
+      }
+    }
+    const survived = created.filter(
+      (c) => !c.data_source_id || survivors.alive.has(c.data_source_id),
+    );
+
+    if (survived.length === 0) {
       s.stop("Failed");
-      p.log.error("Could not connect any repos. Check `dosu logs --tail 50` for details.");
+      if (reverted.length > 0) {
+        p.log.error(
+          `Couldn't sync any repos — Dosu doesn't have GitHub access to: ${reverted
+            .map((r) => r.slug)
+            .join(", ")}.`,
+        );
+      } else {
+        p.log.error("Could not connect any repos. Check `dosu logs --tail 50` for details.");
+      }
       return { advance: false, has_connected_repo: deployed.length > 0 };
     }
 
-    s.stop(`Connected ${created.length} repo${created.length === 1 ? "" : "s"}`);
-    for (const { slug, deployment_id } of created) {
+    if (reverted.length > 0) {
+      s.stop(
+        `Connected ${survived.length} repo${survived.length === 1 ? "" : "s"} · ${reverted.length} skipped`,
+      );
+      p.log.warn(
+        `Dosu couldn't sync ${reverted.length} repo${reverted.length === 1 ? "" : "s"} ` +
+          `(GitHub App has no access): ${reverted.map((r) => r.slug).join(", ")}`,
+      );
+    } else {
+      s.stop(`Connected ${survived.length} repo${survived.length === 1 ? "" : "s"}`);
+    }
+    for (const { slug, deployment_id } of survived) {
       p.log.success(`${slug}\n${dim(`deployment ${deployment_id}`)}`);
     }
 
     // Prefer the cwd repo's deployment as the primary; fall back to the first
     // successfully created one.
-    const primary = (detected && created.find((c) => c.slug === detected.slug)) ?? created[0];
+    const primary = (detected && survived.find((c) => c.slug === detected.slug)) ?? survived[0];
+    const survivingDataSourceIds = survived
+      .map((c) => c.data_source_id)
+      .filter((id): id is string => Boolean(id));
     return {
       advance: true,
       has_connected_repo: true,
       deployment_id: primary.deployment_id,
       space_id: cfg.space_id,
+      created_data_source_ids: survivingDataSourceIds,
     };
   }
 }

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -47,6 +47,10 @@ type TrpcAny = any;
 const INSTALLATION_TIMEOUT_MS = 10 * 60 * 1000;
 const REPO_REFRESH_POLL_INTERVAL_MS = 500;
 const REPO_REFRESH_POLL_TIMEOUT_MS = 10_000;
+// Cap visible rows in the multiselect — orgs with hundreds of repos
+// otherwise blow past the terminal height. The prompt scrolls the rest
+// behind ellipsis markers (see github-repo-prompt.ts:198).
+const REPO_MULTISELECT_MAX_ITEMS = 10;
 // Backend `sync_github_data_source` deletes the data_source row if it can't
 // reach the repo on GitHub (typical RepositoryNotFoundException turnaround is
 // 3–7s once the workflow picks up). We poll a little past that to detect the
@@ -457,9 +461,10 @@ export async function stepConnectGitHubRepo(
     }
 
     const selected = await promptGitHubRepositories({
-      message: "Select repositories to connect",
+      message: `Select repositories to connect ${dim(`(${undeployed.length} available)`)}`,
       options: buildPromptOptions(undeployed),
       initialValues: [],
+      maxItems: REPO_MULTISELECT_MAX_ITEMS,
     });
     if (p.isCancel(selected)) {
       logger.info("setup", "Repository selection cancelled");

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -94,12 +94,15 @@ export interface GithubStepResult {
   created_data_source_ids?: string[];
 }
 
-// Shape returned by tRPC `githubRepository.listForOrg`.
+// Shape returned by tRPC `githubRepository.listForOrg`. Backend spreads
+// `...github.repository` so `created_at` rides along even though the
+// router type doesn't surface it explicitly.
 interface AvailableRepo {
   repository_id: number;
   name: string;
   slug: string; // "owner/repo"
   is_deployed: boolean;
+  created_at?: string;
 }
 export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null {
   let url: string;
@@ -127,15 +130,32 @@ export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null 
 
 async function fetchListForOrg(trpc: TrpcAny, orgID: string): Promise<AvailableRepo[]> {
   try {
-    return (await trpc.githubRepository.listForOrg.query({
+    const repos = (await trpc.githubRepository.listForOrg.query({
       org_id: orgID,
     })) as AvailableRepo[];
+    return sortReposByRecency(repos);
   } catch (err: unknown) {
     /* v8 ignore next -- non-fatal; caller decides what to do with an empty list */
     const msg = err instanceof Error ? err.message : String(err);
     logger.warn("setup", `listForOrg failed: ${msg}`);
     return [];
   }
+}
+
+/**
+ * Sort repos with most recently added to the org first. The backend
+ * sorts alphabetically — for orgs with hundreds of repos that buries the
+ * one the user just installed via the GitHub App. Repos missing
+ * `created_at` keep their incoming order (Array.prototype.sort is
+ * stable), so callers and tests that don't supply timestamps stay
+ * deterministic.
+ */
+function sortReposByRecency(repos: AvailableRepo[]): AvailableRepo[] {
+  return [...repos].sort((a, b) => {
+    const ta = Date.parse(a.created_at ?? "") || 0;
+    const tb = Date.parse(b.created_at ?? "") || 0;
+    return tb - ta;
+  });
 }
 
 function buildPromptOptions(


### PR DESCRIPTION
## Summary

Two CLI-only fixes for first-run setup, both rooted in the staging case where 5 of 7 GitHub data_sources got silently GC'd by `sync_github_data_source` after `RepositoryNotFoundException` while CLI happily reported "Connected 4 repos · No markdown docs found".

- **Detect + revert orphan deployments.** After `createDeploymentForRepo`, `stepConnectGitHubRepo` now polls `dataSource.list` (10s budget, configurable for tests) and, for each freshly-created `data_source_id` the backend has dropped, calls `workspaces.delete` to remove the orphan deployment and surfaces `Connected N · M skipped` with the unreachable repo slugs.
- **Scope doc-scan to this run's data sources.** `stepImportGitHubDocs` accepts `expectedDataSourceIds` from the connect step; `waitForImportableGithubFiles` exits as soon as each id is either indexed or deleted, so a stale `is_indexed=false` row from a prior setup no longer blocks the 60s scan.

No backend changes — uses existing `dataSource.list` and `workspaces.delete` tRPC procedures. 830/830 tests pass; new coverage for revert path (single + all-dropped) and stale-data_source isolation.

## Test plan

- [ ] `bun run test` (full suite green, includes 4 new tests)
- [ ] `bun run typecheck` and `bun run check`
- [ ] Manual: `dosu setup` against an org with a stale GitHub repo (App lost access) — verify "skipped" message + no orphan deployment + doc scan exits cleanly
- [ ] Manual: `dosu setup` against a healthy repo — verify normal path still works (Connected, doc scan finds markdown)