### PR TITLE
feat: add agent-friendly setup flags

### DIFF
--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -156,6 +156,25 @@ describe("startOAuthFlow", () => {
     await flowPromise;
   });
 
+  it("can expose the auth URL without opening the browser", async () => {
+    const onAuthURL = vi.fn();
+    const flowPromise = startOAuthFlow(
+      undefined,
+      "/cli/auth",
+      {},
+      { openBrowser: false, onAuthURL },
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockOpenDefault).not.toHaveBeenCalled();
+    expect(onAuthURL).toHaveBeenCalledWith(
+      "https://app.dosu.dev/cli/auth?callback=http%3A%2F%2Flocalhost%3A12345%2Fcallback",
+    );
+
+    resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
+    await flowPromise;
+  });
+
   it("clears the timeout timer after successful token receipt", async () => {
     vi.useFakeTimers();
 

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -17,6 +17,7 @@ export async function startOAuthFlow(
   signal?: AbortSignal,
   path: string = "/cli/auth",
   params: Record<string, string> = {},
+  opts: { openBrowser?: boolean; onAuthURL?: (url: string) => void } = {},
 ): Promise<TokenResponse> {
   const { server, tokenPromise } = await startCallbackServer();
 
@@ -27,11 +28,14 @@ export async function startOAuthFlow(
     logger.debug("auth.flow", `Callback URL: ${callbackURL}`);
     const authURL = buildAuthURL(callbackURL, path, params);
     logger.info("auth.flow", `Auth URL: ${authURL}`);
+    opts.onAuthURL?.(authURL);
 
-    // Open browser — dynamic import to avoid bundling issues
-    const open = await import("open");
-    await open.default(authURL);
-    logger.info("auth.flow", "Browser open command executed");
+    if (opts.openBrowser !== false) {
+      // Open browser — dynamic import to avoid bundling issues
+      const open = await import("open");
+      await open.default(authURL);
+      logger.info("auth.flow", "Browser open command executed");
+    }
 
     // 8 min < Supabase's ~10 min OAuth state TTL, so we surface a useful
     // message before users hit a stale-state error.

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -158,6 +158,24 @@ describe("CLI actions", () => {
       expect(updated.refresh_token).toBe("refreshed_ref");
     });
 
+    it("passes --no-open through to OAuth flow", async () => {
+      mockStartOAuthFlow.mockResolvedValue({
+        access_token: "new_tok",
+        refresh_token: "new_ref",
+        expires_in: 3600,
+      });
+
+      await run("login", "--no-open");
+
+      expect(logSpy).toHaveBeenCalledWith("Starting authentication...");
+      expect(mockStartOAuthFlow).toHaveBeenCalledWith(
+        undefined,
+        "/cli/auth",
+        {},
+        expect.objectContaining({ openBrowser: false }),
+      );
+    });
+
     it("prints curated OAuth callback errors without saving credentials", async () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const originalExitCode = process.exitCode;
@@ -429,6 +447,13 @@ describe("CLI actions", () => {
 
       expect(mockRunSetup).toHaveBeenCalledWith({
         deploymentID: undefined,
+        mode: undefined,
+        yes: false,
+        openBrowser: true,
+        toolIDs: [],
+        skipMcp: false,
+        skipSkill: false,
+        skipGitHub: false,
       });
     });
 
@@ -439,6 +464,30 @@ describe("CLI actions", () => {
 
       expect(mockRunSetup).toHaveBeenCalledWith({
         deploymentID: "dep_456",
+        mode: undefined,
+        yes: false,
+        openBrowser: true,
+        toolIDs: [],
+        skipMcp: false,
+        skipSkill: false,
+        skipGitHub: false,
+      });
+    });
+
+    it("passes agent setup defaults and requested tools", async () => {
+      mockRunSetup.mockResolvedValue(undefined);
+
+      await run("setup", "--agent", "--tool", "codex", "--tool", "cursor", "--skip-skill");
+
+      expect(mockRunSetup).toHaveBeenCalledWith({
+        deploymentID: undefined,
+        mode: undefined,
+        yes: true,
+        openBrowser: false,
+        toolIDs: ["codex", "cursor"],
+        skipMcp: false,
+        skipSkill: true,
+        skipGitHub: true,
       });
     });
   });

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -490,6 +490,40 @@ describe("CLI actions", () => {
         skipGitHub: true,
       });
     });
+
+    it("rejects invalid --mode values before running setup", async () => {
+      await expect(run("setup", "--mode", "enterprise")).rejects.toThrow(
+        "invalid --mode value 'enterprise'",
+      );
+      expect(mockRunSetup).not.toHaveBeenCalled();
+    });
+
+    it("passes explicit setup flags without --agent", async () => {
+      mockRunSetup.mockResolvedValue(undefined);
+
+      await run(
+        "setup",
+        "--mode",
+        "cloud",
+        "--no-open",
+        "--yes",
+        "--tool",
+        "codex",
+        "--skip-mcp",
+        "--skip-github",
+      );
+
+      expect(mockRunSetup).toHaveBeenCalledWith({
+        deploymentID: undefined,
+        mode: "cloud",
+        yes: true,
+        openBrowser: false,
+        toolIDs: ["codex"],
+        skipMcp: true,
+        skipSkill: false,
+        skipGitHub: true,
+      });
+    });
   });
 
   // ── logs ────────────────────────────────────────────────────────────────

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -69,6 +69,9 @@ describe("CLI", () => {
     expect(cmd).toBeDefined();
     const opts = cmd?.options.find((o) => o.long === "--deployment");
     expect(opts).toBeDefined();
+    expect(cmd?.options.find((o) => o.long === "--agent")).toBeDefined();
+    expect(cmd?.options.find((o) => o.long === "--tool")).toBeDefined();
+    expect(cmd?.options.find((o) => o.long === "--no-open")).toBeDefined();
   });
 
   it("mcp add has --global flag", () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -57,7 +57,8 @@ export function createProgram(): Command {
   program
     .command("login")
     .description("Authenticate with Dosu via OAuth")
-    .action(async () => {
+    .option("--no-open", "Print the login URL instead of opening a browser")
+    .action(async (opts: { open?: boolean }) => {
       const cfg = loadConfig();
       if (isAuthenticated(cfg) && !isTokenExpired(cfg)) {
         console.log("You are already logged in.");
@@ -65,12 +66,31 @@ export function createProgram(): Command {
         return;
       }
 
-      console.log("Opening browser for authentication...");
+      console.log(
+        opts.open === false
+          ? "Starting authentication..."
+          : "Opening browser for authentication...",
+      );
       const { startOAuthFlow } = await import("../auth/flow");
       const { OAuthCallbackError } = await import("../auth/errors");
       let token: Awaited<ReturnType<typeof startOAuthFlow>>;
       try {
-        token = await startOAuthFlow();
+        token = await startOAuthFlow(
+          undefined,
+          "/cli/auth",
+          {},
+          {
+            openBrowser: opts.open !== false,
+            onAuthURL:
+              opts.open === false
+                ? (url) => {
+                    console.log("Open this URL to authenticate:");
+                    console.log(url);
+                    console.log("\nWaiting for login to complete...");
+                  }
+                : undefined,
+          },
+        );
       } catch (err) {
         if (err instanceof OAuthCallbackError) {
           console.error(err.userMessage);
@@ -231,18 +251,46 @@ export function createProgram(): Command {
     .description("Set up Dosu MCP for your AI tools")
     .option("--deployment <id>", "Skip to tool configuration for a specific MCP")
     .option("--mode <mode>", "Force OSS or Cloud mode, skipping the interactive prompt (oss|cloud)")
-    .action(async (opts: { deployment?: string; mode?: string }) => {
-      const { runSetup } = await import("../setup/flow");
-      let mode: "oss" | "cloud" | undefined;
-      if (opts.mode !== undefined) {
-        const normalized = opts.mode.toLowerCase();
-        if (normalized !== "oss" && normalized !== "cloud") {
-          throw new Error(`invalid --mode value '${opts.mode}' (expected 'oss' or 'cloud')`);
+    .option("--agent", "Run an agent-assisted setup with safe defaults", false)
+    .option("-y, --yes", "Accept setup defaults and skip confirmation prompts", false)
+    .option("--no-open", "Print browser login URLs instead of opening them")
+    .option("--tool <agent>", "Configure a specific AI tool; may be repeated", collectValues, [])
+    .option("--skip-mcp", "Do not configure AI tool MCP entries", false)
+    .option("--skip-skill", "Do not install the Dosu agent skill", false)
+    .option("--skip-github", "Do not run GitHub repository/doc onboarding", false)
+    .action(
+      async (opts: {
+        deployment?: string;
+        mode?: string;
+        agent?: boolean;
+        yes?: boolean;
+        open?: boolean;
+        tool?: string[];
+        skipMcp?: boolean;
+        skipSkill?: boolean;
+        skipGithub?: boolean;
+      }) => {
+        const { runSetup } = await import("../setup/flow");
+        let mode: "oss" | "cloud" | undefined;
+        if (opts.mode !== undefined) {
+          const normalized = opts.mode.toLowerCase();
+          if (normalized !== "oss" && normalized !== "cloud") {
+            throw new Error(`invalid --mode value '${opts.mode}' (expected 'oss' or 'cloud')`);
+          }
+          mode = normalized;
         }
-        mode = normalized;
-      }
-      await runSetup({ deploymentID: opts.deployment, mode });
-    });
+        await runSetup({
+          deploymentID: opts.deployment,
+          mode,
+          yes: opts.agent === true || opts.yes === true,
+          openBrowser: opts.agent === true ? false : opts.open !== false,
+          toolIDs: opts.tool ?? [],
+          skipMcp: opts.skipMcp === true,
+          skipSkill: opts.skipSkill === true,
+          skipGitHub: opts.agent === true || opts.skipGithub === true,
+        });
+      },
+    );
 
   // logs
   program
@@ -280,6 +328,11 @@ export function createProgram(): Command {
     });
 
   return program;
+}
+
+function collectValues(value: string, previous: string[]): string[] {
+  previous.push(value);
+  return previous;
 }
 
 export async function execute(): Promise<void> {

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1647,6 +1647,47 @@ describe("runSetup checkpoint behavior", () => {
     expect(saved.refresh_token).toBe("ref-fresh");
   });
 
+  it("supports agent-mediated login and explicit tool configuration", async () => {
+    saveConfig(
+      makeCfg({
+        access_token: "",
+        refresh_token: "",
+        expires_at: 0,
+        deployment_id: undefined,
+        deployment_name: undefined,
+      }),
+    );
+    mockStartOAuthFlow.mockResolvedValue({
+      access_token: "tok-agent",
+      refresh_token: "ref-agent",
+      expires_in: 3600,
+    } as TokenResponse);
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+
+    await runSetup({
+      yes: true,
+      openBrowser: false,
+      toolIDs: ["cursor"],
+      skipSkill: true,
+      skipGitHub: true,
+    });
+
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(mockStartOAuthFlow).toHaveBeenCalledWith(
+      undefined,
+      "/cli/auth",
+      expect.any(Object),
+      expect.objectContaining({ openBrowser: false }),
+    );
+    expect(p.multiselect).not.toHaveBeenCalled();
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+
+    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu).toBeDefined();
+    expect(loadConfig().access_token).toBe("tok-agent");
+  });
+
   it("mints a new API key when the existing one is invalid", async () => {
     saveConfig(makeCfg({ api_key: undefined }));
     const methods = setupAuthed();

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1701,6 +1701,73 @@ describe("runSetup checkpoint behavior", () => {
     expect(loadConfig().access_token).toBe("tok-agent");
   });
 
+  it("reports multiple organizations instead of prompting in yes mode", async () => {
+    saveConfig(makeCfg({ deployment_id: undefined, deployment_name: undefined }));
+    setupAuthed({
+      getOrgs: vi.fn().mockResolvedValue([
+        { org_id: "o1", name: "Org1" },
+        { org_id: "o2", name: "Org2" },
+      ]),
+    });
+
+    await runSetup({ yes: true, skipMcp: true, skipSkill: true, skipGitHub: true });
+
+    expect(p.select).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select an organization" }),
+    );
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Multiple organizations"));
+  });
+
+  it("reports multiple MCPs instead of prompting in yes mode", async () => {
+    saveConfig(makeCfg({ deployment_id: undefined, deployment_name: undefined }));
+    setupAuthed({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([
+          makeDeployment({ deployment_id: "d1", name: "Deploy1" }),
+          makeDeployment({ deployment_id: "d2", name: "Deploy2" }),
+        ]),
+    });
+
+    await runSetup({ yes: true, skipMcp: true, skipSkill: true, skipGitHub: true });
+
+    expect(p.select).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select an MCP" }),
+    );
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Multiple MCPs"));
+  });
+
+  it("reports unknown requested tools", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+
+    await runSetup({
+      yes: true,
+      toolIDs: ["unknown-agent"],
+      skipSkill: true,
+      skipGitHub: true,
+    });
+
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Unknown AI tool"));
+  });
+
+  it("reports stdio-only requested tools", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [
+      ClaudeDesktopProvider(),
+    ]);
+
+    await runSetup({
+      yes: true,
+      toolIDs: ["claude-desktop"],
+      skipSkill: true,
+      skipGitHub: true,
+    });
+
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("not supported by setup"));
+  });
+
   it("mints a new API key when the existing one is invalid", async () => {
     saveConfig(makeCfg({ api_key: undefined }));
     const methods = setupAuthed();

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1622,6 +1622,19 @@ describe("runSetup checkpoint behavior", () => {
     expect(p.log.message).not.toHaveBeenCalledWith(expect.stringContaining("Try it out"));
   });
 
+  it("--yes accepts the default MCP setup choice", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+
+    await runSetup({ yes: true, skipSkill: true, skipGitHub: true });
+
+    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu).toBeDefined();
+  });
+
   it("persists a fresh token after successful authentication", async () => {
     // Fresh config (no token yet) → user authenticates → token is saved.
     saveConfig(

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -18,6 +18,15 @@ export interface SetupOptions {
   deploymentID?: string;
   /** Force a specific mode, bypassing the default. "cloud" = standard flow, "oss" = public-libraries-only. */
   mode?: SetupMode | "cloud";
+  /** Accept setup defaults and avoid prompts where flags provide enough information. */
+  yes?: boolean;
+  /** Open browser windows automatically. Set false for agent-mediated login URLs. */
+  openBrowser?: boolean;
+  /** Explicit AI tools to configure during setup. Bypasses the tool multiselect. */
+  toolIDs?: string[];
+  skipMcp?: boolean;
+  skipSkill?: boolean;
+  skipGitHub?: boolean;
 }
 
 export type ConfigAction = "install" | "remove" | "skip";
@@ -101,7 +110,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   }
 
   // Authenticate — always runs so we can verify/refresh tokens.
-  const authedCfg = await stepAuthenticate(cfg, onboardingRunID);
+  const authedCfg = await stepAuthenticate(cfg, onboardingRunID, opts);
   if (!authedCfg) return;
   cfg = authedCfg;
   await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_auth_completed");
@@ -164,6 +173,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   // (re)run); GitHub docs import only shows during first-run onboarding.
   const choices = await stepOneShotConfirm({
     includeGitHub: cloudSetupContext?.kind === "onboarding",
+    setupOptions: opts,
   });
   if (!choices) {
     await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
@@ -186,7 +196,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   let skillCompleted = false;
   let docsImported = false;
   if (choices.configureMcp) {
-    const configured = await stepConfigureMcpTools(cfg);
+    const configured = await stepConfigureMcpTools(cfg, opts.toolIDs);
     if (configured === null) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
         reason: "mcp_selection_cancelled",
@@ -350,7 +360,16 @@ function applyModeOverride(cfg: Config, opts: SetupOptions): void {
  */
 async function stepOneShotConfirm(opts: {
   includeGitHub: boolean;
+  setupOptions?: SetupOptions;
 }): Promise<OneShotChoices | null> {
+  if (opts.setupOptions?.yes) {
+    return {
+      configureMcp: !opts.setupOptions.skipMcp && (opts.setupOptions.toolIDs?.length ?? 0) > 0,
+      installSkill: !opts.setupOptions.skipSkill,
+      connectGitHub: opts.includeGitHub && !opts.setupOptions.skipGitHub,
+    };
+  }
+
   type Item = { value: keyof OneShotChoices; label: string };
   const items: Item[] = [
     { value: "configureMcp", label: "Install Dosu MCP" },
@@ -388,7 +407,18 @@ async function stepOneShotConfirm(opts: {
  * Returns the ConfigResult array on success, or null if the user cancelled.
  * An empty detection pool is treated as success (nothing to do).
  */
-async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null> {
+async function stepConfigureMcpTools(
+  cfg: Config,
+  requestedToolIDs?: string[],
+): Promise<ConfigResult[] | null> {
+  if (requestedToolIDs && requestedToolIDs.length > 0) {
+    const selection = selectRequestedTools(requestedToolIDs);
+    if (!selection) return null;
+    const results = stepConfigureTools(cfg, selection);
+    stepShowSummary(results);
+    return results;
+  }
+
   const detected = stepDetectTools();
   if (detected.length === 0) {
     p.log.warn(
@@ -430,6 +460,7 @@ export async function runInstallSkill(): Promise<boolean> {
 async function stepAuthenticate(
   existingCfg?: Config,
   onboardingRunID?: string,
+  opts: SetupOptions = {},
 ): Promise<Config | null> {
   logger.info("setup", "Step: authenticate");
   const cfg = existingCfg ?? loadConfig();
@@ -464,23 +495,29 @@ async function stepAuthenticate(
     }
   }
 
-  const shouldLogin = await p.confirm({ message: "Open browser to log in?" });
-  if (p.isCancel(shouldLogin) || !shouldLogin) {
-    if (onboardingRunID) {
-      await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_cancelled", {
-        reason: p.isCancel(shouldLogin) ? "prompt_cancelled" : "login_declined",
-      });
+  if (!opts.yes && opts.openBrowser !== false) {
+    const shouldLogin = await p.confirm({ message: "Open browser to log in?" });
+    if (p.isCancel(shouldLogin) || !shouldLogin) {
+      if (onboardingRunID) {
+        await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_cancelled", {
+          reason: p.isCancel(shouldLogin) ? "prompt_cancelled" : "login_declined",
+        });
+      }
+      return null;
     }
-    return null;
   }
 
   if (onboardingRunID) {
     await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_auth_started");
   }
-  return await openBrowserForSetup(cfg, onboardingRunID);
+  return await openBrowserForSetup(cfg, onboardingRunID, opts);
 }
 
-async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promise<Config | null> {
+async function openBrowserForSetup(
+  cfg: Config,
+  onboardingRunID?: string,
+  opts: SetupOptions = {},
+): Promise<Config | null> {
   try {
     const { startOAuthFlow } = await import("../auth/flow");
     const s = p.spinner();
@@ -489,6 +526,17 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
       undefined,
       "/cli/auth",
       onboardingRunID ? { onboarding_run_id: onboardingRunID } : {},
+      {
+        openBrowser: opts.openBrowser !== false,
+        onAuthURL:
+          opts.openBrowser === false
+            ? (url) => {
+                p.log.info(
+                  `Open this URL to authenticate:\n${url}\n\nWaiting for login to complete...`,
+                );
+              }
+            : undefined,
+      },
     );
     s.stop("Authenticated");
     logger.info("setup", "Browser auth completed");
@@ -633,9 +681,9 @@ async function resolveDeployment(
     }
     return true;
   }
-  const org = await stepSelectOrg(apiClient);
+  const org = await stepSelectOrg(apiClient, opts.yes === true);
   if (!org) return false;
-  const d = await stepSelectDeployment(apiClient, org);
+  const d = await stepSelectDeployment(apiClient, org, opts.yes === true);
   if (!d) return false;
   cfg.mode = undefined;
   applyDeployment(cfg, d);
@@ -650,7 +698,7 @@ async function fetchDeployments(apiClient: Client): Promise<Deployment[]> {
   }
 }
 
-async function stepSelectOrg(apiClient: Client): Promise<Org | null> {
+async function stepSelectOrg(apiClient: Client, noPrompt = false): Promise<Org | null> {
   try {
     const orgs = await apiClient.getOrgs();
     if (orgs.length === 0) {
@@ -661,6 +709,12 @@ async function stepSelectOrg(apiClient: Client): Promise<Org | null> {
       logger.info("setup", `Selected org: ${orgs[0].name} (auto, only one)`);
       p.log.success(`Organization\n${dim(orgs[0].name)}`);
       return orgs[0];
+    }
+    if (noPrompt) {
+      p.log.error(
+        "Multiple organizations found. Run `dosu deployments list --json`, choose a deployment, then re-run setup with `--deployment <id>`.",
+      );
+      return null;
     }
     const selected = await p.select({
       message: "Select an organization",
@@ -702,7 +756,11 @@ async function stepResolveDeployment(apiClient: Client, id: string): Promise<Dep
   }
 }
 
-async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deployment | null> {
+async function stepSelectDeployment(
+  apiClient: Client,
+  org: Org,
+  noPrompt = false,
+): Promise<Deployment | null> {
   try {
     const allDeployments = await apiClient.getDeployments();
     const deployments = allDeployments.filter((d) => d.org_id === org.org_id);
@@ -715,6 +773,12 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
       logger.info("setup", `Selected deployment: ${deployments[0].name} (auto, only one)`);
       p.log.success(`Using MCP\n${dim(deployments[0].name)}`);
       return deployments[0];
+    }
+    if (noPrompt) {
+      p.log.error(
+        "Multiple MCPs found. Run `dosu deployments list --json`, choose one, then re-run setup with `--deployment <id>`.",
+      );
+      return null;
     }
     const selected = await p.select({
       message: "Select an MCP",
@@ -767,6 +831,27 @@ export function isStdioOnly(p: SetupProvider): boolean {
 
 export function stepDetectTools(): SetupProvider[] {
   return allSetupProviders().filter((p) => p.isInstalled() && !isStdioOnly(p));
+}
+
+function selectRequestedTools(requestedToolIDs: string[]): ToolSelection | null {
+  const normalized = [...new Set(requestedToolIDs.map((id) => id.toLowerCase()))];
+  const providers = allSetupProviders();
+  const selected: SetupProvider[] = [];
+
+  for (const id of normalized) {
+    const provider = providers.find((p) => p.id() === id);
+    if (!provider) {
+      p.log.error(`Unknown AI tool '${id}'. Run 'dosu mcp list' to see available tools.`);
+      return null;
+    }
+    if (isStdioOnly(provider)) {
+      p.log.error(`${provider.name()} is not supported by setup. Use 'dosu mcp add ${id}'.`);
+      return null;
+    }
+    selected.push(provider);
+  }
+
+  return { toInstall: selected, toRemove: [], skipped: [] };
 }
 
 async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection | null> {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -364,7 +364,7 @@ async function stepOneShotConfirm(opts: {
 }): Promise<OneShotChoices | null> {
   if (opts.setupOptions?.yes) {
     return {
-      configureMcp: !opts.setupOptions.skipMcp && (opts.setupOptions.toolIDs?.length ?? 0) > 0,
+      configureMcp: !opts.setupOptions.skipMcp,
       installSkill: !opts.setupOptions.skipSkill,
       connectGitHub: opts.includeGitHub && !opts.setupOptions.skipGitHub,
     };


### PR DESCRIPTION
## What changed
- Added `--agent`, `--yes`, `--no-open`, repeated `--tool`, and skip flags to `dosu setup`.
- Added `--no-open` support to `dosu login` and OAuth flow callbacks so auth URLs can be surfaced without opening a browser.
- Updated setup flow handling for non-interactive agent defaults, explicit tool selection, and prompt avoidance.
- Added tests covering the new CLI options and setup/OAuth behavior.

## Why
This makes setup easier for agent-mediated environments where opening a browser or answering prompts is not practical, while still allowing explicit tool configuration.

## Follow-up / test notes
- Tests were not run locally as part of this PR creation flow.