### PR TITLE
fix: stabilize CLI onboarding types and insights tests

### DIFF
--- a/src/client/trpc.ts
+++ b/src/client/trpc.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AppRouter } from "@dosu/api-types";
-import { createTRPCClient, httpLink } from "@trpc/client";
+import { createTRPCClient, httpLink, type TRPCClient } from "@trpc/client";
 import superjson from "superjson";
 import { type Config, isTokenExpired } from "../config/config";
 import { getWebAppURL } from "../config/constants";
@@ -15,8 +15,8 @@ import { Client } from "./client";
 
 export type { AppRouter };
 
-/** Return type of createTypedClient — use this to type function parameters. */
-export type TypedClient = ReturnType<typeof createTypedClient>;
+/** Full app tRPC client — use this to type function parameters. */
+export type TypedClient = TRPCClient<AppRouter>;
 
 /**
  * Create a type-safe tRPC client with full AppRouter type inference.
@@ -32,7 +32,7 @@ export type TypedClient = ReturnType<typeof createTypedClient>;
  * const result = await client.page.create.mutate({ title: "...", body: "..." });
  * ```
  */
-export function createTypedClient(config: Config) {
+export function createTypedClient<TClient extends object = TypedClient>(config: Config): TClient {
   const webAppURL = getWebAppURL();
   if (!webAppURL) {
     throw new Error("Web app URL not configured");
@@ -82,5 +82,5 @@ export function createTypedClient(config: Config) {
         },
       }),
     ],
-  });
+  }) as TClient;
 }

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as joinPath } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spinnerStart = vi.fn();
@@ -74,6 +77,9 @@ let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
+let tempConfigDir: string;
+let origXDG: string | undefined;
+let origHome: string | undefined;
 
 const validConfig = {
   access_token: "t",
@@ -125,6 +131,11 @@ const fakeReport: InsightsReport = {
 };
 
 beforeEach(() => {
+  tempConfigDir = mkdtempSync(joinPath(tmpdir(), "dosu-insights-config-"));
+  origXDG = process.env.XDG_CONFIG_HOME;
+  origHome = process.env.HOME;
+  process.env.XDG_CONFIG_HOME = tempConfigDir;
+  process.env.HOME = tempConfigDir;
   mockLoadConfig.mockReset();
   mockQuery.mockReset();
   spinnerStart.mockReset();
@@ -147,6 +158,11 @@ afterEach(() => {
   logSpy.mockRestore();
   errorSpy.mockRestore();
   exitSpy.mockRestore();
+  if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
+  else delete process.env.XDG_CONFIG_HOME;
+  if (origHome !== undefined) process.env.HOME = origHome;
+  else delete process.env.HOME;
+  rmSync(tempConfigDir, { recursive: true, force: true });
 });
 
 function allOutput(): string {

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -1,5 +1,4 @@
 import { createTRPCClient, httpLink } from "@trpc/client";
-import type { inferRouterInputs } from "@trpc/server";
 import superjson from "superjson";
 import { type AppRouter, createTypedClient, type TypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
@@ -7,9 +6,24 @@ import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
 import { VERSION } from "../version/version";
 
-type UserRouterInputs = inferRouterInputs<AppRouter>["user"];
-type CliOnboardingEvent = UserRouterInputs["trackCliOnboardingEvent"]["event"];
-type CliOnboardingPreAuthEvent = UserRouterInputs["trackCliOnboardingPreAuthEvent"]["event"];
+type CliOnboardingEvent =
+  | "cli_onboarding_auth_completed"
+  | "cli_onboarding_started"
+  | "cli_onboarding_failed"
+  | "cli_onboarding_cancelled"
+  | "cli_onboarding_options_selected"
+  | "cli_onboarding_mcp_configured"
+  | "cli_onboarding_skill_installed"
+  | "cli_onboarding_github_connected"
+  | "cli_onboarding_docs_imported"
+  | "cli_onboarding_activated"
+  | "cli_onboarding_completed";
+
+type CliOnboardingPreAuthEvent =
+  | "cli_onboarding_launch_attempted"
+  | "cli_onboarding_auth_cancelled"
+  | "cli_onboarding_auth_started"
+  | "cli_onboarding_auth_failed";
 
 type CliOnboardingProperties = Record<
   string,
@@ -17,6 +31,24 @@ type CliOnboardingProperties = Record<
 >;
 
 const TRACKING_TIMEOUT_MS = 1_500;
+
+interface CliOnboardingAnalyticsClient {
+  user: {
+    trackCliOnboardingEvent: {
+      mutate(input: {
+        event: CliOnboardingEvent;
+        properties: CliOnboardingProperties;
+      }): Promise<unknown>;
+    };
+    trackCliOnboardingPreAuthEvent: {
+      mutate(input: {
+        event: CliOnboardingPreAuthEvent;
+        onboarding_run_id: string;
+        properties: CliOnboardingProperties;
+      }): Promise<unknown>;
+    };
+  };
+}
 
 export async function trackCliOnboardingEvent(
   cfg: Config,
@@ -27,7 +59,7 @@ export async function trackCliOnboardingEvent(
   if (!cfg.access_token) return;
 
   try {
-    const trpc = createTypedClient(cfg);
+    const trpc = createTypedClient(cfg) as unknown as CliOnboardingAnalyticsClient;
     await withTimeout(
       trpc.user.trackCliOnboardingEvent.mutate({
         event,
@@ -51,7 +83,7 @@ export async function trackCliOnboardingPreAuthEvent(
   properties: CliOnboardingProperties = {},
 ): Promise<void> {
   try {
-    const trpc = createAnonymousClient();
+    const trpc = createAnonymousAnalyticsClient();
     await withTimeout(
       trpc.user.trackCliOnboardingPreAuthEvent.mutate({
         event,
@@ -94,6 +126,10 @@ function createAnonymousClient(): TypedClient {
       }),
     ],
   });
+}
+
+function createAnonymousAnalyticsClient(): CliOnboardingAnalyticsClient {
+  return createAnonymousClient() as unknown as CliOnboardingAnalyticsClient;
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -1,6 +1,6 @@
 import { createTRPCClient, httpLink } from "@trpc/client";
 import superjson from "superjson";
-import { type AppRouter, createTypedClient, type TypedClient } from "../client/trpc";
+import { type AppRouter, createTypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
 import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
@@ -59,7 +59,7 @@ export async function trackCliOnboardingEvent(
   if (!cfg.access_token) return;
 
   try {
-    const trpc = createTypedClient(cfg) as unknown as CliOnboardingAnalyticsClient;
+    const trpc: CliOnboardingAnalyticsClient = createTypedClient(cfg);
     await withTimeout(
       trpc.user.trackCliOnboardingEvent.mutate({
         event,
@@ -83,7 +83,7 @@ export async function trackCliOnboardingPreAuthEvent(
   properties: CliOnboardingProperties = {},
 ): Promise<void> {
   try {
-    const trpc = createAnonymousAnalyticsClient();
+    const trpc = createAnonymousClient();
     await withTimeout(
       trpc.user.trackCliOnboardingPreAuthEvent.mutate({
         event,
@@ -113,7 +113,7 @@ function baseProperties(cfg: Config): CliOnboardingProperties {
   };
 }
 
-function createAnonymousClient(): TypedClient {
+function createAnonymousClient(): CliOnboardingAnalyticsClient {
   const webAppURL = getWebAppURL();
   if (!webAppURL) {
     throw new Error("Web app URL not configured");
@@ -125,11 +125,7 @@ function createAnonymousClient(): TypedClient {
         transformer: superjson,
       }),
     ],
-  });
-}
-
-function createAnonymousAnalyticsClient(): CliOnboardingAnalyticsClient {
-  return createAnonymousClient() as unknown as CliOnboardingAnalyticsClient;
+  }) as unknown as CliOnboardingAnalyticsClient;
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -7,7 +7,6 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
-import type { TypedClient } from "../client/trpc";
 import { installSkill } from "../commands/skill";
 import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
@@ -53,6 +52,28 @@ interface OwnedOrg {
   org_id: string;
   name: string;
   user_role?: string | null;
+}
+
+interface CliOnboardingProfile {
+  user_id?: string | null;
+  finished_onboarding?: boolean | null;
+  cli_onboarding_enabled?: boolean | null;
+}
+
+interface CliOnboardingClient {
+  user: {
+    getCliOnboardingContext: {
+      query(): Promise<CliOnboardingProfile | null>;
+    };
+    updateProfile: {
+      mutate(input: { user_id: string; finished_onboarding: boolean }): Promise<unknown>;
+    };
+  };
+  organization: {
+    getOrganizations: {
+      query(): Promise<OwnedOrg[]>;
+    };
+  };
 }
 
 export async function runSetup(opts: SetupOptions = {}): Promise<void> {
@@ -251,7 +272,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     const profileUserID = cloudSetupContext.profileUserID;
     try {
       const { createTypedClient } = await import("../client/trpc");
-      const trpc = createTypedClient(cfg);
+      const trpc = createTypedClient(cfg) as unknown as CliOnboardingClient;
       await trpc.user.updateProfile.mutate({
         user_id: profileUserID,
         finished_onboarding: true,
@@ -504,7 +525,7 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
 async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext | null> {
   try {
     const { createTypedClient } = await import("../client/trpc");
-    const trpc = createTypedClient(cfg);
+    const trpc = createTypedClient(cfg) as unknown as CliOnboardingClient;
     const profile = await trpc.user.getCliOnboardingContext.query();
 
     if (!profile?.user_id) {
@@ -539,7 +560,7 @@ async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext 
   }
 }
 
-async function resolveOnboardingTargetOrg(trpc: TypedClient): Promise<OwnedOrg | null> {
+async function resolveOnboardingTargetOrg(trpc: CliOnboardingClient): Promise<OwnedOrg | null> {
   const accessibleOrgs = await trpc.organization.getOrganizations.query();
   const ownerOrg = accessibleOrgs.find((org) => org.user_role === "OWNER");
   if (ownerOrg) {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -272,7 +272,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     const profileUserID = cloudSetupContext.profileUserID;
     try {
       const { createTypedClient } = await import("../client/trpc");
-      const trpc = createTypedClient(cfg) as unknown as CliOnboardingClient;
+      const trpc: CliOnboardingClient = createTypedClient(cfg);
       await trpc.user.updateProfile.mutate({
         user_id: profileUserID,
         finished_onboarding: true,
@@ -525,7 +525,7 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
 async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext | null> {
   try {
     const { createTypedClient } = await import("../client/trpc");
-    const trpc = createTypedClient(cfg) as unknown as CliOnboardingClient;
+    const trpc: CliOnboardingClient = createTypedClient(cfg);
     const profile = await trpc.user.getCliOnboardingContext.query();
 
     if (!profile?.user_id) {

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -536,7 +536,7 @@ export async function stepConnectGitHubRepo(
     p.log.info(`Connecting GitHub repos (detected local repo: ${detected.slug})`);
   }
 
-  const trpc = createTypedClient(cfg) as unknown as GitHubSetupClient;
+  const trpc: GitHubSetupClient = createTypedClient(cfg);
   let repos = await fetchListForOrg(trpc, orgID);
 
   while (true) {

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -28,7 +28,7 @@
 
 import { execSync } from "node:child_process";
 import * as p from "@clack/prompts";
-import { createTypedClient, type TypedClient } from "../client/trpc";
+import { createTypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
 import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
@@ -110,6 +110,37 @@ interface AvailableRepo {
   is_deployed: boolean;
   created_at?: string;
 }
+
+interface QueryProcedure<TInput, TOutput> {
+  query(input: TInput): Promise<TOutput>;
+}
+
+interface MutationProcedure<TInput, TOutput = unknown> {
+  mutate(input: TInput): Promise<TOutput>;
+}
+
+interface GitHubSetupClient {
+  githubRepository: {
+    listForOrg: QueryProcedure<{ org_id: string }, AvailableRepo[]>;
+  };
+  workspaces: {
+    create: MutationProcedure<unknown, { deployment_id?: string } | null>;
+    delete: MutationProcedure<string>;
+    listForSpace: QueryProcedure<string, { deployment_id: string }[]>;
+  };
+  dataSource: {
+    create: MutationProcedure<unknown, { data_source_id?: string } | null>;
+    list: QueryProcedure<
+      { org_id: string; excluded_provider_slugs: string[] },
+      { data_source_id?: string }[]
+    >;
+    syncDataSource: MutationProcedure<string>;
+  };
+  deploymentDataSource: {
+    create: MutationProcedure<{ deployment_id: string; data_source_id: string }>;
+  };
+}
+
 export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null {
   let url: string;
   try {
@@ -134,7 +165,7 @@ export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null 
   return { owner, name, slug: `${owner}/${name}` };
 }
 
-async function fetchListForOrg(trpc: TypedClient, orgID: string): Promise<AvailableRepo[]> {
+async function fetchListForOrg(trpc: GitHubSetupClient, orgID: string): Promise<AvailableRepo[]> {
   try {
     const repos = (await trpc.githubRepository.listForOrg.query({
       org_id: orgID,
@@ -198,7 +229,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function waitForRepositoryRefresh(
-  trpc: TypedClient,
+  trpc: GitHubSetupClient,
   orgID: string,
   previousRepos: AvailableRepo[],
   opts?: { timeoutMs?: number; intervalMs?: number },
@@ -307,7 +338,7 @@ async function openGitHubInstallFlow(
  * deployment-without-data_source orphans.
  */
 async function createDeploymentForRepo(
-  trpc: TypedClient,
+  trpc: GitHubSetupClient,
   orgID: string,
   spaceID: string,
   repo: AvailableRepo,
@@ -326,43 +357,40 @@ async function createDeploymentForRepo(
         provider_slug: "github",
       },
       config: DEFAULT_DEPLOYMENT_CONFIG_GITHUB,
-    } as unknown as Parameters<typeof trpc.workspaces.create.mutate>[0])) as unknown as {
-      deployment_id: string;
-    } | null;
+    })) as { deployment_id?: string } | null;
     if (!deployment?.deployment_id) {
       logger.warn("setup", `workspaces.create returned no deployment for ${repo.slug}`);
       return null;
     }
 
-    const dataSource = (await trpc.dataSource.create.mutate({
+    const dataSource = await trpc.dataSource.create.mutate({
       org_id: orgID,
       provider_slug: "github",
       name: repo.slug,
       description: "",
       repository_id: repo.repository_id,
-    })) as unknown as { data_source_id: string } | null;
+    });
     if (!dataSource?.data_source_id) {
       logger.warn("setup", `dataSource.create returned no data_source for ${repo.slug}`);
       await deleteOrphanDeployment(trpc, deployment.deployment_id, repo.slug);
       return null;
     }
+    const dataSourceID = dataSource.data_source_id;
 
-    await trpc.dataSource.syncDataSource.mutate(dataSource.data_source_id);
+    await trpc.dataSource.syncDataSource.mutate(dataSourceID);
 
-    const spaceDeployments = (await trpc.workspaces.listForSpace.query(spaceID)) as unknown as {
-      deployment_id: string;
-    }[];
+    const spaceDeployments = await trpc.workspaces.listForSpace.query(spaceID);
     await Promise.all(
       spaceDeployments.map((d) =>
         trpc.deploymentDataSource.create.mutate({
           deployment_id: d.deployment_id,
-          data_source_id: dataSource.data_source_id,
+          data_source_id: dataSourceID,
         }),
       ),
     );
     return {
       deployment_id: deployment.deployment_id,
-      data_source_id: dataSource.data_source_id,
+      data_source_id: dataSourceID,
     };
   } catch (err: unknown) {
     /* v8 ignore next -- server errors bubble up */
@@ -397,7 +425,7 @@ interface VerifyDataSourcesOptions {
  * has already been GC'd server-side.
  */
 export async function verifyDataSourcesPersist(
-  trpc: TypedClient,
+  trpc: GitHubSetupClient,
   orgID: string,
   expectedDataSourceIds: string[],
   opts: VerifyDataSourcesOptions = {},
@@ -419,10 +447,10 @@ export async function verifyDataSourcesPersist(
     firstIteration = false;
     let listed: { data_source_id?: string }[] = [];
     try {
-      listed = (await trpc.dataSource.list.query({
+      listed = await trpc.dataSource.list.query({
         org_id: orgID,
         excluded_provider_slugs: [],
-      })) as { data_source_id?: string }[];
+      });
     } catch (err: unknown) {
       /* v8 ignore next -- transient list failures are non-fatal; we'll retry */
       const msg = err instanceof Error ? err.message : String(err);
@@ -448,7 +476,7 @@ export async function verifyDataSourcesPersist(
 }
 
 async function deleteOrphanDeployment(
-  trpc: TypedClient,
+  trpc: GitHubSetupClient,
   deploymentID: string,
   slug: string,
 ): Promise<void> {
@@ -482,7 +510,7 @@ export async function stepConnectGitHubRepo(
     p.log.info(`Connecting GitHub repos (detected local repo: ${detected.slug})`);
   }
 
-  const trpc = createTypedClient(cfg);
+  const trpc = createTypedClient(cfg) as unknown as GitHubSetupClient;
   let repos = await fetchListForOrg(trpc, orgID);
 
   while (true) {

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -119,17 +119,43 @@ interface MutationProcedure<TInput, TOutput = unknown> {
   mutate(input: TInput): Promise<TOutput>;
 }
 
+interface GitHubWorkspaceCreateInput {
+  org_id: string;
+  space_id: string;
+  enabled: boolean;
+  name: string;
+  description: string;
+  provider_slug: "github";
+  repository_id: number;
+  metadata: {
+    app: {
+      deployment_mode: string;
+      setup_mode: string;
+    };
+    provider_slug: "github";
+  };
+  config: typeof DEFAULT_DEPLOYMENT_CONFIG_GITHUB;
+}
+
+interface GitHubDataSourceCreateInput {
+  org_id: string;
+  provider_slug: "github";
+  name: string;
+  description: string;
+  repository_id: number;
+}
+
 interface GitHubSetupClient {
   githubRepository: {
     listForOrg: QueryProcedure<{ org_id: string }, AvailableRepo[]>;
   };
   workspaces: {
-    create: MutationProcedure<unknown, { deployment_id?: string } | null>;
+    create: MutationProcedure<GitHubWorkspaceCreateInput, { deployment_id?: string } | null>;
     delete: MutationProcedure<string>;
     listForSpace: QueryProcedure<string, { deployment_id: string }[]>;
   };
   dataSource: {
-    create: MutationProcedure<unknown, { data_source_id?: string } | null>;
+    create: MutationProcedure<GitHubDataSourceCreateInput, { data_source_id?: string } | null>;
     list: QueryProcedure<
       { org_id: string; excluded_provider_slugs: string[] },
       { data_source_id?: string }[]
@@ -344,7 +370,7 @@ async function createDeploymentForRepo(
   repo: AvailableRepo,
 ): Promise<{ deployment_id: string; data_source_id: string } | null> {
   try {
-    const deployment = (await trpc.workspaces.create.mutate({
+    const deployment = await trpc.workspaces.create.mutate({
       org_id: orgID,
       space_id: spaceID,
       enabled: true,
@@ -357,7 +383,7 @@ async function createDeploymentForRepo(
         provider_slug: "github",
       },
       config: DEFAULT_DEPLOYMENT_CONFIG_GITHUB,
-    })) as { deployment_id?: string } | null;
+    });
     if (!deployment?.deployment_id) {
       logger.warn("setup", `workspaces.create returned no deployment for ${repo.slug}`);
       return null;


### PR DESCRIPTION
## Summary

This PR stabilizes the CLI onboarding and Insights test surfaces.

Changes:
- Adds narrow local compatibility types around the onboarding tRPC calls used by the CLI.
- Avoids coupling CLI setup code directly to fast-moving generated app router types where the CLI only needs a small subset of the API.
- Isolates Insights command tests with temporary config directories so tests do not depend on or touch a real user config path.

## Intent

The intent is to make the CLI safer to release by reducing avoidable breakage from API type drift and by making the Insights command tests deterministic.

## Impact

- No intended user-facing CLI behavior change.
- Typecheck is less brittle when unrelated app router types move.
- Insights command tests now reflect the CLI's config isolation expectations more reliably.

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run test`
