### PR TITLE
feat: add Factory coding agent support (MCP + hooks)

### DIFF
--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -535,6 +535,40 @@ describe("lifecycle commands", () => {
     });
   });
 
+  it("install factory writes .factory/hooks.json", async () => {
+    await runInstall("factory", { dir });
+    expect(process.exitCode ?? 0).toBe(0);
+
+    const { factoryHooksPath, inspectFactoryHooks } = await import("../hooks/factory");
+    const inspection = inspectFactoryHooks(factoryHooksPath(dir));
+    expect(inspection.fileExists).toBe(true);
+    expect(inspection.events).toEqual(["UserPromptSubmit", "PostToolUse", "Stop"]);
+
+    expect(stdout()).toContain("Factory");
+  });
+
+  it("uninstall factory removes only the Dosu groups", async () => {
+    await runInstall("factory", { dir });
+    logSpy.mockClear();
+    await runUninstall("factory", { dir });
+
+    const { factoryHooksPath, inspectFactoryHooks } = await import("../hooks/factory");
+    expect(inspectFactoryHooks(factoryHooksPath(dir)).events).toEqual([]);
+    expect(stdout()).toContain("Removed");
+  });
+
+  it("doctor reports the factory section and softens claude checks when factory carries the chain", async () => {
+    await runInstall("factory", { dir });
+    logSpy.mockClear();
+    const checks = await collectDoctorChecks({ dir });
+    const byName = Object.fromEntries(checks.map((c) => [c.name, c.status]));
+    expect(byName).toMatchObject({
+      config: "warn", // claude config missing, but factory hooks are active
+      hooks: "warn",
+      "factory-config": "ok",
+    });
+  });
+
   it("doctor reports ok when fully configured and installed", async () => {
     await runInstall("claude-code", { dir });
     logSpy.mockClear();

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -1,5 +1,5 @@
 /**
- * Dosu knowledge-injection hooks for coding agents (Claude Code, Codex).
+ * Dosu knowledge-injection hooks for coding agents (Claude Code, Codex, Factory).
  *
  * Two kinds of subcommands:
  *  - Hook entrypoints (`user-prompt-submit`, `post-tool-use`, `stop`, `status`) —
@@ -44,8 +44,8 @@ const STOP_WAIT_DEFAULT_MS = 8000; // max time Stop waits for an in-flight looku
 const STOP_POLL_DEFAULT_MS = 1000; // interval between Stop poll attempts
 
 /** Coding agents that have a Dosu hook adapter today. */
-const SUPPORTED_AGENTS = ["claude-code", "codex"];
-type SupportedAgent = "claude-code" | "codex";
+const SUPPORTED_AGENTS = ["claude-code", "codex", "factory"];
+type SupportedAgent = "claude-code" | "codex" | "factory";
 
 /** Hook entrypoints attribute tickets to this agent unless --agent overrides it. */
 const DEFAULT_AGENT: SupportedAgent = "claude-code";
@@ -433,6 +433,21 @@ export async function runInstall(agent: string, opts: LifecycleOptions): Promise
       return;
     }
 
+    if (agent === "factory") {
+      const { installFactoryHooks, factoryHooksPath } = await import("../hooks/factory");
+      const configPath = factoryHooksPath(resolveDir(opts.dir));
+      const { events } = installFactoryHooks(configPath, { stop: opts.stop });
+      if (opts.json) {
+        const { emitStep } = await import("../agent/output");
+        emitStep({ step: "hooks-install", agent, path: configPath, events });
+      } else {
+        console.log(`✓ Installed Dosu hooks for Factory (${events.join(", ")}).`);
+        console.log(`  → ${configPath}`);
+        console.log("  Start a new Factory session in this project to use them.");
+      }
+      return;
+    }
+
     const { installClaudeHooks, claudeLocalSettingsPath } = await import("../hooks/claude-code");
     const configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
     const { events } = installClaudeHooks(configPath, { stop: opts.stop });
@@ -476,6 +491,10 @@ export async function runUninstall(agent: string, opts: LifecycleOptions): Promi
     const { removeCodexHooks, codexHooksPath } = await import("../hooks/codex");
     configPath = codexHooksPath(resolveDir(opts.dir));
     ({ removed } = removeCodexHooks(configPath));
+  } else if (agent === "factory") {
+    const { removeFactoryHooks, factoryHooksPath } = await import("../hooks/factory");
+    configPath = factoryHooksPath(resolveDir(opts.dir));
+    ({ removed } = removeFactoryHooks(configPath));
   } else {
     const { removeClaudeHooks, claudeLocalSettingsPath } = await import("../hooks/claude-code");
     configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
@@ -502,19 +521,26 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
   const checks: DoctorCheck[] = [];
   const { claudeLocalSettingsPath, inspectClaudeHooks } = await import("../hooks/claude-code");
   const { codexHooksPath, inspectCodexHooks } = await import("../hooks/codex");
+  const { factoryHooksPath, inspectFactoryHooks } = await import("../hooks/factory");
   const configPath = claudeLocalSettingsPath(resolveDir(opts.dir));
   const inspection = inspectClaudeHooks(configPath);
   const codexPath = codexHooksPath(resolveDir(opts.dir));
   const codex = inspectCodexHooks(codexPath);
+  const factoryPath = factoryHooksPath(resolveDir(opts.dir));
+  const factory = inspectFactoryHooks(factoryPath);
   const codexInstalled =
     codex.events.includes("UserPromptSubmit") && codex.events.includes("PostToolUse");
+  const factoryInstalled =
+    factory.events.includes("UserPromptSubmit") && factory.events.includes("PostToolUse");
+
+  const alternativeInstalled = codexInstalled || factoryInstalled;
 
   // 1. Claude Code config present + valid JSON. A missing Claude config is
-  // only a warning when Codex hooks carry the chain instead.
+  // only a warning when another agent's hooks carry the chain instead.
   if (!inspection.fileExists) {
     checks.push({
       name: "config",
-      status: codexInstalled ? "warn" : "fail",
+      status: alternativeInstalled ? "warn" : "fail",
       detail: `not found: ${configPath} (run 'dosu hooks install claude-code')`,
     });
   } else if (inspection.parseError) {
@@ -535,7 +561,7 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
   } else {
     checks.push({
       name: "hooks",
-      status: codexInstalled ? "warn" : "fail",
+      status: alternativeInstalled ? "warn" : "fail",
       detail: "UserPromptSubmit + PostToolUse not both installed",
     });
   }
@@ -559,6 +585,29 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
     } else {
       checks.push({
         name: "codex-config",
+        status: "fail",
+        detail: "UserPromptSubmit + PostToolUse not both installed",
+      });
+    }
+  }
+
+  // 2c. Factory hooks (only reported when the Factory hooks file exists).
+  if (factory.fileExists) {
+    if (factory.parseError) {
+      checks.push({
+        name: "factory-config",
+        status: "fail",
+        detail: `invalid JSON: ${factoryPath}`,
+      });
+    } else if (factoryInstalled) {
+      checks.push({
+        name: "factory-config",
+        status: "ok",
+        detail: `installed: ${factory.events.join(", ")} (${factoryPath})`,
+      });
+    } else {
+      checks.push({
+        name: "factory-config",
         status: "fail",
         detail: "UserPromptSubmit + PostToolUse not both installed",
       });
@@ -633,7 +682,7 @@ export async function runDoctor(opts: { dir?: string; json?: boolean }): Promise
 
 export function hooksCommand(): Command {
   const cmd = new Command("hooks").description(
-    "Dosu knowledge-injection hooks for coding agents (Claude Code, Codex)",
+    "Dosu knowledge-injection hooks for coding agents (Claude Code, Codex, Factory)",
   );
 
   /* v8 ignore start -- thin Commander glue: reads fd 0 and delegates to tested handlers */
@@ -697,6 +746,7 @@ export function hooksCommand(): Command {
         "Examples:",
         "  $ dosu hooks install claude-code",
         "  $ dosu hooks install codex",
+        "  $ dosu hooks install factory",
         "  $ dosu hooks install claude-code --no-stop",
         "  $ dosu hooks install codex --dir ./my-project",
         "",
@@ -722,6 +772,7 @@ export function hooksCommand(): Command {
         "Examples:",
         "  $ dosu hooks uninstall claude-code",
         "  $ dosu hooks uninstall codex",
+        "  $ dosu hooks uninstall factory",
       ].join("\n"),
     )
     .action((agent: string, opts: LifecycleOptions) => runUninstall(agent, opts));

--- a/src/hooks/factory.test.ts
+++ b/src/hooks/factory.test.ts
@@ -1,0 +1,164 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  factoryHooksPath,
+  inspectFactoryHooks,
+  installFactoryHooks,
+  removeFactoryHooks,
+} from "./factory";
+
+describe("factory hooks installer", () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-factory-test-"));
+    configPath = factoryHooksPath(tempDir);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function readConfig(): Record<string, unknown> {
+    // biome-ignore lint/suspicious/noExplicitAny: test helper over untyped JSON
+    return JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, any>;
+  }
+
+  it("factoryHooksPath points at the project .factory/hooks.json", () => {
+    expect(factoryHooksPath("/some/project")).toBe(join("/some/project", ".factory", "hooks.json"));
+  });
+
+  it("fresh install writes all three events with the correct Factory hook shape", () => {
+    const { events } = installFactoryHooks(configPath);
+    expect(events).toEqual(["UserPromptSubmit", "PostToolUse", "Stop"]);
+
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    for (const event of events) {
+      expect(cfg.hooks[event]).toHaveLength(1);
+      const group = cfg.hooks[event][0];
+      // No __dosu marker — Factory parsers may reject unknown keys.
+      expect(group.hooks).toHaveLength(1);
+      expect(group.hooks[0].type).toBe("command");
+      expect(group.hooks[0].command).toMatch(/^dosu hooks [a-z-]+ --agent factory$/);
+    }
+    expect(cfg.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+      "dosu hooks user-prompt-submit --agent factory",
+    );
+    expect(cfg.hooks.PostToolUse[0].matcher).toBe("*");
+    // PostToolUse group has matcher + hooks only
+    expect(Object.keys(cfg.hooks.PostToolUse[0]).sort()).toEqual(["hooks", "matcher"]);
+    // UserPromptSubmit and Stop groups have hooks only (no matcher)
+    expect(Object.keys(cfg.hooks.UserPromptSubmit[0]).sort()).toEqual(["hooks"]);
+    expect(Object.keys(cfg.hooks.Stop[0]).sort()).toEqual(["hooks"]);
+  });
+
+  it("--no-stop installs only UserPromptSubmit + PostToolUse", () => {
+    const { events } = installFactoryHooks(configPath, { stop: false });
+    expect(events).toEqual(["UserPromptSubmit", "PostToolUse"]);
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.hooks.Stop).toBeUndefined();
+  });
+
+  it("reinstall is idempotent (no duplicate Dosu groups)", () => {
+    installFactoryHooks(configPath);
+    installFactoryHooks(configPath);
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.hooks.UserPromptSubmit).toHaveLength(1);
+    expect(cfg.hooks.Stop).toHaveLength(1);
+  });
+
+  it("reinstall with --no-stop sweeps the previously installed Dosu Stop group", () => {
+    installFactoryHooks(configPath);
+    installFactoryHooks(configPath, { stop: false });
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.hooks.Stop).toBeUndefined();
+    expect(cfg.hooks.UserPromptSubmit).toHaveLength(1);
+  });
+
+  it("preserves the user's own hooks and unknown top-level keys", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    const userGroup = {
+      matcher: "Bash",
+      hooks: [{ type: "command", command: "python3 my-hook.py" }],
+    };
+    writeFileSync(
+      configPath,
+      JSON.stringify({ somethingElse: { keep: true }, hooks: { PostToolUse: [userGroup] } }),
+    );
+
+    installFactoryHooks(configPath);
+    removeFactoryHooks(configPath);
+
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.somethingElse).toEqual({ keep: true });
+    expect(cfg.hooks.PostToolUse).toEqual([userGroup]);
+  });
+
+  it("refuses to modify a file with invalid JSON", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, "NOT JSON {{{");
+    expect(() => installFactoryHooks(configPath)).toThrow(/refusing to modify/);
+    expect(readFileSync(configPath, "utf-8")).toBe("NOT JSON {{{");
+  });
+
+  it("remove returns false when nothing is installed", () => {
+    expect(removeFactoryHooks(configPath)).toEqual({ removed: false });
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ hooks: {} }));
+    expect(removeFactoryHooks(configPath)).toEqual({ removed: false });
+  });
+
+  it("remove deletes only Dosu groups and drops empty event arrays", () => {
+    installFactoryHooks(configPath);
+    const { removed } = removeFactoryHooks(configPath);
+    expect(removed).toBe(true);
+    // biome-ignore lint/suspicious/noExplicitAny: asserting raw JSON shape
+    const cfg = readConfig() as any;
+    expect(cfg.hooks.UserPromptSubmit).toBeUndefined();
+    expect(cfg.hooks.Stop).toBeUndefined();
+  });
+
+  it("remove leaves an invalid-JSON file untouched", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, "NOT JSON {{{");
+    expect(removeFactoryHooks(configPath)).toEqual({ removed: false });
+    expect(readFileSync(configPath, "utf-8")).toBe("NOT JSON {{{");
+  });
+
+  it("inspect reports missing file, parse errors, and installed events", () => {
+    expect(inspectFactoryHooks(configPath)).toEqual({ fileExists: false, events: [] });
+
+    installFactoryHooks(configPath, { stop: false });
+    expect(inspectFactoryHooks(configPath)).toEqual({
+      fileExists: true,
+      events: ["UserPromptSubmit", "PostToolUse"],
+    });
+
+    writeFileSync(configPath, "NOT JSON {{{");
+    expect(inspectFactoryHooks(configPath)).toEqual({
+      fileExists: true,
+      parseError: true,
+      events: [],
+    });
+  });
+
+  it("inspect does not count user-only events as installed", () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: "command", command: "python3 mine.py" }] }] },
+      }),
+    );
+    expect(inspectFactoryHooks(configPath)).toEqual({ fileExists: true, events: [] });
+    expect(existsSync(configPath)).toBe(true);
+  });
+});

--- a/src/hooks/factory.ts
+++ b/src/hooks/factory.ts
@@ -1,0 +1,153 @@
+/**
+ * Factory Droid hooks installer.
+ *
+ * Writes the Dosu hook block into the project-level Factory hooks file
+ * (`<repo>/.factory/hooks.json`). Factory's hook wire protocol mirrors
+ * Claude Code's: the same event names (`UserPromptSubmit`, `PostToolUse`,
+ * `Stop`), the same stdin fields, and the same stdout contracts. The
+ * `dosu hooks …` entrypoints run unchanged; `--agent factory` attributes
+ * tickets to Factory sessions.
+ *
+ * No `__dosu` marker is added to hook entries — unknown keys may be
+ * rejected by Factory's config parsers. Ownership is detected purely from
+ * the command shape (`dosu hooks …`), reusing the same predicate as the
+ * Claude Code and Codex installers.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { saveJSONConfig } from "../mcp/config-helpers";
+import { DEFAULT_HOOK_EVENTS, isDosuGroup } from "./claude-code";
+
+// biome-ignore lint/suspicious/noExplicitAny: hooks JSON is inherently untyped
+type JsonConfig = Record<string, any>;
+
+interface FactoryHookEntry {
+  type: "command";
+  command: string;
+}
+
+interface FactoryMatcherGroup {
+  matcher?: string;
+  hooks: FactoryHookEntry[];
+}
+
+/** Path to the project-level Factory hooks file under a project root. */
+export function factoryHooksPath(dir: string): string {
+  return join(dir, ".factory", "hooks.json");
+}
+
+/** Map a Factory hook event to its `dosu hooks` subcommand. */
+const EVENT_SUBCOMMAND: Record<string, string> = {
+  UserPromptSubmit: "user-prompt-submit",
+  PostToolUse: "post-tool-use",
+  Stop: "stop",
+};
+
+/**
+ * The command Factory runs for a given hook subcommand. Bare `dosu` from PATH;
+ * `--agent factory` attributes the resulting knowledge tickets to Factory sessions.
+ */
+export function factoryHookCommand(subcommand: string): string {
+  return `dosu hooks ${subcommand} --agent factory`;
+}
+
+function dosuGroup(event: string): FactoryMatcherGroup {
+  const group: FactoryMatcherGroup = {
+    hooks: [{ type: "command", command: factoryHookCommand(EVENT_SUBCOMMAND[event]) }],
+  };
+  if (event === "PostToolUse") group.matcher = "*";
+  return group;
+}
+
+function readHooksFileOrThrow(path: string): JsonConfig {
+  if (!existsSync(path)) return {};
+  const raw = readFileSync(path, "utf-8").trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as JsonConfig;
+  } catch {
+    throw new Error(`refusing to modify ${path}: file exists but is not valid JSON`);
+  }
+}
+
+export interface FactoryInstallOptions {
+  /** Install the `Stop` hook. Defaults to true; pass `false` (via `--no-stop`) to skip it. */
+  stop?: boolean;
+}
+
+/** Merge the Dosu hook block into a Factory hooks.json file. Returns the events installed. */
+export function installFactoryHooks(
+  configPath: string,
+  opts: FactoryInstallOptions = {},
+): { events: string[] } {
+  const config = readHooksFileOrThrow(configPath);
+  const events = DEFAULT_HOOK_EVENTS.filter((e) => e !== "Stop" || opts.stop !== false);
+
+  const hooks: JsonConfig = typeof config.hooks === "object" && config.hooks ? config.hooks : {};
+  for (const event of events) {
+    const groups: unknown[] = Array.isArray(hooks[event]) ? hooks[event] : [];
+    const kept = groups.filter((g) => !isDosuGroup(g));
+    kept.push(dosuGroup(event));
+    hooks[event] = kept;
+  }
+  // Sweep Dosu groups from events not being installed (e.g. --no-stop reinstall).
+  for (const event of DEFAULT_HOOK_EVENTS) {
+    if (!events.includes(event) && Array.isArray(hooks[event])) {
+      const kept = hooks[event].filter((g: unknown) => !isDosuGroup(g));
+      if (kept.length > 0) hooks[event] = kept;
+      else delete hooks[event];
+    }
+  }
+  config.hooks = hooks;
+
+  saveJSONConfig(configPath, config);
+  return { events: [...events] };
+}
+
+/** Remove only Dosu-owned hook groups. Returns whether anything was removed. */
+export function removeFactoryHooks(configPath: string): { removed: boolean } {
+  if (!existsSync(configPath)) return { removed: false };
+  let config: JsonConfig;
+  try {
+    config = readHooksFileOrThrow(configPath);
+  } catch {
+    return { removed: false };
+  }
+  const hooks = config.hooks;
+  if (typeof hooks !== "object" || !hooks) return { removed: false };
+
+  let removed = false;
+  for (const event of Object.keys(hooks)) {
+    if (!Array.isArray(hooks[event])) continue;
+    const kept = hooks[event].filter((g: unknown) => !isDosuGroup(g));
+    if (kept.length !== hooks[event].length) {
+      removed = true;
+      if (kept.length > 0) hooks[event] = kept;
+      else delete hooks[event];
+    }
+  }
+  if (removed) saveJSONConfig(configPath, config);
+  return { removed };
+}
+
+/** Read-only inspection for `doctor`. Never throws. */
+export function inspectFactoryHooks(configPath: string): {
+  fileExists: boolean;
+  parseError?: boolean;
+  events: string[];
+} {
+  if (!existsSync(configPath)) return { fileExists: false, events: [] };
+  let config: JsonConfig;
+  try {
+    config = readHooksFileOrThrow(configPath);
+  } catch {
+    return { fileExists: true, parseError: true, events: [] };
+  }
+  const hooks = config.hooks;
+  if (typeof hooks !== "object" || !hooks) return { fileExists: true, events: [] };
+  const events = Object.keys(hooks).filter(
+    (event) => Array.isArray(hooks[event]) && hooks[event].some((g: unknown) => isDosuGroup(g)),
+  );
+  return { fileExists: true, events };
+}

--- a/src/mcp/providers.test.ts
+++ b/src/mcp/providers.test.ts
@@ -7,9 +7,9 @@ import {
 } from "./providers";
 
 describe("provider registry", () => {
-  it("allProviders returns 15 providers", () => {
+  it("allProviders returns 16 providers", () => {
     const providers = allProviders();
-    expect(providers).toHaveLength(15);
+    expect(providers).toHaveLength(16);
   });
 
   it("all providers have unique IDs", () => {

--- a/src/mcp/providers.ts
+++ b/src/mcp/providers.ts
@@ -39,6 +39,7 @@ import { ClineCliProvider } from "./providers/cline-cli";
 import { CodexProvider } from "./providers/codex";
 import { CopilotProvider } from "./providers/copilot";
 import { CursorProvider } from "./providers/cursor";
+import { FactoryProvider } from "./providers/factory";
 import { GeminiProvider } from "./providers/gemini";
 import { ManualProvider } from "./providers/manual";
 import { MCPorterProvider } from "./providers/mcporter";
@@ -66,6 +67,7 @@ export function allProviders(): Provider[] {
     OpenCodeProvider(),
     AntigravityProvider(),
     MCPorterProvider(),
+    FactoryProvider(),
     ManualProvider(),
   ];
 }

--- a/src/mcp/providers/factory.ts
+++ b/src/mcp/providers/factory.ts
@@ -1,0 +1,14 @@
+import { join } from "node:path";
+import { createJSONProvider } from "./base";
+
+export const FactoryProvider = () =>
+  createJSONProvider({
+    providerName: "Factory",
+    providerID: "factory",
+    local: true,
+    priorityValue: 17,
+    paths: ["~/.factory"],
+    globalPath: "~/.factory/mcp.json",
+    topKey: "mcpServers",
+    localConfigPath: (cwd) => join(cwd, ".factory", "mcp.json"),
+  });


### PR DESCRIPTION
## Summary

- **MCP provider**: reads/writes `~/.factory/mcp.json` (global) and `.factory/mcp.json` (local) using the `mcpServers` key — matches Factory's documented config format
- **Hooks installer**: writes `UserPromptSubmit`, `PostToolUse`, and `Stop` hooks to `.factory/hooks.json` with `--agent factory` attribution; no `__dosu` marker (avoids potential parser rejection, ownership detected by command shape)
- **CLI**: `dosu hooks install factory` / `uninstall factory` wired up; doctor checks include Factory alongside Claude Code + Codex

## Test plan

- [ ] `dosu hooks install factory` creates `.factory/hooks.json` with the three hook events
- [ ] `dosu hooks uninstall factory` removes only Dosu-owned groups, preserves user hooks
- [ ] `dosu hooks doctor` reports factory-config when `.factory/hooks.json` exists
- [ ] `dosu mcp add factory` writes entry into `~/.factory/mcp.json`
- [ ] All 1195 existing tests pass (`bun run test`)