### PR TITLE
fix: wait for fresh GitHub docs before import

### DIFF
--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -210,6 +210,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     ) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_github_connected", {
         created_data_source_count: connectResult.created_data_source_ids?.length ?? 0,
+        created_repository_slugs: connectResult.created_repository_slugs,
       });
     }
     if (connectResult.space_id && !cfg.space_id) {

--- a/src/setup/github-doc-import-step.test.ts
+++ b/src/setup/github-doc-import-step.test.ts
@@ -280,6 +280,36 @@ describe("stepImportGitHubDocs", () => {
     expect(mockTrpc.docImports.importGithubFiles.mutate).not.toHaveBeenCalled();
   });
 
+  it("shows importable docs immediately on the legacy fresh-doc wait path", async () => {
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-pending", provider_slug: "github", is_indexed: false },
+    ]);
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+
+    const result = await stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+
+    const scanSpinner = vi.mocked(p.spinner).mock.results[0]?.value;
+    expect(scanSpinner?.stop).toHaveBeenCalledWith("Docs ready");
+    expect(p.select).not.toHaveBeenCalled();
+    expect(mockPromptGitHubDocsImport).toHaveBeenCalledWith({
+      repositories: [
+        {
+          slug: "acme/api",
+          files: [{ id: "file-1", path: "docs/setup.md", is_synced: false }],
+        },
+      ],
+    });
+    expect(result.advance).toBe(true);
+  });
+
   it("ignores stale org-wide data sources and only waits on this run's set", async () => {
     // Reproduces the bug we hit on staging: a previous setup left a
     // GitHub data source stuck in is_indexed=false (QUEUED). With the old

--- a/src/setup/github-doc-import-step.test.ts
+++ b/src/setup/github-doc-import-step.test.ts
@@ -157,27 +157,38 @@ describe("stepImportGitHubDocs", () => {
   });
 
   it("waits for docs only when a fresh repo was connected in this run", async () => {
-    mockTrpc.docImports.listImportableGithubFiles.query
-      .mockResolvedValueOnce([])
+    vi.useFakeTimers();
+    mockTrpc.dataSource.list.query
       .mockResolvedValueOnce([
-        {
-          id: "file-1",
-          file_path: "docs/auth/login.md",
-          repository_slug: "acme/api",
-          is_synced: false,
-        },
-        {
-          id: "file-2",
-          file_path: "README.md",
-          repository_slug: "acme/api",
-          is_synced: true,
-        },
+        { data_source_id: "ds-fresh", provider_slug: "github", is_indexed: false },
+      ])
+      .mockResolvedValueOnce([
+        { data_source_id: "ds-fresh", provider_slug: "github", is_indexed: true },
       ]);
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValueOnce([
+      {
+        id: "file-1",
+        file_path: "docs/auth/login.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+      {
+        id: "file-2",
+        file_path: "README.md",
+        repository_slug: "acme/api",
+        is_synced: true,
+      },
+    ]);
     mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
 
-    const result = await stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+    const resultPromise = stepImportGitHubDocs(makeCfg(), {
+      waitForFreshDocs: true,
+      expectedDataSourceIds: ["ds-fresh"],
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await resultPromise;
 
-    expect(mockTrpc.docImports.listImportableGithubFiles.query).toHaveBeenCalledTimes(2);
+    expect(mockTrpc.docImports.listImportableGithubFiles.query).toHaveBeenCalledTimes(1);
     expect(mockPromptGitHubDocsImport).toHaveBeenCalledWith({
       repositories: [
         {
@@ -198,6 +209,57 @@ describe("stepImportGitHubDocs", () => {
       file_ids: ["file-1"],
     });
     expect(mockTrpc.docImports.getImportStatus.query).toHaveBeenCalledWith("task-1");
+    expect(result.advance).toBe(true);
+  });
+
+  it("does not show old repo docs before a freshly connected repo finishes scanning", async () => {
+    vi.useFakeTimers();
+    mockTrpc.dataSource.list.query
+      .mockResolvedValueOnce([
+        { data_source_id: "ds-fresh", provider_slug: "github", is_indexed: false },
+      ])
+      .mockResolvedValueOnce([
+        { data_source_id: "ds-fresh", provider_slug: "github", is_indexed: true },
+      ]);
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "old-file",
+        file_path: "docs/old.md",
+        repository_slug: "acme/old",
+        is_synced: false,
+      },
+      {
+        id: "fresh-file",
+        file_path: "docs/fresh.md",
+        repository_slug: "acme/fresh",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["fresh-file"]);
+
+    const resultPromise = stepImportGitHubDocs(makeCfg(), {
+      waitForFreshDocs: true,
+      expectedDataSourceIds: ["ds-fresh"],
+    });
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(mockPromptGitHubDocsImport).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await resultPromise;
+
+    expect(mockPromptGitHubDocsImport).toHaveBeenCalledWith({
+      repositories: [
+        {
+          slug: "acme/fresh",
+          files: [{ id: "fresh-file", path: "docs/fresh.md", is_synced: false }],
+        },
+        {
+          slug: "acme/old",
+          files: [{ id: "old-file", path: "docs/old.md", is_synced: false }],
+        },
+      ],
+    });
     expect(result.advance).toBe(true);
   });
 

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -285,20 +285,32 @@ async function waitForImportableGithubFiles(
 
     const startedAt = Date.now();
     let latestFiles: ImportableGithubFile[] = [];
+    const waitsForExpectedDataSources =
+      expectedDataSourceIds !== undefined && expectedDataSourceIds.length > 0;
 
     while (Date.now() - startedAt < DOC_SCAN_POLL_TIMEOUT_MS) {
-      latestFiles = await fetchImportableGithubFiles(trpc, spaceID);
-      if (latestFiles.length > 0) {
-        spinner.stop("Docs ready");
-        return latestFiles;
-      }
-
       // Distinguish "still indexing" from "indexed but empty". When the
       // caller passed the data_source ids it just created we only wait on
       // those — they're either indexed-or-missing very quickly. Otherwise
       // fall back to watching every GitHub data source in the org (legacy
       // path used by non-onboarding callers).
       const dataSources = await fetchGitHubDataSources(trpc, orgID);
+      if (waitsForExpectedDataSources) {
+        if (isScanComplete(dataSources, expectedDataSourceIds)) {
+          latestFiles = await fetchImportableGithubFiles(trpc, spaceID);
+          spinner.stop(latestFiles.length > 0 ? "Docs ready" : "No markdown docs found");
+          return latestFiles;
+        }
+        await sleep(DOC_SCAN_POLL_INTERVAL_MS);
+        continue;
+      }
+
+      latestFiles = await fetchImportableGithubFiles(trpc, spaceID);
+      if (latestFiles.length > 0) {
+        spinner.stop("Docs ready");
+        return latestFiles;
+      }
+
       if (isScanComplete(dataSources, expectedDataSourceIds)) {
         spinner.stop("No markdown docs found");
         return [];

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -96,6 +96,8 @@ export interface GithubStepResult {
    * stall it.
    */
   created_data_source_ids?: string[];
+  /** Repository slugs for the data sources created in this run. */
+  created_repository_slugs?: string[];
 }
 
 // Shape returned by tRPC `githubRepository.listForOrg`. Backend spreads
@@ -616,6 +618,7 @@ export async function stepConnectGitHubRepo(
       deployment_id: primary.deployment_id,
       space_id: cfg.space_id,
       created_data_source_ids: survived.map((c) => c.data_source_id),
+      created_repository_slugs: survived.map((c) => c.slug),
     };
   }
 }


### PR DESCRIPTION
## What changed
- Wait for freshly created GitHub data sources to finish indexing before fetching importable docs.
- Pass created repository slugs through the GitHub setup result for onboarding tracking.
- Add coverage for fresh repo scan behavior and old repo docs not being shown too early.

## Why
The docs import step could fetch importable files before a newly connected repo finished scanning, which allowed stale docs from older repositories to appear during onboarding.

## Follow-up / test notes
- Commit hooks completed successfully during commit.
- No additional full test run was performed as part of PR creation.