### PR TITLE
chore: add helmor workspace config

### DIFF
--- a/helmor.json
+++ b/helmor.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "setup": "$HELMOR_ROOT_PATH/conductor-setup.sh",
+    "run": "$HELMOR_WORKSPACE_PATH/conductor-run.sh",
+    "archive": ""
+  },
+  "runScriptMode": "nonconcurrent"
+}


### PR DESCRIPTION
## What changed
- Added `helmor.json` with Helmor script hooks for setup and run.
- Left `archive` as an empty script and set `runScriptMode` to `nonconcurrent`.

## Why
- This records the workspace automation configuration needed for this branch.

## Follow-up / test notes
- No tests run; this is a workspace configuration-only change.