### PR TITLE
fix: handle OAuth callback failures

### DIFF
--- a/src/auth/errors.test.ts
+++ b/src/auth/errors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { OAuthCallbackError } from "./errors";
+
+describe("OAuthCallbackError", () => {
+  it("includes retry guidance for bad OAuth state errors", () => {
+    const err = new OAuthCallbackError("bad state", {
+      errorCode: "bad_oauth_state",
+      errorDescription: "OAuth state expired",
+    });
+
+    expect(err.name).toBe("OAuthCallbackError");
+    expect(err.userMessage).toBe(
+      "Authentication failed: OAuth state expired. Run `dosu login` again.",
+    );
+  });
+
+  it("includes retry guidance when the description mentions state", () => {
+    const err = new OAuthCallbackError("OAuth state is invalid");
+
+    expect(err.userMessage).toBe(
+      "Authentication failed: OAuth state is invalid. Run `dosu login` again.",
+    );
+  });
+
+  it("uses the generic auth failure message for non-state errors", () => {
+    const err = new OAuthCallbackError("access denied", {
+      error: "access_denied",
+      errorDescription: "User denied consent",
+    });
+
+    expect(err.error).toBe("access_denied");
+    expect(err.userMessage).toBe("Authentication failed: User denied consent");
+  });
+});

--- a/src/auth/errors.ts
+++ b/src/auth/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * OAuth-specific errors thrown by the auth subsystem.
+ */
+
+export interface OAuthCallbackErrorDetails {
+  error?: string;
+  errorCode?: string;
+  errorDescription?: string;
+}
+
+/**
+ * Thrown when the local /callback listener receives an OAuth error from the
+ * web side (e.g. Supabase rejected the OAuth state because it expired).
+ *
+ * Callers can `instanceof OAuthCallbackError` to print a curated message
+ * instead of falling through to the generic "auth failed" path.
+ */
+export class OAuthCallbackError extends Error {
+  readonly error?: string;
+  readonly errorCode?: string;
+  readonly errorDescription?: string;
+
+  constructor(message: string, details: OAuthCallbackErrorDetails = {}) {
+    super(message);
+    this.name = "OAuthCallbackError";
+    this.error = details.error;
+    this.errorCode = details.errorCode;
+    this.errorDescription = details.errorDescription;
+  }
+
+  /**
+   * Tells the user what to do. Most CLI surfaces just want this one line.
+   */
+  get userMessage(): string {
+    const desc = this.errorDescription ?? this.message;
+    if (this.errorCode === "bad_oauth_state" || /state/i.test(desc)) {
+      return `Authentication failed: ${desc}. Run \`dosu login\` again.`;
+    }
+    return `Authentication failed: ${desc}`;
+  }
+}

--- a/src/auth/errors.ts
+++ b/src/auth/errors.ts
@@ -1,20 +1,10 @@
-/**
- * OAuth-specific errors thrown by the auth subsystem.
- */
-
 export interface OAuthCallbackErrorDetails {
   error?: string;
   errorCode?: string;
   errorDescription?: string;
 }
 
-/**
- * Thrown when the local /callback listener receives an OAuth error from the
- * web side (e.g. Supabase rejected the OAuth state because it expired).
- *
- * Callers can `instanceof OAuthCallbackError` to print a curated message
- * instead of falling through to the generic "auth failed" path.
- */
+/** Thrown when /callback receives OAuth error params from the web side. */
 export class OAuthCallbackError extends Error {
   readonly error?: string;
   readonly errorCode?: string;
@@ -28,9 +18,7 @@ export class OAuthCallbackError extends Error {
     this.errorDescription = details.errorDescription;
   }
 
-  /**
-   * Tells the user what to do. Most CLI surfaces just want this one line.
-   */
+  /** One-line message for CLI surfaces. */
   get userMessage(): string {
     const desc = this.errorDescription ?? this.message;
     if (this.errorCode === "bad_oauth_state" || /state/i.test(desc)) {

--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -175,6 +175,25 @@ describe("startOAuthFlow", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("rejects after 8 minutes with retry guidance", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((callback) => {
+      queueMicrotask(() => {
+        if (typeof callback === "function") callback();
+      });
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    const flowPromise = startOAuthFlow();
+
+    await expect(flowPromise).rejects.toThrow(
+      "Authentication did not complete within 8 minutes. The OAuth state may have expired",
+    );
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 8 * 60 * 1000);
+    expect(mockClose).toHaveBeenCalledOnce();
+
+    setTimeoutSpy.mockRestore();
+  });
+
   it("uses the configured web app URL for building the auth URL", async () => {
     mockGetWebAppURL.mockReturnValue("http://localhost:3001");
 

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -33,14 +33,25 @@ export async function startOAuthFlow(
     await open.default(authURL);
     logger.info("auth.flow", "Browser open command executed");
 
-    // Race: token, abort, or timeout
+    // Race: token, abort, or timeout.
+    //
+    // 8 min is just under Supabase's default OAuth state TTL (~10 min). A
+    // longer wait used to push users past that boundary — they'd come back
+    // to a `bad_oauth_state` error in the browser while the CLI kept
+    // spinning silently. Tightening the window means the worst case is
+    // ~8 min of silence instead of 15, and the message points users at the
+    // right next step.
     const timeout = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(
         () => {
-          logger.warn("auth.flow", "Authentication timed out (15min)");
-          reject(new Error("authentication timeout - please try again"));
+          logger.warn("auth.flow", "Authentication timed out (8min)");
+          reject(
+            new Error(
+              "Authentication did not complete within 8 minutes. The OAuth state may have expired — please run `dosu login` again.",
+            ),
+          );
         },
-        15 * 60 * 1000,
+        8 * 60 * 1000,
       );
     });
 

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -33,14 +33,8 @@ export async function startOAuthFlow(
     await open.default(authURL);
     logger.info("auth.flow", "Browser open command executed");
 
-    // Race: token, abort, or timeout.
-    //
-    // 8 min is just under Supabase's default OAuth state TTL (~10 min). A
-    // longer wait used to push users past that boundary — they'd come back
-    // to a `bad_oauth_state` error in the browser while the CLI kept
-    // spinning silently. Tightening the window means the worst case is
-    // ~8 min of silence instead of 15, and the message points users at the
-    // right next step.
+    // 8 min < Supabase's ~10 min OAuth state TTL, so we surface a useful
+    // message before users hit a stale-state error.
     const timeout = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(
         () => {

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { OAuthCallbackError } from "./errors";
 import { type CallbackServer, startCallbackServer } from "./server";
 
 vi.mock("../debug/logger", () => ({
@@ -161,6 +162,47 @@ describe("auth callback server", () => {
     );
     const html = await resp.text();
     expect(html).toContain("<strong>test@dosu.dev</strong>");
+  });
+
+  it("rejects with OAuthCallbackError when /callback receives error params", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+    // Attach the rejection handler BEFORE issuing the request — the server
+    // rejects synchronously in the request handler, so a late `.catch`
+    // surfaces as an unhandled rejection in the test runner.
+    const errorPromise = result.tokenPromise.catch((e: Error) => e);
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?error=invalid_request&error_code=bad_oauth_state&error_description=${encodeURIComponent("OAuth state has expired")}`,
+    );
+    expect(resp.status).toBe(200);
+    const html = await resp.text();
+    expect(html.toLowerCase()).toContain("authentication failed");
+    expect(html).toContain("OAuth state has expired");
+    expect(html).not.toContain("Authentication Successful");
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(OAuthCallbackError);
+    const callbackErr = error as OAuthCallbackError;
+    expect(callbackErr.errorCode).toBe("bad_oauth_state");
+    expect(callbackErr.errorDescription).toBe("OAuth state has expired");
+    expect(callbackErr.userMessage).toContain("dosu login");
+  });
+
+  it("escapes HTML in error description on the error page (XSS)", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+    // Attach early — see comment in previous test.
+    const drained = result.tokenPromise.catch(() => undefined);
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?error_code=bad_oauth_state&error_description=${encodeURIComponent("<script>alert(1)</script>")}`,
+    );
+    const html = await resp.text();
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+
+    await drained;
   });
 
   it("treats literal string 'null' in refresh_token as empty", async () => {

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -189,6 +189,46 @@ describe("auth callback server", () => {
     expect(callbackErr.userMessage).toContain("dosu login");
   });
 
+  it("uses error_code when OAuth error description is missing", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+    const errorPromise = result.tokenPromise.catch((e: Error) => e);
+
+    const resp = await fetch(
+      `http://localhost:${server.port}/callback?error=server_error&error_code=temporarily_unavailable`,
+    );
+    expect(resp.status).toBe(200);
+    const html = await resp.text();
+    expect(html).toContain("temporarily_unavailable");
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(OAuthCallbackError);
+    const callbackErr = error as OAuthCallbackError;
+    expect(callbackErr.message).toBe("temporarily_unavailable");
+    expect(callbackErr.error).toBe("server_error");
+    expect(callbackErr.errorCode).toBe("temporarily_unavailable");
+    expect(callbackErr.errorDescription).toBe("temporarily_unavailable");
+  });
+
+  it("uses error when OAuth error code and description are missing", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+    const errorPromise = result.tokenPromise.catch((e: Error) => e);
+
+    const resp = await fetch(`http://localhost:${server.port}/callback?error=access_denied`);
+    expect(resp.status).toBe(200);
+    const html = await resp.text();
+    expect(html).toContain("access_denied");
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(OAuthCallbackError);
+    const callbackErr = error as OAuthCallbackError;
+    expect(callbackErr.message).toBe("access_denied");
+    expect(callbackErr.error).toBe("access_denied");
+    expect(callbackErr.errorCode).toBeUndefined();
+    expect(callbackErr.errorDescription).toBe("access_denied");
+  });
+
   it("escapes HTML in error description on the error page (XSS)", async () => {
     const result = await startCallbackServer();
     server = result.server;

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -167,9 +167,7 @@ describe("auth callback server", () => {
   it("rejects with OAuthCallbackError when /callback receives error params", async () => {
     const result = await startCallbackServer();
     server = result.server;
-    // Attach the rejection handler BEFORE issuing the request — the server
-    // rejects synchronously in the request handler, so a late `.catch`
-    // surfaces as an unhandled rejection in the test runner.
+    // Catch attached before fetch — the server rejects synchronously.
     const errorPromise = result.tokenPromise.catch((e: Error) => e);
 
     const resp = await fetch(
@@ -232,7 +230,6 @@ describe("auth callback server", () => {
   it("escapes HTML in error description on the error page (XSS)", async () => {
     const result = await startCallbackServer();
     server = result.server;
-    // Attach early — see comment in previous test.
     const drained = result.tokenPromise.catch(() => undefined);
 
     const resp = await fetch(

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -299,19 +299,14 @@ export async function startCallbackServer(): Promise<{
       return;
     }
 
-    // OAuth error forwarded by the web side (Supabase rejected state, user
-    // denied consent, …). Reject the token promise so the CLI process can
-    // exit immediately with a useful message instead of hanging on
-    // tokenPromise until the timeout fires.
+    // OAuth error forwarded by the web side — reject so the CLI exits now.
     const errorParam = url.searchParams.get("error");
     const errorCodeParam = url.searchParams.get("error_code");
     const errorDescriptionParam = url.searchParams.get("error_description");
     if (errorParam || errorCodeParam || errorDescriptionParam) {
       const rawDescription =
         errorDescriptionParam ?? errorCodeParam ?? errorParam ?? "OAuth authentication failed";
-      // Tag-strip for log lines and the rejection message (so plaintext
-      // surfaces stay clean). The HTML page does its own escape on the raw
-      // value — that's where the actual XSS defence lives.
+      // Tag-strip for plaintext surfaces; HTML escape happens in the template.
       const sanitized = rawDescription.replace(/<[^>]*>/g, "");
       logger.warn(
         "auth.server",

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -3,12 +3,70 @@
  */
 
 import { logger } from "../debug/logger";
+import { OAuthCallbackError } from "./errors";
 
 export interface TokenResponse {
   access_token: string;
   refresh_token: string;
   expires_in: number;
   email?: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function buildErrorHtml(message: string): string {
+  const safe = escapeHtml(message);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dosu CLI - Authentication Failed</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #fafafa;
+    color: #171717;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+}
+.container {
+    max-width: 480px;
+    width: 100%;
+    text-align: center;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 40px 32px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+h1 { font-size: 20px; font-weight: 600; color: #b91c1c; margin-bottom: 12px; }
+p { font-size: 14px; color: #4b5563; line-height: 1.5; }
+.detail { margin-top: 16px; padding: 12px; background: #fef2f2; border-radius: 8px; color: #991b1b; font-size: 13px; }
+.next { margin-top: 20px; color: #6b7280; font-size: 13px; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #f3f4f6; padding: 2px 6px; border-radius: 4px; color: #111827; }
+</style>
+</head>
+<body>
+<div class="container">
+    <h1>Authentication Failed</h1>
+    <p>The OAuth flow could not be completed.</p>
+    <div class="detail">${safe}</div>
+    <p class="next">You can close this tab. In your terminal, run <code>dosu login</code> again.</p>
+</div>
+</body>
+</html>`;
 }
 
 const CALLBACK_HTML_EXTRACT = `<!DOCTYPE html>
@@ -215,9 +273,11 @@ export async function startCallbackServer(): Promise<{
   tokenPromise: Promise<TokenResponse>;
 }> {
   let resolveToken: (token: TokenResponse) => void;
+  let rejectToken: (err: Error) => void;
 
-  const tokenPromise = new Promise<TokenResponse>((resolve) => {
+  const tokenPromise = new Promise<TokenResponse>((resolve, reject) => {
     resolveToken = resolve;
+    rejectToken = reject;
   });
 
   const http = require("node:http") as typeof import("node:http");
@@ -236,6 +296,35 @@ export async function startCallbackServer(): Promise<{
       logger.debug("auth.server", `404: ${url.pathname}`);
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found");
+      return;
+    }
+
+    // OAuth error forwarded by the web side (Supabase rejected state, user
+    // denied consent, …). Reject the token promise so the CLI process can
+    // exit immediately with a useful message instead of hanging on
+    // tokenPromise until the timeout fires.
+    const errorParam = url.searchParams.get("error");
+    const errorCodeParam = url.searchParams.get("error_code");
+    const errorDescriptionParam = url.searchParams.get("error_description");
+    if (errorParam || errorCodeParam || errorDescriptionParam) {
+      const rawDescription = errorDescriptionParam ?? errorCodeParam ?? errorParam ?? "OAuth authentication failed";
+      // Tag-strip for log lines and the rejection message (so plaintext
+      // surfaces stay clean). The HTML page does its own escape on the raw
+      // value — that's where the actual XSS defence lives.
+      const sanitized = rawDescription.replace(/<[^>]*>/g, "");
+      logger.warn(
+        "auth.server",
+        `OAuth callback received error: code=${errorCodeParam ?? "n/a"} description=${sanitized}`,
+      );
+      rejectToken?.(
+        new OAuthCallbackError(sanitized, {
+          error: errorParam ?? undefined,
+          errorCode: errorCodeParam ?? undefined,
+          errorDescription: sanitized,
+        }),
+      );
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(buildErrorHtml(rawDescription));
       return;
     }
 

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -307,7 +307,8 @@ export async function startCallbackServer(): Promise<{
     const errorCodeParam = url.searchParams.get("error_code");
     const errorDescriptionParam = url.searchParams.get("error_description");
     if (errorParam || errorCodeParam || errorDescriptionParam) {
-      const rawDescription = errorDescriptionParam ?? errorCodeParam ?? errorParam ?? "OAuth authentication failed";
+      const rawDescription =
+        errorDescriptionParam ?? errorCodeParam ?? errorParam ?? "OAuth authentication failed";
       // Tag-strip for log lines and the rejection message (so plaintext
       // surfaces stay clean). The HTML page does its own escape on the raw
       // value — that's where the actual XSS defence lives.

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OAuthCallbackError } from "../auth/errors";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
 import { allProviders } from "../mcp/providers";
@@ -155,6 +156,28 @@ describe("CLI actions", () => {
       const updated = loadConfig();
       expect(updated.access_token).toBe("refreshed_tok");
       expect(updated.refresh_token).toBe("refreshed_ref");
+    });
+
+    it("prints curated OAuth callback errors without saving credentials", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const originalExitCode = process.exitCode;
+      mockStartOAuthFlow.mockRejectedValue(
+        new OAuthCallbackError("OAuth state expired", {
+          errorCode: "bad_oauth_state",
+          errorDescription: "OAuth state expired",
+        }),
+      );
+
+      await run("login");
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Authentication failed: OAuth state expired. Run `dosu login` again.",
+      );
+      expect(process.exitCode).toBe(1);
+      expect(loadConfig().access_token).toBe("");
+
+      process.exitCode = originalExitCode;
+      errorSpy.mockRestore();
     });
   });
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -66,7 +66,21 @@ export function createProgram(): Command {
 
       console.log("Opening browser for authentication...");
       const { startOAuthFlow } = await import("../auth/flow");
-      const token = await startOAuthFlow();
+      const { OAuthCallbackError } = await import("../auth/errors");
+      let token: Awaited<ReturnType<typeof startOAuthFlow>>;
+      try {
+        token = await startOAuthFlow();
+      } catch (err) {
+        // Curated message for the now-typed OAuth callback error (e.g.
+        // bad_oauth_state). Anything else falls through to Commander's
+        // default error reporting.
+        if (err instanceof OAuthCallbackError) {
+          console.error(err.userMessage);
+          process.exitCode = 1;
+          return;
+        }
+        throw err;
+      }
 
       cfg.access_token = token.access_token;
       cfg.refresh_token = token.refresh_token;

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -72,9 +72,6 @@ export function createProgram(): Command {
       try {
         token = await startOAuthFlow();
       } catch (err) {
-        // Curated message for the now-typed OAuth callback error (e.g.
-        // bad_oauth_state). Anything else falls through to Commander's
-        // default error reporting.
         if (err instanceof OAuthCallbackError) {
           console.error(err.userMessage);
           process.exitCode = 1;

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -123,6 +123,7 @@ vi.mock("./github-doc-import-step", () => ({
 }));
 
 import * as p from "@clack/prompts";
+import { OAuthCallbackError } from "../auth/errors";
 import { startOAuthFlow } from "../auth/flow";
 import type { TokenResponse } from "../auth/server";
 import { Client } from "../client/client";
@@ -707,6 +708,22 @@ describe("runSetup integration", () => {
     await runSetup();
 
     expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it("logs curated OAuth callback errors during browser login", async () => {
+    vi.mocked(p.confirm).mockResolvedValue(true);
+    mockStartOAuthFlow.mockRejectedValue(
+      new OAuthCallbackError("OAuth state expired", {
+        errorCode: "bad_oauth_state",
+        errorDescription: "OAuth state expired",
+      }),
+    );
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      "Authentication failed: OAuth state expired. Run `dosu login` again.",
+    );
   });
 
   it("completes full flow with existing token and no tools", async () => {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -483,7 +483,6 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
     logger.error("setup", `Auth failed: ${msg}`);
     const { OAuthCallbackError } = await import("../auth/errors");
     if (err instanceof OAuthCallbackError) {
-      // Curated single-line message; the noisy stack stays in the debug log.
       p.log.error(err.userMessage);
       if (onboardingRunID) {
         await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_failed", {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -481,6 +481,17 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
     /* v8 ignore next 2 -- err is always Error in practice */
     const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
     logger.error("setup", `Auth failed: ${msg}`);
+    const { OAuthCallbackError } = await import("../auth/errors");
+    if (err instanceof OAuthCallbackError) {
+      // Curated single-line message; the noisy stack stays in the debug log.
+      p.log.error(err.userMessage);
+      if (onboardingRunID) {
+        await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_failed", {
+          reason: err.errorCode ?? err.errorDescription ?? "oauth_callback_error",
+        });
+      }
+      return null;
+    }
     p.log.error(`Authentication failed: ${err instanceof Error ? err.message : String(err)}`);
     if (onboardingRunID) {
       await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_failed", {

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -50,6 +50,7 @@ vi.mock("picocolors", () => ({
 // ---------------------------------------------------------------------------
 
 import * as p from "@clack/prompts";
+import { OAuthCallbackError } from "../auth/errors";
 import { startOAuthFlow } from "../auth/flow";
 import { Client } from "../client/client";
 import { executeInsights } from "../commands/insights";
@@ -325,6 +326,25 @@ describe("runTUI", () => {
     await runTUI();
 
     expect(p.log.error).toHaveBeenCalledWith("Authentication failed: auth timeout");
+  });
+
+  it("shows curated OAuth callback errors", async () => {
+    writeRealConfig(makeCfg({ access_token: "" }));
+    mockConfirm.mockResolvedValueOnce(true);
+    mockStartOAuthFlow.mockRejectedValueOnce(
+      new OAuthCallbackError("OAuth state expired", {
+        errorCode: "bad_oauth_state",
+        errorDescription: "OAuth state expired",
+      }),
+    );
+    mockIsCancel.mockReturnValue(false);
+    mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      "Authentication failed: OAuth state expired. Run `dosu login` again.",
+    );
   });
 
   it("does nothing when user cancels confirm prompt", async () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -108,6 +108,11 @@ async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<v
     saveConfig(cfg);
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
+    const { OAuthCallbackError } = await import("../auth/errors");
+    if (err instanceof OAuthCallbackError) {
+      p.log.error(err.userMessage);
+      return;
+    }
     p.log.error(`Authentication failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 }


### PR DESCRIPTION
## What changed
- Added a typed OAuth callback error for failed browser auth redirects.
- Made the local callback server reject immediately when OAuth error parameters are returned, and render an escaped failure page.
- Updated login, setup, and TUI auth flows to show a concise retry message for OAuth callback failures.
- Shortened the OAuth timeout to 8 minutes to avoid waiting beyond the likely state expiry window.
- Added callback server tests for OAuth error handling and HTML escaping.

## Why
Users could hit Supabase OAuth state expiry in the browser while the CLI kept waiting until its longer timeout. This makes the CLI fail promptly with a useful message and keeps the browser error page safe.

## Follow-up / test notes
- Tests were not run locally during PR creation.