### PR TITLE
fix: self-heal token refresh across concurrent CLI processes

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Config } from "../config/config";
-import { isAuthenticated, isTokenExpired, saveConfig } from "../config/config";
+import { isAuthenticated, isTokenExpired, loadConfig, saveConfig } from "../config/config";
 import { getBackendURL, getSupabaseAnonKey, getSupabaseURL } from "../config/constants";
 
 export class SessionExpiredError extends Error {
@@ -162,12 +162,50 @@ export class Client {
 
   /**
    * Public method to refresh token externally (used during auth step).
+   *
+   * Multi-process self-healing: sibling CLI processes rotate the refresh
+   * token through the shared config file, and GoTrue refresh tokens are
+   * single-use — replaying a stale one outside the reuse interval can revoke
+   * the ENTIRE session for every client holding it. So: adopt the newest
+   * on-disk tokens before refreshing (a long-lived process may hold a stale
+   * in-memory copy), and on failure re-read the config once in case a
+   * sibling rotated mid-flight.
    */
   async refreshToken(): Promise<void> {
+    this.adoptNewerDiskTokens();
     if (!this.config.refresh_token) {
       throw new Error("no refresh token available");
     }
 
+    try {
+      await this.refreshTokenOnce();
+    } catch (err) {
+      // A sibling may have rotated the token between our config read and the
+      // request landing. If the file now holds a different token, retry once
+      // with it before declaring the session dead.
+      if (!this.adoptNewerDiskTokens()) {
+        throw err;
+      }
+      await this.refreshTokenOnce();
+    }
+  }
+
+  /**
+   * Sync in-memory tokens from the config file when a sibling process saved
+   * a different refresh token. Returns true when tokens were adopted.
+   */
+  private adoptNewerDiskTokens(): boolean {
+    const disk = loadConfig();
+    if (!disk.refresh_token || disk.refresh_token === this.config.refresh_token) {
+      return false;
+    }
+    this.config.access_token = disk.access_token;
+    this.config.refresh_token = disk.refresh_token;
+    this.config.expires_at = disk.expires_at;
+    return true;
+  }
+
+  private async refreshTokenOnce(): Promise<void> {
     const supabaseURL = getSupabaseURL();
     const endpoint = `${supabaseURL}/auth/v1/token?grant_type=refresh_token`;
 

--- a/src/client/refresh.test.ts
+++ b/src/client/refresh.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Refresh self-healing tests.
+ *
+ * GoTrue rotates refresh tokens on every use, and replaying a stale token
+ * outside the ~10s reuse interval can revoke the ENTIRE session (reuse
+ * detection) — killing every client that shares it. Multiple CLI processes
+ * (TUI, parallel commands, hooks-era installs) share one config file, so a
+ * process holding a stale in-memory token can kill the session for all of
+ * them. These tests pin the client's defenses:
+ *
+ * 1. adopt-before-refresh — refresh with the newest on-disk token, never a
+ *    stale in-memory copy (long-lived TUI scenario).
+ * 2. retry-after-rotation — when a refresh fails because a sibling rotated
+ *    the token mid-flight, re-read the config and retry once with the newer
+ *    token before declaring the session dead.
+ * 3. two-client relay — a stale client adopts its sibling's rotation instead
+ *    of replaying the dead token (which, against real GoTrue, would revoke
+ *    the session for BOTH).
+ *
+ * The fake GoTrue mirrors hosted behavior outside the reuse interval: only
+ * the CURRENT refresh token succeeds; anything else gets a 400
+ * (refresh_token_already_used).
+ */
+
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { type Config, loadConfig, saveConfig } from "../config/config";
+import { Client } from "./client";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+/** Stateful fake GoTrue: strict rotation with reuse detection. */
+class FakeGoTrue {
+  current: string;
+  /** Every refresh_token value presented to the endpoint, in order. */
+  presented: string[] = [];
+  /** Number of rejected (stale-token) refresh attempts. */
+  rejections = 0;
+  private rotations = 0;
+
+  constructor(initial: string) {
+    this.current = initial;
+  }
+
+  handle = async (_url: unknown, options?: { body?: string }): Promise<Response> => {
+    const body = JSON.parse(options?.body ?? "{}") as { refresh_token?: string };
+    const presented = body.refresh_token ?? "";
+    this.presented.push(presented);
+    if (presented !== this.current) {
+      this.rejections += 1;
+      return new Response(JSON.stringify({ error_code: "refresh_token_already_used" }), {
+        status: 400,
+      });
+    }
+    this.rotations += 1;
+    this.current = `rt-${this.rotations}`;
+    return new Response(
+      JSON.stringify({
+        access_token: `at-${this.rotations}`,
+        refresh_token: this.current,
+        expires_in: 3600,
+      }),
+      { status: 200 },
+    );
+  };
+}
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    access_token: "at-stale",
+    refresh_token: "rt-stale",
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    ...overrides,
+  };
+}
+
+describe("refresh self-healing", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  let tempDir: string;
+
+  beforeAll(() => {
+    for (const key of ["SUPABASE_URL", "SUPABASE_ANON_KEY"]) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.SUPABASE_URL = "https://test.supabase.co";
+    process.env.SUPABASE_ANON_KEY = "test-anon-key";
+  });
+
+  afterAll(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val !== undefined) {
+        process.env[key] = val;
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-refresh-test-"));
+    process.env.XDG_CONFIG_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("refreshes with the newest on-disk token, not a stale in-memory copy", async () => {
+    // A sibling process already rotated the token and saved it.
+    saveConfig(makeConfig({ access_token: "at-disk", refresh_token: "rt-disk" }));
+    const gotrue = new FakeGoTrue("rt-disk");
+    mockFetch.mockImplementation(gotrue.handle);
+
+    // This process still holds the pre-rotation tokens in memory (e.g. a
+    // TUI that has been open for a while).
+    const cfg = makeConfig({ refresh_token: "rt-stale" });
+    await new Client(cfg).refreshToken();
+
+    expect(gotrue.presented).toEqual(["rt-disk"]); // never "rt-stale"
+    expect(gotrue.rejections).toBe(0);
+    expect(cfg.refresh_token).toBe("rt-1");
+    expect(loadConfig().refresh_token).toBe("rt-1"); // rotation persisted
+  });
+
+  it("retries once with the on-disk token when a sibling rotates mid-flight", async () => {
+    // Memory and disk agree when the refresh starts...
+    saveConfig(makeConfig({ refresh_token: "rt-a" }));
+    const cfg = loadConfig();
+
+    // ...but a sibling has ALREADY rotated rt-a -> rt-b server-side; its
+    // save lands while our (stale) request is in flight.
+    const gotrue = new FakeGoTrue("rt-b");
+    let siblingSaved = false;
+    mockFetch.mockImplementation(async (url: unknown, options?: { body?: string }) => {
+      const resp = await gotrue.handle(url, options);
+      if (!siblingSaved) {
+        siblingSaved = true;
+        saveConfig(makeConfig({ access_token: "at-b", refresh_token: "rt-b" }));
+      }
+      return resp;
+    });
+
+    await new Client(cfg).refreshToken();
+
+    expect(gotrue.presented).toEqual(["rt-a", "rt-b"]); // failed once, healed
+    expect(cfg.refresh_token).toBe("rt-1");
+    expect(loadConfig().refresh_token).toBe("rt-1");
+  });
+
+  it("two clients sharing one config file relay the rotation instead of killing it", async () => {
+    saveConfig(makeConfig({ refresh_token: "rt-0" }));
+    const gotrue = new FakeGoTrue("rt-0");
+    mockFetch.mockImplementation(gotrue.handle);
+
+    // Both processes load the same config...
+    const a = loadConfig();
+    const b = loadConfig();
+
+    // ...A refreshes first (rt-0 -> rt-1), then B — whose in-memory token is
+    // now stale — must adopt A's rotation (rt-1 -> rt-2), not replay rt-0.
+    await new Client(a).refreshToken();
+    await new Client(b).refreshToken();
+
+    expect(gotrue.presented).toEqual(["rt-0", "rt-1"]);
+    expect(gotrue.rejections).toBe(0); // a replayed token would kill the session
+    expect(loadConfig().refresh_token).toBe("rt-2");
+
+    // The config dir contains exactly the config file — no stray tmp files.
+    expect(readdirSync(join(tempDir, "dosu-cli"))).toEqual(["config.json"]);
+  });
+
+  it("still fails cleanly when the session is truly dead (no newer token on disk)", async () => {
+    saveConfig(makeConfig({ refresh_token: "rt-dead" }));
+    const cfg = loadConfig();
+    const gotrue = new FakeGoTrue("rt-elsewhere"); // nothing we hold will work
+    mockFetch.mockImplementation(gotrue.handle);
+
+    await expect(new Client(cfg).refreshToken()).rejects.toThrow("refresh failed with status 400");
+    // One attempt only — disk has nothing newer to retry with.
+    expect(gotrue.presented).toEqual(["rt-dead"]);
+  });
+});

--- a/src/config/config.atomic.test.ts
+++ b/src/config/config.atomic.test.ts
@@ -1,0 +1,81 @@
+/**
+ * saveConfig atomicity tests.
+ *
+ * Concurrent CLI processes share one config file. A direct write to the
+ * final path can interleave with a sibling's write or be observed half
+ * written; a clobbered/corrupt refresh token gets replayed on the next
+ * refresh and can revoke the whole session under GoTrue reuse detection.
+ * saveConfig must therefore write a temp file and atomically rename it
+ * over the final path.
+ */
+
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    writeFileSync: vi.fn(actual.writeFileSync),
+    renameSync: vi.fn(actual.renameSync),
+  };
+});
+
+import { renameSync, writeFileSync } from "node:fs";
+import { type Config, getConfigPath, loadConfig, saveConfig } from "./config";
+
+describe("saveConfig atomicity", () => {
+  let origXDG: string | undefined;
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.mocked(writeFileSync).mockClear();
+    vi.mocked(renameSync).mockClear();
+    origXDG = process.env.XDG_CONFIG_HOME;
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-atomic-test-"));
+    process.env.XDG_CONFIG_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    if (origXDG !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXDG;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes a temp file and atomically renames it over the final path", () => {
+    const cfg: Config = { access_token: "tok", refresh_token: "ref", expires_at: 1 };
+    saveConfig(cfg);
+
+    const finalPath = getConfigPath();
+
+    // The data write must never target the final path directly.
+    const writtenPaths = vi.mocked(writeFileSync).mock.calls.map((c) => String(c[0]));
+    expect(writtenPaths).not.toContain(finalPath);
+
+    // ...and must land via exactly one rename onto the final path.
+    expect(vi.mocked(renameSync)).toHaveBeenCalledTimes(1);
+    const [from, to] = vi.mocked(renameSync).mock.calls[0];
+    expect(String(to)).toBe(finalPath);
+    expect(String(from)).not.toBe(finalPath);
+    // The temp file must live in the same directory (rename is only atomic
+    // within a filesystem).
+    expect(dirname(String(from))).toBe(dirname(finalPath));
+
+    // Result round-trips and leaves no stray temp files behind.
+    expect(loadConfig()).toEqual(cfg);
+    expect(readdirSync(dirname(finalPath))).toEqual(["config.json"]);
+  });
+
+  it("keeps the 0600 mode on the written file", () => {
+    saveConfig({ access_token: "tok", refresh_token: "ref", expires_at: 1 });
+    const dataWrite = vi
+      .mocked(writeFileSync)
+      .mock.calls.find((c) => String(c[0]).includes("dosu-cli"));
+    expect(dataWrite?.[2]).toMatchObject({ mode: 0o600 });
+  });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,7 @@
  * Config management — load/save JSON config from XDG config directory.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 /** Setup mode: OSS = public libraries only, undefined = standard (cloud) flow. */
@@ -68,7 +68,15 @@ export function saveConfig(cfg: Config): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  writeFileSync(path, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+  // Write-then-rename so concurrent CLI processes never observe a partially
+  // written config and never interleave writes. A clobbered refresh token
+  // would be replayed on the next refresh, and GoTrue's reuse detection can
+  // revoke the whole session for a replayed token. The temp file lives in
+  // the same directory (rename is only atomic within one filesystem) and is
+  // pid-suffixed so sibling processes never share it.
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+  renameSync(tmp, path);
 }
 
 export function isAuthenticated(cfg: Config): boolean {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
+    setupFiles: ["./vitest.setup.ts"],
     pool: "forks",
     testTimeout: 30_000,
     hookTimeout: 30_000,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,11 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Isolate every test file from the developer's real ~/.config/dosu-cli:
+// the Client re-reads the config file during token refresh (multi-process
+// self-healing), so any test exercising refresh paths would otherwise read
+// — and could try to mutate — real credentials. Each vitest fork gets its
+// own empty config home; tests that need specific config contents (e.g.
+// config.test.ts) still override this per-test.
+process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "dosu-vitest-"));


### PR DESCRIPTION
## What

CLI-side defense-in-depth for the disconnect bug fixed server-side in dosu-ai/dosu#10989 + dosu-ai/dosu#10990. GoTrue refresh tokens are single-use — replaying a stale one outside the ~10s reuse interval returns `refresh_token_already_used` and permanently locks the client out. Multiple CLI processes share `~/.config/dosu-cli/config.json`, so one process holding a stale in-memory token could kill the session for all of them.

Three defenses, each pinned by a test that **fails on `main`**:

| Defense | Scenario it fixes |
|---|---|
| `refreshToken()` adopts the newest on-disk tokens before refreshing | A long-lived TUI holds week-old in-memory tokens while siblings rotated the session |
| On refresh failure, re-read the config once and retry with a sibling's newer token | A sibling rotates mid-flight between our config read and our request landing |
| `saveConfig()` writes a pid-suffixed temp file + atomic rename | Two processes interleaving writes could clobber a fresh token with a dead one |

Plus `vitest.setup.ts`: every test fork gets an isolated `XDG_CONFIG_HOME` — the client now reads the config during refresh, and tests must never touch a developer's real `~/.config/dosu-cli`.

## Proof

**Red → green (TDD).** The 4 new behavior tests on unmodified `main`: 3 die with `refresh failed with status 400` (the exact production failure), 1 atomicity test fails on direct-path write. After the fix: all pass.

**Mechanism reproduction against real GoTrue** (supabase local v2.189, archived in `.agent-contexts/cli-disconnect-verify/`):
- *Old architecture* (browser + CLI share one session): browser rotates RT1→RT2→RT3; CLI replays RT1 after 12s → **`400 refresh_token_already_used` — the reported disconnect, reproduced**. (Observed: local GoTrue leniently kept the browser's RT3 alive; hosted docs state the whole session is terminated — either way the CLI is dead.)
- *New architecture* (independent sessions): identical choreography, zero casualties.

## Test results

- Full suite: **1161 passed** (59 files), zero regressions
- Coverage: 95.3% stmts / 90.5% branches / 98.1% funcs / 95.3% lines (thresholds 95/90/80/95)
- `tsc --noEmit` + biome: clean