### PR TITLE
fix(auth): gracefully handle missing browser in OAuth flow

### DIFF
--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -208,6 +208,23 @@ describe("startOAuthFlow", () => {
     setTimeoutSpy.mockRestore();
   });
 
+  it("prints the auth URL and continues waiting when browser cannot be opened", async () => {
+    mockOpenDefault.mockRejectedValueOnce(new Error("Executable not found in $PATH: xdg-open"));
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const flowPromise = startOAuthFlow();
+    await flowReady();
+
+    // URL should have been printed
+    const printed = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(printed).toContain("https://app.dosu.dev/cli/auth");
+    consoleSpy.mockRestore();
+
+    // flow still resolves when the token arrives
+    resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
+    await expect(flowPromise).resolves.toMatchObject({ access_token: "a" });
+  });
+
   it("uses the configured web app URL for building the auth URL", async () => {
     mockGetWebAppURL.mockReturnValue("http://localhost:3001");
 

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -30,8 +30,23 @@ export async function startOAuthFlow(
 
     // Open browser — dynamic import to avoid bundling issues
     const open = await import("open");
-    await open.default(authURL);
-    logger.info("auth.flow", "Browser open command executed");
+    let browserOpened = false;
+    try {
+      await open.default(authURL);
+      browserOpened = true;
+      logger.info("auth.flow", "Browser open command executed");
+    } catch (openErr) {
+      logger.warn(
+        "auth.flow",
+        `Could not open browser automatically: ${openErr instanceof Error ? openErr.message : String(openErr)}`,
+      );
+    }
+
+    if (!browserOpened) {
+      console.log("\nCould not open a browser automatically.");
+      console.log("Please open this URL in your browser to log in:\n");
+      console.log(`  ${authURL}\n`);
+    }
 
     // 8 min < Supabase's ~10 min OAuth state TTL, so we surface a useful
     // message before users hit a stale-state error.


### PR DESCRIPTION
## Summary

- Catches the error thrown by the `open` package when no browser launcher is available (e.g. `xdg-open` not found on headless Linux)
- Prints the auth URL to the terminal so users can copy and open it manually
- The local callback server keeps running, so login still completes once the user opens the URL

## Test plan

- [ ] New unit test covers the case where `open.default` rejects — verifies the URL is printed and the flow continues waiting for the token
- [ ] Existing auth flow tests all pass (`bunx vitest run src/auth/flow`)