### PR TITLE
fix: use API key auth for hooks

### DIFF
--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -127,6 +127,6 @@ describe("CLI", () => {
       ]),
     );
     const install = cmd?.commands.find((c) => c.name() === "install");
-    expect(install?.options.find((o) => o.long === "--with-stop")).toBeDefined();
+    expect(install?.options.find((o) => o.long === "--no-stop")).toBeDefined();
   });
 });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -289,4 +289,37 @@ describe("Client", () => {
       await expect(client.createAPIKey("dep-1", "cli")).rejects.toThrow("failed to create API key");
     });
   });
+
+  describe("api-key requests", () => {
+    it("postWithApiKey sends the X-Dosu-API-Key header and JSON body (no OAuth token)", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ticket_id: "t1" }, 202));
+      const client = new Client(makeConfig({ api_key: "key-abc" }));
+      const resp = await client.postWithApiKey("/v1/tickets/knowledge", { prompt: "p" });
+      expect(resp.status).toBe(202);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://api.test.dev/v1/tickets/knowledge");
+      expect(options.method).toBe("POST");
+      expect(options.headers["X-Dosu-API-Key"]).toBe("key-abc");
+      expect(options.headers["Supabase-Access-Token"]).toBeUndefined();
+      expect(JSON.parse(options.body)).toEqual({ prompt: "p" });
+    });
+
+    it("getWithApiKey sends the header, no body, and surfaces 401 without refreshing", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
+      const client = new Client(makeConfig({ api_key: "key-abc" }));
+      const resp = await client.getWithApiKey("/v1/tickets/knowledge/t1");
+      expect(resp.status).toBe(401); // surfaced as-is — no OAuth refresh/retry
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.method).toBe("GET");
+      expect(options.body).toBeUndefined();
+      expect(options.headers["X-Dosu-API-Key"]).toBe("key-abc");
+    });
+
+    it("throws when no API key is configured", async () => {
+      const client = new Client(makeConfig({ api_key: undefined }));
+      await expect(client.postWithApiKey("/x", {})).rejects.toThrow("no API key available");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -120,6 +120,47 @@ export class Client {
   }
 
   /**
+   * API-key-authenticated requests (`X-Dosu-API-Key`) — the same credential the
+   * MCP integration uses. Unlike {@link doRequest}, these carry no Supabase OAuth
+   * token and never refresh: the API key is long-lived, so callers that run as
+   * frequent short-lived processes (e.g. the knowledge hooks) are not subject to
+   * hourly token expiry or refresh-token rotation races.
+   */
+  async getWithApiKey(path: string): Promise<Response> {
+    return this.apiKeyRequest("GET", path);
+  }
+
+  async postWithApiKey(path: string, body: unknown): Promise<Response> {
+    return this.apiKeyRequest("POST", path, body);
+  }
+
+  private async apiKeyRequest(method: string, path: string, body?: unknown): Promise<Response> {
+    if (!this.config.api_key) {
+      throw new Error("no API key available");
+    }
+    const url = this.baseURL + path;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-Dosu-API-Key": this.config.api_key,
+    };
+
+    const options: RequestInit = { method, headers };
+    if (body !== undefined) {
+      options.body = JSON.stringify(body);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    options.signal = controller.signal;
+
+    try {
+      return await fetch(url, options);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
    * Public method to refresh token externally (used during auth step).
    */
   async refreshToken(): Promise<void> {

--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -131,11 +131,13 @@ describe("runUserPromptSubmit", () => {
     expect(printed.hookSpecificOutput.additionalContext).toContain("Keep working normally");
   });
 
-  it("no-ops without a session id, an empty prompt, or when not configured", async () => {
+  it("no-ops without a session id, an empty prompt, or when missing api key / deployment", async () => {
     await runUserPromptSubmit({ prompt: "x" });
     await runUserPromptSubmit({ session_id: "s", prompt: "   " });
     vi.mocked(loadState).mockReturnValue(null);
     vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, deployment_id: undefined });
+    await runUserPromptSubmit({ session_id: "s", prompt: "real" });
+    vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, api_key: undefined });
     await runUserPromptSubmit({ session_id: "s", prompt: "real" });
     expect(requestCreateTicket).not.toHaveBeenCalled();
     expect(stdout()).toBe("");

--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -278,7 +278,7 @@ describe("runPostToolUse", () => {
   });
 });
 
-describe("runStop (opt-in)", () => {
+describe("runStop", () => {
   it("continues without a session, on the loop-guard, or without a pending ticket", async () => {
     await runStop({});
     await runStop({ session_id: "s", stop_hook_active: true });
@@ -412,7 +412,7 @@ describe("lifecycle commands", () => {
     await runInstall("claude-code", { dir, json: true });
     const line = JSON.parse(logSpy.mock.calls[0][0]);
     expect(line.step).toBe("hooks-install");
-    expect(line.events).toEqual(["UserPromptSubmit", "PostToolUse"]);
+    expect(line.events).toEqual(["UserPromptSubmit", "PostToolUse", "Stop"]);
   });
 
   it("rejects an unsupported agent and a non-local scope", async () => {

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -102,7 +102,7 @@ export async function runUserPromptSubmit(
   }
 
   const cfg = loadConfig();
-  if (!isAuthenticated(cfg) || !cfg.deployment_id) {
+  if (!cfg.api_key || !cfg.deployment_id) {
     logger.debug("hooks", "submit skipped reason=not-configured");
     return; // a hook never prompts the user; `doctor` surfaces this
   }
@@ -167,7 +167,7 @@ export async function runPostToolUse(input: HookInput, now: number = Date.now())
   }
 
   const cfg = loadConfig();
-  if (!isAuthenticated(cfg) || !cfg.deployment_id) {
+  if (!cfg.api_key || !cfg.deployment_id) {
     saveState({ ...state, lastCheckedAt: now });
     return;
   }
@@ -219,7 +219,7 @@ export async function runPostToolUse(input: HookInput, now: number = Date.now())
   }
 }
 
-/** Stop (opt-in): last-chance delivery. Blocks ONLY for a ready-but-undelivered ticket. */
+/** Stop: last-chance delivery at end of turn. Blocks ONLY for a ready-but-undelivered ticket. */
 export async function runStop(input: HookInput, now: number = Date.now()): Promise<void> {
   const sessionId = input.session_id;
   if (!sessionId) return printContinue();
@@ -234,7 +234,7 @@ export async function runStop(input: HookInput, now: number = Date.now()): Promi
   }
 
   const cfg = loadConfig();
-  if (!isAuthenticated(cfg) || !cfg.deployment_id) return printContinue();
+  if (!cfg.api_key || !cfg.deployment_id) return printContinue();
 
   const tc = await import("../hooks/ticket-client");
   let resp: import("../hooks/ticket-client").TicketStatusResponse;
@@ -340,7 +340,7 @@ function resolveDir(dir?: string): string {
 export interface LifecycleOptions {
   scope?: string;
   dir?: string;
-  withStop?: boolean;
+  stop?: boolean;
   json?: boolean;
 }
 
@@ -373,7 +373,7 @@ export async function runInstall(agent: string, opts: LifecycleOptions): Promise
   const { installClaudeHooks, claudeLocalSettingsPath } = await import("../hooks/claude-code");
   const configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
   try {
-    const { events } = installClaudeHooks(configPath, { withStop: opts.withStop });
+    const { events } = installClaudeHooks(configPath, { stop: opts.stop });
     if (opts.json) {
       const { emitStep } = await import("../agent/output");
       emitStep({ step: "hooks-install", path: configPath, events });
@@ -484,8 +484,10 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
     });
   }
 
-  // 5. Backend reachable + key valid (best-effort; optimistic on network error).
-  if (cfg.api_key && cfg.deployment_id && isAuthenticated(cfg)) {
+  // 5. Backend reachable + API key valid (best-effort; optimistic on network error).
+  // This validates the SAME credential the hooks use (`X-Dosu-API-Key`), so it
+  // reflects real hook auth — independent of the OAuth login state above.
+  if (cfg.api_key && cfg.deployment_id) {
     const { Client } = await import("../client/client");
     const ok = await new Client(cfg).validateAPIKey(cfg.api_key, cfg.deployment_id);
     checks.push({
@@ -497,7 +499,7 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
     checks.push({
       name: "backend",
       status: "warn",
-      detail: "skipped (not authenticated / no deployment)",
+      detail: "skipped (no API key / no deployment)",
     });
   }
 
@@ -547,7 +549,7 @@ export function hooksCommand(): Command {
 
   cmd
     .command("stop")
-    .description("Hook entrypoint (opt-in): last-chance non-blocking delivery")
+    .description("Hook entrypoint: last-chance knowledge delivery when the agent stops")
     .action(async () => {
       await runHookEntrypoint("stop", readStdinRaw());
     });
@@ -574,7 +576,10 @@ export function hooksCommand(): Command {
     .addArgument(new Argument("<agent>", "coding agent to configure").choices(SUPPORTED_AGENTS))
     .option("--scope <scope>", "Config scope (local only)", "local")
     .option("--dir <path>", "Project root (defaults to current directory)")
-    .option("--with-stop", "Also install the optional Stop hook", false)
+    .option(
+      "--no-stop",
+      "Skip the Stop hook (knowledge then delivers mid-session only, less reliably)",
+    )
     .option("--json", "Emit machine-readable JSON", false)
     .addHelpText(
       "after",
@@ -584,7 +589,7 @@ export function hooksCommand(): Command {
         "",
         "Examples:",
         "  $ dosu hooks install claude-code",
-        "  $ dosu hooks install claude-code --with-stop",
+        "  $ dosu hooks install claude-code --no-stop",
         "  $ dosu hooks install claude-code --dir ./my-project",
       ].join("\n"),
     )

--- a/src/hooks/claude-code.test.ts
+++ b/src/hooks/claude-code.test.ts
@@ -29,9 +29,9 @@ describe("hooks/claude-code installer", () => {
     expect(hookCommand("post-tool-use")).toBe("dosu hooks post-tool-use");
   });
 
-  it("installs UserPromptSubmit + PostToolUse with a marker, dosu command, and 0o600 perms", () => {
+  it("installs UserPromptSubmit + PostToolUse + Stop with a marker, dosu command, and 0o600 perms", () => {
     const { events } = installClaudeHooks(configPath);
-    expect(events).toEqual(["UserPromptSubmit", "PostToolUse"]);
+    expect(events).toEqual(["UserPromptSubmit", "PostToolUse", "Stop"]);
     expect(statSync(configPath).mode & 0o777).toBe(0o600);
 
     const cfg = loadJSONConfig(configPath);
@@ -39,15 +39,16 @@ describe("hooks/claude-code installer", () => {
     expect(post.matcher).toBe("*");
     expect(post.hooks[0].command).toBe("dosu hooks post-tool-use");
     expect(post.hooks[0].__dosu).toBe(true);
-    // UserPromptSubmit groups omit the matcher.
+    // UserPromptSubmit / Stop groups omit the matcher.
     expect(cfg.hooks.UserPromptSubmit[0].matcher).toBeUndefined();
-    expect(cfg.hooks.Stop).toBeUndefined();
+    expect(cfg.hooks.Stop[0].matcher).toBeUndefined();
+    expect(cfg.hooks.Stop[0].hooks[0].__dosu).toBe(true);
   });
 
-  it("--with-stop additionally installs a Stop group", () => {
-    const { events } = installClaudeHooks(configPath, { withStop: true });
-    expect(events).toContain("Stop");
-    expect(loadJSONConfig(configPath).hooks.Stop[0].hooks[0].__dosu).toBe(true);
+  it("--no-stop (stop: false) omits the Stop group", () => {
+    const { events } = installClaudeHooks(configPath, { stop: false });
+    expect(events).toEqual(["UserPromptSubmit", "PostToolUse"]);
+    expect(loadJSONConfig(configPath).hooks.Stop).toBeUndefined();
   });
 
   it("preserves existing user hooks and sibling settings when merging", () => {
@@ -93,7 +94,7 @@ describe("hooks/claude-code installer", () => {
         },
       }),
     );
-    installClaudeHooks(configPath, { withStop: true });
+    installClaudeHooks(configPath);
     const { removed } = removeClaudeHooks(configPath);
     expect(removed).toBe(true);
     const cfg = loadJSONConfig(configPath);
@@ -147,7 +148,7 @@ describe("hooks/claude-code installer", () => {
     expect(inspectClaudeHooks(configPath)).toEqual({
       fileExists: true,
       parseError: false,
-      events: ["UserPromptSubmit", "PostToolUse"],
+      events: ["UserPromptSubmit", "PostToolUse", "Stop"],
     });
     writeFileSync(configPath, "{ broken");
     expect(inspectClaudeHooks(configPath)).toEqual({

--- a/src/hooks/claude-code.ts
+++ b/src/hooks/claude-code.ts
@@ -12,8 +12,13 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { saveJSONConfig } from "../mcp/config-helpers";
 
-/** Events the default install owns. `Stop` is added only with `--with-stop`. */
-export const DEFAULT_HOOK_EVENTS = ["UserPromptSubmit", "PostToolUse"] as const;
+/**
+ * Events the default install owns. `Stop` is included by default (opt out with
+ * `--no-stop`): it is the reliable last-chance delivery point. The async backend
+ * lookup often becomes ready only after the agent has stopped calling tools, so a
+ * `PostToolUse`-only install frequently never delivers; `Stop` closes that gap.
+ */
+export const DEFAULT_HOOK_EVENTS = ["UserPromptSubmit", "PostToolUse", "Stop"] as const;
 const MARKER = "__dosu";
 
 // biome-ignore lint/suspicious/noExplicitAny: settings JSON is inherently untyped
@@ -105,7 +110,8 @@ function readSettingsOrThrow(path: string): JsonConfig {
 }
 
 export interface InstallOptions {
-  withStop?: boolean;
+  /** Install the `Stop` hook. Defaults to true; pass `false` (via `--no-stop`) to skip it. */
+  stop?: boolean;
 }
 
 /** Merge the Dosu hook block into a Claude Code settings file. Returns the events installed. */
@@ -117,7 +123,8 @@ export function installClaudeHooks(
   if (typeof cfg.hooks !== "object" || cfg.hooks === null) {
     cfg.hooks = {};
   }
-  const events = [...DEFAULT_HOOK_EVENTS, ...(opts.withStop ? ["Stop"] : [])];
+  const includeStop = opts.stop !== false;
+  const events = DEFAULT_HOOK_EVENTS.filter((event) => event !== "Stop" || includeStop);
   for (const event of events) {
     const existing: HookGroup[] = Array.isArray(cfg.hooks[event]) ? cfg.hooks[event] : [];
     // Drop any prior Dosu group first so reinstall/upgrade is idempotent.

--- a/src/hooks/prompts.ts
+++ b/src/hooks/prompts.ts
@@ -14,7 +14,7 @@ export const LOOKUP_STARTED_NOTE =
   "quietly to work faster and avoid wrong assumptions. Mention Dosu only if it materially " +
   "changes your answer.";
 
-/** Framing prefix prepended to the (opt-in) Stop hook's blocking reason. */
+/** Framing prefix prepended to the Stop hook's blocking reason. */
 export const STOP_PREFIX =
   "Dosu knowledge finished after your last action. Re-check your current conclusion against " +
   "it, then continue or finish — do not redo work it merely confirms.";

--- a/src/hooks/ticket-client.test.ts
+++ b/src/hooks/ticket-client.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../config/config";
 
-const post = vi.fn();
-const get = vi.fn();
+const postWithApiKey = vi.fn();
+const getWithApiKey = vi.fn();
 
 vi.mock("../client/client", () => ({
-  Client: vi.fn(() => ({ post, get })),
+  Client: vi.fn(() => ({ postWithApiKey, getWithApiKey })),
 }));
 
 import {
@@ -23,12 +23,12 @@ function jsonResponse(status: number, body: unknown) {
 
 describe("hooks/ticket-client", () => {
   beforeEach(() => {
-    post.mockReset();
-    get.mockReset();
+    postWithApiKey.mockReset();
+    getWithApiKey.mockReset();
   });
 
   it("requestCreateTicket returns the parsed 202 body", async () => {
-    post.mockResolvedValue(
+    postWithApiKey.mockResolvedValue(
       jsonResponse(202, { ticket_id: "t1", status: "pending", created_at: "x", expires_at: "y" }),
     );
     const res = await requestCreateTicket(cfg, {
@@ -38,21 +38,21 @@ describe("hooks/ticket-client", () => {
       prompt: "p",
     });
     expect(res.ticket_id).toBe("t1");
-    expect(post).toHaveBeenCalledWith(
+    expect(postWithApiKey).toHaveBeenCalledWith(
       "/v1/tickets/knowledge",
       expect.objectContaining({ prompt: "p" }),
     );
   });
 
   it("requestCreateTicket throws TicketHttpError on a non-2xx status", async () => {
-    post.mockResolvedValue(jsonResponse(400, {}));
+    postWithApiKey.mockResolvedValue(jsonResponse(400, {}));
     await expect(
       requestCreateTicket(cfg, { deployment_id: "d", agent: "a", session_id: "s", prompt: "p" }),
     ).rejects.toBeInstanceOf(TicketHttpError);
   });
 
   it("requestGetTicket parses ready and pending", async () => {
-    get.mockResolvedValueOnce(
+    getWithApiKey.mockResolvedValueOnce(
       jsonResponse(200, {
         ticket_id: "t",
         status: "ready",
@@ -66,14 +66,14 @@ describe("hooks/ticket-client", () => {
     expect(ready.status).toBe("ready");
     expect(ready.result?.context).toBe("c");
 
-    get.mockResolvedValueOnce(
+    getWithApiKey.mockResolvedValueOnce(
       jsonResponse(202, { ticket_id: "t", status: "pending", result: null, error: null }),
     );
     expect((await requestGetTicket(cfg, "t")).status).toBe("pending");
   });
 
   it("requestGetTicket coerces an unknown status to failed", async () => {
-    get.mockResolvedValue(
+    getWithApiKey.mockResolvedValue(
       jsonResponse(200, { ticket_id: "t", status: "weird", result: { context: "c" }, error: null }),
     );
     const res = await requestGetTicket(cfg, "t");
@@ -82,9 +82,9 @@ describe("hooks/ticket-client", () => {
   });
 
   it("requestGetTicket throws TicketHttpError for 404/5xx", async () => {
-    get.mockResolvedValueOnce(jsonResponse(404, {}));
+    getWithApiKey.mockResolvedValueOnce(jsonResponse(404, {}));
     await expect(requestGetTicket(cfg, "t")).rejects.toBeInstanceOf(TicketHttpError);
-    get.mockResolvedValueOnce(jsonResponse(503, {}));
+    getWithApiKey.mockResolvedValueOnce(jsonResponse(503, {}));
     await expect(requestGetTicket(cfg, "t")).rejects.toBeInstanceOf(TicketHttpError);
   });
 

--- a/src/hooks/ticket-client.ts
+++ b/src/hooks/ticket-client.ts
@@ -1,11 +1,12 @@
 /**
  * Knowledge-ticket API client.
  *
- * Talks to the deployment-scoped ticket endpoints via the shared authenticated
- * `Client` (token refresh + 401/403 retry). The base URL is resolved from
- * `getBackendURL()` / `*_OVERRIDE`, so integration tests and local dev point at
- * the fake API by exporting `DOSU_BACKEND_URL_OVERRIDE` — the code path is
- * identical against the real and fake backends.
+ * Talks to the deployment-scoped ticket endpoints with the deployment **API key**
+ * (`X-Dosu-API-Key`) via `Client.{post,get}WithApiKey` — the same long-lived
+ * credential the MCP integration uses. It deliberately does NOT use the Supabase
+ * OAuth token: hooks run as frequent, short-lived processes, and an hourly-expiring
+ * token (refreshed via rotation through a single shared config file) would race and
+ * fail silently. The base URL is resolved from `getBackendURL()` / `*_OVERRIDE`.
  *
  * This module is lazy-imported only off the hook fast-path (i.e. only when a
  * create or a poll is actually required), per the latency mitigations.
@@ -93,7 +94,7 @@ export async function requestCreateTicket(
   req: CreateTicketRequest,
 ): Promise<CreateTicketResponse> {
   const client = new Client(cfg);
-  const resp = await client.post(TICKETS_PATH, req);
+  const resp = await client.postWithApiKey(TICKETS_PATH, req);
   if (resp.status !== 202 && resp.status !== 200 && resp.status !== 201) {
     throw new TicketHttpError(resp.status);
   }
@@ -106,7 +107,7 @@ export async function requestGetTicket(
   ticketId: string,
 ): Promise<TicketStatusResponse> {
   const client = new Client(cfg);
-  const resp = await client.get(`${TICKETS_PATH}/${encodeURIComponent(ticketId)}`);
+  const resp = await client.getWithApiKey(`${TICKETS_PATH}/${encodeURIComponent(ticketId)}`);
   if (resp.status !== 200 && resp.status !== 202) {
     throw new TicketHttpError(resp.status);
   }


### PR DESCRIPTION
## What changed
- Added API-key-authenticated client request helpers that send X-Dosu-API-Key without Supabase OAuth tokens.
- Updated knowledge hook ticket creation and polling to use the deployment API key.
- Made the Claude Code Stop hook install by default, with --no-stop as the opt-out.
- Updated hook doctor checks and tests to match API key based hook behavior.

## Why
Hooks run as frequent short-lived processes, so relying on expiring Supabase OAuth tokens can fail when refresh-token rotation races through the shared config file. The deployment API key is the same long-lived credential used by the MCP integration and better matches hook execution.

The Stop hook is also the reliable last-chance delivery point for async knowledge results that may become ready after the agent stops calling tools.

## Tests
- bunx vitest run src/client/client.test.ts src/hooks/ticket-client.test.ts src/hooks/claude-code.test.ts src/commands/hooks.test.ts src/cli/cli.test.ts