### PR TITLE
fix: harden CLI secret handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "commander": "^13.1.0",
     "open": "^10.1.0",
     "picocolors": "^1.1.1",
-    "superjson": "^2.2.6"
+    "superjson": "^2.2.6",
+    "write-file-atomic": "^5.0.1"
   }
 }

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../debug/logger";
 import { OAuthCallbackError } from "./errors";
 import { type CallbackServer, startCallbackServer } from "./server";
 
@@ -62,6 +63,23 @@ describe("auth callback server", () => {
     expect(token.access_token).toBe("tok123");
     expect(token.refresh_token).toBe("ref456");
     expect(token.expires_in).toBe(7200);
+  });
+
+  it("does not pass token-bearing callback URLs to debug logs", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+    const debug = vi.mocked(logger.debug);
+    debug.mockClear();
+
+    await fetch(
+      `http://localhost:${server.port}/callback?access_token=tok123&refresh_token=ref456&expires_in=7200`,
+    );
+    await result.tokenPromise;
+
+    const debugOutput = debug.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(debugOutput).toContain("has-token=true");
+    expect(debugOutput).not.toContain("tok123");
+    expect(debugOutput).not.toContain("ref456");
   });
 
   it("defaults expires_in to 3600 when not provided", async () => {

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -289,7 +289,7 @@ export async function startCallbackServer(): Promise<{
     const ua = req.headers["user-agent"] ?? "none";
     logger.debug(
       "auth.server",
-      `Request: ${req.method} ${req.url} cookie-len=${cookieLen} ua=${ua} has-token=${url.searchParams.has("access_token")}`,
+      `Request: ${req.method} ${url.pathname} cookie-len=${cookieLen} ua=${ua} has-token=${url.searchParams.has("access_token")}`,
     );
 
     if (url.pathname !== "/callback") {

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -353,6 +353,14 @@ describe("CLI actions", () => {
       await expect(run("mcp", "add", "cursor")).rejects.toThrow("no MCP selected");
     });
 
+    it("throws error when API key is missing before writing tool config", async () => {
+      const cfg = authenticatedConfig();
+      cfg.api_key = undefined;
+      saveConfig(cfg);
+
+      await expect(run("mcp", "add", "cursor", "--global")).rejects.toThrow("no API key available");
+    });
+
     it("supports OSS mode without a selected deployment", async () => {
       const cfg = authenticatedConfig();
       cfg.mode = "oss";
@@ -375,9 +383,18 @@ describe("CLI actions", () => {
 
       const output = allLogOutput();
       expect(output).toContain("dep_123");
-      expect(output).toContain("key_abc");
+      expect(output).not.toContain("key_abc");
+      expect(output).toContain("Secret hidden");
       // Manual provider returns early, no "Successfully added" message
       expect(output).not.toContain("Successfully added");
+    });
+
+    it("only prints the full manual API key when --show-secret is passed", async () => {
+      saveConfig(authenticatedConfig());
+
+      await run("mcp", "add", "manual", "--show-secret");
+
+      expect(allLogOutput()).toContain("key_abc");
     });
 
     it("auto-sets global when provider does not support local", async () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -147,7 +147,8 @@ export function createProgram(): Command {
     .command("add <agent>")
     .description("Add Dosu MCP to an AI tool")
     .option("-g, --global", "Add globally (all projects) instead of project-local", false)
-    .action((toolId: string, opts: { global: boolean }) => {
+    .option("--show-secret", "Print full manual configuration secrets", false)
+    .action((toolId: string, opts: { global: boolean; showSecret: boolean }) => {
       let provider: Provider;
       try {
         provider = getProvider(toolId.toLowerCase());
@@ -165,9 +166,12 @@ export function createProgram(): Command {
       if (cfg.mode !== MODE_OSS && !cfg.deployment_id) {
         throw new Error("no MCP selected. Run 'dosu' to open the TUI and select an MCP");
       }
+      if (!cfg.api_key) {
+        throw new Error("no API key available. Run 'dosu setup' to create one");
+      }
 
       if (provider.id() === "manual") {
-        provider.install(cfg, false);
+        provider.install(cfg, false, { showSecret: opts.showSecret });
         return;
       }
 
@@ -180,7 +184,7 @@ export function createProgram(): Command {
       const scope = global ? "global (all projects)" : "project-local";
       console.log(`Adding Dosu MCP to ${provider.name()} (${scope})...`);
 
-      provider.install(cfg, global);
+      provider.install(cfg, global, { showSecret: opts.showSecret });
 
       console.log(`\n✓ Successfully added Dosu MCP to ${provider.name()}!`);
       if (global) {

--- a/src/debug/logger.test.ts
+++ b/src/debug/logger.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { logger } from "./logger";
+import { logger, redactSecrets } from "./logger";
 
 let tempDir: string;
 let origXDG: string | undefined;
@@ -26,6 +26,13 @@ function logPath(): string {
 }
 
 describe("logger", () => {
+  describe("redactSecrets", () => {
+    it("redacts apikey assignments", () => {
+      expect(redactSecrets("apikey=secret-value")).toBe("apikey=[REDACTED]");
+      expect(redactSecrets("apikey: secret-value")).toBe("apikey: [REDACTED]");
+    });
+  });
+
   describe("getLogPath", () => {
     it("returns path ending with dosu-cli/debug.log", () => {
       const p = logger.getLogPath();

--- a/src/debug/logger.ts
+++ b/src/debug/logger.ts
@@ -45,7 +45,7 @@ export function redactSecrets(message: string): string {
     redacted = redacted.replace(queryPattern, `$1${REDACTED}`);
   }
   redacted = redacted.replace(
-    /(\b(?:access_token|refresh_token|api_key|id_token|token)\b\s*[:=]\s*)("[^"]+"|'[^']+'|[^\s,]+)/gi,
+    /(\b(?:access_token|refresh_token|api_key|apikey|id_token|token)\b\s*[:=]\s*)("[^"]+"|'[^']+'|[^\s,]+)/gi,
     `$1${REDACTED}`,
   );
   redacted = redacted.replace(/(X-Dosu-API-Key:\s*)[^\s,]+/gi, `$1${REDACTED}`);

--- a/src/debug/logger.ts
+++ b/src/debug/logger.ts
@@ -23,10 +23,35 @@ type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 const MAX_LOG_SIZE = 1_048_576; // 1 MB
 const TRUNCATE_KEEP = 524_288; // 512 KB
 const LOG_FILENAME = "debug.log";
+const REDACTED = "[REDACTED]";
+const SECRET_QUERY_KEYS = [
+  "access_token",
+  "refresh_token",
+  "api_key",
+  "apikey",
+  "token",
+  "id_token",
+  "code",
+];
 
 let initialized = false;
 let debugToConsole = false;
 let logFilePath: string | null = null;
+
+export function redactSecrets(message: string): string {
+  let redacted = message;
+  for (const key of SECRET_QUERY_KEYS) {
+    const queryPattern = new RegExp(`([?&]${key}=)[^\\s&#]+`, "gi");
+    redacted = redacted.replace(queryPattern, `$1${REDACTED}`);
+  }
+  redacted = redacted.replace(
+    /(\b(?:access_token|refresh_token|api_key|id_token|token)\b\s*[:=]\s*)("[^"]+"|'[^']+'|[^\s,]+)/gi,
+    `$1${REDACTED}`,
+  );
+  redacted = redacted.replace(/(X-Dosu-API-Key:\s*)[^\s,]+/gi, `$1${REDACTED}`);
+  redacted = redacted.replace(/(Authorization:\s*Bearer\s+)[^\s,]+/gi, `$1${REDACTED}`);
+  return redacted;
+}
 
 function ensureInit(): void {
   if (!initialized) {
@@ -95,7 +120,8 @@ function initLogger(opts: { debug?: boolean }): void {
 function writeEntry(level: LogLevel, mod: string, message: string): void {
   ensureInit();
   const timestamp = new Date().toISOString();
-  const line = `[${timestamp}] [${level}] [${mod}] ${message}\n`;
+  const safeMessage = redactSecrets(message);
+  const line = `[${timestamp}] [${level}] [${mod}] ${safeMessage}\n`;
 
   try {
     appendFileSync(resolveLogPath(), line, { mode: 0o600 });

--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   removeJSONServer,
   saveJSONConfig,
   stripJSONComments,
+  writeSecureFile,
 } from "./config-helpers";
 
 describe("mcpURL", () => {
@@ -137,6 +138,16 @@ describe("JSON config file operations", () => {
     it("writes config files with owner-only permissions", () => {
       const path = join(tempDir, "secret.json");
       saveJSONConfig(path, { headers: { "X-Dosu-API-Key": "key" } });
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+    });
+
+    it("replaces existing loose-permission files with owner-only permissions", () => {
+      const path = join(tempDir, "secret.json");
+      writeFileSync(path, "old secret", { mode: 0o644 });
+
+      writeSecureFile(path, "new secret");
+
+      expect(readFileSync(path, "utf-8")).toBe("new secret");
       expect(statSync(path).mode & 0o777).toBe(0o600);
     });
   });

--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -39,6 +39,11 @@ describe("mcpHeaders", () => {
   it("returns correct header map", () => {
     const headers = mcpHeaders("my-api-key");
     expect(headers).toEqual({ "X-Dosu-API-Key": "my-api-key" });
+  });
+
+  it("throws instead of returning an empty header map when the API key is missing", () => {
+    expect(() => mcpHeaders(undefined)).toThrow("API key is required");
+    expect(() => mcpHeaders("")).toThrow("API key is required");
   });
 });
 
@@ -127,6 +132,12 @@ describe("JSON config file operations", () => {
       const path = join(tempDir, "deep", "nested", "out.json");
       saveJSONConfig(path, { x: 1 });
       expect(JSON.parse(readFileSync(path, "utf-8"))).toEqual({ x: 1 });
+    });
+
+    it("writes config files with owner-only permissions", () => {
+      const path = join(tempDir, "secret.json");
+      saveJSONConfig(path, { headers: { "X-Dosu-API-Key": "key" } });
+      expect(statSync(path).mode & 0o777).toBe(0o600);
     });
   });
 

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -2,9 +2,20 @@
  * Shared JSON config helpers for MCP provider configuration.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname } from "node:path";
 import { getBackendURL } from "../config/constants";
+
+type WriteFileAtomicOptions = {
+  mode: number;
+  chown: false;
+};
+
+const require = createRequire(import.meta.url);
+const writeFileAtomic = require("write-file-atomic") as {
+  sync(path: string, data: string, options: WriteFileAtomicOptions): void;
+};
 
 // biome-ignore lint/suspicious/noExplicitAny: JSON config values are inherently untyped
 type JsonConfig = Record<string, any>;
@@ -109,16 +120,16 @@ export function stripJSONComments(data: string): string {
  * Writes a JSON config file, creating parent directories as needed.
  */
 export function saveJSONConfig(path: string, cfg: JsonConfig): void {
+  writeSecureFile(path, JSON.stringify(cfg, null, 2));
+}
+
+/** Writes a secret-bearing config file atomically with owner-only permissions. */
+export function writeSecureFile(path: string, content: string): void {
   const dir = dirname(path);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  writeFileSync(path, JSON.stringify(cfg, null, 2), { mode: 0o600 });
-  try {
-    chmodSync(path, 0o600);
-  } catch {
-    // Best effort: Windows and some filesystems may not support chmod.
-  }
+  writeFileAtomic.sync(path, content, { mode: 0o600, chown: false });
 }
 
 /**

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -2,7 +2,7 @@
  * Shared JSON config helpers for MCP provider configuration.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { getBackendURL } from "../config/constants";
 
@@ -26,7 +26,10 @@ export function mcpBaseURL(): string {
 /**
  * Returns the standard MCP headers with API key auth.
  */
-export function mcpHeaders(apiKey: string): Record<string, string> {
+export function mcpHeaders(apiKey: string | undefined): Record<string, string> {
+  if (!apiKey) {
+    throw new Error("API key is required. Run 'dosu setup' to create one.");
+  }
   return { "X-Dosu-API-Key": apiKey };
 }
 
@@ -108,9 +111,14 @@ export function stripJSONComments(data: string): string {
 export function saveJSONConfig(path: string, cfg: JsonConfig): void {
   const dir = dirname(path);
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  writeFileSync(path, JSON.stringify(cfg, null, 2));
+  writeFileSync(path, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // Best effort: Windows and some filesystems may not support chmod.
+  }
 }
 
 /**

--- a/src/mcp/providers.ts
+++ b/src/mcp/providers.ts
@@ -7,11 +7,15 @@ import type { Config } from "../config/config";
 /**
  * Provider is the base interface for MCP tool providers.
  */
+export interface ProviderInstallOptions {
+  showSecret?: boolean;
+}
+
 export interface Provider {
   name(): string;
   id(): string;
   supportsLocal(): boolean;
-  install(cfg: Config, global: boolean): void;
+  install(cfg: Config, global: boolean, opts?: ProviderInstallOptions): void;
   remove(global: boolean): void;
 }
 

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -36,16 +36,14 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     type: "http",
     // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
     url: mcpURL(cfg.deployment_id!),
-    // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-    headers: mcpHeaders(cfg.api_key!),
+    headers: mcpHeaders(cfg.api_key),
   });
 
   // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
   const defaultBuildOSSServer = (cfg: Config): Record<string, any> => ({
     type: "http",
     url: mcpBaseURL(),
-    // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-    headers: mcpHeaders(cfg.api_key!),
+    headers: mcpHeaders(cfg.api_key),
   });
 
   const buildServer = opts.buildServer ?? defaultBuildServer;

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -4,7 +4,7 @@
  * For full parity, we'd need a TOML library. For now, use JSON config as Codex also supports it.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
 import { mcpBaseURL, mcpHeaders, mcpURL } from "../config-helpers";
@@ -31,8 +31,13 @@ function readTOML(path: string): string {
 
 function writeTOML(path: string, content: string): void {
   const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(path, content);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(path, content, { mode: 0o600 });
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // Best effort: Windows and some filesystems may not support chmod.
+  }
 }
 
 function mcpEndpoint(cfg: Config): string {
@@ -47,8 +52,7 @@ function installDosuToTOML(path: string, cfg: Config): void {
   content = removeDosuFromTOML(content);
   // Append new section
   const url = mcpEndpoint(cfg);
-  // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-  const headers = mcpHeaders(cfg.api_key!);
+  const headers = mcpHeaders(cfg.api_key);
   const headerEntries = Object.entries(headers)
     .map(([k, v]) => `${k} = "${v}"`)
     .join("\n");

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -4,10 +4,10 @@
  * For full parity, we'd need a TOML library. For now, use JSON config as Codex also supports it.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
-import { mcpBaseURL, mcpHeaders, mcpURL } from "../config-helpers";
+import { mcpBaseURL, mcpHeaders, mcpURL, writeSecureFile } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
 import type { SetupProvider } from "../providers";
 
@@ -30,14 +30,7 @@ function readTOML(path: string): string {
 }
 
 function writeTOML(path: string, content: string): void {
-  const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-  writeFileSync(path, content, { mode: 0o600 });
-  try {
-    chmodSync(path, 0o600);
-  } catch {
-    // Best effort: Windows and some filesystems may not support chmod.
-  }
+  writeSecureFile(path, content);
 }
 
 function mcpEndpoint(cfg: Config): string {

--- a/src/mcp/providers/manual.ts
+++ b/src/mcp/providers/manual.ts
@@ -10,7 +10,8 @@ function mcpEndpoint(cfg: Config): string {
 
 function maskSecret(secret: string): string {
   if (secret.length <= 8) return "[hidden]";
-  return `${secret.slice(0, 4)}...${secret.slice(-4)}`;
+  const visibleChars = Math.min(4, Math.floor(secret.length / 4));
+  return `${secret.slice(0, visibleChars)}...${secret.slice(-visibleChars)}`;
 }
 
 export const ManualProvider = (): Provider => ({

--- a/src/mcp/providers/manual.ts
+++ b/src/mcp/providers/manual.ts
@@ -1,6 +1,6 @@
 import { type Config, MODE_OSS } from "../../config/config";
-import { mcpBaseURL, mcpURL } from "../config-helpers";
-import type { Provider } from "../providers";
+import { mcpBaseURL, mcpHeaders, mcpURL } from "../config-helpers";
+import type { Provider, ProviderInstallOptions } from "../providers";
 
 function mcpEndpoint(cfg: Config): string {
   if (cfg.mode === MODE_OSS) return mcpBaseURL();
@@ -8,18 +8,29 @@ function mcpEndpoint(cfg: Config): string {
   return mcpURL(cfg.deployment_id);
 }
 
+function maskSecret(secret: string): string {
+  if (secret.length <= 8) return "[hidden]";
+  return `${secret.slice(0, 4)}...${secret.slice(-4)}`;
+}
+
 export const ManualProvider = (): Provider => ({
   name: () => "Manual Configuration",
   id: () => "manual",
   supportsLocal: () => false,
 
-  install(cfg: Config): void {
+  install(cfg: Config, _global: boolean, opts: ProviderInstallOptions = {}): void {
     const url = mcpEndpoint(cfg);
+    const apiKey = mcpHeaders(cfg.api_key)["X-Dosu-API-Key"];
+    const headerValue = opts.showSecret ? apiKey : maskSecret(apiKey);
     console.log("Use these details to configure the Dosu MCP server in your client:");
     console.log();
     console.log(`  Transport:      HTTP`);
     console.log(`  Endpoint:       ${url}`);
-    console.log(`  Header:         X-Dosu-API-Key: ${cfg.api_key}`);
+    console.log(`  Header:         X-Dosu-API-Key: ${headerValue}`);
+    if (!opts.showSecret) {
+      console.log();
+      console.log("  Secret hidden. Re-run with --show-secret to print the full API key.");
+    }
     console.log();
   },
 

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -337,6 +345,20 @@ describe("CodexProvider", () => {
     expect(content).toContain("[other_section]");
     expect(content).toContain('key = "value"');
     expect(content).toContain("[mcp_servers.dosu]");
+  });
+
+  it("global install replaces loose-permission TOML config with owner-only permissions", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    const configPath = join(tempDir, "codex-home", "config.toml");
+    mkdirSync(join(tempDir, "codex-home"), { recursive: true });
+    writeFileSync(configPath, '[other_section]\nkey = "value"\n', { mode: 0o644 });
+
+    provider.install(makeCfg(), true);
+
+    expect(readFileSync(configPath, "utf-8")).toContain("[mcp_servers.dosu]");
+    expect(statSync(configPath).mode & 0o777).toBe(0o600);
   });
 
   it("global remove deletes dosu section from TOML", async () => {
@@ -679,6 +701,37 @@ describe("ManualProvider", () => {
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("key-abc");
+
+    logSpy.mockRestore();
+  });
+
+  it("hides short API keys completely", async () => {
+    const { ManualProvider } = await import("./manual");
+    const provider = ManualProvider();
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    provider.install(makeCfg({ api_key: "shortkey" }), false);
+
+    const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(allOutput).toContain("X-Dosu-API-Key: [hidden]");
+    expect(allOutput).not.toContain("shortkey");
+
+    logSpy.mockRestore();
+  });
+
+  it("reveals less of medium-length API keys", async () => {
+    const { ManualProvider } = await import("./manual");
+    const provider = ManualProvider();
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    provider.install(makeCfg({ api_key: "abcdefghijkl" }), false);
+
+    const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(allOutput).toContain("X-Dosu-API-Key: abc...jkl");
+    expect(allOutput).not.toContain("abcd...ijkl");
+    expect(allOutput).not.toContain("abcdefghijkl");
 
     logSpy.mockRestore();
   });

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -662,8 +662,23 @@ describe("ManualProvider", () => {
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("dep-123");
-    expect(allOutput).toContain("key-abc");
+    expect(allOutput).not.toContain("key-abc");
+    expect(allOutput).toContain("Secret hidden");
     expect(allOutput).toContain("X-Dosu-API-Key");
+
+    logSpy.mockRestore();
+  });
+
+  it("install logs the full API key when requested", async () => {
+    const { ManualProvider } = await import("./manual");
+    const provider = ManualProvider();
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    provider.install(makeCfg(), false, { showSecret: true });
+
+    const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(allOutput).toContain("key-abc");
 
     logSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

This PR tightens how the CLI handles secrets while configuring MCP clients.

Changes:
- Fails `dosu mcp add` before writing config if the saved API key is missing.
- Masks the manual MCP API key output by default.
- Adds `--show-secret` for users who explicitly need the full manual configuration value.
- Redacts token-like values in debug logs.
- Avoids logging OAuth callback URLs with token-bearing query strings.
- Writes MCP JSON/TOML config files with owner-only permissions where supported.

## Intent

The intent is to reduce the chance of accidentally exposing credentials or writing broken MCP configs, while keeping the manual setup path available for users who need it.

## Impact

- Users with incomplete local credentials get a clear error instead of a config file with empty headers.
- Manual setup is safer by default.
- Debug logs are less likely to contain sensitive token material.
- Existing automated MCP installs should continue to work with valid credentials.

## Validation

- `bun run typecheck`
- `bun run check`
- Focused CLI, provider, logger, and auth callback tests
