### PR TITLE
fix: bake the rotated Supabase publishable key into production builds

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,4 +2,4 @@ DOSU_DEV=false
 DOSU_WEB_APP_URL=https://app.dosu.dev
 DOSU_BACKEND_URL=https://api.dosu.dev
 SUPABASE_URL=https://wldmetsoicvieidlsqrb.supabase.co
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndsbG1ldHNvaWN2aWVpZGxzcXJiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzQ0NjA1NjUsImV4cCI6MjA1MDAzNjU2NX0.15LIxqSMVRnxsvLrk0GPjL1aSYPfOeaeFMdJXqgc5Xs
+SUPABASE_ANON_KEY=sb_publishable_NePQHMbqqlFOp1aaHbp5Bg_zyA-kYd6


### PR DESCRIPTION
### What

Production Supabase migrated to the new API keys overnight and the legacy anon key was disabled. The anon key is **baked into every published CLI bundle at build time** (`.env.production` → `bun build --define`), so every deployed build's token refresh started failing with `401 Invalid API key` — shown to users as the misleading *"Token expired. Run 'dosu login'"*.

Login kept "working" (session minting happens server-side with the backend's own, deploy-time-fresh key), which made this look supernatural: re-login succeeds, then dies again within the hour at the first CLI-side refresh.

### Evidence

- The dead session was a never-used generation-0 refresh token — reuse detection impossible; replaying the refresh with the baked key from the installed 0.18.1 bundle → `401 {"message":"Invalid API key"}`
- Same refresh with the new `sb_publishable_…` key → 200, session alive the whole time

### Verification

- Bundle built from this commit contains the new key (1×) and the legacy key 0×
- `node bin/dosu.js status` with no overrides against a real production session → `Status: Logged in`

`sb_publishable_*` is public by design (already shipped to every browser by the web app) — committing it mirrors the legacy anon key before it.

### Follow-ups (separate)

- Distinguish `Invalid API key` from genuine session expiry in `ensureFreshSession` messaging ("CLI build outdated — update @dosu/cli")
- Ops note: rotating Supabase keys requires a same-day CLI release — the bake-time coupling is documented in CLAUDE.md but needs a line in the rotation playbook
- Confirm the backend's `SUPABASE_API_KEY` env was also rotated to `sb_secret_*` (otherwise the next `dosu login` mint will 502)