### PR TITLE
fix: align with explicit-library-membership backend changes

### DIFF
--- a/src/commands/sources.test.ts
+++ b/src/commands/sources.test.ts
@@ -152,7 +152,9 @@ describe("sources sync", () => {
 
     await run("sync", "ds1");
 
-    expect(mockMutate).toHaveBeenCalledWith("dataSource.syncDataSource", "ds1");
+    expect(mockMutate).toHaveBeenCalledWith("dataSource.syncDataSource", {
+      data_source_id: "ds1",
+    });
   });
 
   it("outputs JSON with --json", async () => {

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -102,8 +102,15 @@ export function sourcesCommand(): Command {
     .option("--json", "Output as JSON")
     .action(async (id: string, opts: { json?: boolean }) => {
       const cfg = requireConfig();
-      const client = createTypedClient(cfg);
-      await client.dataSource.syncDataSource.mutate(id);
+      type SyncClient = {
+        dataSource: {
+          syncDataSource: {
+            mutate(input: { data_source_id: string }): Promise<boolean>;
+          };
+        };
+      };
+      const client = createTypedClient<SyncClient>(cfg);
+      await client.dataSource.syncDataSource.mutate({ data_source_id: id });
 
       if (opts.json) {
         printResult({ success: true, id }, opts);

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -512,8 +512,6 @@ describe("stepConnectGitHubRepo", () => {
     expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledWith({
       data_source_id: "ds-B",
     });
-    // attachToSpace fires once per created data source so the backend's
-    // SDS→DDS trigger fans the source out across the space's library.
     expect(mockTrpc.dataSource.attachToSpace.mutate).toHaveBeenCalledTimes(2);
     expect(mockTrpc.dataSource.attachToSpace.mutate).toHaveBeenCalledWith({
       space_id: "space-1",

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -24,6 +24,7 @@ const {
     dataSource: {
       create: { mutate: vi.fn() },
       syncDataSource: { mutate: vi.fn() },
+      attachToSpace: { mutate: vi.fn() },
       list: { query: vi.fn() },
     },
     deploymentDataSource: { create: { mutate: vi.fn() } },
@@ -505,8 +506,23 @@ describe("stepConnectGitHubRepo", () => {
     // syncDataSource fires once per created data source so the backend
     // enqueues `sync_data_source` and clones the repo.
     expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledTimes(2);
-    expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledWith("ds-A");
-    expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledWith("ds-B");
+    expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledWith({
+      data_source_id: "ds-A",
+    });
+    expect(mockTrpc.dataSource.syncDataSource.mutate).toHaveBeenCalledWith({
+      data_source_id: "ds-B",
+    });
+    // attachToSpace fires once per created data source so the backend's
+    // SDS→DDS trigger fans the source out across the space's library.
+    expect(mockTrpc.dataSource.attachToSpace.mutate).toHaveBeenCalledTimes(2);
+    expect(mockTrpc.dataSource.attachToSpace.mutate).toHaveBeenCalledWith({
+      space_id: "space-1",
+      data_source_ids: ["ds-A"],
+    });
+    expect(mockTrpc.dataSource.attachToSpace.mutate).toHaveBeenCalledWith({
+      space_id: "space-1",
+      data_source_ids: ["ds-B"],
+    });
     // deploymentDataSource.create fires once per (selected repo × space deployments):
     // 2 repos × 3 deployments = 6 invocations.
     expect(mockTrpc.deploymentDataSource.create.mutate).toHaveBeenCalledTimes(6);

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -160,7 +160,8 @@ interface GitHubSetupClient {
       { org_id: string; excluded_provider_slugs: string[] },
       { data_source_id?: string }[]
     >;
-    syncDataSource: MutationProcedure<string>;
+    syncDataSource: MutationProcedure<{ data_source_id: string }>;
+    attachToSpace: MutationProcedure<{ space_id: string; data_source_ids: string[] }, number>;
   };
   deploymentDataSource: {
     create: MutationProcedure<{ deployment_id: string; data_source_id: string }>;
@@ -403,8 +404,12 @@ async function createDeploymentForRepo(
     }
     const dataSourceID = dataSource.data_source_id;
 
-    await trpc.dataSource.syncDataSource.mutate(dataSourceID);
+    await trpc.dataSource.syncDataSource.mutate({ data_source_id: dataSourceID });
 
+    await trpc.dataSource.attachToSpace.mutate({
+      space_id: spaceID,
+      data_source_ids: [dataSourceID],
+    });
     const spaceDeployments = await trpc.workspaces.listForSpace.query(spaceID);
     await Promise.all(
       spaceDeployments.map((d) =>


### PR DESCRIPTION
Adapts the CLI to the contract changes in the [Library PR](https://github.com/dosu-ai/dosu/pull/10464) backend PR

- `dataSource.syncDataSource` now expects `{ data_source_id }` 
- Call `dataSource.attachToSpace` after connecting a repo so the new source lands in the space library (backend now requires explicit `space_data_source` writes).

