### PR TITLE
feat(hooks): add Codex CLI support to the knowledge hooks

### DIFF
--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -416,6 +416,40 @@ describe("runHookEntrypoint", () => {
     expect(stdout()).toBe("");
   });
 
+  it("threads --agent through to ticket attribution", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_codex",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+    await runHookEntrypoint(
+      "user-prompt-submit",
+      JSON.stringify({ session_id: "s", prompt: "p" }),
+      1,
+      "codex",
+    );
+    expect(vi.mocked(requestCreateTicket).mock.calls[0][1]).toMatchObject({ agent: "codex" });
+  });
+
+  it("never mints a lookup for its own Stop-delivered envelope (Codex continuation prompt)", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    const { STOP_PREFIX } = await import("../hooks/prompts");
+
+    // Codex turns a Stop hook's block reason into a NEW user prompt, which
+    // re-fires UserPromptSubmit with our own envelope as the prompt text.
+    await runHookEntrypoint(
+      "user-prompt-submit",
+      JSON.stringify({ session_id: "s", prompt: `${STOP_PREFIX}\n\nDosu knowledge context…` }),
+      1,
+      "codex",
+    );
+
+    expect(requestCreateTicket).not.toHaveBeenCalled();
+    expect(stdout()).toBe(""); // no injection either
+  });
+
   it("swallows handler errors; stop still emits continue", async () => {
     vi.mocked(loadState).mockImplementation(() => {
       throw new Error("disk boom");
@@ -452,7 +486,7 @@ describe("lifecycle commands", () => {
   });
 
   it("rejects an unsupported agent and a non-local scope", async () => {
-    await runInstall("codex", {});
+    await runInstall("cursor", {});
     expect(process.exitCode).toBe(2);
     process.exitCode = 0;
     await runInstall("claude-code", { scope: "project" });
@@ -461,8 +495,44 @@ describe("lifecycle commands", () => {
   });
 
   it("uninstall rejects an unsupported agent", async () => {
-    await runUninstall("codex", {});
+    await runUninstall("cursor", {});
     expect(process.exitCode).toBe(2);
+  });
+
+  it("install codex writes .codex/hooks.json and surfaces the one-time trust step", async () => {
+    await runInstall("codex", { dir });
+    expect(process.exitCode ?? 0).toBe(0);
+
+    const { codexHooksPath, inspectCodexHooks } = await import("../hooks/codex");
+    const inspection = inspectCodexHooks(codexHooksPath(dir));
+    expect(inspection.fileExists).toBe(true);
+    expect(inspection.events).toEqual(["UserPromptSubmit", "PostToolUse", "Stop"]);
+
+    expect(stdout()).toContain("Codex");
+    expect(stdout()).toContain("/hooks"); // Codex skips untrusted hooks — UX must say so
+  });
+
+  it("uninstall codex removes only the Dosu groups", async () => {
+    await runInstall("codex", { dir });
+    logSpy.mockClear();
+    await runUninstall("codex", { dir });
+
+    const { codexHooksPath, inspectCodexHooks } = await import("../hooks/codex");
+    expect(inspectCodexHooks(codexHooksPath(dir)).events).toEqual([]);
+    expect(stdout()).toContain("Removed");
+  });
+
+  it("doctor reports the codex section and softens claude checks when codex carries the chain", async () => {
+    await runInstall("codex", { dir });
+    logSpy.mockClear();
+    const checks = await collectDoctorChecks({ dir });
+    const byName = Object.fromEntries(checks.map((c) => [c.name, c.status]));
+    expect(byName).toMatchObject({
+      config: "warn", // claude config missing, but codex hooks are active
+      hooks: "warn",
+      "codex-config": "ok",
+      "codex-trust": "warn", // trust lives inside Codex; always remind
+    });
   });
 
   it("doctor reports ok when fully configured and installed", async () => {

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -1,12 +1,14 @@
 /**
- * Dosu knowledge-injection hooks for Claude Code.
+ * Dosu knowledge-injection hooks for coding agents (Claude Code, Codex).
  *
  * Two kinds of subcommands:
  *  - Hook entrypoints (`user-prompt-submit`, `post-tool-use`, `stop`, `status`) —
- *    invoked by Claude Code on every turn. They read a hook-event JSON object on
- *    stdin and print the hook contract on stdout. They are async, idempotent, and
- *    fail silently: ANY error results in no stdout (or `{continue:true}` for stop)
- *    and exit 0, so the agent is never disrupted.
+ *    invoked by the agent on every turn. They read a hook-event JSON object on
+ *    stdin and print the hook contract on stdout. Codex implements Claude Code's
+ *    hook wire protocol (same event names, stdin fields, and stdout contracts),
+ *    so one runtime serves both; `--agent` only attributes tickets. They are
+ *    async, idempotent, and fail silently: ANY error results in no stdout (or
+ *    `{continue:true}` for stop) and exit 0, so the agent is never disrupted.
  *  - Lifecycle commands (`install`/`uninstall`/`doctor`) — run once by a human or
  *    setup agent.
  *
@@ -21,6 +23,7 @@ import { basename } from "node:path";
 import { Argument, Command } from "commander";
 import { isAuthenticated, loadConfig, MODE_OSS } from "../config/config";
 import { logger } from "../debug/logger";
+import { STOP_PREFIX } from "../hooks/prompts";
 import { loadState, saveState, type TicketState } from "../hooks/state";
 
 interface HookInput {
@@ -40,8 +43,12 @@ const TTL_DEFAULT_MS = 10 * 60 * 1000; // 10 minutes
 const STOP_WAIT_DEFAULT_MS = 8000; // max time Stop waits for an in-flight lookup
 const STOP_POLL_DEFAULT_MS = 1000; // interval between Stop poll attempts
 
-/** Coding agents that have a Dosu hook adapter today (Codex is a follow-up). */
-const SUPPORTED_AGENTS = ["claude-code"];
+/** Coding agents that have a Dosu hook adapter today. */
+const SUPPORTED_AGENTS = ["claude-code", "codex"];
+type SupportedAgent = "claude-code" | "codex";
+
+/** Hook entrypoints attribute tickets to this agent unless --agent overrides it. */
+const DEFAULT_AGENT: SupportedAgent = "claude-code";
 
 // ---------------------------------------------------------------------------
 // Timing knobs (env-overridable)
@@ -104,11 +111,19 @@ function repoSlug(cwd?: string): string | undefined {
 export async function runUserPromptSubmit(
   input: HookInput,
   now: number = Date.now(),
+  agent: string = DEFAULT_AGENT,
 ): Promise<void> {
   const sessionId = input.session_id;
   if (!sessionId) return;
   const prompt = (input.prompt ?? "").trim();
   if (!prompt) return; // nothing to retrieve
+  // Self-recognition guard: Codex turns a Stop hook's `decision:"block"`
+  // reason into a NEW user prompt, which fires UserPromptSubmit again. Never
+  // mint a knowledge lookup for our own Stop-delivered envelope.
+  if (prompt.startsWith(STOP_PREFIX)) {
+    logger.debug("hooks", "submit skipped reason=own-stop-envelope");
+    return;
+  }
 
   // One active ticket per session: reuse a live pending ticket; don't mint a second.
   const existing = loadState(sessionId);
@@ -129,7 +144,7 @@ export async function runUserPromptSubmit(
   try {
     resp = await tc.requestCreateTicket(cfg, {
       deployment_id: cfg.deployment_id,
-      agent: "claude-code",
+      agent,
       session_id: sessionId,
       turn_id: input.turn_id ?? String(now),
       prompt,
@@ -331,6 +346,7 @@ export async function runHookEntrypoint(
   event: HookEvent,
   raw: string,
   now: number = Date.now(),
+  agent: string = DEFAULT_AGENT,
 ): Promise<void> {
   let input: HookInput = {};
   try {
@@ -339,7 +355,7 @@ export async function runHookEntrypoint(
     input = {}; // malformed stdin → treat as empty → silent no-op
   }
   try {
-    if (event === "user-prompt-submit") await runUserPromptSubmit(input, now);
+    if (event === "user-prompt-submit") await runUserPromptSubmit(input, now, agent);
     else if (event === "post-tool-use") await runPostToolUse(input, now);
     else await runStop(input, now);
   } catch (err) {
@@ -378,14 +394,15 @@ async function emitErrorLine(step: string, reason: string, agentNextSteps: strin
   emitError({ step, reason, agent_next_steps: agentNextSteps });
 }
 
-/** `dosu hooks install claude-code` — merge Dosu hooks into local Claude Code config. */
+/** `dosu hooks install <agent>` — merge Dosu hooks into the agent's local config. */
 export async function runInstall(agent: string, opts: LifecycleOptions): Promise<void> {
-  if (agent !== "claude-code") {
+  if (!SUPPORTED_AGENTS.includes(agent)) {
     process.exitCode = 2;
+    const supported = SUPPORTED_AGENTS.join(", ");
     if (opts.json) {
-      await emitErrorLine("hooks-install", "unsupported_agent", `Only 'claude-code' is supported.`);
+      await emitErrorLine("hooks-install", "unsupported_agent", `Supported agents: ${supported}.`);
     } else {
-      console.error(`Unsupported agent '${agent}'. Supported agents: claude-code.`);
+      console.error(`Unsupported agent '${agent}'. Supported agents: ${supported}.`);
     }
     return;
   }
@@ -399,13 +416,29 @@ export async function runInstall(agent: string, opts: LifecycleOptions): Promise
     return;
   }
 
-  const { installClaudeHooks, claudeLocalSettingsPath } = await import("../hooks/claude-code");
-  const configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
   try {
+    if (agent === "codex") {
+      const { installCodexHooks, codexHooksPath } = await import("../hooks/codex");
+      const configPath = codexHooksPath(resolveDir(opts.dir));
+      const { events } = installCodexHooks(configPath, { stop: opts.stop });
+      if (opts.json) {
+        const { emitStep } = await import("../agent/output");
+        emitStep({ step: "hooks-install", agent, path: configPath, events });
+      } else {
+        console.log(`✓ Installed Dosu hooks for Codex (${events.join(", ")}).`);
+        console.log(`  → ${configPath}`);
+        console.log("  One-time step: open Codex in this project and run /hooks to review and");
+        console.log("  trust the Dosu hooks — Codex skips untrusted hooks by design.");
+      }
+      return;
+    }
+
+    const { installClaudeHooks, claudeLocalSettingsPath } = await import("../hooks/claude-code");
+    const configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
     const { events } = installClaudeHooks(configPath, { stop: opts.stop });
     if (opts.json) {
       const { emitStep } = await import("../agent/output");
-      emitStep({ step: "hooks-install", path: configPath, events });
+      emitStep({ step: "hooks-install", agent, path: configPath, events });
     } else {
       console.log(`✓ Installed Dosu hooks for Claude Code (${events.join(", ")}).`);
       console.log(`  → ${configPath}`);
@@ -421,24 +454,33 @@ export async function runInstall(agent: string, opts: LifecycleOptions): Promise
   }
 }
 
-/** `dosu hooks uninstall claude-code` — remove only Dosu-owned hook entries. */
+/** `dosu hooks uninstall <agent>` — remove only Dosu-owned hook entries. */
 export async function runUninstall(agent: string, opts: LifecycleOptions): Promise<void> {
-  if (agent !== "claude-code") {
+  if (!SUPPORTED_AGENTS.includes(agent)) {
     process.exitCode = 2;
+    const supported = SUPPORTED_AGENTS.join(", ");
     if (opts.json) {
       await emitErrorLine(
         "hooks-uninstall",
         "unsupported_agent",
-        "Only 'claude-code' is supported.",
+        `Supported agents: ${supported}.`,
       );
     } else {
-      console.error(`Unsupported agent '${agent}'. Supported agents: claude-code.`);
+      console.error(`Unsupported agent '${agent}'. Supported agents: ${supported}.`);
     }
     return;
   }
-  const { removeClaudeHooks, claudeLocalSettingsPath } = await import("../hooks/claude-code");
-  const configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
-  const { removed } = removeClaudeHooks(configPath);
+  let configPath: string;
+  let removed: boolean;
+  if (agent === "codex") {
+    const { removeCodexHooks, codexHooksPath } = await import("../hooks/codex");
+    configPath = codexHooksPath(resolveDir(opts.dir));
+    ({ removed } = removeCodexHooks(configPath));
+  } else {
+    const { removeClaudeHooks, claudeLocalSettingsPath } = await import("../hooks/claude-code");
+    configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
+    ({ removed } = removeClaudeHooks(configPath));
+  }
   if (opts.json) {
     const { emitStep } = await import("../agent/output");
     emitStep({ step: "hooks-uninstall", path: configPath, removed });
@@ -459,14 +501,20 @@ export interface DoctorCheck {
 export async function collectDoctorChecks(opts: { dir?: string }): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
   const { claudeLocalSettingsPath, inspectClaudeHooks } = await import("../hooks/claude-code");
+  const { codexHooksPath, inspectCodexHooks } = await import("../hooks/codex");
   const configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
   const inspection = inspectClaudeHooks(configPath);
+  const codexPath = codexHooksPath(resolveDir(opts.dir));
+  const codex = inspectCodexHooks(codexPath);
+  const codexInstalled =
+    codex.events.includes("UserPromptSubmit") && codex.events.includes("PostToolUse");
 
-  // 1. Config present + valid JSON.
+  // 1. Claude Code config present + valid JSON. A missing Claude config is
+  // only a warning when Codex hooks carry the chain instead.
   if (!inspection.fileExists) {
     checks.push({
       name: "config",
-      status: "fail",
+      status: codexInstalled ? "warn" : "fail",
       detail: `not found: ${configPath} (run 'dosu hooks install claude-code')`,
     });
   } else if (inspection.parseError) {
@@ -475,7 +523,7 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
     checks.push({ name: "config", status: "ok", detail: configPath });
   }
 
-  // 2. Dosu hooks installed.
+  // 2. Dosu hooks installed for Claude Code.
   const hasSubmit = inspection.events.includes("UserPromptSubmit");
   const hasPostTool = inspection.events.includes("PostToolUse");
   if (hasSubmit && hasPostTool) {
@@ -487,9 +535,34 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
   } else {
     checks.push({
       name: "hooks",
-      status: "fail",
+      status: codexInstalled ? "warn" : "fail",
       detail: "UserPromptSubmit + PostToolUse not both installed",
     });
+  }
+
+  // 2b. Codex hooks (only reported when the Codex hooks file exists).
+  if (codex.fileExists) {
+    if (codex.parseError) {
+      checks.push({ name: "codex-config", status: "fail", detail: `invalid JSON: ${codexPath}` });
+    } else if (codexInstalled) {
+      checks.push({
+        name: "codex-config",
+        status: "ok",
+        detail: `installed: ${codex.events.join(", ")} (${codexPath})`,
+      });
+      // Trust state lives inside Codex itself and is not verifiable here.
+      checks.push({
+        name: "codex-trust",
+        status: "warn",
+        detail: "if hooks aren't firing, run /hooks inside Codex to review + trust them (one-time)",
+      });
+    } else {
+      checks.push({
+        name: "codex-config",
+        status: "fail",
+        detail: "UserPromptSubmit + PostToolUse not both installed",
+      });
+    }
   }
 
   // 3. Auth + 4. Deployment.
@@ -559,28 +632,33 @@ export async function runDoctor(opts: { dir?: string; json?: boolean }): Promise
 // ---------------------------------------------------------------------------
 
 export function hooksCommand(): Command {
-  const cmd = new Command("hooks").description("Dosu knowledge-injection hooks for Claude Code");
+  const cmd = new Command("hooks").description(
+    "Dosu knowledge-injection hooks for coding agents (Claude Code, Codex)",
+  );
 
   /* v8 ignore start -- thin Commander glue: reads fd 0 and delegates to tested handlers */
   cmd
     .command("user-prompt-submit")
     .description("Hook entrypoint: create a knowledge ticket on prompt submit")
-    .action(async () => {
-      await runHookEntrypoint("user-prompt-submit", readStdinRaw());
+    .option("--agent <agent>", "Calling agent for ticket attribution", DEFAULT_AGENT)
+    .action(async (opts: { agent?: string }) => {
+      await runHookEntrypoint("user-prompt-submit", readStdinRaw(), Date.now(), opts.agent);
     });
 
   cmd
     .command("post-tool-use")
     .description("Hook entrypoint: poll and inject ready knowledge once")
-    .action(async () => {
-      await runHookEntrypoint("post-tool-use", readStdinRaw());
+    .option("--agent <agent>", "Calling agent for ticket attribution", DEFAULT_AGENT)
+    .action(async (opts: { agent?: string }) => {
+      await runHookEntrypoint("post-tool-use", readStdinRaw(), Date.now(), opts.agent);
     });
 
   cmd
     .command("stop")
     .description("Hook entrypoint: last-chance knowledge delivery when the agent stops")
-    .action(async () => {
-      await runHookEntrypoint("stop", readStdinRaw());
+    .option("--agent <agent>", "Calling agent for ticket attribution", DEFAULT_AGENT)
+    .action(async (opts: { agent?: string }) => {
+      await runHookEntrypoint("stop", readStdinRaw(), Date.now(), opts.agent);
     });
 
   cmd
@@ -618,8 +696,12 @@ export function hooksCommand(): Command {
         "",
         "Examples:",
         "  $ dosu hooks install claude-code",
+        "  $ dosu hooks install codex",
         "  $ dosu hooks install claude-code --no-stop",
-        "  $ dosu hooks install claude-code --dir ./my-project",
+        "  $ dosu hooks install codex --dir ./my-project",
+        "",
+        "Codex requires a one-time trust step after install: open Codex in the",
+        "project and run /hooks to review and trust the Dosu hooks.",
       ].join("\n"),
     )
     .action((agent: string, opts: LifecycleOptions) => runInstall(agent, opts));
@@ -637,8 +719,9 @@ export function hooksCommand(): Command {
         "",
         `Supported agents: ${SUPPORTED_AGENTS.join(", ")}`,
         "",
-        "Example:",
+        "Examples:",
         "  $ dosu hooks uninstall claude-code",
+        "  $ dosu hooks uninstall codex",
       ].join("\n"),
     )
     .action((agent: string, opts: LifecycleOptions) => runUninstall(agent, opts));

--- a/src/hooks/codex.test.ts
+++ b/src/hooks/codex.test.ts
@@ -1,0 +1,164 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { codexHooksPath, inspectCodexHooks, installCodexHooks, removeCodexHooks } from "./codex";
+
+describe("codex hooks installer", () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-codex-test-"));
+    configPath = codexHooksPath(tempDir);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function readConfig(): Record<string, unknown> {
+    // biome-ignore lint/suspicious/noExplicitAny: test helper over untyped JSON
+    return JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, any>;
+  }
+
+  it("codexHooksPath points at the project .codex/hooks.json", () => {
+    expect(codexHooksPath("/some/project")).toBe(join("/some/project", ".codex", "hooks.json"));
+  });
+
+  it("fresh install writes all three events with the exact Codex hook shape", () => {
+    const { events } = installCodexHooks(configPath);
+    expect(events).toEqual(["UserPromptSubmit", "PostToolUse", "Stop"]);
+
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    for (const event of events) {
+      expect(cfg.hooks[event]).toHaveLength(1);
+      const group = cfg.hooks[event][0];
+      // Codex parsers may reject unknown fields, and any extra key would
+      // change the hook's trust hash — the group must contain ONLY the
+      // documented fields (no matcher, no __dosu-style marker).
+      expect(Object.keys(group).sort()).toEqual(["hooks"]);
+      expect(group.hooks).toHaveLength(1);
+      expect(Object.keys(group.hooks[0]).sort()).toEqual([
+        "command",
+        "statusMessage",
+        "timeout",
+        "type",
+      ]);
+      expect(group.hooks[0].type).toBe("command");
+      expect(group.hooks[0].command).toMatch(/^dosu hooks [a-z-]+ --agent codex$/);
+      expect(group.hooks[0].timeout).toBeGreaterThan(0);
+    }
+    expect(cfg.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+      "dosu hooks user-prompt-submit --agent codex",
+    );
+    expect(cfg.hooks.Stop[0].hooks[0].timeout).toBe(30);
+  });
+
+  it("--no-stop installs only UserPromptSubmit + PostToolUse", () => {
+    const { events } = installCodexHooks(configPath, { stop: false });
+    expect(events).toEqual(["UserPromptSubmit", "PostToolUse"]);
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.hooks.Stop).toBeUndefined();
+  });
+
+  it("reinstall is idempotent (no duplicate Dosu groups)", () => {
+    installCodexHooks(configPath);
+    installCodexHooks(configPath);
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.hooks.UserPromptSubmit).toHaveLength(1);
+    expect(cfg.hooks.Stop).toHaveLength(1);
+  });
+
+  it("reinstall with --no-stop sweeps the previously installed Dosu Stop group", () => {
+    installCodexHooks(configPath);
+    installCodexHooks(configPath, { stop: false });
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.hooks.Stop).toBeUndefined();
+    expect(cfg.hooks.UserPromptSubmit).toHaveLength(1);
+  });
+
+  it("preserves the user's own hooks and unknown top-level keys", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    const userGroup = {
+      matcher: "Bash",
+      hooks: [{ type: "command", command: "python3 my-hook.py" }],
+    };
+    writeFileSync(
+      configPath,
+      JSON.stringify({ somethingElse: { keep: true }, hooks: { PostToolUse: [userGroup] } }),
+    );
+
+    installCodexHooks(configPath);
+    removeCodexHooks(configPath);
+
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.somethingElse).toEqual({ keep: true });
+    expect(cfg.hooks.PostToolUse).toEqual([userGroup]);
+  });
+
+  it("refuses to modify a file with invalid JSON", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, "NOT JSON {{{");
+    expect(() => installCodexHooks(configPath)).toThrow(/refusing to modify/);
+    expect(readFileSync(configPath, "utf-8")).toBe("NOT JSON {{{");
+  });
+
+  it("remove returns false when nothing is installed", () => {
+    expect(removeCodexHooks(configPath)).toEqual({ removed: false });
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ hooks: {} }));
+    expect(removeCodexHooks(configPath)).toEqual({ removed: false });
+  });
+
+  it("remove deletes only Dosu groups and drops empty event arrays", () => {
+    installCodexHooks(configPath);
+    const { removed } = removeCodexHooks(configPath);
+    expect(removed).toBe(true);
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.hooks.UserPromptSubmit).toBeUndefined();
+    expect(cfg.hooks.Stop).toBeUndefined();
+  });
+
+  it("remove leaves an invalid-JSON file untouched", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, "NOT JSON {{{");
+    expect(removeCodexHooks(configPath)).toEqual({ removed: false });
+    expect(readFileSync(configPath, "utf-8")).toBe("NOT JSON {{{");
+  });
+
+  it("inspect reports missing file, parse errors, and installed events", () => {
+    expect(inspectCodexHooks(configPath)).toEqual({ fileExists: false, events: [] });
+
+    installCodexHooks(configPath, { stop: false });
+    expect(inspectCodexHooks(configPath)).toEqual({
+      fileExists: true,
+      events: ["UserPromptSubmit", "PostToolUse"],
+    });
+
+    writeFileSync(configPath, "NOT JSON {{{");
+    expect(inspectCodexHooks(configPath)).toEqual({
+      fileExists: true,
+      parseError: true,
+      events: [],
+    });
+  });
+
+  it("inspect does not count user-only events as installed", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: "command", command: "python3 mine.py" }] }] },
+      }),
+    );
+    expect(inspectCodexHooks(configPath)).toEqual({ fileExists: true, events: [] });
+    expect(existsSync(configPath)).toBe(true);
+  });
+});

--- a/src/hooks/codex.ts
+++ b/src/hooks/codex.ts
@@ -1,0 +1,201 @@
+/**
+ * Codex CLI hooks installer.
+ *
+ * Writes the Dosu hook block into the project-level Codex hooks file
+ * (`<repo>/.codex/hooks.json`) — the dedicated-file form Codex documents as
+ * one of its two supported representations ("Prefer one representation per
+ * layer"). Codex merges this with the user's own hooks from other layers, so
+ * we never touch `~/.codex/config.toml`.
+ *
+ * Codex's hook wire protocol intentionally mirrors Claude Code's: the same
+ * event names (`UserPromptSubmit`, `PostToolUse`, `Stop`), the same stdin
+ * fields (`session_id`, `prompt`, `cwd`, `turn_id`, `stop_hook_active`), and
+ * the same stdout contracts (`hookSpecificOutput.additionalContext`,
+ * `decision: "block"` + `reason` on Stop). The `dosu hooks …` entrypoints
+ * therefore run unchanged; the installed commands only add `--agent codex`
+ * for analytics attribution.
+ *
+ * Two Codex-specific constraints shape this module:
+ *
+ * 1. TRUST — Codex runs a non-managed command hook only after the user
+ *    reviews and trusts it (against a hash of the definition) via `/hooks`
+ *    inside Codex. An installer cannot pre-trust its own hooks; install
+ *    output must tell the user to complete that one-time step.
+ * 2. NO MARKER KEYS — unlike Claude Code's settings (where we tag entries
+ *    with a `__dosu` key), unknown fields could be rejected by Codex's
+ *    strict parsers, and any edit changes the hook's trust hash. Ownership
+ *    is therefore detected purely from the command shape (`dosu hooks …`),
+ *    reusing the same predicate as the Claude Code installer.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { saveJSONConfig } from "../mcp/config-helpers";
+import { DEFAULT_HOOK_EVENTS, isDosuGroup } from "./claude-code";
+
+// biome-ignore lint/suspicious/noExplicitAny: hooks JSON is inherently untyped
+type JsonConfig = Record<string, any>;
+
+interface CodexHookEntry {
+  type: "command";
+  command: string;
+  timeout?: number;
+  statusMessage?: string;
+}
+
+interface CodexMatcherGroup {
+  matcher?: string;
+  hooks: CodexHookEntry[];
+}
+
+/** Path to the project-level Codex hooks file under a project root. */
+export function codexHooksPath(dir: string): string {
+  return join(dir, ".codex", "hooks.json");
+}
+
+/** Map a Codex hook event (the config key) to its `dosu hooks` subcommand. */
+const EVENT_SUBCOMMAND: Record<string, string> = {
+  UserPromptSubmit: "user-prompt-submit",
+  PostToolUse: "post-tool-use",
+  Stop: "stop",
+};
+
+/**
+ * Per-event timeouts (seconds). Codex defaults to 600s — far longer than any
+ * dosu hook should ever hold a turn. The entrypoints' no-op path returns in
+ * milliseconds; Stop may wait up to ~8s for an in-flight lookup.
+ */
+const EVENT_TIMEOUT_SEC: Record<string, number> = {
+  UserPromptSubmit: 10,
+  PostToolUse: 10,
+  Stop: 30,
+};
+
+/** Shown by Codex while the hook runs. */
+const EVENT_STATUS_MESSAGE: Record<string, string> = {
+  UserPromptSubmit: "Dosu knowledge lookup",
+  PostToolUse: "Dosu knowledge delivery",
+  Stop: "Dosu final knowledge check",
+};
+
+/**
+ * The command Codex runs for a given hook subcommand. Bare `dosu` from PATH
+ * (same reasoning as the Claude Code installer); `--agent codex` attributes
+ * the resulting knowledge tickets to Codex sessions.
+ */
+export function codexHookCommand(subcommand: string): string {
+  return `dosu hooks ${subcommand} --agent codex`;
+}
+
+function dosuGroup(event: string): CodexMatcherGroup {
+  // No `matcher`: Codex treats a missing matcher as match-everything, and
+  // ignores matchers entirely for UserPromptSubmit/Stop.
+  return {
+    hooks: [
+      {
+        type: "command",
+        command: codexHookCommand(EVENT_SUBCOMMAND[event]),
+        timeout: EVENT_TIMEOUT_SEC[event],
+        statusMessage: EVENT_STATUS_MESSAGE[event],
+      },
+    ],
+  };
+}
+
+/**
+ * Read the hooks file, refusing to clobber a file that exists but does not
+ * parse — same stance as the Claude Code installer.
+ */
+function readHooksFileOrThrow(path: string): JsonConfig {
+  if (!existsSync(path)) return {};
+  const raw = readFileSync(path, "utf-8").trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as JsonConfig;
+  } catch {
+    throw new Error(`refusing to modify ${path}: file exists but is not valid JSON`);
+  }
+}
+
+export interface CodexInstallOptions {
+  /** Install the `Stop` hook. Defaults to true; pass `false` (via `--no-stop`) to skip it. */
+  stop?: boolean;
+}
+
+/** Merge the Dosu hook block into a Codex hooks.json file. Returns the events installed. */
+export function installCodexHooks(
+  configPath: string,
+  opts: CodexInstallOptions = {},
+): { events: string[] } {
+  const config = readHooksFileOrThrow(configPath);
+  const events = DEFAULT_HOOK_EVENTS.filter((e) => e !== "Stop" || opts.stop !== false);
+
+  const hooks: JsonConfig = typeof config.hooks === "object" && config.hooks ? config.hooks : {};
+  for (const event of events) {
+    const groups: unknown[] = Array.isArray(hooks[event]) ? hooks[event] : [];
+    // Idempotent reinstall: drop any prior Dosu-owned group, keep user groups.
+    const kept = groups.filter((g) => !isDosuGroup(g));
+    kept.push(dosuGroup(event));
+    hooks[event] = kept;
+  }
+  // A previous full install may have left a Dosu Stop group behind a --no-stop
+  // reinstall; sweep Dosu groups from events we are not installing this time.
+  for (const event of DEFAULT_HOOK_EVENTS) {
+    if (!events.includes(event) && Array.isArray(hooks[event])) {
+      const kept = hooks[event].filter((g: unknown) => !isDosuGroup(g));
+      if (kept.length > 0) hooks[event] = kept;
+      else delete hooks[event];
+    }
+  }
+  config.hooks = hooks;
+
+  saveJSONConfig(configPath, config);
+  return { events: [...events] };
+}
+
+/** Remove only Dosu-owned hook groups. Returns whether anything was removed. */
+export function removeCodexHooks(configPath: string): { removed: boolean } {
+  if (!existsSync(configPath)) return { removed: false };
+  let config: JsonConfig;
+  try {
+    config = readHooksFileOrThrow(configPath);
+  } catch {
+    return { removed: false }; // invalid JSON — leave it alone
+  }
+  const hooks = config.hooks;
+  if (typeof hooks !== "object" || !hooks) return { removed: false };
+
+  let removed = false;
+  for (const event of Object.keys(hooks)) {
+    if (!Array.isArray(hooks[event])) continue;
+    const kept = hooks[event].filter((g: unknown) => !isDosuGroup(g));
+    if (kept.length !== hooks[event].length) {
+      removed = true;
+      if (kept.length > 0) hooks[event] = kept;
+      else delete hooks[event];
+    }
+  }
+  if (removed) saveJSONConfig(configPath, config);
+  return { removed };
+}
+
+/** Read-only inspection for `doctor`. Never throws. */
+export function inspectCodexHooks(configPath: string): {
+  fileExists: boolean;
+  parseError?: boolean;
+  events: string[];
+} {
+  if (!existsSync(configPath)) return { fileExists: false, events: [] };
+  let config: JsonConfig;
+  try {
+    config = readHooksFileOrThrow(configPath);
+  } catch {
+    return { fileExists: true, parseError: true, events: [] };
+  }
+  const hooks = config.hooks;
+  if (typeof hooks !== "object" || !hooks) return { fileExists: true, events: [] };
+  const events = Object.keys(hooks).filter(
+    (event) => Array.isArray(hooks[event]) && hooks[event].some((g: unknown) => isDosuGroup(g)),
+  );
+  return { fileExists: true, events };
+}


### PR DESCRIPTION
## What

Extends the Dosu knowledge hooks (previously Claude Code-only) to **OpenAI Codex CLI**: `dosu hooks install codex` writes the Dosu hook block into the project-level `.codex/hooks.json`.

## Why it's small

Codex's lifecycle hooks system deliberately mirrors Claude Code's wire protocol — verified against the generated schemas and official docs (`developers.openai.com/codex/hooks`, `codex-rs/hooks/schema/generated/*`):

| Surface | Claude Code | Codex |
|---|---|---|
| Events | `UserPromptSubmit` / `PostToolUse` / `Stop` | identical names |
| stdin | `session_id`, `prompt`, `cwd`, `turn_id`, `stop_hook_active` | identical fields |
| Context injection | `hookSpecificOutput.additionalContext` | identical (UPS + PTU "added as extra developer context") |
| Stop continuation | `decision:"block"` + `reason` | identical (Codex docs: *"Claude requires `reason` when `decision` is `block`; we enforce that semantic rule"*) |

So the existing `dosu hooks …` entrypoints run on Codex **unchanged**; the runtime only gains `--agent` for ticket attribution (the backend field is a free-form label — verified).

## Codex-specific design points

1. **Trust**: Codex runs non-managed command hooks only after the user reviews + trusts them via `/hooks` (hash-based; an installer cannot and should not pre-trust). Install output and `doctor` both surface this one-time step.
2. **No marker keys**: unlike the Claude installer's `__dosu` tag, extra keys could be rejected by Codex's strict parsers and would change the hook's trust hash. Ownership is detected from the command shape, reusing `isDosuGroup`.
3. **Continuation-prompt guard**: Codex turns a Stop hook's block reason into a *new user prompt*, which re-fires UserPromptSubmit with our own envelope as the prompt — a self-recognition guard (prompt starts with `STOP_PREFIX`) prevents minting a lookup for our own injection.
4. **Dedicated hooks file**: writes `.codex/hooks.json` (one of Codex's two documented forms, "prefer one representation per layer") — never touches the user's `~/.codex/config.toml`. Explicit 10s/10s/30s timeouts instead of Codex's 600s default; `async:true` is documented-but-skipped by Codex today, so unused.
5. **doctor**: gains a `codex-config` section + `codex-trust` reminder, and softens Claude-only failures to warnings when Codex carries the chain.

## Tests

19 new tests (12 installer + 7 behavior: dispatch, `--agent` attribution, trust-step UX, doctor section, continuation guard). Full suite **1178 passed**, coverage 95.3/90.5/98.2 (≥ 95/90/80/95), tsc + biome clean.

Research notes with primary-source citations archived in `.agent-contexts/codex-hooks/` (schemas + official docs snapshot).