### PR TITLE
feat: bounded-wait at Stop for last-chance knowledge delivery

### DIFF
--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -281,9 +281,17 @@ describe("runPostToolUse", () => {
 });
 
 describe("runStop", () => {
-  it("continues without a session, on the loop-guard, or without a pending ticket", async () => {
+  // Default the Stop wait to 0 so the pending-path tests poll once and never sleep.
+  beforeEach(() => {
+    process.env.DOSU_HOOK_STOP_WAIT_MS = "0";
+  });
+  afterEach(() => {
+    delete process.env.DOSU_HOOK_STOP_WAIT_MS;
+    delete process.env.DOSU_HOOK_STOP_POLL_MS;
+  });
+
+  it("continues without a session or without a pending ticket", async () => {
     await runStop({});
-    await runStop({ session_id: "s", stop_hook_active: true });
     vi.mocked(loadState).mockReturnValue(null);
     await runStop({ session_id: "s" });
     expect(requestGetTicket).not.toHaveBeenCalled();
@@ -318,7 +326,7 @@ describe("runStop", () => {
     expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ status: "delivered" }));
   });
 
-  it("continues (never blocks) when the ticket is still pending", async () => {
+  it("continues (no block) when the ticket is still in flight after the wait", async () => {
     vi.mocked(loadState).mockReturnValue(pending());
     vi.mocked(requestGetTicket).mockResolvedValue({
       ticket_id: "kt_1",
@@ -330,6 +338,32 @@ describe("runStop", () => {
     });
     await runStop({ session_id: "sess" }, 70_000);
     expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
+    expect(saveState).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "pending", lastCheckedAt: 70_000 }),
+    );
+  });
+
+  it("waits, re-polls, and delivers when the ticket flips ready mid-wait", async () => {
+    process.env.DOSU_HOOK_STOP_WAIT_MS = "50";
+    process.env.DOSU_HOOK_STOP_POLL_MS = "1";
+    vi.mocked(loadState).mockReturnValue(pending());
+    const pendingResp = {
+      ticket_id: "kt_1",
+      status: "pending" as const,
+      created_at: "x",
+      expires_at: "y",
+      result: null,
+      error: null,
+    };
+    vi.mocked(requestGetTicket)
+      .mockResolvedValueOnce(pendingResp)
+      .mockResolvedValueOnce(pendingResp)
+      .mockResolvedValue(readyResp("READY MID-WAIT"));
+    await runStop({ session_id: "sess" }, 70_000);
+    expect(requestGetTicket).toHaveBeenCalledTimes(3);
+    const printed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(printed.decision).toBe("block");
+    expect(printed.reason).toContain("READY MID-WAIT");
   });
 
   it("continues on a poll error (never holds the agent open)", async () => {

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -37,12 +37,14 @@ type HookEvent = "user-prompt-submit" | "post-tool-use" | "stop";
 
 const COOLDOWN_DEFAULT_MS = 3000;
 const TTL_DEFAULT_MS = 10 * 60 * 1000; // 10 minutes
+const STOP_WAIT_DEFAULT_MS = 8000; // max time Stop waits for an in-flight lookup
+const STOP_POLL_DEFAULT_MS = 1000; // interval between Stop poll attempts
 
 /** Coding agents that have a Dosu hook adapter today (Codex is a follow-up). */
 const SUPPORTED_AGENTS = ["claude-code"];
 
 // ---------------------------------------------------------------------------
-// Timing knobs (env-overridable; production relies on the cooldown only)
+// Timing knobs (env-overridable)
 // ---------------------------------------------------------------------------
 
 function cooldownMs(): number {
@@ -53,6 +55,18 @@ function cooldownMs(): number {
 function ttlMs(): number {
   const n = Number.parseInt(process.env.DOSU_HOOK_TTL_MS ?? "", 10);
   return Number.isFinite(n) && n > 0 ? n : TTL_DEFAULT_MS;
+}
+
+/** Max time the Stop hook will wait for an in-flight lookup before finishing. */
+function stopWaitMs(): number {
+  const n = Number.parseInt(process.env.DOSU_HOOK_STOP_WAIT_MS ?? "", 10);
+  return Number.isFinite(n) && n >= 0 ? n : STOP_WAIT_DEFAULT_MS;
+}
+
+/** Interval between Stop-hook poll attempts while waiting for a ready ticket. */
+function stopPollMs(): number {
+  const n = Number.parseInt(process.env.DOSU_HOOK_STOP_POLL_MS ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : STOP_POLL_DEFAULT_MS;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +80,8 @@ function printHookContext(event: string, additionalContext: string): void {
 function printContinue(): void {
   console.log(JSON.stringify({ continue: true }));
 }
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 function sid8(sessionId: string): string {
   return sessionId.slice(0, 8);
@@ -219,49 +235,62 @@ export async function runPostToolUse(input: HookInput, now: number = Date.now())
   }
 }
 
-/** Stop: last-chance delivery at end of turn. Blocks ONLY for a ready-but-undelivered ticket. */
+/**
+ * Stop: last-chance delivery at end of turn.
+ *
+ * If the ticket is ready, block once with the knowledge as today. If it is still
+ * in flight, briefly WAIT for it (poll every `DOSU_HOOK_STOP_POLL_MS` up to
+ * `DOSU_HOOK_STOP_WAIT_MS`, default 8s) rather than finish without it — Stop is
+ * the final chance. The agent is given NO extra instruction: it simply pauses
+ * while the lookup lands, then either receives the knowledge or continues.
+ * Delivery latches `delivered` (terminal), so there is no re-fire loop to guard.
+ */
 export async function runStop(input: HookInput, now: number = Date.now()): Promise<void> {
   const sessionId = input.session_id;
   if (!sessionId) return printContinue();
-  // Loop-guard: a Stop triggered by a prior Stop-hook block must not re-block.
-  if (input.stop_hook_active === true) return printContinue();
 
   const state = loadState(sessionId);
   if (!state) return printContinue();
   if (state.status !== "pending" || now > state.expiresAt) return printContinue();
-  if (state.lastCheckedAt !== undefined && now - state.lastCheckedAt < cooldownMs()) {
-    return printContinue();
-  }
 
   const cfg = loadConfig();
   if (!cfg.api_key || !cfg.deployment_id) return printContinue();
 
   const tc = await import("../hooks/ticket-client");
-  let resp: import("../hooks/ticket-client").TicketStatusResponse;
-  try {
-    resp = await tc.requestGetTicket(cfg, state.ticketId);
-  } catch {
-    saveState({ ...state, lastCheckedAt: now }); // never hold the agent open
-    return printContinue();
-  }
+  const pollMs = stopPollMs();
+  const maxWaits = pollMs > 0 ? Math.floor(stopWaitMs() / pollMs) : 0;
 
-  if (resp.status === "ready" && resp.result) {
-    // Consume the ticket either way, but only BLOCK the agent for real knowledge.
-    // A bare save nudge (knowledge gap, empty context) is not worth holding the
-    // agent open at Stop — drop it rather than block on nothing actionable.
-    saveState({ ...state, status: "delivered", deliveredAt: now, lastCheckedAt: now });
-    if (resp.result.context.trim()) {
-      const { buildReadyEnvelope, STOP_PREFIX } = await import("../hooks/prompts");
-      const envelope = buildReadyEnvelope(
-        resp.result.context,
-        resp.result.save_recommended ?? false,
-      );
-      console.log(JSON.stringify({ decision: "block", reason: `${STOP_PREFIX}\n\n${envelope}` }));
-      logger.info("hooks", `stop tid=${state.ticketId} delivered=true`);
-      return;
+  for (let waited = 0; ; waited++) {
+    let resp: import("../hooks/ticket-client").TicketStatusResponse;
+    try {
+      resp = await tc.requestGetTicket(cfg, state.ticketId);
+    } catch {
+      saveState({ ...state, lastCheckedAt: now }); // never hold the agent open
+      return printContinue();
     }
-    logger.debug("hooks", `stop tid=${state.ticketId} delivered=true gap-no-block`);
-    return printContinue();
+
+    if (resp.status === "ready" && resp.result) {
+      // Consume the ticket either way, but only BLOCK the agent for real knowledge.
+      // A bare save nudge (knowledge gap, empty context) is not worth holding the
+      // agent open at Stop — drop it rather than block on nothing actionable.
+      saveState({ ...state, status: "delivered", deliveredAt: now, lastCheckedAt: now });
+      if (resp.result.context.trim()) {
+        const { buildReadyEnvelope, STOP_PREFIX } = await import("../hooks/prompts");
+        const envelope = buildReadyEnvelope(
+          resp.result.context,
+          resp.result.save_recommended ?? false,
+        );
+        console.log(JSON.stringify({ decision: "block", reason: `${STOP_PREFIX}\n\n${envelope}` }));
+        logger.info("hooks", `stop tid=${state.ticketId} delivered=true`);
+        return;
+      }
+      logger.debug("hooks", `stop tid=${state.ticketId} delivered=true gap-no-block`);
+      return printContinue();
+    }
+
+    // Keep waiting only while still pending and within the budget.
+    if (resp.status !== "pending" || waited >= maxWaits) break;
+    await sleep(pollMs);
   }
 
   saveState({ ...state, lastCheckedAt: now });


### PR DESCRIPTION
### Summary

The Stop hook is the last chance to deliver Dosu knowledge for a turn. Previously it polled a pending ticket **once** and, if not yet ready, released the agent immediately — so a lookup still in flight at end of turn was missed entirely.

This makes Stop **wait briefly** for an in-flight lookup: poll every `DOSU_HOOK_STOP_POLL_MS` (default 1s) up to `DOSU_HOOK_STOP_WAIT_MS` (default 8s), deliver (`decision: block`) the moment the ticket flips ready, and release cleanly (`continue`) on timeout. The agent gets **no extra instruction** — it just pauses under Claude Code's "hook running" cover, then either receives the knowledge or finishes.

Delivery latches the terminal `delivered` state, so there is no re-fire loop — the prior `stop_hook_active` loop-guard and the cooldown gate are removed as unnecessary.

### Why now

Pairs with backend [dosu#10921](https://github.com/dosu-ai/dosu/pull/10921) (parallelize the knowledge-ticket per-source search), which cuts prod ticket latency from ~25s toward ~6–8s — inside this wait window. Without that fix the 8s budget can't catch a cold lookup; with it, Stop reliably delivers in-turn.

### Testing

- `bunx vitest run src/commands/hooks` — 38 tests, incl. new `waits, re-polls, and delivers when the ticket flips ready mid-wait` and `continues (no block) when the ticket is still in flight after the wait`.
- Full suite **1155 passed**; `typecheck` + `biome` clean.
- **Manual end-to-end against prod** (`api.dosu.dev`): built a prod binary from this branch and drove the hooks via stdin — with a 35s budget Stop waited ~21s, caught the ready flip, and emitted `decision: block` with the real knowledge envelope (state latched `delivered`); with the default 8s budget it waited ~13s then released with `continue`.

Two env knobs (`DOSU_HOOK_STOP_WAIT_MS`=8000, `DOSU_HOOK_STOP_POLL_MS`=1000) allow tuning to real prod p90 after #10921 deploys.
