### PR TITLE
fix: refresh expired CLI sessions

### DIFF
--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -15,6 +15,26 @@ vi.mock("../auth/flow", () => ({
   startOAuthFlow: (...args: unknown[]) => mockStartOAuthFlow(...args),
 }));
 
+const { mockRefreshToken } = vi.hoisted(() => ({
+  mockRefreshToken: vi.fn(),
+}));
+vi.mock("../client/client", () => ({
+  Client: class MockClient {
+    private cfg: { refresh_token?: string };
+
+    constructor(cfg: { refresh_token?: string }) {
+      this.cfg = cfg;
+    }
+
+    refreshToken() {
+      if (!this.cfg.refresh_token) {
+        throw new Error("no refresh token available");
+      }
+      return mockRefreshToken(this.cfg);
+    }
+  },
+}));
+
 const mockRunTUI = vi.fn();
 vi.mock("../tui/tui", () => ({
   runTUI: (...args: unknown[]) => mockRunTUI(...args),
@@ -91,6 +111,15 @@ function allLogOutput(): string {
   return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
 }
 
+function mockSuccessfulRefresh(accessToken: string, refreshToken: string): void {
+  mockRefreshToken.mockImplementationOnce(async (cfg: Config) => {
+    cfg.access_token = accessToken;
+    cfg.refresh_token = refreshToken;
+    cfg.expires_at = Math.floor(Date.now() / 1000) + 3600;
+    saveConfig(cfg);
+  });
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe("CLI actions", () => {
@@ -138,14 +167,32 @@ describe("CLI actions", () => {
       expect(cfg.expires_at).toBeGreaterThan(0);
     });
 
-    it("runs OAuth flow when token is expired", async () => {
+    it("refreshes the session when token is expired", async () => {
       const cfg = authenticatedConfig();
       cfg.expires_at = Math.floor(Date.now() / 1000) - 1000; // expired
       saveConfig(cfg);
 
+      mockSuccessfulRefresh("refreshed_tok", "refreshed_ref");
+
+      await run("login");
+
+      expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith("Session refreshed.");
+
+      const updated = loadConfig();
+      expect(updated.access_token).toBe("refreshed_tok");
+      expect(updated.refresh_token).toBe("refreshed_ref");
+    });
+
+    it("runs OAuth flow when expired token cannot be refreshed", async () => {
+      const cfg = authenticatedConfig();
+      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000; // expired
+      saveConfig(cfg);
+
+      mockRefreshToken.mockRejectedValueOnce(new Error("refresh failed"));
       mockStartOAuthFlow.mockResolvedValue({
-        access_token: "refreshed_tok",
-        refresh_token: "refreshed_ref",
+        access_token: "oauth_tok",
+        refresh_token: "oauth_ref",
         expires_in: 7200,
       });
 
@@ -154,8 +201,8 @@ describe("CLI actions", () => {
       expect(mockStartOAuthFlow).toHaveBeenCalledOnce();
 
       const updated = loadConfig();
-      expect(updated.access_token).toBe("refreshed_tok");
-      expect(updated.refresh_token).toBe("refreshed_ref");
+      expect(updated.access_token).toBe("oauth_tok");
+      expect(updated.refresh_token).toBe("oauth_ref");
     });
 
     it("prints curated OAuth callback errors without saving credentials", async () => {
@@ -232,12 +279,26 @@ describe("CLI actions", () => {
     it("shows token-expired status", async () => {
       const cfg = authenticatedConfig();
       cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
+      cfg.refresh_token = "";
       saveConfig(cfg);
 
       await run("status");
 
       expect(logSpy).toHaveBeenCalledWith("Status: Token expired");
       expect(logSpy).toHaveBeenCalledWith("Run 'dosu login' to re-authenticate.");
+    });
+
+    it("refreshes expired token before showing logged-in status", async () => {
+      const cfg = authenticatedConfig();
+      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
+      saveConfig(cfg);
+      mockSuccessfulRefresh("status_tok", "status_ref");
+
+      await run("status");
+
+      expect(logSpy).toHaveBeenCalledWith("Status: Logged in");
+      expect(allLogOutput()).not.toContain("Status: Token expired");
+      expect(loadConfig().access_token).toBe("status_tok");
     });
 
     it("shows no deployment when none selected", async () => {
@@ -342,9 +403,24 @@ describe("CLI actions", () => {
     it("throws error when token is expired", async () => {
       const cfg = authenticatedConfig();
       cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
+      cfg.refresh_token = "";
       saveConfig(cfg);
 
       await expect(run("mcp", "add", "cursor")).rejects.toThrow("session expired");
+    });
+
+    it("refreshes expired token before adding MCP config", async () => {
+      const cfg = authenticatedConfig();
+      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
+      saveConfig(cfg);
+      mockSuccessfulRefresh("mcp_tok", "mcp_ref");
+
+      await run("mcp", "add", "cursor", "--global");
+
+      const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+      const cursorConfig = JSON.parse(readFileSync(cursorConfigPath, "utf-8"));
+      expect(cursorConfig.mcpServers.dosu).toBeDefined();
+      expect(loadConfig().access_token).toBe("mcp_tok");
     });
 
     it("throws error when no deployment selected", async () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -4,6 +4,7 @@
 
 import { readFileSync, unlinkSync } from "node:fs";
 import { Command } from "commander";
+import { Client } from "../client/client";
 import { analyticsCommand } from "../commands/analytics";
 import { askCommand } from "../commands/ask";
 import { deploymentsCommand } from "../commands/deployments";
@@ -21,6 +22,7 @@ import { suggestCommand } from "../commands/suggest";
 import { tagsCommand } from "../commands/tags";
 import { threadsCommand } from "../commands/threads";
 import {
+  type Config,
   getConfigPath,
   isAuthenticated,
   isTokenExpired,
@@ -100,10 +102,17 @@ export function createProgram(): Command {
       }
 
       const cfg = loadConfig();
-      if (isAuthenticated(cfg) && !isTokenExpired(cfg)) {
-        console.log("You are already logged in.");
-        console.log("Run 'dosu logout' first to re-authenticate.");
-        return;
+      if (isAuthenticated(cfg)) {
+        if (!isTokenExpired(cfg)) {
+          console.log("You are already logged in.");
+          console.log("Run 'dosu logout' first to re-authenticate.");
+          return;
+        }
+        if (await ensureFreshSession(cfg)) {
+          console.log("Session refreshed.");
+          console.log(`Credentials saved to ${getConfigPath()}`);
+          return;
+        }
       }
 
       console.log("Opening browser for authentication...");
@@ -156,14 +165,14 @@ export function createProgram(): Command {
   program
     .command("status")
     .description("Show current authentication and MCP status")
-    .action(() => {
+    .action(async () => {
       const cfg = loadConfig();
       if (!isAuthenticated(cfg)) {
         console.log("Status: Not logged in");
         console.log("Run 'dosu login' to authenticate.");
         return;
       }
-      if (isTokenExpired(cfg)) {
+      if (isTokenExpired(cfg) && !(await ensureFreshSession(cfg))) {
         console.log("Status: Token expired");
         console.log("Run 'dosu login' to re-authenticate.");
       } else {
@@ -191,7 +200,7 @@ export function createProgram(): Command {
     .description("Add Dosu MCP to an AI tool")
     .option("-g, --global", "Add globally (all projects) instead of project-local", false)
     .option("--show-secret", "Print full manual configuration secrets", false)
-    .action((toolId: string, opts: { global: boolean; showSecret: boolean }) => {
+    .action(async (toolId: string, opts: { global: boolean; showSecret: boolean }) => {
       let provider: Provider;
       try {
         provider = getProvider(toolId.toLowerCase());
@@ -203,7 +212,7 @@ export function createProgram(): Command {
       if (!isAuthenticated(cfg)) {
         throw new Error("not logged in. Run 'dosu login' first");
       }
-      if (isTokenExpired(cfg)) {
+      if (isTokenExpired(cfg) && !(await ensureFreshSession(cfg))) {
         throw new Error("session expired. Run 'dosu login' to re-authenticate");
       }
       if (cfg.mode !== MODE_OSS && !cfg.deployment_id) {
@@ -367,6 +376,18 @@ export function createProgram(): Command {
     });
 
   return program;
+}
+
+async function ensureFreshSession(cfg: Config): Promise<boolean> {
+  if (!isTokenExpired(cfg)) return true;
+  try {
+    logger.debug("cli", "token expired, attempting refresh");
+    await new Client(cfg).refreshToken();
+    return true;
+  } catch (err: unknown) {
+    logger.debug("cli", `token refresh failed: ${err instanceof Error ? err.message : err}`);
+    return false;
+  }
 }
 
 export async function execute(): Promise<void> {


### PR DESCRIPTION
## What changed
- Attempt to refresh expired CLI sessions before falling back to OAuth login.
- Refresh expired sessions before reporting status or adding MCP config.
- Added CLI action tests for refresh success and fallback behavior.

## Why
Expired sessions with a valid refresh token should recover automatically instead of forcing users through re-authentication or failing MCP setup.

## Tests
- bunx vitest run src/cli/cli-actions.test.ts

## Follow-up
- None currently.