### PR TITLE
test: make OAuth flow tests deterministic

### DIFF
--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -42,6 +42,22 @@ function createMockServer(): CallbackServer {
   };
 }
 
+/**
+ * Deterministically wait until the flow under test has opened the browser
+ * and armed its timeout/abort race. Fixed-duration sleeps flaked on slow CI
+ * runners (coverage-instrumented dynamic import of "open" can take >10ms):
+ * the assertion then saw zero open() calls, and the leaked unresolved flow
+ * created its 8-minute timer under a later test's fake timers, cascading
+ * into that test's timer-count assertion.
+ */
+async function flowReady(): Promise<void> {
+  await vi.waitFor(() => expect(mockOpenDefault).toHaveBeenCalledOnce());
+  // open() resolving hands control back to the flow on the microtask queue;
+  // a macrotask barrier guarantees the timeout/abort race is armed before
+  // the test acts (e.g. fires an abort the flow must be listening for).
+  await new Promise((r) => setImmediate(r));
+}
+
 describe("startOAuthFlow", () => {
   let mockServer: CallbackServer;
   let resolveToken: (token: TokenResponse) => void;
@@ -77,9 +93,7 @@ describe("startOAuthFlow", () => {
     };
 
     const flowPromise = startOAuthFlow();
-
-    // Let the async setup run
-    await new Promise((r) => setTimeout(r, 10));
+    await flowReady();
 
     resolveToken(expectedToken);
 
@@ -95,7 +109,7 @@ describe("startOAuthFlow", () => {
     };
 
     const flowPromise = startOAuthFlow();
-    await new Promise((r) => setTimeout(r, 10));
+    await flowReady();
 
     resolveToken(token);
     await flowPromise;
@@ -105,7 +119,7 @@ describe("startOAuthFlow", () => {
 
   it("closes the server when tokenPromise rejects", async () => {
     const flowPromise = startOAuthFlow();
-    await new Promise((r) => setTimeout(r, 10));
+    await flowReady();
 
     rejectToken(new Error("something went wrong"));
 
@@ -119,7 +133,7 @@ describe("startOAuthFlow", () => {
     const controller = new AbortController();
 
     const flowPromise = startOAuthFlow(controller.signal);
-    await new Promise((r) => setTimeout(r, 10));
+    await flowReady();
 
     controller.abort();
 
@@ -131,7 +145,7 @@ describe("startOAuthFlow", () => {
 
   it("opens the browser with the correct auth URL", async () => {
     const flowPromise = startOAuthFlow();
-    await new Promise((r) => setTimeout(r, 10));
+    await flowReady();
 
     expect(mockOpenDefault).toHaveBeenCalledOnce();
     const calledURL = mockOpenDefault.mock.calls[0]?.[0] as string;
@@ -147,7 +161,7 @@ describe("startOAuthFlow", () => {
     const flowPromise = startOAuthFlow(undefined, "/cli/auth", {
       onboarding_run_id: "run-123",
     });
-    await new Promise((r) => setTimeout(r, 10));
+    await flowReady();
 
     const calledURL = mockOpenDefault.mock.calls[0]?.[0] as string;
     expect(calledURL).toContain("onboarding_run_id=run-123");
@@ -198,7 +212,7 @@ describe("startOAuthFlow", () => {
     mockGetWebAppURL.mockReturnValue("http://localhost:3001");
 
     const flowPromise = startOAuthFlow();
-    await new Promise((r) => setTimeout(r, 10));
+    await flowReady();
 
     expect(mockOpenDefault).toHaveBeenCalledOnce();
     const calledURL = mockOpenDefault.mock.calls[0]?.[0] as string;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         "**/index.ts", // barrel re-export files
         "src/index.ts", // CLI entry point
         ".context/*", // local agent scratch files
+        ".agent-contexts/**", // local agent scratch files (gitignored; stray .ts here would sink coverage)
         "bin/*", // generated npm bundle
         "scripts/*", // build scripts (spawn Bun)
         "vitest.config.ts", // config file


### PR DESCRIPTION
## What

Fixes the main-branch CI failure after #79 (run 27391027591). Two pre-existing `startOAuthFlow` tests raced a **fixed 10ms sleep** against the flow's async setup (`await import("open")`):

1. `includes extra auth URL params` — on a slow coverage-instrumented runner the sleep lost; the assertion read `mock.calls[0]` as `undefined` → *"the given combination of arguments (undefined and string) is invalid"*.
2. Its failure **leaked an unresolved flow**; that flow's 8-minute timeout was then created under the NEXT test's fake timers and never cleared → `clears the timeout timer` saw `getTimerCount() === 1`.

The same tree passed on the PR run and locally — a classic timing flake that surfaced on the main push.

## Fix

`flowReady()` replaces all six fixed sleeps: `vi.waitFor` until `open()` has been called, plus a macrotask barrier so the timeout/abort race is armed before the test acts (the abort test needs the listener registered). Condition-based waits cannot lose the race by construction, and no test can leak an unresolved flow when its premise assertion holds.

Also adds `.agent-contexts/**` to the coverage exclude list, mirroring the existing `.context/*` entry — it's a gitignored local agent scratch dir; a stray `.ts` file there sinks local coverage below thresholds (CI unaffected, the dir is never committed).

## Verification

- `src/auth/flow.test.ts` × 10 consecutive runs: all green
- Full suite with coverage: **1161 passed**, 95.3/90.5/98.1/95.3 (≥ 95/90/80/95), exit 0
- tsc + biome clean

## Note on the release

`test:` commits don't trigger semantic-release, but the pending `fix:` from #79 does — once this merges and main goes green, **0.18.1 publishes automatically** with the refresh self-healing fix.