### PR TITLE
feat(hooks): surface Dosu attribution as a team-knowledge cross-check

### DIFF
--- a/src/hooks/prompts.test.ts
+++ b/src/hooks/prompts.test.ts
@@ -16,7 +16,7 @@ describe("hooks/prompts", () => {
     expect(out).toContain("Dosu knowledge context for this task:");
     expect(out).toContain("ROUTE MAP BODY");
     expect(out).toContain("verify adjacent");
-    expect(out).toContain("one brief quoted note");
+    expect(out).toContain("one brief cited note");
   });
 
   it("envelope contains no hardcoded file paths or relevance/threshold numbers", () => {

--- a/src/hooks/prompts.ts
+++ b/src/hooks/prompts.ts
@@ -11,8 +11,8 @@
 export const LOOKUP_STARTED_NOTE =
   "Dosu started a background knowledge lookup for this request. Keep working normally — " +
   "do not wait or pause for it. If Dosu context arrives during this session, fold it in " +
-  "quietly to work faster and avoid wrong assumptions. Mention Dosu only if it materially " +
-  "changes your answer.";
+  "quietly to work faster and avoid wrong assumptions. Mention Dosu when its context " +
+  "helps you.";
 
 /** Framing prefix prepended to the Stop hook's blocking reason. */
 export const STOP_PREFIX =
@@ -51,12 +51,16 @@ export function buildReadyEnvelope(context: string, saveRecommended = false): st
         "- Use it quietly to answer faster and with fewer broad searches. Keep working normally.",
         "- This is the known likely path, not the full boundary. Before finalizing, verify adjacent " +
           "public/API entrypoints and edge cases that this route map may not cover.",
-        "- Attribution: mention Dosu only if this context materially changed what you checked, helped " +
-          "locate something non-obvious, or prevented a wrong conclusion. If it merely confirmed what " +
-          "you already found, do not mention it.",
-        "- If you do attribute, use one brief quoted note placed next to the specific finding it helped " +
-          'with. Do not open with "Dosu told me…", do not add a closing praise paragraph, and do not ' +
-          "reference any ticket or lookup id.",
+        "- Attribution: this context is your team's existing knowledge (docs, past PRs, discussions) " +
+          "surfaced by Dosu — not the live code you're reading. For each main finding it speaks to, " +
+          "add one brief cited note on how the team's knowledge relates: if it agrees, note it in a " +
+          "line and cite the source; if it differs, flag it as worth confirming and reconcile before " +
+          "finalizing; if it adds something the code alone wouldn't tell you (a rationale, a gotcha, " +
+          "a past decision), surface it, cited.",
+        "- Surface this at each main finding the context speaks to — but skip the ones it is " +
+          "genuinely silent on, and never invent agreement or disagreement. Keep each note brief and " +
+          'next to the finding; do not open with "Dosu told me…", do not add a closing praise ' +
+          "paragraph, and do not reference any ticket or lookup id.",
       ].join("\n"),
     );
   }


### PR DESCRIPTION
### Summary

Makes Dosu attribution more visible in the agent's output, and reframes it as a **team-knowledge cross-check** rather than a generic "Dosu helped" mention.

Before, the injected knowledge envelope told the agent to mention Dosu *only* when it materially changed the outcome, and to stay silent when it *merely confirmed* the agent's own findings. In practice attribution was rare — users couldn't tell Dosu was contributing.

This reframes the attribution instruction in `buildReadyEnvelope`:

- The injected context is **the team's existing knowledge** (docs, past PRs, discussions) surfaced by Dosu — not the live code the agent is reading.
- For each main finding the context speaks to, the agent adds **one brief cited note** on how the team's knowledge relates: **agrees** (one line), **differs** (flag as worth confirming + reconcile), or **adds** something the code alone wouldn't show (a rationale, a gotcha, a past decision) — citing the source.
- Honesty guards retained: skip findings the context is genuinely silent on, **never invent** agreement or disagreement; keep notes brief, no "Dosu told me…", no praise paragraph, no ticket id.

Also softens the lookup-started note: `Mention Dosu only if it materially changes your answer` → `Mention Dosu when its context helps you`.

### Notes

- The change is injected prompt text only (`src/hooks/prompts.ts`); the real attribution frequency/quality is empirical — worth watching after release that "agrees" notes don't become reflexive/forced (raise the bar a notch if they do).
- Two bigger, separate levers for "users feel Dosu's presence" are intentionally out of scope here: a deterministic UI indicator (Helmor side), and reducing the backend knowledge-gap rate.

### Testing

- `bunx vitest run src/hooks/prompts` — 8 passed (incl. the updated `one brief cited note` assertion).
- `typecheck` + `biome` clean.
