### PR TITLE
fix: select only MCP deployments in agent setup

### DIFF
--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -253,7 +253,7 @@ describe("runAgentSetup", () => {
     });
   });
 
-  it("errors with multiple_deployments when the user has more than one", async () => {
+  it("errors with multiple_deployments when the user has more than one dosu_mcp", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
       access_token: "tok",
@@ -291,6 +291,114 @@ describe("runAgentSetup", () => {
       step: "deployment",
       status: "error",
       reason: "multiple_deployments",
+      candidates: [
+        { deployment_id: "dep-1", name: "acme/main", org_id: "org-1", org_name: "acme" },
+        { deployment_id: "dep-2", name: "acme/staging", org_id: "org-1", org_name: "acme" },
+      ],
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("auto-picks the lone dosu_mcp when other non-MCP deployments coexist", async () => {
+    mockExchangeTicket.mockResolvedValue({
+      status: "authenticated",
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_in: 3600,
+      email: "user@example.com",
+    });
+    mockClient.getDeployments.mockResolvedValue([
+      {
+        deployment_id: "dep-chat",
+        name: "In-App Chat",
+        description: "",
+        provider_slug: "dosu_app",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-1",
+      },
+      {
+        deployment_id: "dep-mcp",
+        name: "acme/main",
+        description: "",
+        provider_slug: "dosu_mcp",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-2",
+      },
+      {
+        deployment_id: "dep-kb",
+        name: "Knowledge Base",
+        description: "",
+        provider_slug: "dosu_knowledge_store",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-3",
+      },
+    ]);
+    mockClient.validateAPIKey.mockResolvedValue(false);
+    mockClient.createAPIKey.mockResolvedValue({
+      api_key: "sk_user_z",
+      id: "k3",
+      name: "dosu-cli",
+      key_prefix: "sk_user_z",
+    });
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt-good" });
+
+    expect(code).toBe(0);
+    const events = emittedEvents();
+    const depEvent = events.find((e) => e.step === "deployment");
+    expect(depEvent).toMatchObject({
+      step: "deployment",
+      status: "ok",
+      deployment_id: "dep-mcp",
+      name: "acme/main",
+    });
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("errors with no_mcp_deployment when account has deployments but none are MCP", async () => {
+    mockExchangeTicket.mockResolvedValue({
+      status: "authenticated",
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_in: 3600,
+    });
+    mockClient.getDeployments.mockResolvedValue([
+      {
+        deployment_id: "dep-chat",
+        name: "In-App Chat",
+        description: "",
+        provider_slug: "dosu_app",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-1",
+      },
+      {
+        deployment_id: "dep-gh",
+        name: "acme/repo",
+        description: "",
+        provider_slug: "github",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-2",
+      },
+    ]);
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt" });
+
+    expect(code).toBe(1);
+    const events = emittedEvents();
+    expect(events.at(-1)).toMatchObject({
+      step: "deployment",
+      status: "error",
+      reason: "no_mcp_deployment",
     });
     expect(claudeProvider.install).not.toHaveBeenCalled();
   });

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -14,9 +14,10 @@
  */
 
 import { exchangeTicket, mintTicket } from "../auth/ticket";
-import { Client } from "../client/client";
+import { Client, type Deployment } from "../client/client";
 import { type Config, loadConfig, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
+import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
 import { isStdioOnly } from "../setup/flow";
 import { emitError, emitNeedUserAction, emitStep } from "./output";
@@ -273,12 +274,14 @@ async function resolveDeployment(
     return { code: 0, cfg };
   }
 
-  // Auto-pick if the user has exactly one deployment; otherwise refuse and
-  // let the user choose. Agent mode is intentionally strict here — we'd
-  // rather error than guess wrong.
+  // No explicit --deployment and nothing locked in — try to find a unique
+  // MCP-backed deployment to auto-pick. An account can have many non-MCP
+  // deployments (in-app chat, knowledge stores, GitHub/Slack integrations)
+  // which are not valid targets for agent setup, so we filter to
+  // `dosu_mcp` slug before counting.
   try {
-    const deployments = await client.getDeployments();
-    if (deployments.length === 0) {
+    const allDeployments = await client.getDeployments();
+    if (allDeployments.length === 0) {
       emitError({
         step: "deployment",
         reason: "no_deployments",
@@ -287,8 +290,21 @@ async function resolveDeployment(
       });
       return { code: 1, cfg };
     }
-    if (deployments.length === 1) {
-      const d = deployments[0];
+
+    const mcpDeployments = allDeployments.filter((d) => d.provider_slug === MCP_PROVIDER_SLUG);
+
+    if (mcpDeployments.length === 0) {
+      emitError({
+        step: "deployment",
+        reason: "no_mcp_deployment",
+        agent_next_steps:
+          "Account has deployments but none of them back an MCP server. Tell the user to create an MCP deployment at https://app.dosu.dev, or pass --deployment <id> to target a specific deployment.",
+      });
+      return { code: 1, cfg };
+    }
+
+    if (mcpDeployments.length === 1) {
+      const d = mcpDeployments[0];
       cfg.deployment_id = d.deployment_id;
       cfg.deployment_name = d.name;
       cfg.org_id = d.org_id;
@@ -302,11 +318,21 @@ async function resolveDeployment(
       });
       return { code: 0, cfg };
     }
+
+    // Multiple MCP-backed deployments — agent must ask the user. We attach
+    // the filtered candidates inline so the driving agent doesn't need to
+    // call `dosu deployments list --json` and re-filter on its own.
+    const candidates = mcpDeployments.map((d) => ({
+      deployment_id: d.deployment_id,
+      name: d.name,
+      org_id: d.org_id,
+      org_name: d.org_name,
+    }));
     emitError({
       step: "deployment",
       reason: "multiple_deployments",
-      agent_next_steps:
-        "User has multiple Dosu deployments. Ask the user which one to use, then re-run the same command with `--deployment <id>`. Run 'dosu deployments list --json' to list options.",
+      candidates,
+      agent_next_steps: `User has ${mcpDeployments.length} MCP deployments. Show these options to the user and re-run the same command with \`--deployment <id>\`:\n${formatCandidates(mcpDeployments)}`,
     });
     return { code: 1, cfg };
   } catch (err: unknown) {
@@ -319,6 +345,10 @@ async function resolveDeployment(
     });
     return { code: 1, cfg };
   }
+}
+
+function formatCandidates(deployments: Deployment[]): string {
+  return deployments.map((d) => `  - ${d.name} (${d.org_name}) — ${d.deployment_id}`).join("\n");
 }
 
 async function ensureAPIKey(client: Client, cfg: Config): Promise<{ code: number; cfg: Config }> {

--- a/src/agent/output.ts
+++ b/src/agent/output.ts
@@ -57,13 +57,25 @@ export function emitNeedUserAction(opts: {
  * Emit a structured error with a `reason` machine code and a human/agent
  * remediation string. `reason` is for telemetry / agents to switch on;
  * `agent_next_steps` is what the calling agent should tell the user.
+ *
+ * Additional fields can be attached (e.g. `candidates` for a list of
+ * deployments to pick from) — they're spread into the JSON line so the
+ * driving agent can consume them programmatically without parsing
+ * `agent_next_steps` prose.
  */
-export function emitError(opts: { step: string; reason: string; agent_next_steps: string }): void {
+export function emitError(opts: {
+  step: string;
+  reason: string;
+  agent_next_steps: string;
+  [key: string]: unknown;
+}): void {
+  const { step, reason, agent_next_steps, ...rest } = opts;
   emitJSONLine({
-    step: opts.step,
+    step,
     status: "error",
-    reason: opts.reason,
-    agent_next_steps: opts.agent_next_steps,
+    reason,
+    ...rest,
+    agent_next_steps,
   });
 }
 

--- a/src/mcp/constants.ts
+++ b/src/mcp/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Provider slug for MCP-backed deployments — these are the deployments
+ * that back an installable MCP server (`dosu mcp add <tool>`).
+ *
+ * Other provider slugs (`dosu_app`, `dosu_knowledge_store`, `github`,
+ * `slack`, `teams`, …) exist on the same account but are not valid
+ * targets for agent setup — they don't expose an MCP endpoint.
+ */
+export const MCP_PROVIDER_SLUG = "dosu_mcp";

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -10,6 +10,7 @@ import { Client, type Deployment, type Org, SessionExpiredError } from "../clien
 import { installSkill } from "../commands/skill";
 import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
+import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
 import { dim, info } from "./styles";
@@ -602,7 +603,7 @@ async function resolveOnboardingDeployment(
   const deployments = await fetchDeployments(apiClient);
   const orgDeployments = deployments.filter((deployment) => deployment.org_id === targetOrg.org_id);
   return (
-    orgDeployments.find((deployment) => deployment.provider_slug === "dosu_mcp") ??
+    orgDeployments.find((deployment) => deployment.provider_slug === MCP_PROVIDER_SLUG) ??
     orgDeployments[0] ??
     null
   );


### PR DESCRIPTION
## What changed
- Filter agent setup deployment auto-selection to MCP-backed deployments only.
- Return a structured candidates array when multiple MCP deployments exist.
- Add a shared MCP provider slug constant and reuse it in setup flow.
- Add tests for mixed deployment accounts and accounts with no MCP deployment.

## Why
Accounts can contain non-MCP deployments such as app chat, knowledge stores, or other integrations. Agent setup should not auto-select those as MCP targets, and should give agents structured choices when there are multiple valid MCP deployments.

## Tests
- bunx vitest run src/agent/flow.test.ts

## Follow-up
- None noted.