### PR TITLE
fix: Target supported agents for skill install

### DIFF
--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -72,9 +72,24 @@ afterEach(() => {
 describe("skill install", () => {
   it("runs npx skills add with correct args", async () => {
     await run("install");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills add dosu-ai/dosu-skill -g -s dosu -y", {
-      stdio: "inherit",
-    });
+    expect(mockExecSync).toHaveBeenCalledWith(
+      [
+        "npx skills add dosu-ai/dosu-skill -g",
+        "-a claude-code -a cursor -a gemini-cli -a codex -a windsurf",
+        "-a zed -a cline -a github-copilot -a opencode -a antigravity",
+        "-s dosu -y",
+      ].join(" "),
+      {
+        stdio: "inherit",
+      },
+    );
+  });
+
+  it("does not let skills auto-target PromptScript", async () => {
+    await run("install");
+    const command = String(mockExecSync.mock.calls[0][0]);
+    expect(command).toContain("-a claude-code");
+    expect(command).not.toContain("promptscript");
   });
 
   it("prints success message", async () => {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -14,6 +14,22 @@ import {
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
 const SKILL_NAME = "dosu";
+const SUPPORTED_SKILL_AGENTS = [
+  "claude-code",
+  "cursor",
+  "gemini-cli",
+  "codex",
+  "windsurf",
+  "zed",
+  "cline",
+  "github-copilot",
+  "opencode",
+  "antigravity",
+];
+
+function supportedSkillAgentArgs(): string {
+  return SUPPORTED_SKILL_AGENTS.map((agent) => `-a ${agent}`).join(" ");
+}
 
 /**
  * Install the Dosu skill via `npx skills`. After a successful install we try
@@ -24,7 +40,7 @@ const SKILL_NAME = "dosu";
  */
 export async function installSkill(): Promise<{ success: boolean; sha?: string }> {
   try {
-    execSync(`npx skills add ${SKILL_REPO} -g -s ${SKILL_NAME} -y`, {
+    execSync(`npx skills add ${SKILL_REPO} -g ${supportedSkillAgentArgs()} -s ${SKILL_NAME} -y`, {
       stdio: "inherit",
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Limit Dosu skill install to explicitly supported agent targets.
- Add coverage to prevent PromptScript from being auto-targeted.

## Tests
- `bunx vitest run src/commands/skill.test.ts`
- `bun run typecheck`
- `bun run check`
- Isolated `HOME` smoke test with `npx skills add ... -g -a <supported-agent> ... -s dosu -y`
