### PR TITLE
fix: update status deployment prompt

### DIFF
--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -249,7 +249,9 @@ describe("CLI actions", () => {
       await run("status");
 
       expect(logSpy).toHaveBeenCalledWith("MCP: None selected");
-      expect(logSpy).toHaveBeenCalledWith("Run 'dosu' to open the TUI and select an MCP.");
+      const output = allLogOutput();
+      expect(output).toContain("dosu deployments list");
+      expect(output).toContain("dosu deployments switch <id>");
     });
 
     it("shows OSS mode without requiring a deployment", async () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -136,7 +136,9 @@ export function createProgram(): Command {
         console.log(`MCP ID: ${cfg.deployment_id}`);
       } else {
         console.log("MCP: None selected");
-        console.log("Run 'dosu' to open the TUI and select an MCP.");
+        console.log(
+          "Run 'dosu deployments list' to see available MCPs, then 'dosu deployments switch <id>' to select one.",
+        );
       }
     });
 


### PR DESCRIPTION
## What changed
- Updated the `dosu status` empty-deployment message to point users at `dosu deployments list` and `dosu deployments switch <id>`.
- Adjusted the CLI action test to assert the new deployment workflow guidance.

## Why
The previous message told users to open the TUI to select an MCP, but the CLI now has deployment commands that provide a more direct path.

## Tests
- `bunx vitest run src/cli/cli-actions.test.ts`