### PR TITLE
feat: track CLI onboarding analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",
-    "@dosu/api-types": "0.0.4",
+    "@dosu/api-types": "0.0.7",
     "commander": "^13.1.0",
     "open": "^10.1.0",
     "picocolors": "^1.1.1",

--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -143,6 +143,19 @@ describe("startOAuthFlow", () => {
     await flowPromise;
   });
 
+  it("includes extra auth URL params", async () => {
+    const flowPromise = startOAuthFlow(undefined, "/cli/auth", {
+      onboarding_run_id: "run-123",
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const calledURL = mockOpenDefault.mock.calls[0]?.[0] as string;
+    expect(calledURL).toContain("onboarding_run_id=run-123");
+
+    resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
+    await flowPromise;
+  });
+
   it("clears the timeout timer after successful token receipt", async () => {
     vi.useFakeTimers();
 

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -16,6 +16,7 @@ import { startCallbackServer, type TokenResponse } from "./server";
 export async function startOAuthFlow(
   signal?: AbortSignal,
   path: string = "/cli/auth",
+  params: Record<string, string> = {},
 ): Promise<TokenResponse> {
   const { server, tokenPromise } = await startCallbackServer();
 
@@ -24,7 +25,7 @@ export async function startOAuthFlow(
   try {
     const callbackURL = `http://localhost:${server.port}/callback`;
     logger.debug("auth.flow", `Callback URL: ${callbackURL}`);
-    const authURL = buildAuthURL(callbackURL, path);
+    const authURL = buildAuthURL(callbackURL, path, params);
     logger.info("auth.flow", `Auth URL: ${authURL}`);
 
     // Open browser — dynamic import to avoid bundling issues
@@ -62,8 +63,12 @@ export async function startOAuthFlow(
   }
 }
 
-function buildAuthURL(callbackURL: string, path: string): string {
+function buildAuthURL(
+  callbackURL: string,
+  path: string,
+  extraParams: Record<string, string>,
+): string {
   const webAppURL = getWebAppURL();
-  const params = new URLSearchParams({ callback: callbackURL });
+  const params = new URLSearchParams({ callback: callbackURL, ...extraParams });
   return `${webAppURL}${path}?${params}`;
 }

--- a/src/commands/analytics.test.ts
+++ b/src/commands/analytics.test.ts
@@ -70,7 +70,7 @@ describe("analytics", () => {
       totalResponses: 42,
       totalWithResponse: 36,
       byConfidence: { high: 20, medium: 10, low: 12 },
-      reactions: { totalPositive: 5, totalNegative: 1, reactionRate: 0.14, positiveRate: 0.83 },
+      reactions: { totalPositive: 5, totalNegative: 1, positiveRate: 0.83 },
     });
 
     await run();
@@ -87,7 +87,7 @@ describe("analytics", () => {
       totalResponses: 10,
       totalWithResponse: 8,
       byConfidence: { high: 5, medium: 3, low: 2 },
-      reactions: { totalPositive: 2, totalNegative: 0, reactionRate: 0.2, positiveRate: 1 },
+      reactions: { totalPositive: 2, totalNegative: 0, positiveRate: 1 },
     });
 
     await run("--days", "7");
@@ -101,7 +101,7 @@ describe("analytics", () => {
       totalResponses: 42,
       totalWithResponse: 36,
       byConfidence: { high: 20, medium: 10, low: 12 },
-      reactions: { totalPositive: 5, totalNegative: 1, reactionRate: 0.14, positiveRate: 0.83 },
+      reactions: { totalPositive: 5, totalNegative: 1, positiveRate: 0.83 },
     });
 
     await run("--json");
@@ -116,7 +116,7 @@ describe("analytics", () => {
       totalResponses: 100,
       totalWithResponse: 86,
       byConfidence: { high: 50, medium: 30, low: 20 },
-      reactions: { totalPositive: 90, totalNegative: 10, reactionRate: 0.5, positiveRate: 0.923 },
+      reactions: { totalPositive: 90, totalNegative: 10, positiveRate: 0.923 },
     });
 
     await run();

--- a/src/commands/analytics.ts
+++ b/src/commands/analytics.ts
@@ -50,7 +50,6 @@ export function analyticsCommand(): Command {
           ["Low Confidence", String(stats.byConfidence.low)],
           ["Positive Reactions", String(stats.reactions.totalPositive)],
           ["Negative Reactions", String(stats.reactions.totalNegative)],
-          ["Reaction Rate", pct(stats.reactions.reactionRate)],
           ["Positive Rate", pct(stats.reactions.positiveRate)],
         ],
         { rawData: stats },

--- a/src/setup/analytics.test.ts
+++ b/src/setup/analytics.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../config/config";
+
+const { mockCreateTypedClient, mockCreateTRPCClient, mockDebug, mockGetWebAppURL, mockHttpLink } =
+  vi.hoisted(() => ({
+    mockCreateTypedClient: vi.fn(),
+    mockCreateTRPCClient: vi.fn(),
+    mockDebug: vi.fn(),
+    mockGetWebAppURL: vi.fn(),
+    mockHttpLink: vi.fn((opts: unknown) => ({ type: "httpLink", opts })),
+  }));
+
+vi.mock("../client/trpc", () => ({
+  createTypedClient: mockCreateTypedClient,
+}));
+
+vi.mock("@trpc/client", () => ({
+  createTRPCClient: mockCreateTRPCClient,
+  httpLink: mockHttpLink,
+}));
+
+vi.mock("../config/constants", () => ({
+  getWebAppURL: mockGetWebAppURL,
+}));
+
+vi.mock("../debug/logger", () => ({
+  logger: { debug: mockDebug },
+}));
+
+import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
+
+const mutate = vi.fn();
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    access_token: "token",
+    refresh_token: "refresh",
+    expires_at: 0,
+    org_id: "org-1",
+    deployment_id: "dep-1",
+    space_id: "space-1",
+    ...overrides,
+  };
+}
+
+function mockTrackingClient() {
+  const client = {
+    user: {
+      trackCliOnboardingEvent: { mutate },
+      trackCliOnboardingPreAuthEvent: { mutate },
+    },
+  };
+  mockCreateTypedClient.mockReturnValue(client);
+  mockCreateTRPCClient.mockReturnValue(client);
+  return client;
+}
+
+describe("setup analytics", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mutate.mockReset().mockResolvedValue(undefined);
+    mockCreateTypedClient.mockReset();
+    mockCreateTRPCClient.mockReset();
+    mockDebug.mockReset();
+    mockGetWebAppURL.mockReset().mockReturnValue("https://app.test.dev");
+    mockHttpLink.mockClear();
+    mockTrackingClient();
+  });
+
+  it("skips authenticated tracking when access_token is missing", async () => {
+    await trackCliOnboardingEvent(
+      makeConfig({ access_token: "" }),
+      "run-1",
+      "cli_onboarding_started",
+    );
+
+    expect(mockCreateTypedClient).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("tracks authenticated onboarding events with base and custom properties", async () => {
+    await trackCliOnboardingEvent(
+      makeConfig({ mode: "oss" }),
+      "run-1",
+      "cli_onboarding_completed",
+      {
+        completed_mcp: true,
+      },
+    );
+
+    expect(mockCreateTypedClient).toHaveBeenCalledWith(
+      expect.objectContaining({ access_token: "token" }),
+    );
+    expect(mutate).toHaveBeenCalledWith({
+      event: "cli_onboarding_completed",
+      properties: expect.objectContaining({
+        onboarding_run_id: "run-1",
+        mode: "oss",
+        org_id: "org-1",
+        deployment_id: "dep-1",
+        space_id: "space-1",
+        completed_mcp: true,
+      }),
+    });
+  });
+
+  it("logs and swallows authenticated tracking failures", async () => {
+    mutate.mockRejectedValueOnce("network down");
+
+    await expect(
+      trackCliOnboardingEvent(makeConfig(), "run-1", "cli_onboarding_failed"),
+    ).resolves.toBeUndefined();
+
+    expect(mockDebug).toHaveBeenCalledWith(
+      "setup",
+      "CLI onboarding analytics failed: cli_onboarding_failed: network down",
+    );
+  });
+
+  it("logs Error instances from authenticated tracking failures", async () => {
+    mutate.mockRejectedValueOnce(new Error("request failed"));
+
+    await expect(
+      trackCliOnboardingEvent(makeConfig(), "run-1", "cli_onboarding_failed"),
+    ).resolves.toBeUndefined();
+
+    expect(mockDebug).toHaveBeenCalledWith(
+      "setup",
+      "CLI onboarding analytics failed: cli_onboarding_failed: request failed",
+    );
+  });
+
+  it("tracks pre-auth events through the anonymous client", async () => {
+    await trackCliOnboardingPreAuthEvent("run-2", "cli_onboarding_auth_started", {
+      source: "setup",
+    });
+
+    expect(mockHttpLink).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://app.test.dev/api/trpc" }),
+    );
+    expect(mockCreateTRPCClient).toHaveBeenCalledWith({
+      links: [expect.objectContaining({ type: "httpLink" })],
+    });
+    expect(mutate).toHaveBeenCalledWith({
+      event: "cli_onboarding_auth_started",
+      onboarding_run_id: "run-2",
+      properties: expect.objectContaining({
+        mode: "cloud",
+        source: "setup",
+      }),
+    });
+  });
+
+  it("logs and swallows pre-auth client setup failures", async () => {
+    mockGetWebAppURL.mockReturnValueOnce("");
+
+    await expect(
+      trackCliOnboardingPreAuthEvent("run-2", "cli_onboarding_auth_failed"),
+    ).resolves.toBeUndefined();
+
+    expect(mockDebug).toHaveBeenCalledWith(
+      "setup",
+      "CLI onboarding pre-auth analytics failed: cli_onboarding_auth_failed: Web app URL not configured",
+    );
+  });
+
+  it("logs non-Error pre-auth tracking failures", async () => {
+    mutate.mockRejectedValueOnce("anonymous network down");
+
+    await expect(
+      trackCliOnboardingPreAuthEvent("run-2", "cli_onboarding_auth_failed"),
+    ).resolves.toBeUndefined();
+
+    expect(mockDebug).toHaveBeenCalledWith(
+      "setup",
+      "CLI onboarding pre-auth analytics failed: cli_onboarding_auth_failed: anonymous network down",
+    );
+  });
+
+  it("clears the tracking timeout after successful tracking", async () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    mutate.mockResolvedValueOnce(undefined);
+
+    await trackCliOnboardingEvent(makeConfig(), "run-1", "cli_onboarding_started");
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -1,0 +1,60 @@
+import { createTypedClient } from "../client/trpc";
+import type { Config } from "../config/config";
+import { logger } from "../debug/logger";
+import { VERSION } from "../version/version";
+
+export type CliOnboardingEvent =
+  | "cli_onboarding_started"
+  | "cli_onboarding_auth_completed"
+  | "cli_onboarding_options_selected"
+  | "cli_onboarding_mcp_configured"
+  | "cli_onboarding_skill_installed"
+  | "cli_onboarding_github_connected"
+  | "cli_onboarding_docs_imported"
+  | "cli_onboarding_completed"
+  | "cli_onboarding_activated"
+  | "cli_onboarding_cancelled"
+  | "cli_onboarding_failed";
+
+type CliOnboardingProperties = Record<
+  string,
+  string | number | boolean | null | undefined | string[]
+>;
+
+// `@dosu/api-types` can trail app routers; keep this best-effort tracking path narrow.
+// biome-ignore lint/suspicious/noExplicitAny: see note above.
+type TrpcAny = any;
+
+export async function trackCliOnboardingEvent(
+  cfg: Config,
+  event: CliOnboardingEvent,
+  properties: CliOnboardingProperties = {},
+): Promise<void> {
+  if (!cfg.access_token) return;
+
+  try {
+    const trpc = createTypedClient(cfg) as TrpcAny;
+    await trpc.user.trackCliOnboardingEvent.mutate({
+      event,
+      properties: {
+        ...baseProperties(cfg),
+        ...properties,
+      },
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.debug("setup", `CLI onboarding analytics failed: ${event}: ${msg}`);
+  }
+}
+
+function baseProperties(cfg: Config): CliOnboardingProperties {
+  return {
+    cli_version: VERSION,
+    platform: process.platform,
+    arch: process.arch,
+    mode: cfg.mode ?? "cloud",
+    org_id: cfg.org_id,
+    deployment_id: cfg.deployment_id,
+    space_id: cfg.space_id,
+  };
+}

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -21,6 +21,8 @@ type CliOnboardingProperties = Record<
   string | number | boolean | null | undefined | string[]
 >;
 
+const TRACKING_TIMEOUT_MS = 1_500;
+
 // `@dosu/api-types` can trail app routers; keep this best-effort tracking path narrow.
 // biome-ignore lint/suspicious/noExplicitAny: see note above.
 type TrpcAny = any;
@@ -34,13 +36,16 @@ export async function trackCliOnboardingEvent(
 
   try {
     const trpc = createTypedClient(cfg) as TrpcAny;
-    await trpc.user.trackCliOnboardingEvent.mutate({
-      event,
-      properties: {
-        ...baseProperties(cfg),
-        ...properties,
-      },
-    });
+    await withTimeout(
+      trpc.user.trackCliOnboardingEvent.mutate({
+        event,
+        properties: {
+          ...baseProperties(cfg),
+          ...properties,
+        },
+      }),
+      TRACKING_TIMEOUT_MS,
+    );
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.debug("setup", `CLI onboarding analytics failed: ${event}: ${msg}`);
@@ -57,4 +62,18 @@ function baseProperties(cfg: Config): CliOnboardingProperties {
     deployment_id: cfg.deployment_id,
     space_id: cfg.space_id,
   };
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error("tracking timeout")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -1,4 +1,5 @@
 import { createTRPCClient, httpLink } from "@trpc/client";
+import type { inferRouterInputs } from "@trpc/server";
 import superjson from "superjson";
 import { type AppRouter, createTypedClient, type TypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
@@ -6,24 +7,9 @@ import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
 import { VERSION } from "../version/version";
 
-export type CliOnboardingEvent =
-  | "cli_onboarding_started"
-  | "cli_onboarding_auth_completed"
-  | "cli_onboarding_options_selected"
-  | "cli_onboarding_mcp_configured"
-  | "cli_onboarding_skill_installed"
-  | "cli_onboarding_github_connected"
-  | "cli_onboarding_docs_imported"
-  | "cli_onboarding_completed"
-  | "cli_onboarding_activated"
-  | "cli_onboarding_cancelled"
-  | "cli_onboarding_failed";
-
-export type CliOnboardingPreAuthEvent =
-  | "cli_onboarding_launch_attempted"
-  | "cli_onboarding_auth_started"
-  | "cli_onboarding_auth_cancelled"
-  | "cli_onboarding_auth_failed";
+type UserRouterInputs = inferRouterInputs<AppRouter>["user"];
+type CliOnboardingEvent = UserRouterInputs["trackCliOnboardingEvent"]["event"];
+type CliOnboardingPreAuthEvent = UserRouterInputs["trackCliOnboardingPreAuthEvent"]["event"];
 
 type CliOnboardingProperties = Record<
   string,

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -1,6 +1,6 @@
 import { createTRPCClient, httpLink } from "@trpc/client";
 import superjson from "superjson";
-import { createTypedClient } from "../client/trpc";
+import { type AppRouter, createTypedClient, type TypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
 import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
@@ -32,10 +32,6 @@ type CliOnboardingProperties = Record<
 
 const TRACKING_TIMEOUT_MS = 1_500;
 
-// `@dosu/api-types` can trail app routers; keep this best-effort tracking path narrow.
-// biome-ignore lint/suspicious/noExplicitAny: see note above.
-type TrpcAny = any;
-
 export async function trackCliOnboardingEvent(
   cfg: Config,
   onboardingRunID: string,
@@ -45,7 +41,7 @@ export async function trackCliOnboardingEvent(
   if (!cfg.access_token) return;
 
   try {
-    const trpc = createTypedClient(cfg) as TrpcAny;
+    const trpc = createTypedClient(cfg);
     await withTimeout(
       trpc.user.trackCliOnboardingEvent.mutate({
         event,
@@ -99,19 +95,19 @@ function baseProperties(cfg: Config): CliOnboardingProperties {
   };
 }
 
-function createAnonymousClient(): TrpcAny {
+function createAnonymousClient(): TypedClient {
   const webAppURL = getWebAppURL();
   if (!webAppURL) {
     throw new Error("Web app URL not configured");
   }
-  return createTRPCClient({
+  return createTRPCClient<AppRouter>({
     links: [
       httpLink({
         url: `${webAppURL}/api/trpc`,
         transformer: superjson,
       }),
     ],
-  }) as TrpcAny;
+  });
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -1,5 +1,8 @@
+import { createTRPCClient, httpLink } from "@trpc/client";
+import superjson from "superjson";
 import { createTypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
+import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
 import { VERSION } from "../version/version";
 
@@ -16,6 +19,12 @@ export type CliOnboardingEvent =
   | "cli_onboarding_cancelled"
   | "cli_onboarding_failed";
 
+export type CliOnboardingPreAuthEvent =
+  | "cli_onboarding_launch_attempted"
+  | "cli_onboarding_auth_started"
+  | "cli_onboarding_auth_cancelled"
+  | "cli_onboarding_auth_failed";
+
 type CliOnboardingProperties = Record<
   string,
   string | number | boolean | null | undefined | string[]
@@ -29,6 +38,7 @@ type TrpcAny = any;
 
 export async function trackCliOnboardingEvent(
   cfg: Config,
+  onboardingRunID: string,
   event: CliOnboardingEvent,
   properties: CliOnboardingProperties = {},
 ): Promise<void> {
@@ -41,6 +51,7 @@ export async function trackCliOnboardingEvent(
         event,
         properties: {
           ...baseProperties(cfg),
+          onboarding_run_id: onboardingRunID,
           ...properties,
         },
       }),
@@ -49,6 +60,30 @@ export async function trackCliOnboardingEvent(
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.debug("setup", `CLI onboarding analytics failed: ${event}: ${msg}`);
+  }
+}
+
+export async function trackCliOnboardingPreAuthEvent(
+  onboardingRunID: string,
+  event: CliOnboardingPreAuthEvent,
+  properties: CliOnboardingProperties = {},
+): Promise<void> {
+  try {
+    const trpc = createAnonymousClient();
+    await withTimeout(
+      trpc.user.trackCliOnboardingPreAuthEvent.mutate({
+        event,
+        onboarding_run_id: onboardingRunID,
+        properties: {
+          ...baseProperties({ access_token: "", refresh_token: "", expires_at: 0 }),
+          ...properties,
+        },
+      }),
+      TRACKING_TIMEOUT_MS,
+    );
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.debug("setup", `CLI onboarding pre-auth analytics failed: ${event}: ${msg}`);
   }
 }
 
@@ -62,6 +97,21 @@ function baseProperties(cfg: Config): CliOnboardingProperties {
     deployment_id: cfg.deployment_id,
     space_id: cfg.space_id,
   };
+}
+
+function createAnonymousClient(): TrpcAny {
+  const webAppURL = getWebAppURL();
+  if (!webAppURL) {
+    throw new Error("Web app URL not configured");
+  }
+  return createTRPCClient({
+    links: [
+      httpLink({
+        url: `${webAppURL}/api/trpc`,
+        transformer: superjson,
+      }),
+    ],
+  }) as TrpcAny;
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1722,6 +1722,46 @@ describe("runSetup checkpoint behavior", () => {
     );
   });
 
+  it("does not track activation when docs import is only queued", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({
+      advance: true,
+      has_connected_repo: true,
+      created_data_source_ids: ["ds-1"],
+    });
+    mockStepImportGitHubDocs.mockResolvedValue({
+      advance: true,
+      imported: false,
+      imported_count: 0,
+      queued: true,
+      task_id: "task-1",
+    });
+
+    await runSetup();
+
+    const events = trackedCliOnboardingEvents().map((input) => input.event);
+    expect(events).not.toContain("cli_onboarding_docs_imported");
+    expect(events).not.toContain("cli_onboarding_activated");
+    expect(trackedCliOnboardingEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "cli_onboarding_completed",
+          properties: expect.objectContaining({
+            completed_skill: true,
+            imported_docs: false,
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("does not call updateProfile during ordinary cloud setup", async () => {
     saveConfig(makeCfg());
     setupAuthed();

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -68,6 +68,7 @@ const mockTrpc = vi.hoisted(() => ({
       query: vi.fn().mockResolvedValue({ user_id: "test-user-id", finished_onboarding: true }),
     },
     updateProfile: { mutate: vi.fn().mockResolvedValue(null) },
+    trackCliOnboardingEvent: { mutate: vi.fn().mockResolvedValue({ ok: true }) },
   },
   organization: {
     getOrganizations: {
@@ -182,6 +183,7 @@ function installRemoteSetupDefaults() {
     { org_id: "o1", name: "Org1", user_role: "OWNER" },
   ]);
   mockTrpc.user.updateProfile.mutate.mockResolvedValue(null);
+  mockTrpc.user.trackCliOnboardingEvent.mutate.mockResolvedValue({ ok: true });
 }
 
 // ---------------------------------------------------------------------------
@@ -234,6 +236,10 @@ function makeDeployment(overrides: Record<string, unknown> = {}) {
     space_id: "s1",
     ...overrides,
   };
+}
+
+function trackedCliOnboardingEvents() {
+  return mockTrpc.user.trackCliOnboardingEvent.mutate.mock.calls.map(([input]) => input);
 }
 
 // ---------------------------------------------------------------------------
@@ -1649,6 +1655,71 @@ describe("runSetup checkpoint behavior", () => {
       user_id: "test-user-id",
       finished_onboarding: true,
     });
+  });
+
+  it("tracks completion when at least one valuable onboarding action succeeds", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(trackedCliOnboardingEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ event: "cli_onboarding_skill_installed" }),
+        expect.objectContaining({
+          event: "cli_onboarding_completed",
+          properties: expect.objectContaining({
+            completed_mcp: false,
+            completed_skill: true,
+            imported_docs: false,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("tracks docs import as activation during first-run onboarding", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({
+      advance: true,
+      has_connected_repo: true,
+      created_data_source_ids: ["ds-1"],
+    });
+    mockStepImportGitHubDocs.mockResolvedValue({
+      advance: true,
+      imported: true,
+      imported_count: 3,
+      failed_count: 0,
+      task_id: "task-1",
+    });
+
+    await runSetup();
+
+    expect(trackedCliOnboardingEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ event: "cli_onboarding_github_connected" }),
+        expect.objectContaining({
+          event: "cli_onboarding_docs_imported",
+          properties: expect.objectContaining({ imported_count: 3, task_id: "task-1" }),
+        }),
+        expect.objectContaining({
+          event: "cli_onboarding_activated",
+          properties: expect.objectContaining({ imported_count: 3 }),
+        }),
+        expect.objectContaining({
+          event: "cli_onboarding_completed",
+          properties: expect.objectContaining({ imported_docs: true }),
+        }),
+      ]),
+    );
   });
 
   it("does not call updateProfile during ordinary cloud setup", async () => {

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -69,6 +69,7 @@ const mockTrpc = vi.hoisted(() => ({
     },
     updateProfile: { mutate: vi.fn().mockResolvedValue(null) },
     trackCliOnboardingEvent: { mutate: vi.fn().mockResolvedValue({ ok: true }) },
+    trackCliOnboardingPreAuthEvent: { mutate: vi.fn().mockResolvedValue({ ok: true }) },
   },
   organization: {
     getOrganizations: {
@@ -82,6 +83,10 @@ const mockTrpc = vi.hoisted(() => ({
   },
   dataSource: { create: { mutate: vi.fn() } },
   deploymentDataSource: { create: { mutate: vi.fn().mockResolvedValue({}) } },
+}));
+vi.mock("@trpc/client", () => ({
+  createTRPCClient: vi.fn(() => mockTrpc),
+  httpLink: vi.fn(() => ({})),
 }));
 vi.mock("../client/trpc", () => ({
   createTypedClient: vi.fn(() => mockTrpc),
@@ -184,6 +189,7 @@ function installRemoteSetupDefaults() {
   ]);
   mockTrpc.user.updateProfile.mutate.mockResolvedValue(null);
   mockTrpc.user.trackCliOnboardingEvent.mutate.mockResolvedValue({ ok: true });
+  mockTrpc.user.trackCliOnboardingPreAuthEvent.mutate.mockResolvedValue({ ok: true });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -225,7 +225,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       });
       return;
     }
-    docsImported = importResult.imported === true;
+    docsImported = importResult.imported === true && (importResult.imported_count ?? 0) > 0;
     if (docsImported) {
       await trackCliOnboardingEvent(cfg, "cli_onboarding_docs_imported", {
         imported_count: importResult.imported_count ?? 0,

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -2,6 +2,7 @@
  * Setup flow — interactive wizard.
  */
 
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
@@ -10,7 +11,7 @@ import { installSkill } from "../commands/skill";
 import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
-import { trackCliOnboardingEvent } from "./analytics";
+import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
 import { dim, info } from "./styles";
 
 export interface SetupOptions {
@@ -58,6 +59,7 @@ interface OwnedOrg {
 type TrpcAny = any;
 
 export async function runSetup(opts: SetupOptions = {}): Promise<void> {
+  const onboardingRunID = randomUUID();
   logger.info(
     "setup",
     `Setup flow started${opts.deploymentID ? ` deployment=${opts.deploymentID}` : ""}${
@@ -65,6 +67,10 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     }`,
   );
   p.intro("Dosu CLI Setup");
+  await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_launch_attempted", {
+    has_deployment_option: Boolean(opts.deploymentID),
+    mode_option: opts.mode,
+  });
 
   let cfg = loadConfig();
 
@@ -77,10 +83,10 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   }
 
   // Authenticate — always runs so we can verify/refresh tokens.
-  const authedCfg = await stepAuthenticate(cfg);
+  const authedCfg = await stepAuthenticate(cfg, onboardingRunID);
   if (!authedCfg) return;
   cfg = authedCfg;
-  await trackCliOnboardingEvent(cfg, "cli_onboarding_auth_completed");
+  await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_auth_completed");
 
   const apiClient = new Client(cfg);
   let cloudSetupContext: CloudSetupContext | null = null;
@@ -90,7 +96,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     s.start("Loading your workspace...");
     cloudSetupContext = await resolveCloudSetupContext(cfg);
     if (!cloudSetupContext) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
         reason: "cloud_setup_context_failed",
       });
       s.stop("Workspace load failed");
@@ -98,7 +104,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     }
     s.stop("Workspace loaded");
   }
-  await trackCliOnboardingEvent(cfg, "cli_onboarding_started", {
+  await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_started", {
     flow_kind: cloudSetupContext?.kind ?? "oss",
   });
 
@@ -109,7 +115,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   if (cfg.mode !== MODE_OSS && cloudSetupContext?.kind === "onboarding") {
     const ok = await bindOnboardingDeployment(apiClient, cfg, cloudSetupContext.targetOrg ?? null);
     if (!ok) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
         reason: "onboarding_deployment_failed",
       });
       return;
@@ -117,7 +123,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   } else if (!cfg.deployment_id || opts.deploymentID) {
     const ok = await resolveDeployment(apiClient, cfg, opts);
     if (!ok) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
         reason: "deployment_resolution_failed",
       });
       return;
@@ -128,7 +134,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   // before minting a new one, so it's safe to call on every run.
   const apiKey = await stepMintAPIKey(apiClient, cfg);
   if (!apiKey) {
-    await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+    await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
       reason: "api_key_failed",
     });
     return;
@@ -142,12 +148,12 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     includeGitHub: cloudSetupContext?.kind === "onboarding",
   });
   if (!choices) {
-    await trackCliOnboardingEvent(cfg, "cli_onboarding_cancelled", {
+    await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
       reason: "options_cancelled",
     });
     return;
   }
-  await trackCliOnboardingEvent(cfg, "cli_onboarding_options_selected", {
+  await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_options_selected", {
     configure_mcp: choices.configureMcp,
     install_skill: choices.installSkill,
     connect_github: choices.connectGitHub,
@@ -164,7 +170,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   if (choices.configureMcp) {
     const configured = await stepConfigureMcpTools(cfg);
     if (configured === null) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_cancelled", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
         reason: "mcp_selection_cancelled",
       });
       return;
@@ -175,7 +181,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     );
     mcpCompleted = configuredProviders.length > 0;
     if (mcpCompleted) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_mcp_configured", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_mcp_configured", {
         provider_count: configuredProviders.length,
         providers: configuredProviders.map((r) => r.provider.id()),
       });
@@ -186,7 +192,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   if (choices.installSkill) {
     skillCompleted = await runInstallSkill();
     if (skillCompleted) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_skill_installed");
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_skill_installed");
     }
   }
 
@@ -195,7 +201,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     const { stepConnectGitHubRepo } = await import("./github-step");
     const connectResult = await stepConnectGitHubRepo(cfg);
     if (!connectResult.advance) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_cancelled", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
         reason: "github_connect_not_advanced",
         has_connected_repo: connectResult.has_connected_repo,
       });
@@ -205,7 +211,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       connectResult.has_connected_repo ||
       (connectResult.created_data_source_ids?.length ?? 0) > 0
     ) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_github_connected", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_github_connected", {
         created_data_source_count: connectResult.created_data_source_ids?.length ?? 0,
       });
     }
@@ -220,19 +226,19 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       expectedDataSourceIds: connectResult.created_data_source_ids,
     });
     if (!importResult.advance) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
         reason: "github_docs_import_failed",
       });
       return;
     }
     docsImported = importResult.imported === true && (importResult.imported_count ?? 0) > 0;
     if (docsImported) {
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_docs_imported", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_docs_imported", {
         imported_count: importResult.imported_count ?? 0,
         failed_count: importResult.failed_count ?? 0,
         task_id: importResult.task_id,
       });
-      await trackCliOnboardingEvent(cfg, "cli_onboarding_activated", {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_activated", {
         imported_count: importResult.imported_count ?? 0,
         failed_count: importResult.failed_count ?? 0,
       });
@@ -273,7 +279,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   }
 
   if (mcpCompleted || skillCompleted || docsImported) {
-    await trackCliOnboardingEvent(cfg, "cli_onboarding_completed", {
+    await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_completed", {
       completed_mcp: mcpCompleted,
       completed_skill: skillCompleted,
       imported_docs: docsImported,
@@ -402,7 +408,10 @@ export async function runInstallSkill(): Promise<boolean> {
   }
 }
 
-async function stepAuthenticate(existingCfg?: Config): Promise<Config | null> {
+async function stepAuthenticate(
+  existingCfg?: Config,
+  onboardingRunID?: string,
+): Promise<Config | null> {
   logger.info("setup", "Step: authenticate");
   const cfg = existingCfg ?? loadConfig();
 
@@ -437,17 +446,31 @@ async function stepAuthenticate(existingCfg?: Config): Promise<Config | null> {
   }
 
   const shouldLogin = await p.confirm({ message: "Open browser to log in?" });
-  if (p.isCancel(shouldLogin) || !shouldLogin) return null;
+  if (p.isCancel(shouldLogin) || !shouldLogin) {
+    if (onboardingRunID) {
+      await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_cancelled", {
+        reason: p.isCancel(shouldLogin) ? "prompt_cancelled" : "login_declined",
+      });
+    }
+    return null;
+  }
 
-  return await openBrowserForSetup(cfg);
+  if (onboardingRunID) {
+    await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_started");
+  }
+  return await openBrowserForSetup(cfg, onboardingRunID);
 }
 
-async function openBrowserForSetup(cfg: Config): Promise<Config | null> {
+async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promise<Config | null> {
   try {
     const { startOAuthFlow } = await import("../auth/flow");
     const s = p.spinner();
     s.start("Waiting for authentication...");
-    const token = await startOAuthFlow(undefined, "/cli/auth");
+    const token = await startOAuthFlow(
+      undefined,
+      "/cli/auth",
+      onboardingRunID ? { onboarding_run_id: onboardingRunID } : {},
+    );
     s.stop("Authenticated");
     logger.info("setup", "Browser auth completed");
 
@@ -461,6 +484,11 @@ async function openBrowserForSetup(cfg: Config): Promise<Config | null> {
     const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
     logger.error("setup", `Auth failed: ${msg}`);
     p.log.error(`Authentication failed: ${err instanceof Error ? err.message : String(err)}`);
+    if (onboardingRunID) {
+      await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_failed", {
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
     return null;
   }
 }

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -10,6 +10,7 @@ import { installSkill } from "../commands/skill";
 import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
+import { trackCliOnboardingEvent } from "./analytics";
 import { dim, info } from "./styles";
 
 export interface SetupOptions {
@@ -79,6 +80,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   const authedCfg = await stepAuthenticate(cfg);
   if (!authedCfg) return;
   cfg = authedCfg;
+  await trackCliOnboardingEvent(cfg, "cli_onboarding_auth_completed");
 
   const apiClient = new Client(cfg);
   let cloudSetupContext: CloudSetupContext | null = null;
@@ -88,11 +90,17 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     s.start("Loading your workspace...");
     cloudSetupContext = await resolveCloudSetupContext(cfg);
     if (!cloudSetupContext) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+        reason: "cloud_setup_context_failed",
+      });
       s.stop("Workspace load failed");
       return;
     }
     s.stop("Workspace loaded");
   }
+  await trackCliOnboardingEvent(cfg, "cli_onboarding_started", {
+    flow_kind: cloudSetupContext?.kind ?? "oss",
+  });
 
   // Deployment: first-run onboarding binds the user's default deployment.
   // Otherwise we only run the interactive picker when we don't already have
@@ -100,16 +108,31 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   // explicitly switch. Everyday re-runs reuse the stored deployment silently.
   if (cfg.mode !== MODE_OSS && cloudSetupContext?.kind === "onboarding") {
     const ok = await bindOnboardingDeployment(apiClient, cfg, cloudSetupContext.targetOrg ?? null);
-    if (!ok) return;
+    if (!ok) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+        reason: "onboarding_deployment_failed",
+      });
+      return;
+    }
   } else if (!cfg.deployment_id || opts.deploymentID) {
     const ok = await resolveDeployment(apiClient, cfg, opts);
-    if (!ok) return;
+    if (!ok) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+        reason: "deployment_resolution_failed",
+      });
+      return;
+    }
   }
 
   // API key: `stepMintAPIKey` is idempotent — it validates an existing key
   // before minting a new one, so it's safe to call on every run.
   const apiKey = await stepMintAPIKey(apiClient, cfg);
-  if (!apiKey) return;
+  if (!apiKey) {
+    await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+      reason: "api_key_failed",
+    });
+    return;
+  }
   cfg.api_key = apiKey;
   saveConfig(cfg);
 
@@ -118,29 +141,74 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   const choices = await stepOneShotConfirm({
     includeGitHub: cloudSetupContext?.kind === "onboarding",
   });
-  if (!choices) return;
+  if (!choices) {
+    await trackCliOnboardingEvent(cfg, "cli_onboarding_cancelled", {
+      reason: "options_cancelled",
+    });
+    return;
+  }
+  await trackCliOnboardingEvent(cfg, "cli_onboarding_options_selected", {
+    configure_mcp: choices.configureMcp,
+    install_skill: choices.installSkill,
+    connect_github: choices.connectGitHub,
+  });
 
   // MCP tools. Track whether at least one agent ended up with Dosu MCP
   // configured (newly installed or previously installed) so we only nudge
   // the user with the "Try it out" prompt when there's actually an agent
   // they can paste it into.
   let mcpConfiguredThisRun = false;
+  let mcpCompleted = false;
+  let skillCompleted = false;
+  let docsImported = false;
   if (choices.configureMcp) {
     const configured = await stepConfigureMcpTools(cfg);
-    if (configured === null) return;
+    if (configured === null) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_cancelled", {
+        reason: "mcp_selection_cancelled",
+      });
+      return;
+    }
     mcpConfiguredThisRun = configured.some((r) => r.action === "install" || r.action === "skip");
+    const configuredProviders = configured.filter(
+      (r) => (r.action === "install" || r.action === "skip") && !r.error,
+    );
+    mcpCompleted = configuredProviders.length > 0;
+    if (mcpCompleted) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_mcp_configured", {
+        provider_count: configuredProviders.length,
+        providers: configuredProviders.map((r) => r.provider.id()),
+      });
+    }
   }
 
   // Dosu skill
   if (choices.installSkill) {
-    await runInstallSkill();
+    skillCompleted = await runInstallSkill();
+    if (skillCompleted) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_skill_installed");
+    }
   }
 
   let githubOnboardingDone = !choices.connectGitHub;
   if (choices.connectGitHub && cloudSetupContext?.kind === "onboarding") {
     const { stepConnectGitHubRepo } = await import("./github-step");
     const connectResult = await stepConnectGitHubRepo(cfg);
-    if (!connectResult.advance) return;
+    if (!connectResult.advance) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_cancelled", {
+        reason: "github_connect_not_advanced",
+        has_connected_repo: connectResult.has_connected_repo,
+      });
+      return;
+    }
+    if (
+      connectResult.has_connected_repo ||
+      (connectResult.created_data_source_ids?.length ?? 0) > 0
+    ) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_github_connected", {
+        created_data_source_count: connectResult.created_data_source_ids?.length ?? 0,
+      });
+    }
     if (connectResult.space_id && !cfg.space_id) {
       cfg.space_id = connectResult.space_id;
       saveConfig(cfg);
@@ -151,7 +219,24 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       waitForFreshDocs: Boolean(connectResult.deployment_id),
       expectedDataSourceIds: connectResult.created_data_source_ids,
     });
-    if (!importResult.advance) return;
+    if (!importResult.advance) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_failed", {
+        reason: "github_docs_import_failed",
+      });
+      return;
+    }
+    docsImported = importResult.imported === true;
+    if (docsImported) {
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_docs_imported", {
+        imported_count: importResult.imported_count ?? 0,
+        failed_count: importResult.failed_count ?? 0,
+        task_id: importResult.task_id,
+      });
+      await trackCliOnboardingEvent(cfg, "cli_onboarding_activated", {
+        imported_count: importResult.imported_count ?? 0,
+        failed_count: importResult.failed_count ?? 0,
+      });
+    }
     githubOnboardingDone = true;
   }
 
@@ -184,6 +269,14 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       mode: cfg.mode,
       docsImported: choices.connectGitHub && githubOnboardingDone,
       hasAgentsMd: existsSync(join(process.cwd(), "AGENTS.md")),
+    });
+  }
+
+  if (mcpCompleted || skillCompleted || docsImported) {
+    await trackCliOnboardingEvent(cfg, "cli_onboarding_completed", {
+      completed_mcp: mcpCompleted,
+      completed_skill: skillCompleted,
+      imported_docs: docsImported,
     });
   }
 

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -7,6 +7,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
+import type { TypedClient } from "../client/trpc";
 import { installSkill } from "../commands/skill";
 import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
@@ -53,10 +54,6 @@ interface OwnedOrg {
   name: string;
   user_role?: string | null;
 }
-
-// `@dosu/api-types` trails a few app routers; use a narrow local cast in setup.
-// biome-ignore lint/suspicious/noExplicitAny: see note above
-type TrpcAny = any;
 
 export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   const onboardingRunID = randomUUID();
@@ -253,7 +250,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     const profileUserID = cloudSetupContext.profileUserID;
     try {
       const { createTypedClient } = await import("../client/trpc");
-      const trpc = createTypedClient(cfg) as TrpcAny;
+      const trpc = createTypedClient(cfg);
       await trpc.user.updateProfile.mutate({
         user_id: profileUserID,
         finished_onboarding: true,
@@ -496,12 +493,8 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
 async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext | null> {
   try {
     const { createTypedClient } = await import("../client/trpc");
-    const trpc = createTypedClient(cfg) as TrpcAny;
-    const profile = (await trpc.user.getCliOnboardingContext.query()) as {
-      user_id?: string;
-      finished_onboarding?: boolean | null;
-      cli_onboarding_enabled?: boolean | null;
-    } | null;
+    const trpc = createTypedClient(cfg);
+    const profile = await trpc.user.getCliOnboardingContext.query();
 
     if (!profile?.user_id) {
       p.log.error("Could not load your profile.");
@@ -535,16 +528,12 @@ async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext 
   }
 }
 
-async function resolveOnboardingTargetOrg(trpc: TrpcAny): Promise<OwnedOrg | null> {
-  const ownerOrgs = (await trpc.organization.getOrganizations.query({
-    userRole: "OWNER",
-    exact: true,
-  })) as OwnedOrg[];
-  if (ownerOrgs.length > 0) {
-    return ownerOrgs[0];
+async function resolveOnboardingTargetOrg(trpc: TypedClient): Promise<OwnedOrg | null> {
+  const accessibleOrgs = await trpc.organization.getOrganizations.query();
+  const ownerOrg = accessibleOrgs.find((org) => org.user_role === "OWNER");
+  if (ownerOrg) {
+    return ownerOrg;
   }
-
-  const accessibleOrgs = (await trpc.organization.getOrganizations.query()) as OwnedOrg[];
   return accessibleOrgs[0] ?? null;
 }
 

--- a/src/setup/github-doc-import-step.test.ts
+++ b/src/setup/github-doc-import-step.test.ts
@@ -272,6 +272,8 @@ describe("stepImportGitHubDocs", () => {
 
     expect(mockTrpc.docImports.importGithubFiles.mutate).not.toHaveBeenCalled();
     expect(result.advance).toBe(true);
+    expect(result.imported).toBe(false);
+    expect(result.imported_count).toBe(0);
   });
 
   it("polls import status until the task succeeds", async () => {
@@ -331,6 +333,8 @@ describe("stepImportGitHubDocs", () => {
       "Imported 1 doc.\nYour GitHub docs are ready, and onboarding is complete.",
     );
     expect(result.advance).toBe(true);
+    expect(result.imported).toBe(true);
+    expect(result.imported_count).toBe(1);
   });
 
   it("falls back to the client-selected count when server reports total=0 during STARTING", async () => {
@@ -444,6 +448,9 @@ describe("stepImportGitHubDocs", () => {
       "Imported 1 of 2 docs; 1 failed.\nYou can review the failed docs later, but onboarding is complete.",
     );
     expect(result.advance).toBe(true);
+    expect(result.imported).toBe(true);
+    expect(result.imported_count).toBe(1);
+    expect(result.failed_count).toBe(1);
   });
 
   it("lets onboarding continue if progress polling becomes unavailable", async () => {
@@ -469,6 +476,9 @@ describe("stepImportGitHubDocs", () => {
       "The import is still running in the background.\nCheck status later with: dosu docs import-status task-1",
     );
     expect(result.advance).toBe(true);
+    expect(result.imported).toBe(false);
+    expect(result.imported_count).toBe(0);
+    expect(result.queued).toBe(true);
   });
 
   it("shows an immediate empty state when no docs are currently importable", async () => {

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { createTypedClient } from "../client/trpc";
+import { createTypedClient, type TypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
 import { logger } from "../debug/logger";
 import {
@@ -7,9 +7,6 @@ import {
   type GitHubImportRepositoryOption,
   promptGitHubDocsImport,
 } from "./github-doc-import-prompt";
-
-// biome-ignore lint/suspicious/noExplicitAny: `@dosu/api-types` does not fully cover these routes yet.
-type TrpcAny = any;
 
 const DOC_SCAN_POLL_INTERVAL_MS = 2_000;
 const DOC_SCAN_POLL_TIMEOUT_MS = 60_000;
@@ -93,7 +90,7 @@ export async function stepImportGitHubDocs(
     return { advance: false };
   }
 
-  const trpc: TrpcAny = createTypedClient(cfg);
+  const trpc = createTypedClient(cfg);
   const files = opts.waitForFreshDocs
     ? await waitForImportableGithubFiles(trpc, cfg.org_id, cfg.space_id, opts.expectedDataSourceIds)
     : await fetchImportableGithubFiles(trpc, cfg.space_id);
@@ -186,7 +183,7 @@ export async function stepImportGitHubDocs(
 }
 
 async function waitForImportTaskCompletion(
-  trpc: TrpcAny,
+  trpc: TypedClient,
   taskID: string,
   spinner: ReturnType<typeof p.spinner>,
   expectedTotal: number,
@@ -276,7 +273,7 @@ function handleImportCompletion(
 }
 
 async function waitForImportableGithubFiles(
-  trpc: TrpcAny,
+  trpc: TypedClient,
   orgID: string,
   spaceID: string,
   expectedDataSourceIds?: string[],
@@ -356,7 +353,10 @@ function isScanComplete(
   return dataSources.length > 0 && dataSources.every((ds) => ds.is_indexed === true);
 }
 
-async function fetchGitHubDataSources(trpc: TrpcAny, orgID: string): Promise<GitHubDataSource[]> {
+async function fetchGitHubDataSources(
+  trpc: TypedClient,
+  orgID: string,
+): Promise<GitHubDataSource[]> {
   try {
     const dataSources = (await trpc.dataSource.list.query({
       org_id: orgID,
@@ -371,7 +371,7 @@ async function fetchGitHubDataSources(trpc: TrpcAny, orgID: string): Promise<Git
 }
 
 async function fetchImportableGithubFiles(
-  trpc: TrpcAny,
+  trpc: TypedClient,
   spaceID: string,
 ): Promise<ImportableGithubFile[]> {
   try {
@@ -408,7 +408,7 @@ function buildRepositories(files: ImportableGithubFile[]): GitHubImportRepositor
     .sort((a, b) => a.slug.localeCompare(b.slug));
 }
 
-async function getKnowledgeStoreID(trpc: TrpcAny, spaceID: string): Promise<string | null> {
+async function getKnowledgeStoreID(trpc: TypedClient, spaceID: string): Promise<string | null> {
   try {
     const store = (await trpc.knowledgeStore.getBySpaceId.query({
       space_id: spaceID,

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -59,6 +59,10 @@ interface ImportTaskStatusResponse {
 
 export interface GitHubDocsImportStepResult {
   advance: boolean;
+  imported?: boolean;
+  imported_count?: number;
+  failed_count?: number;
+  task_id?: string;
 }
 
 export interface GitHubDocsImportStepOptions {
@@ -98,7 +102,7 @@ export async function stepImportGitHubDocs(
 
   if (files.length === 0) {
     p.log.info("No markdown docs available to import right now. You can import them later.");
-    return { advance: true };
+    return { advance: true, imported: false, imported_count: 0 };
   }
 
   const repositories = buildRepositories(files);
@@ -111,7 +115,7 @@ export async function stepImportGitHubDocs(
   const fileIDs = selected as string[];
   if (fileIDs.length === 0) {
     p.log.info("Skipped importing docs for now. You can import them later.");
-    return { advance: true };
+    return { advance: true, imported: false, imported_count: 0 };
   }
 
   const knowledgeStoreID = await getKnowledgeStoreID(trpc, cfg.space_id);
@@ -133,7 +137,7 @@ export async function stepImportGitHubDocs(
       spinner.stop("Import task started");
       p.log.success("Import task started.");
       p.log.info("Your docs should finish importing in a few minutes.");
-      return { advance: true };
+      return { advance: true, imported: true, imported_count: fileIDs.length };
     }
 
     spinner.stop("Import task started");
@@ -153,11 +157,17 @@ export async function stepImportGitHubDocs(
       p.log.info(
         `The import is still running in the background.\nCheck status later with: dosu docs import-status ${taskID}`,
       );
-      return { advance: true };
+      return { advance: true, imported: true, imported_count: fileIDs.length, task_id: taskID };
     }
 
     handleImportCompletion(finalStatus, progressSpinner);
-    return { advance: true };
+    return {
+      advance: true,
+      imported: true,
+      imported_count: finalStatus.detail?.completed ?? fileIDs.length,
+      failed_count: finalStatus.detail?.failed ?? 0,
+      task_id: taskID,
+    };
   } catch (err: unknown) {
     spinner.stop("Failed");
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -62,6 +62,7 @@ export interface GitHubDocsImportStepResult {
   imported?: boolean;
   imported_count?: number;
   failed_count?: number;
+  queued?: boolean;
   task_id?: string;
 }
 
@@ -137,7 +138,7 @@ export async function stepImportGitHubDocs(
       spinner.stop("Import task started");
       p.log.success("Import task started.");
       p.log.info("Your docs should finish importing in a few minutes.");
-      return { advance: true, imported: true, imported_count: fileIDs.length };
+      return { advance: true, imported: false, imported_count: 0, queued: true };
     }
 
     spinner.stop("Import task started");
@@ -157,14 +158,21 @@ export async function stepImportGitHubDocs(
       p.log.info(
         `The import is still running in the background.\nCheck status later with: dosu docs import-status ${taskID}`,
       );
-      return { advance: true, imported: true, imported_count: fileIDs.length, task_id: taskID };
+      return {
+        advance: true,
+        imported: false,
+        imported_count: 0,
+        queued: true,
+        task_id: taskID,
+      };
     }
 
     handleImportCompletion(finalStatus, progressSpinner);
+    const importedCount = finalStatus.detail?.completed ?? 0;
     return {
       advance: true,
-      imported: true,
-      imported_count: finalStatus.detail?.completed ?? fileIDs.length,
+      imported: importedCount > 0,
+      imported_count: importedCount,
       failed_count: finalStatus.detail?.failed ?? 0,
       task_id: taskID,
     };

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -28,7 +28,7 @@
 
 import { execSync } from "node:child_process";
 import * as p from "@clack/prompts";
-import { createTypedClient } from "../client/trpc";
+import { createTypedClient, type TypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
 import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
@@ -40,13 +40,6 @@ import {
 } from "./github-repo-prompt";
 import { startInstallationCallbackServer } from "./installation-server";
 import { dim } from "./styles";
-
-// `@dosu/api-types` lags the tRPC routers we just added on the server side
-// (`githubRepository.listForOrg`, `dataSource.create`). Runtime routing is
-// dynamic, so we bypass compile-time type checks for those two procedures
-// until a new `@dosu/api-types` version is published that knows about them.
-// biome-ignore lint/suspicious/noExplicitAny: see note above
-type TrpcAny = any;
 
 const INSTALLATION_TIMEOUT_MS = 10 * 60 * 1000;
 const REPO_REFRESH_POLL_INTERVAL_MS = 500;
@@ -139,7 +132,7 @@ export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null 
   return { owner, name, slug: `${owner}/${name}` };
 }
 
-async function fetchListForOrg(trpc: TrpcAny, orgID: string): Promise<AvailableRepo[]> {
+async function fetchListForOrg(trpc: TypedClient, orgID: string): Promise<AvailableRepo[]> {
   try {
     const repos = (await trpc.githubRepository.listForOrg.query({
       org_id: orgID,
@@ -203,7 +196,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function waitForRepositoryRefresh(
-  trpc: TrpcAny,
+  trpc: TypedClient,
   orgID: string,
   previousRepos: AvailableRepo[],
   opts?: { timeoutMs?: number; intervalMs?: number },
@@ -312,7 +305,7 @@ async function openGitHubInstallFlow(
  * deployment-without-data_source orphans.
  */
 async function createDeploymentForRepo(
-  trpc: TrpcAny,
+  trpc: TypedClient,
   orgID: string,
   spaceID: string,
   repo: AvailableRepo,
@@ -402,7 +395,7 @@ interface VerifyDataSourcesOptions {
  * has already been GC'd server-side.
  */
 export async function verifyDataSourcesPersist(
-  trpc: TrpcAny,
+  trpc: TypedClient,
   orgID: string,
   expectedDataSourceIds: string[],
   opts: VerifyDataSourcesOptions = {},
@@ -453,7 +446,7 @@ export async function verifyDataSourcesPersist(
 }
 
 async function deleteOrphanDeployment(
-  trpc: TrpcAny,
+  trpc: TypedClient,
   deploymentID: string,
   slug: string,
 ): Promise<void> {
@@ -487,7 +480,7 @@ export async function stepConnectGitHubRepo(
     p.log.info(`Connecting GitHub repos (detected local repo: ${detected.slug})`);
   }
 
-  const trpc: TrpcAny = createTypedClient(cfg);
+  const trpc = createTypedClient(cfg);
   let repos = await fetchListForOrg(trpc, orgID);
 
   while (true) {


### PR DESCRIPTION
## Summary

Adds run-scoped PostHog tracking for CLI onboarding.

Each `dosu setup` run now gets an `onboarding_run_id`, which is used to connect pre-auth launch/auth events with post-auth setup events. This lets us measure conversion for a single CLI onboarding run from launch through auth, setup completion, and docs activation.

## Events tracked

Pre-auth:
- `cli_onboarding_launch_attempted`
- `cli_onboarding_auth_started`
- `cli_onboarding_auth_cancelled`
- `cli_onboarding_auth_failed`

Post-auth:
- `cli_onboarding_auth_completed`
- `cli_onboarding_started`
- `cli_onboarding_options_selected`
- `cli_onboarding_mcp_configured`
- `cli_onboarding_skill_installed`
- `cli_onboarding_github_connected`
- `cli_onboarding_docs_imported`
- `cli_onboarding_completed`
- `cli_onboarding_activated`
- `cli_onboarding_cancelled`
- `cli_onboarding_failed`

## Success definitions

- Completion: the run successfully completes at least one valuable action: MCP setup, skill install, or docs import.
- Activation: the run imports docs successfully with `imported_count > 0`.

Import task queued/started does not count as activation.

## Notes

This tracks conversion for a single CLI onboarding run, keyed by `onboarding_run_id`, rather than user lifecycle attribution.

Tracking is best-effort and timeout-bound so analytics failures do not block onboarding.

## Test plan

- `bunx vitest run src/auth/flow.test.ts src/setup/github-doc-import-step.test.ts src/setup/flow.test.ts`
- `bun run typecheck`
- `bun run check`
