### PR TITLE
Supply-chain hardening, Vitest 4 + TypeScript 6, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           bun-version: "1.3.2"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Check linting and formatting
         run: bun run check
@@ -36,7 +36,7 @@ jobs:
           bun-version: "1.3.2"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run typecheck
         run: bunx tsc --noEmit
@@ -53,7 +53,7 @@ jobs:
           bun-version: "1.3.2"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run tests with coverage
         run: bunx vitest run --coverage
@@ -75,7 +75,7 @@ jobs:
           bun-version: "1.3.2"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Verify build compiles
         run: |
@@ -109,7 +109,7 @@ jobs:
           node-version: "24.10.0"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build npm package
         run: |
@@ -158,7 +158,7 @@ jobs:
           node-version: "24.10.0"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Release
         id: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     outputs:
       released: ${{ steps.release.outputs.released }}
       version: ${{ steps.release.outputs.version }}
@@ -165,6 +166,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
   update-homebrew:
     needs: release

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ dist/
 /dosu-cli-*.tgz
 
 # Bun
-bun.lock
+# bun.lock is committed for reproducible installs (see AGENTS.md › Dependencies)
 *.bun-build
 
 # Environment — only .local files are ignored (contain personal overrides)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,17 +31,23 @@ bun run check                   # Biome lint + format check (used in CI)
 
 **Entry point:** `src/index.ts` → `src/cli/cli.ts` (Commander program)
 
-Running `dosu` with no args launches the interactive TUI (`src/tui/tui.ts`). Subcommands: `login`, `logout`, `status`, `setup`, `mcp add|list`.
+Running `dosu` with no args launches the interactive TUI (`src/tui/tui.ts`). Two broad families of subcommands are registered in `src/cli/cli.ts`:
+
+- **Local / MCP management** — `login`, `logout`, `status`, `setup`, `mcp add|list`, `logs`.
+- **Dosu platform** (require an authenticated deployment) — `ask`, `knowledge`, `docs`, `suggest`, `threads`, `review`, `sources`, `integrations`, `tags`, `members`, `org`, `deployments`, `analytics`, `insights`, `skill`, `hooks`. Each lives in `src/commands/<name>.ts` and talks to the backend via `src/client/`.
 
 Key modules:
 
-- **`src/auth/`** — Browser-based OAuth flow. Starts a local HTTP server on a random port, opens the browser to the Dosu web app, receives the token via redirect callback.
+- **`src/auth/`** — Browser-based OAuth flow. Starts a local HTTP server on a random port, opens the browser to the Dosu web app, receives the token via redirect callback. `ticket.ts` backs the agent ticket flow (`login --request`/`--check`).
 - **`src/client/`** — Authenticated HTTP client for the Dosu backend API. Handles token refresh (Supabase `/auth/v1/token`) and auto-retry on 401/403.
-- **`src/config/`** — CLI's own config (`~/.config/dosu-cli/config.json`). Stores access/refresh tokens, deployment ID, API key. `constants.ts` has env-aware URL getters (dev vs prod, overridable via env vars).
+- **`src/config/`** — CLI's own config (`~/.config/dosu-cli/config.json`). Stores access/refresh tokens, deployment ID, API key. Supports OSS vs Cloud `mode`. `constants.ts` has env-aware URL getters (dev vs prod, overridable via env vars).
 - **`src/mcp/`** — Provider system for AI tool integrations. Each provider in `providers/` knows how to detect, install, and remove the Dosu MCP entry from that tool's config file. `base.ts` provides `createJSONProvider()` — a factory that covers most tools with just config path + top-level key. `config-helpers.ts` handles JSON/JSONC read/write. `detect.ts` handles path expansion and platform-aware detection.
+- **`src/commands/`** — The Dosu platform command layer (the list above). Thin Commander wrappers over `src/client/` calls; `output.ts` standardizes human vs JSON output.
 - **`src/setup/`** — Interactive setup wizard (authenticate → select org → select deployment → mint API key → detect installed tools → configure). Uses `@clack/prompts`.
+- **`src/agent/`** — Non-interactive setup for coding agents (`setup --agent --tool <id>`) and the ticket-based login commands (`login --request`/`--check`). Emits machine-readable JSON via `output.ts` for agent consumption.
+- **`src/hooks/`** — Coding-agent hook entrypoints invoked as `dosu hooks <user-prompt-submit|post-tool-use|stop>`. They mint, poll, and inject Dosu "knowledge tickets" into an agent's turn. These run on the agent's hot path on every turn, so they must stay fast and keep stdout clean — `src/cli/cli.ts` deliberately skips the update checks for them.
 - **`src/tui/`** — Main menu TUI when running `dosu` with no subcommand.
-- **`src/version/`** — Version string from build-time env vars (`DOSU_VERSION`, `DOSU_COMMIT`, `DOSU_DATE`).
+- **`src/version/`** — Version string from build-time env vars (`DOSU_VERSION`, `DOSU_COMMIT`, `DOSU_DATE`), plus background update checks (`update-check.ts`, `skill-update-check.ts`).
 
 ## Testing
 
@@ -49,6 +55,13 @@ Key modules:
 - Vitest with `pool: "forks"` (not threads) — required for tests that mock `node:fs`
 - Coverage thresholds enforced: 95% statements, 90% branches, 80% functions, 95% lines
 - Build scripts in `scripts/` also have their own tests
+- **Mocking a class that's constructed with `new`** (e.g. `Client`): the `vi.fn()` implementation must be a regular `function`, not an arrow — Vitest 4 cannot `new` an arrow. `biome.json` turns off `complexity/useArrowFunction` for `*.test.ts` so the linter's auto-fix can't rewrite these back to arrows and rebreak the tests.
+
+## Dependencies & Packaging
+
+- **`bun.lock` is committed.** It pins the full transitive tree for reproducible installs across machines and CI. Run `bun update` to bump deps (this is also where the install gate below applies).
+- **`bunfig.toml` sets `minimumReleaseAge = 259200`** (3 days) — `bun install`/`bun update` ignore package versions published in the last 3 days, a supply-chain delay against compromised fresh releases. Add `minimumReleaseAgeExcludes = [...]` if a package ever needs to bypass it.
+- **The published npm package is a self-contained bundle.** `build:npm` runs `bun build --target node`, which inlines every dependency into `bin/dosu.js` (the only code file shipped — see `files` in `package.json`). Because nothing is resolved from `node_modules` at runtime, **all deps live in `devDependencies` and the package declares zero runtime `dependencies`** — so `npm install @dosu/cli` pulls no transitive packages. Keep new runtime deps in `devDependencies`; only add a real `dependencies` entry if something genuinely cannot be bundled (e.g. a native binary), and verify with the isolated-bundle run before doing so.
 
 ## Code Style (Biome)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # dosu-cli
 
+> Connect [Dosu](https://dosu.dev) to your AI coding tools. `dosu` authenticates you, picks a Dosu deployment, and wires the Dosu MCP server into Claude Code, Cursor, Codex, and more — plus commands to drive the Dosu platform from your terminal.
+
+[![npm version](https://img.shields.io/npm/v/@dosu/cli.svg)](https://www.npmjs.com/package/@dosu/cli)
+[![CI](https://github.com/dosu-ai/dosu-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/dosu-ai/dosu-cli/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/dosu-ai/dosu-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/dosu-ai/dosu-cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](#license)
+
+## Quick Start
+
+```bash
+npx @dosu/cli setup
+```
+
+The interactive wizard authenticates you via browser OAuth, lets you pick a Dosu deployment (or OSS / public-library mode), mints an API key, detects which AI tools you have installed, and writes the Dosu MCP server entry into each one's config. Restart your AI tool and Dosu is available.
+
+Run `dosu` with no arguments any time to open the interactive menu.
+
 ## Installation
 
 ### npx / npm (Recommended)
@@ -65,30 +82,117 @@ Or right-click the binary, select "Open", and click "Open" in the dialog.
 
 **Note:** Installing via Homebrew avoids this issue automatically.
 
+## Usage
+
+### Core commands
+
+| Command | Description |
+|---|---|
+| `dosu` | Launch the interactive TUI menu |
+| `dosu setup` | Run the setup wizard (auth → deployment → detect tools → configure) |
+| `dosu login` | Authenticate with Dosu via browser OAuth |
+| `dosu logout` | Clear saved credentials |
+| `dosu status` | Show current authentication and MCP status |
+| `dosu mcp list` | List supported AI tools |
+| `dosu mcp add <tool>` | Add the Dosu MCP server to a specific tool |
+| `dosu logs` | View or manage debug logs (`--tail`, `--clear`) |
+
+`dosu mcp add` takes `-g, --global` to install for all projects instead of project-local, and `--show-secret` to print the full manual config.
+
+### Platform commands
+
+Once authenticated against a deployment, you can drive the Dosu platform without leaving the terminal:
+
+| Command | Description |
+|---|---|
+| `dosu ask` | Ask a question and get an AI-generated answer |
+| `dosu knowledge` | Search and browse your knowledge base |
+| `dosu docs` | Manage documents (list, create, update, import, publish, AI-generate) |
+| `dosu suggest` | Review and accept AI document suggestions |
+| `dosu threads` | List and manage conversation threads |
+| `dosu review` | Document review workflow |
+| `dosu sources` | Manage connected data sources (list, sync, update) |
+| `dosu integrations` | List and inspect platform integrations (Slack, GitHub, …) |
+| `dosu tags` | Manage knowledge base tags |
+| `dosu members` | Manage team members and access requests |
+| `dosu org` | Show organization information |
+| `dosu deployments` | List / show / switch deployments |
+| `dosu analytics` | View usage statistics |
+| `dosu insights` | Open a visual report of your Dosu space activity |
+| `dosu skill` | Install / update / remove the Dosu agent skill |
+| `dosu hooks` | Install / remove / diagnose Dosu coding-agent hooks |
+
+Run `dosu <command> --help` for subcommands and flags.
+
+### Supported AI tools
+
+`dosu mcp add <id>` and the setup wizard support:
+
+| ID | Tool |
+|---|---|
+| `claude` | Claude Code |
+| `claude-desktop` | Claude Desktop |
+| `cursor` | Cursor |
+| `vscode` | VS Code |
+| `codex` | Codex CLI |
+| `gemini` | Gemini CLI |
+| `windsurf` | Windsurf |
+| `zed` | Zed |
+| `cline` | Cline |
+| `cline-cli` | Cline CLI |
+| `copilot` | GitHub Copilot CLI |
+| `opencode` | OpenCode |
+| `antigravity` | Antigravity |
+| `mcporter` | MCPorter |
+| `factory` | Factory |
+| `manual` | Manual Configuration (prints config to paste yourself) |
+
+### Non-interactive / agent setup
+
+For coding agents and CI, `setup` has a non-interactive mode:
+
+```bash
+dosu setup --agent --tool claude
+```
+
+Combine with `dosu login --request` / `--check <ticket>` for human-in-the-loop authentication, and `--mode oss|cloud` to skip the mode prompt.
+
+## Configuration
+
+Credentials and the selected deployment live in `~/.config/dosu-cli/config.json`. Set `DOSU_DEV=true` to isolate config under `~/.config/dosu-cli-dev/`.
+
+To repoint a published build at a different backend without rebuilding, set any of these runtime overrides:
+
+- `DOSU_WEB_APP_URL_OVERRIDE`
+- `DOSU_BACKEND_URL_OVERRIDE`
+- `SUPABASE_URL_OVERRIDE`
+- `SUPABASE_ANON_KEY_OVERRIDE`
+
+## Development
+
+```bash
+bun install        # install dependencies
+bun run dev        # run the CLI from source
+bun run test       # run tests (vitest)
+bun run check      # lint + format check (Biome)
+bun run typecheck  # tsc --noEmit
+```
+
+See [AGENTS.md](AGENTS.md) for architecture and contributor notes.
+
 ## Releasing (for maintainers)
 
-Releases are automated via `bun build --compile` and GitHub Actions.
+Releases are fully automated with [semantic-release](https://github.com/semantic-release/semantic-release) — there are no manual version tags. Every push to a release branch is analyzed for [Conventional Commit](https://www.conventionalcommits.org/) messages, which determine the version bump.
 
-### Creating a Release
+| Branch | npm dist-tag | Version shape |
+|---|---|---|
+| `main` | `latest` | `0.20.1` |
+| `alpha` | `alpha` | `0.20.1-alpha.1` |
 
-1. **Ensure all changes are committed and pushed to `main`**
+On a qualifying push, the CI pipeline bumps the version, builds binaries for all platforms, creates a GitHub release with the archives, publishes to npm, and (for stable releases only) updates the Homebrew formula.
 
-2. **Create and push a new tag:**
-   ```bash
-   git tag v0.2.0
-   git push origin v0.2.0
-   ```
+Commit messages that don't follow Conventional Commits are invisible to semantic-release and won't trigger a release. See [AGENTS.md](AGENTS.md) for the full type → release-impact table and the alpha channel workflow.
 
-3. **GitHub Actions will automatically:**
-   - Run tests
-   - Build binaries for all platforms (macOS, Linux, Windows)
-   - Create a GitHub release with the binaries
-   - Publish to npm (`@dosu/cli`)
-   - Update the Homebrew formula
+## License
 
-### Version Naming
-
-- Production releases: `v1.0.0`, `v1.1.0`, `v2.0.0`
-- Pre-releases: `v0.1.0-alpha`, `v0.1.0-beta`, `v0.1.0-rc1`
-
-Pre-release tags (containing `-alpha`, `-beta`, `-rc`) are automatically marked as pre-releases on GitHub and published to npm under the `next` dist-tag.
+MIT — see the `license` field in [package.json](package.json).

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -33,7 +33,19 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "useArrowFunction": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,1244 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@dosu/cli",
+      "devDependencies": {
+        "@biomejs/biome": "^2.5.0",
+        "@clack/prompts": "^0.10.1",
+        "@dosu/api-types": "0.0.7",
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/exec": "^7.1.0",
+        "@semantic-release/git": "^10.0.1",
+        "@trpc/client": "11.8.0",
+        "@trpc/server": "11.8.0",
+        "@types/bun": "^1.3.14",
+        "@vitest/coverage-v8": "^4.1.9",
+        "commander": "^13.1.0",
+        "open": "^10.2.0",
+        "picocolors": "^1.1.1",
+        "semantic-release": "^25.0.5",
+        "superjson": "^2.2.6",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.9",
+        "write-file-atomic": "^5.0.1",
+      },
+    },
+  },
+  "packages": {
+    "@actions/core": ["@actions/core@3.0.1", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA=="],
+
+    "@actions/exec": ["@actions/exec@3.0.0", "", { "dependencies": { "@actions/io": "^3.0.2" } }, "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw=="],
+
+    "@actions/http-client": ["@actions/http-client@4.0.1", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg=="],
+
+    "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
+
+    "@clack/core": ["@clack/core@0.4.2", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg=="],
+
+    "@clack/prompts": ["@clack/prompts@0.10.1", "", { "dependencies": { "@clack/core": "0.4.2", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@dosu/api-types": ["@dosu/api-types@0.0.7", "", { "dependencies": { "@trpc/server": "11.8.0" } }, "sha512-07cSza106G6BeODUTM9MiBKX7e0h7HXASq6rbB/U8OS7+pSK+E5OOTFRaZvBhY9KJ5YHql2532gR5Tj2ys1WBw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-retry": ["@octokit/plugin-retry@8.1.0", "", { "dependencies": { "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": ">=7" } }, "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw=="],
+
+    "@octokit/plugin-throttling": ["@octokit/plugin-throttling@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": "^7.0.0" } }, "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg=="],
+
+    "@octokit/request": ["@octokit/request@10.0.10", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
+
+    "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
+
+    "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.3", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.2", "", { "os": "android", "cpu": "arm" }, "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.2", "", { "os": "linux", "cpu": "arm" }, "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.2", "", { "os": "none", "cpu": "arm64" }, "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
+
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
+    "@semantic-release/changelog": ["@semantic-release/changelog@6.0.3", "", { "dependencies": { "@semantic-release/error": "^3.0.0", "aggregate-error": "^3.0.0", "fs-extra": "^11.0.0", "lodash": "^4.17.4" }, "peerDependencies": { "semantic-release": ">=18.0.0" } }, "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag=="],
+
+    "@semantic-release/commit-analyzer": ["@semantic-release/commit-analyzer@13.0.1", "", { "dependencies": { "conventional-changelog-angular": "^8.0.0", "conventional-changelog-writer": "^8.0.0", "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.0.0", "debug": "^4.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "micromatch": "^4.0.2" }, "peerDependencies": { "semantic-release": ">=20.1.0" } }, "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ=="],
+
+    "@semantic-release/error": ["@semantic-release/error@3.0.0", "", {}, "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="],
+
+    "@semantic-release/exec": ["@semantic-release/exec@7.1.0", "", { "dependencies": { "@semantic-release/error": "^4.0.0", "aggregate-error": "^3.0.0", "debug": "^4.0.0", "execa": "^9.0.0", "lodash-es": "^4.17.21", "parse-json": "^8.0.0" }, "peerDependencies": { "semantic-release": ">=24.1.0" } }, "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ=="],
+
+    "@semantic-release/git": ["@semantic-release/git@10.0.1", "", { "dependencies": { "@semantic-release/error": "^3.0.0", "aggregate-error": "^3.0.0", "debug": "^4.0.0", "dir-glob": "^3.0.0", "execa": "^5.0.0", "lodash": "^4.17.4", "micromatch": "^4.0.0", "p-reduce": "^2.0.0" }, "peerDependencies": { "semantic-release": ">=18.0.0" } }, "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w=="],
+
+    "@semantic-release/github": ["@semantic-release/github@12.0.8", "", { "dependencies": { "@octokit/core": "^7.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-retry": "^8.0.0", "@octokit/plugin-throttling": "^11.0.0", "@semantic-release/error": "^4.0.0", "aggregate-error": "^5.0.0", "debug": "^4.3.4", "dir-glob": "^3.0.1", "http-proxy-agent": "^9.0.0", "https-proxy-agent": "^9.0.0", "issue-parser": "^7.0.0", "lodash-es": "^4.17.21", "mime": "^4.0.0", "p-filter": "^4.0.0", "tinyglobby": "^0.2.14", "undici": "^7.0.0", "url-join": "^5.0.0" }, "peerDependencies": { "semantic-release": ">=24.1.0" } }, "sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw=="],
+
+    "@semantic-release/npm": ["@semantic-release/npm@13.1.5", "", { "dependencies": { "@actions/core": "^3.0.0", "@semantic-release/error": "^4.0.0", "aggregate-error": "^5.0.0", "env-ci": "^11.2.0", "execa": "^9.0.0", "fs-extra": "^11.0.0", "lodash-es": "^4.17.21", "nerf-dart": "^1.0.0", "normalize-url": "^9.0.0", "npm": "^11.6.2", "rc": "^1.2.8", "read-pkg": "^10.0.0", "registry-auth-token": "^5.0.0", "semver": "^7.1.2", "tempy": "^3.0.0" }, "peerDependencies": { "semantic-release": ">=20.1.0" } }, "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg=="],
+
+    "@semantic-release/release-notes-generator": ["@semantic-release/release-notes-generator@14.1.1", "", { "dependencies": { "conventional-changelog-angular": "^8.0.0", "conventional-changelog-writer": "^8.0.0", "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.0.0", "debug": "^4.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "read-package-up": "^11.0.0" }, "peerDependencies": { "semantic-release": ">=20.1.0" } }, "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA=="],
+
+    "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
+
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@trpc/client": ["@trpc/client@11.8.0", "", { "peerDependencies": { "@trpc/server": "11.8.0", "typescript": ">=5.7.2" } }, "sha512-imJQeESX1hAapDaC4JB91yvXg41AZfBuTh/scnEiN/hAubZa5s/ikp0n+w29q2GCf+hREkr3WptUFKFJoDAIug=="],
+
+    "@trpc/server": ["@trpc/server@11.8.0", "", { "peerDependencies": { "typescript": ">=5.7.2" } }, "sha512-DphyQnLuyX2nwJCQGWQ9zYz4hZGvRhSBqDhQ0SH3tDhQ3PU4u68xofA0pJ741Ir4InEAFD+TtJVLAQy+wVOkiQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+
+    "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.9", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.9", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.9", "vitest": "4.1.9" }, "optionalPeers": ["@vitest/browser"] }, "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
+    "agent-base": ["agent-base@9.0.0", "", {}, "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA=="],
+
+    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
+
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "argv-formatter": ["argv-formatter@1.0.0", "", {}, "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw=="],
+
+    "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA=="],
+
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
+    "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
+
+    "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
+
+    "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
+
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
+
+    "color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
+
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
+
+    "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
+
+    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "conventional-changelog-angular": ["conventional-changelog-angular@8.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg=="],
+
+    "conventional-changelog-writer": ["conventional-changelog-writer@8.4.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "conventional-commits-filter": "^5.0.0", "handlebars": "^4.7.7", "meow": "^13.0.0", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "dist/cli/index.js" } }, "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g=="],
+
+    "conventional-commits-filter": ["conventional-commits-filter@5.0.0", "", {}, "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q=="],
+
+    "conventional-commits-parser": ["conventional-commits-parser@6.4.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "meow": "^13.0.0" }, "bin": { "conventional-commits-parser": "dist/cli/index.js" } }, "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw=="],
+
+    "convert-hrtime": ["convert-hrtime@5.0.0", "", {}, "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crypto-random-string": ["crypto-random-string@4.0.0", "", { "dependencies": { "type-fest": "^1.0.1" } }, "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
+
+    "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
+
+    "env-ci": ["env-ci@11.2.0", "", { "dependencies": { "execa": "^8.0.0", "java-properties": "^1.0.2" } }, "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
+
+    "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
+
+    "find-versions": ["find-versions@6.0.0", "", { "dependencies": { "semver-regex": "^4.0.5", "super-regex": "^1.0.0" } }, "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA=="],
+
+    "fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-timeout": ["function-timeout@1.0.2", "", {}, "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "git-log-parser": ["git-log-parser@1.2.1", "", { "dependencies": { "argv-formatter": "~1.0.0", "spawn-error-forwarder": "~1.0.0", "split2": "~1.0.0", "stream-combiner2": "~1.1.1", "through2": "~2.0.0", "traverse": "0.6.8" } }, "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hook-std": ["hook-std@4.0.0", "", {}, "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@9.1.0", "", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4", "proxy-agent-negotiate": "1.1.0" } }, "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@9.1.0", "", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4", "proxy-agent-negotiate": "1.1.0" } }, "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA=="],
+
+    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-from-esm": ["import-from-esm@2.0.0", "", { "dependencies": { "debug": "^4.3.4", "import-meta-resolve": "^4.0.0" } }, "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "issue-parser": ["issue-parser@7.0.2", "", { "dependencies": { "lodash.capitalize": "^4.2.1", "lodash.escaperegexp": "^4.1.2", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.uniqby": "^4.7.0" } }, "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "java-properties": ["java-properties@1.0.2", "", {}, "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "json-parse-better-errors": ["json-parse-better-errors@1.0.2", "", {}, "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
+
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "load-json-file": ["load-json-file@4.0.0", "", { "dependencies": { "graceful-fs": "^4.1.2", "parse-json": "^4.0.0", "pify": "^3.0.0", "strip-bom": "^3.0.0" } }, "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw=="],
+
+    "locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
+    "lodash.capitalize": ["lodash.capitalize@4.2.1", "", {}, "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw=="],
+
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
+    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.uniqby": ["lodash.uniqby@4.7.0", "", {}, "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="],
+
+    "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
+
+    "make-asynchronous": ["make-asynchronous@1.1.0", "", { "dependencies": { "p-event": "^6.0.0", "type-fest": "^4.6.0", "web-worker": "^1.5.0" } }, "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "marked-terminal": ["marked-terminal@7.3.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "ansi-regex": "^6.1.0", "chalk": "^5.4.1", "cli-highlight": "^2.1.11", "cli-table3": "^0.6.5", "node-emoji": "^2.2.0", "supports-hyperlinks": "^3.1.0" }, "peerDependencies": { "marked": ">=1 <16" } }, "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw=="],
+
+    "meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "nerf-dart": ["nerf-dart@1.0.0", "", {}, "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="],
+
+    "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
+
+    "normalize-package-data": ["normalize-package-data@8.0.0", "", { "dependencies": { "hosted-git-info": "^9.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ=="],
+
+    "normalize-url": ["normalize-url@9.0.1", "", {}, "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg=="],
+
+    "npm": ["npm@11.17.0", "", { "dependencies": { "@isaacs/string-locale-compare": "^1.1.0", "@npmcli/arborist": "^9.8.0", "@npmcli/config": "^10.11.0", "@npmcli/fs": "^5.0.0", "@npmcli/map-workspaces": "^5.0.3", "@npmcli/metavuln-calculator": "^9.0.3", "@npmcli/package-json": "^7.0.5", "@npmcli/promise-spawn": "^9.0.1", "@npmcli/redact": "^4.0.0", "@npmcli/run-script": "^10.0.4", "@sigstore/tuf": "^4.0.2", "abbrev": "^4.0.0", "archy": "~1.0.0", "cacache": "^20.0.4", "chalk": "^5.6.2", "ci-info": "^4.4.0", "fastest-levenshtein": "^1.0.16", "fs-minipass": "^3.0.3", "glob": "^13.0.6", "graceful-fs": "^4.2.11", "hosted-git-info": "^9.0.3", "ini": "^6.0.0", "init-package-json": "^8.2.5", "is-cidr": "^6.0.4", "json-parse-even-better-errors": "^5.0.0", "libnpmaccess": "^10.0.3", "libnpmdiff": "^8.1.10", "libnpmexec": "^10.3.0", "libnpmfund": "^7.0.24", "libnpmorg": "^8.0.1", "libnpmpack": "^9.1.10", "libnpmpublish": "^11.2.0", "libnpmsearch": "^9.0.1", "libnpmteam": "^8.0.2", "libnpmversion": "^8.0.4", "make-fetch-happen": "^15.0.6", "minimatch": "^10.2.5", "minipass": "^7.1.3", "minipass-pipeline": "^1.2.4", "ms": "^2.1.2", "node-gyp": "^12.4.0", "nopt": "^9.0.0", "npm-audit-report": "^7.0.0", "npm-install-checks": "^8.0.0", "npm-package-arg": "^13.0.2", "npm-pick-manifest": "^11.0.3", "npm-profile": "^12.0.1", "npm-registry-fetch": "^19.1.1", "npm-user-validate": "^4.0.0", "p-map": "^7.0.4", "pacote": "^21.5.1", "parse-conflict-json": "^5.0.1", "proc-log": "^6.1.0", "qrcode-terminal": "^0.12.0", "read": "^5.0.1", "semver": "^7.8.4", "spdx-expression-parse": "^4.0.0", "ssri": "^13.0.1", "supports-color": "^10.2.2", "tar": "^7.5.16", "text-table": "~0.2.0", "tiny-relative-date": "^2.0.2", "treeverse": "^3.0.0", "validate-npm-package-name": "^7.0.2", "which": "^6.0.1" }, "bin": { "npm": "bin/npm-cli.js", "npx": "bin/npx-cli.js" } }, "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw=="],
+
+    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "p-each-series": ["p-each-series@3.0.0", "", {}, "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw=="],
+
+    "p-event": ["p-event@6.0.1", "", { "dependencies": { "p-timeout": "^6.1.2" } }, "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w=="],
+
+    "p-filter": ["p-filter@4.1.0", "", { "dependencies": { "p-map": "^7.0.1" } }, "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw=="],
+
+    "p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
+
+    "p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
+
+    "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
+
+    "p-reduce": ["p-reduce@2.1.0", "", {}, "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="],
+
+    "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+
+    "p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
+
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
+
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
+
+    "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
+
+    "pkg-conf": ["pkg-conf@2.1.0", "", { "dependencies": { "find-up": "^2.0.0", "load-json-file": "^4.0.0" } }, "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
+
+    "proxy-agent-negotiate": ["proxy-agent-negotiate@1.1.0", "", { "peerDependencies": { "kerberos": "^2.0.0" }, "optionalPeers": ["kerberos"] }, "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "read-package-up": ["read-package-up@12.0.0", "", { "dependencies": { "find-up-simple": "^1.0.1", "read-pkg": "^10.0.0", "type-fest": "^5.2.0" } }, "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw=="],
+
+    "read-pkg": ["read-pkg@10.1.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.4", "normalize-package-data": "^8.0.0", "parse-json": "^8.3.0", "type-fest": "^5.4.4", "unicorn-magic": "^0.4.0" } }, "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg=="],
+
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "registry-auth-token": ["registry-auth-token@5.1.1", "", { "dependencies": { "@pnpm/npm-conf": "^3.0.2" } }, "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "semantic-release": ["semantic-release@25.0.5", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "semver-regex": ["semver-regex@4.0.5", "", {}, "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "signale": ["signale@1.4.0", "", { "dependencies": { "chalk": "^2.3.2", "figures": "^2.0.0", "pkg-conf": "^2.1.0" } }, "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "skin-tone": ["skin-tone@2.0.0", "", { "dependencies": { "unicode-emoji-modifier-base": "^1.0.0" } }, "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "spawn-error-forwarder": ["spawn-error-forwarder@1.0.0", "", {}, "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g=="],
+
+    "spdx-correct": ["spdx-correct@3.2.0", "", { "dependencies": { "spdx-expression-parse": "^3.0.0", "spdx-license-ids": "^3.0.0" } }, "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA=="],
+
+    "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
+
+    "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+
+    "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
+
+    "split2": ["split2@1.0.0", "", { "dependencies": { "through2": "~2.0.0" } }, "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "stream-combiner2": ["stream-combiner2@1.1.1", "", { "dependencies": { "duplexer2": "~0.1.0", "readable-stream": "^2.0.2" } }, "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "super-regex": ["super-regex@1.1.0", "", { "dependencies": { "function-timeout": "^1.0.1", "make-asynchronous": "^1.0.1", "time-span": "^5.1.0" } }, "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ=="],
+
+    "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-hyperlinks": ["supports-hyperlinks@3.2.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "temp-dir": ["temp-dir@3.0.0", "", {}, "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw=="],
+
+    "tempy": ["tempy@3.2.0", "", { "dependencies": { "is-stream": "^3.0.0", "temp-dir": "^3.0.0", "type-fest": "^2.12.2", "unique-string": "^3.0.0" } }, "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
+
+    "time-span": ["time-span@5.1.0", "", { "dependencies": { "convert-hrtime": "^5.0.0" } }, "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "traverse": ["traverse@0.6.8", "", {}, "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA=="],
+
+    "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
+
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
+    "unique-string": ["unique-string@3.0.0", "", { "dependencies": { "crypto-random-string": "^4.0.0" } }, "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
+
+    "vite": ["vite@7.3.5", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
+    "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "@actions/http-client/undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
+
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
+
+    "@semantic-release/exec/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
+
+    "@semantic-release/git/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "@semantic-release/github/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
+
+    "@semantic-release/github/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
+
+    "@semantic-release/npm/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
+
+    "@semantic-release/npm/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
+
+    "@semantic-release/release-notes-generator/read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
+
+    "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cli-highlight/yargs": ["yargs@16.2.2", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w=="],
+
+    "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
+
+    "env-ci/execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
+
+    "execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "load-json-file/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "npm/@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
+
+    "npm/@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "npm/@isaacs/string-locale-compare": ["@isaacs/string-locale-compare@1.1.0", "", { "bundled": true }, "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="],
+
+    "npm/@npmcli/agent": ["@npmcli/agent@4.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^11.2.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg=="],
+
+    "npm/@npmcli/arborist": ["@npmcli/arborist@9.8.0", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@isaacs/string-locale-compare": "^1.1.0", "@npmcli/fs": "^5.0.0", "@npmcli/installed-package-contents": "^4.0.0", "@npmcli/map-workspaces": "^5.0.0", "@npmcli/metavuln-calculator": "^9.0.2", "@npmcli/name-from-folder": "^4.0.0", "@npmcli/node-gyp": "^5.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/query": "^5.0.0", "@npmcli/redact": "^4.0.0", "@npmcli/run-script": "^10.0.0", "bin-links": "^6.0.0", "cacache": "^20.0.1", "common-ancestor-path": "^2.0.0", "hosted-git-info": "^9.0.0", "json-stringify-nice": "^1.1.4", "lru-cache": "^11.2.1", "minimatch": "^10.0.3", "nopt": "^9.0.0", "npm-install-checks": "^8.0.0", "npm-package-arg": "^13.0.0", "npm-pick-manifest": "^11.0.1", "npm-registry-fetch": "^19.0.0", "pacote": "^21.0.2", "parse-conflict-json": "^5.0.1", "proc-log": "^6.0.0", "proggy": "^4.0.0", "promise-all-reject-late": "^1.0.0", "promise-call-limit": "^3.0.1", "semver": "^7.3.7", "ssri": "^13.0.0", "treeverse": "^3.0.0", "walk-up-path": "^4.0.0" }, "bundled": true, "bin": { "arborist": "bin/index.js" } }, "sha512-bqjei/1+uait6wA30G7IElMs5VCyGpuVPFQYsvzqhTEEAVmDMsHBCFstcT2lLfeQDvi8MeUQHStfHSArvdTQuw=="],
+
+    "npm/@npmcli/config": ["@npmcli/config@10.11.0", "", { "dependencies": { "@npmcli/map-workspaces": "^5.0.0", "@npmcli/package-json": "^7.0.0", "ci-info": "^4.0.0", "ini": "^6.0.0", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "walk-up-path": "^4.0.0" }, "bundled": true }, "sha512-YeRrOREeF9rYlwQfqbjJc8bjplzdzz2dapOVfV3gl3kSMFn0wEI9+QZQADmAvdd+MKTeOr/ISgNmdxJj6layAA=="],
+
+    "npm/@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" }, "bundled": true }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
+
+    "npm/@npmcli/git": ["@npmcli/git@7.0.2", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/promise-spawn": "^9.0.0", "ini": "^6.0.0", "lru-cache": "^11.2.1", "npm-pick-manifest": "^11.0.1", "proc-log": "^6.0.0", "semver": "^7.3.5", "which": "^6.0.0" } }, "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg=="],
+
+    "npm/@npmcli/installed-package-contents": ["@npmcli/installed-package-contents@4.0.0", "", { "dependencies": { "npm-bundled": "^5.0.0", "npm-normalize-package-bin": "^5.0.0" }, "bin": { "installed-package-contents": "bin/index.js" } }, "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA=="],
+
+    "npm/@npmcli/map-workspaces": ["@npmcli/map-workspaces@5.0.3", "", { "dependencies": { "@npmcli/name-from-folder": "^4.0.0", "@npmcli/package-json": "^7.0.0", "glob": "^13.0.0", "minimatch": "^10.0.3" }, "bundled": true }, "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw=="],
+
+    "npm/@npmcli/metavuln-calculator": ["@npmcli/metavuln-calculator@9.0.3", "", { "dependencies": { "cacache": "^20.0.0", "json-parse-even-better-errors": "^5.0.0", "pacote": "^21.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5" }, "bundled": true }, "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg=="],
+
+    "npm/@npmcli/name-from-folder": ["@npmcli/name-from-folder@4.0.0", "", {}, "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg=="],
+
+    "npm/@npmcli/node-gyp": ["@npmcli/node-gyp@5.0.0", "", {}, "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ=="],
+
+    "npm/@npmcli/package-json": ["@npmcli/package-json@7.0.5", "", { "dependencies": { "@npmcli/git": "^7.0.0", "glob": "^13.0.0", "hosted-git-info": "^9.0.0", "json-parse-even-better-errors": "^5.0.0", "proc-log": "^6.0.0", "semver": "^7.5.3", "spdx-expression-parse": "^4.0.0" }, "bundled": true }, "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ=="],
+
+    "npm/@npmcli/promise-spawn": ["@npmcli/promise-spawn@9.0.1", "", { "dependencies": { "which": "^6.0.0" }, "bundled": true }, "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q=="],
+
+    "npm/@npmcli/query": ["@npmcli/query@5.0.0", "", { "dependencies": { "postcss-selector-parser": "^7.0.0" } }, "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ=="],
+
+    "npm/@npmcli/redact": ["@npmcli/redact@4.0.0", "", { "bundled": true }, "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q=="],
+
+    "npm/@npmcli/run-script": ["@npmcli/run-script@10.0.4", "", { "dependencies": { "@npmcli/node-gyp": "^5.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^9.0.0", "node-gyp": "^12.1.0", "proc-log": "^6.0.0" }, "bundled": true }, "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg=="],
+
+    "npm/@sigstore/bundle": ["@sigstore/bundle@4.0.0", "", { "dependencies": { "@sigstore/protobuf-specs": "^0.5.0" } }, "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A=="],
+
+    "npm/@sigstore/core": ["@sigstore/core@3.2.1", "", {}, "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g=="],
+
+    "npm/@sigstore/protobuf-specs": ["@sigstore/protobuf-specs@0.5.1", "", {}, "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g=="],
+
+    "npm/@sigstore/sign": ["@sigstore/sign@4.1.1", "", { "dependencies": { "@gar/promise-retry": "^1.0.2", "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.2.0", "@sigstore/protobuf-specs": "^0.5.0", "make-fetch-happen": "^15.0.4", "proc-log": "^6.1.0" } }, "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ=="],
+
+    "npm/@sigstore/tuf": ["@sigstore/tuf@4.0.2", "", { "dependencies": { "@sigstore/protobuf-specs": "^0.5.0", "tuf-js": "^4.1.0" }, "bundled": true }, "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ=="],
+
+    "npm/@sigstore/verify": ["@sigstore/verify@3.1.1", "", { "dependencies": { "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.2.1", "@sigstore/protobuf-specs": "^0.5.0" } }, "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA=="],
+
+    "npm/@tufjs/canonical-json": ["@tufjs/canonical-json@2.0.0", "", {}, "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA=="],
+
+    "npm/@tufjs/models": ["@tufjs/models@4.1.0", "", { "dependencies": { "@tufjs/canonical-json": "2.0.0", "minimatch": "^10.1.1" } }, "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww=="],
+
+    "npm/abbrev": ["abbrev@4.0.0", "", { "bundled": true }, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
+
+    "npm/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "npm/aproba": ["aproba@2.1.0", "", {}, "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew=="],
+
+    "npm/archy": ["archy@1.0.0", "", { "bundled": true }, "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="],
+
+    "npm/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "npm/bin-links": ["bin-links@6.0.2", "", { "dependencies": { "cmd-shim": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "proc-log": "^6.0.0", "read-cmd-shim": "^6.0.0", "write-file-atomic": "^7.0.0" } }, "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w=="],
+
+    "npm/binary-extensions": ["binary-extensions@3.1.0", "", {}, "sha512-Jvvd9hy1w+xUad8+ckQsWA/V1AoyubOvqn0aygjMOVM4BfIaRav1NFS3LsTSDaV4n4FtcCtQXvzep1E6MboqwQ=="],
+
+    "npm/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "npm/cacache": ["cacache@20.0.4", "", { "dependencies": { "@npmcli/fs": "^5.0.0", "fs-minipass": "^3.0.0", "glob": "^13.0.0", "lru-cache": "^11.1.0", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^13.0.0" }, "bundled": true }, "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA=="],
+
+    "npm/chalk": ["chalk@5.6.2", "", { "bundled": true }, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "npm/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "npm/ci-info": ["ci-info@4.4.0", "", { "bundled": true }, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "npm/cidr-regex": ["cidr-regex@5.0.5", "", {}, "sha512-59tdLZcC+BJXa4C5rOmVSuJTy/UneqfJJtCraqwdx5BDHTkGrBtKCUl3u2uiCFvXu+wk0kVuX8axX7yHCZOI9w=="],
+
+    "npm/cmd-shim": ["cmd-shim@8.0.0", "", {}, "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA=="],
+
+    "npm/common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
+
+    "npm/cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "npm/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "npm/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "npm/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "npm/exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
+    "npm/fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", { "bundled": true }, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
+
+    "npm/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "npm/fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" }, "bundled": true }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
+
+    "npm/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" }, "bundled": true }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "npm/graceful-fs": ["graceful-fs@4.2.11", "", { "bundled": true }, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "npm/hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" }, "bundled": true }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
+
+    "npm/http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "npm/http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "npm/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "npm/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "npm/ignore-walk": ["ignore-walk@8.0.0", "", { "dependencies": { "minimatch": "^10.0.3" } }, "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A=="],
+
+    "npm/ini": ["ini@6.0.0", "", { "bundled": true }, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "npm/init-package-json": ["init-package-json@8.2.5", "", { "dependencies": { "@npmcli/package-json": "^7.0.0", "npm-package-arg": "^13.0.0", "promzard": "^3.0.1", "read": "^5.0.1", "semver": "^7.7.2", "validate-npm-package-name": "^7.0.0" }, "bundled": true }, "sha512-IknQ+upLuJU6t3p0uo9wS3GjFD/1GtxIwcIGYOWR8zL2HxQeJwvxYTgZr9brJ8pyZ4kvpkebM8ZKcyqOeLOHSg=="],
+
+    "npm/ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "npm/is-cidr": ["is-cidr@6.0.4", "", { "dependencies": { "cidr-regex": "^5.0.4" }, "bundled": true }, "sha512-tOIBU3QiXy0W4LvHbcKWAWSuQfGwDiEILphFCAZtDqj7C57uv3ClO6K8aNEGV4VTA7bWJlpQ0suKQkUe6Rd6ag=="],
+
+    "npm/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
+    "npm/json-parse-even-better-errors": ["json-parse-even-better-errors@5.0.0", "", { "bundled": true }, "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ=="],
+
+    "npm/json-stringify-nice": ["json-stringify-nice@1.1.4", "", {}, "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw=="],
+
+    "npm/jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
+
+    "npm/just-diff": ["just-diff@6.0.2", "", {}, "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA=="],
+
+    "npm/just-diff-apply": ["just-diff-apply@5.5.0", "", {}, "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw=="],
+
+    "npm/libnpmaccess": ["libnpmaccess@10.0.3", "", { "dependencies": { "npm-package-arg": "^13.0.0", "npm-registry-fetch": "^19.0.0" }, "bundled": true }, "sha512-JPHTfWJxIK+NVPdNMNGnkz4XGX56iijPbe0qFWbdt68HL+kIvSzh+euBL8npLZvl2fpaxo+1eZSdoG15f5YdIQ=="],
+
+    "npm/libnpmdiff": ["libnpmdiff@8.1.10", "", { "dependencies": { "@npmcli/arborist": "^9.8.0", "@npmcli/installed-package-contents": "^4.0.0", "binary-extensions": "^3.0.0", "diff": "^8.0.2", "minimatch": "^10.0.3", "npm-package-arg": "^13.0.0", "pacote": "^21.0.2", "tar": "^7.5.1" }, "bundled": true }, "sha512-UWZPUjkaCuE6+b5kgFrfeIjCR/4IWdU1QRu6jAGgUrk4sKMgnrHKdZ5JzNM4SnPfzLC51+Ts/woEKG7JMEJsPw=="],
+
+    "npm/libnpmexec": ["libnpmexec@10.3.0", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/arborist": "^9.8.0", "@npmcli/package-json": "^7.0.0", "@npmcli/run-script": "^10.0.0", "ci-info": "^4.0.0", "npm-package-arg": "^13.0.0", "pacote": "^21.0.2", "proc-log": "^6.0.0", "read": "^5.0.1", "semver": "^7.3.7", "signal-exit": "^4.1.0", "walk-up-path": "^4.0.0" }, "bundled": true }, "sha512-JzRj0fVmvBpqrQJ+3Cv0VGPjiDvJbnBu+nbUXKJ/5BUISoSYd0KShyjZsZaIiMZLlDjzFgvDXMZZP2bhVhhVdQ=="],
+
+    "npm/libnpmfund": ["libnpmfund@7.0.24", "", { "dependencies": { "@npmcli/arborist": "^9.8.0" }, "bundled": true }, "sha512-ubiggibzvG9TQr8KO0Jf6hLQbvfJHr+I4Lo740qV+/03e0SLSRjnHArqgffubEFtmtvrHfeNX/YYFfZaeaiE7A=="],
+
+    "npm/libnpmorg": ["libnpmorg@8.0.1", "", { "dependencies": { "aproba": "^2.0.0", "npm-registry-fetch": "^19.0.0" }, "bundled": true }, "sha512-/QeyXXg4hqMw0ESM7pERjIT2wbR29qtFOWIOug/xO4fRjS3jJJhoAPQNsnHtdwnCqgBdFpGQ45aIdFFZx2YhTA=="],
+
+    "npm/libnpmpack": ["libnpmpack@9.1.10", "", { "dependencies": { "@npmcli/arborist": "^9.8.0", "@npmcli/run-script": "^10.0.0", "npm-package-arg": "^13.0.0", "pacote": "^21.0.2" }, "bundled": true }, "sha512-J8V8wUBkqRRVtAn43zTMcw3vFyODlOGkS9jq4esolBLCwxuMDjNarWn5Og+DeZLocsHYtlqc963a1hUFOrKIHQ=="],
+
+    "npm/libnpmpublish": ["libnpmpublish@11.2.0", "", { "dependencies": { "@npmcli/package-json": "^7.0.0", "ci-info": "^4.0.0", "npm-package-arg": "^13.0.0", "npm-registry-fetch": "^19.0.0", "proc-log": "^6.0.0", "semver": "^7.3.7", "sigstore": "^4.0.0", "ssri": "^13.0.0" }, "bundled": true }, "sha512-fAEts7UCM2r1xhI82Dv9PK4gFGZoyD7Z5sfIwBQKoO/f67VNVDC0DeH3uH1Yi+T4kwt5iBuCKkZ5XcpxfvsGHQ=="],
+
+    "npm/libnpmsearch": ["libnpmsearch@9.0.1", "", { "dependencies": { "npm-registry-fetch": "^19.0.0" }, "bundled": true }, "sha512-oKw58X415ERY/BOGV3jQPVMcep8YeMRWMzuuqB0BAIM5VxicOU1tQt19ExCu4SV77SiTOEoziHxGEgJGw3FBYQ=="],
+
+    "npm/libnpmteam": ["libnpmteam@8.0.2", "", { "dependencies": { "aproba": "^2.0.0", "npm-registry-fetch": "^19.0.0" }, "bundled": true }, "sha512-ypLrDUQoi8EhG+gzx5ENMcYq23YjPV17Mfvx4nOnQiHOi8vp47+4GvZBrMsEM4yeHPwxguF/HZoXH4rJfHdH/w=="],
+
+    "npm/libnpmversion": ["libnpmversion@8.0.4", "", { "dependencies": { "@npmcli/git": "^7.0.0", "@npmcli/run-script": "^10.0.0", "json-parse-even-better-errors": "^5.0.0", "proc-log": "^6.0.0", "semver": "^7.3.7" }, "bundled": true }, "sha512-5NiNpLxXkNeLHCYVTLxX/qRgdAoRAjiR0arFdVpQ5kZOJ2b0pHdXS9G3qC7uiqVsLa/gfQQIbQIEPdmSMKXF2A=="],
+
+    "npm/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+
+    "npm/make-fetch-happen": ["make-fetch-happen@15.0.6", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/agent": "^4.0.0", "@npmcli/redact": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^6.0.0", "ssri": "^13.0.0" }, "bundled": true }, "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw=="],
+
+    "npm/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" }, "bundled": true }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "npm/minipass": ["minipass@7.1.3", "", { "bundled": true }, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "npm/minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
+
+    "npm/minipass-fetch": ["minipass-fetch@5.0.2", "", { "dependencies": { "minipass": "^7.0.3", "minipass-sized": "^2.0.0", "minizlib": "^3.0.1" }, "optionalDependencies": { "iconv-lite": "^0.7.2" } }, "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ=="],
+
+    "npm/minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
+
+    "npm/minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" }, "bundled": true }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
+
+    "npm/minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
+
+    "npm/minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "npm/ms": ["ms@2.1.3", "", { "bundled": true }, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "npm/mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
+    "npm/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "npm/node-gyp": ["node-gyp@12.4.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bundled": true, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw=="],
+
+    "npm/nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bundled": true, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
+
+    "npm/npm-audit-report": ["npm-audit-report@7.0.0", "", { "bundled": true }, "sha512-bluLL4xwGr/3PERYz50h2Upco0TJMDcLcymuFnfDWeGO99NqH724MNzhWi5sXXuXf2jbytFF0LyR8W+w1jTI6A=="],
+
+    "npm/npm-bundled": ["npm-bundled@5.0.0", "", { "dependencies": { "npm-normalize-package-bin": "^5.0.0" } }, "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw=="],
+
+    "npm/npm-install-checks": ["npm-install-checks@8.0.0", "", { "dependencies": { "semver": "^7.1.1" }, "bundled": true }, "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA=="],
+
+    "npm/npm-normalize-package-bin": ["npm-normalize-package-bin@5.0.0", "", {}, "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag=="],
+
+    "npm/npm-package-arg": ["npm-package-arg@13.0.2", "", { "dependencies": { "hosted-git-info": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "validate-npm-package-name": "^7.0.0" }, "bundled": true }, "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA=="],
+
+    "npm/npm-packlist": ["npm-packlist@10.0.4", "", { "dependencies": { "ignore-walk": "^8.0.0", "proc-log": "^6.0.0" } }, "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng=="],
+
+    "npm/npm-pick-manifest": ["npm-pick-manifest@11.0.3", "", { "dependencies": { "npm-install-checks": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "npm-package-arg": "^13.0.0", "semver": "^7.3.5" }, "bundled": true }, "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ=="],
+
+    "npm/npm-profile": ["npm-profile@12.0.2", "", { "dependencies": { "npm-registry-fetch": "^19.0.0", "proc-log": "^6.1.0" }, "bundled": true }, "sha512-+OKkPvqvx83vRG8aIetzABI99e5uzZZ6HIS5zCr+oRPSuDL0Buk1KJh/LqyR0BuiWmLeDWGI77igNYipztLm1w=="],
+
+    "npm/npm-registry-fetch": ["npm-registry-fetch@19.1.1", "", { "dependencies": { "@npmcli/redact": "^4.0.0", "jsonparse": "^1.3.1", "make-fetch-happen": "^15.0.0", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minizlib": "^3.0.1", "npm-package-arg": "^13.0.0", "proc-log": "^6.0.0" }, "bundled": true }, "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw=="],
+
+    "npm/npm-user-validate": ["npm-user-validate@4.0.0", "", { "bundled": true }, "sha512-TP+Ziq/qPi/JRdhaEhnaiMkqfMGjhDLoh/oRfW+t5aCuIfJxIUxvwk6Sg/6ZJ069N/Be6gs00r+aZeJTfS9uHQ=="],
+
+    "npm/p-map": ["p-map@7.0.4", "", { "bundled": true }, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
+
+    "npm/pacote": ["pacote@21.5.1", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/git": "^7.0.0", "@npmcli/installed-package-contents": "^4.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^9.0.0", "@npmcli/run-script": "^10.0.0", "cacache": "^20.0.0", "fs-minipass": "^3.0.0", "minipass": "^7.0.2", "npm-package-arg": "^13.0.0", "npm-packlist": "^10.0.1", "npm-pick-manifest": "^11.0.1", "npm-registry-fetch": "^19.0.0", "proc-log": "^6.0.0", "sigstore": "^4.0.0", "ssri": "^13.0.0", "tar": "^7.4.3" }, "bundled": true, "bin": { "pacote": "bin/index.js" } }, "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg=="],
+
+    "npm/parse-conflict-json": ["parse-conflict-json@5.0.1", "", { "dependencies": { "json-parse-even-better-errors": "^5.0.0", "just-diff": "^6.0.0", "just-diff-apply": "^5.2.0" }, "bundled": true }, "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ=="],
+
+    "npm/path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "npm/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "npm/postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
+
+    "npm/proc-log": ["proc-log@6.1.0", "", { "bundled": true }, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
+
+    "npm/proggy": ["proggy@4.0.0", "", {}, "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ=="],
+
+    "npm/promise-all-reject-late": ["promise-all-reject-late@1.0.1", "", {}, "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw=="],
+
+    "npm/promise-call-limit": ["promise-call-limit@3.0.2", "", {}, "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw=="],
+
+    "npm/promzard": ["promzard@3.0.1", "", { "dependencies": { "read": "^5.0.0" } }, "sha512-M5mHhWh+Adz0BIxgSrqcc6GTCSconR7zWQV9vnOSptNtr6cSFlApLc28GbQhuN6oOWBQeV2C0bNE47JCY/zu3Q=="],
+
+    "npm/qrcode-terminal": ["qrcode-terminal@0.12.0", "", { "bundled": true, "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="],
+
+    "npm/read": ["read@5.0.1", "", { "dependencies": { "mute-stream": "^3.0.0" }, "bundled": true }, "sha512-+nsqpqYkkpet2UVPG8ZiuE8d113DK4vHYEoEhcrXBAlPiq6di7QRTuNiKQAbaRYegobuX2BpZ6QjanKOXnJdTA=="],
+
+    "npm/read-cmd-shim": ["read-cmd-shim@6.0.0", "", {}, "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A=="],
+
+    "npm/safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "npm/semver": ["semver@7.8.5", "", { "bundled": true, "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "npm/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "npm/sigstore": ["sigstore@4.1.1", "", { "dependencies": { "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.2.1", "@sigstore/protobuf-specs": "^0.5.0", "@sigstore/sign": "^4.1.1", "@sigstore/tuf": "^4.0.2", "@sigstore/verify": "^3.1.1" } }, "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w=="],
+
+    "npm/smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "npm/socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "npm/socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "npm/spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
+
+    "npm/spdx-expression-parse": ["spdx-expression-parse@4.0.0", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" }, "bundled": true }, "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ=="],
+
+    "npm/spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
+
+    "npm/ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" }, "bundled": true }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
+
+    "npm/supports-color": ["supports-color@10.2.2", "", { "bundled": true }, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "npm/tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" }, "bundled": true }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
+
+    "npm/text-table": ["text-table@0.2.0", "", { "bundled": true }, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
+
+    "npm/tiny-relative-date": ["tiny-relative-date@2.0.2", "", { "bundled": true }, "sha512-rGxAbeL9z3J4pI2GtBEoFaavHdO4RKAU54hEuOef5kfx5aPqiQtbhYktMOTL5OA33db8BjsDcLXuNp+/v19PHw=="],
+
+    "npm/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "npm/treeverse": ["treeverse@3.0.0", "", { "bundled": true }, "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ=="],
+
+    "npm/tuf-js": ["tuf-js@4.1.0", "", { "dependencies": { "@tufjs/models": "4.1.0", "debug": "^4.4.3", "make-fetch-happen": "^15.0.1" } }, "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ=="],
+
+    "npm/undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
+
+    "npm/util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "npm/validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", { "bundled": true }, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
+
+    "npm/walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "npm/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bundled": true, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
+    "npm/write-file-atomic": ["write-file-atomic@7.0.1", "", { "dependencies": { "signal-exit": "^4.0.1" } }, "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg=="],
+
+    "npm/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "read-package-up/type-fest": ["type-fest@5.7.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg=="],
+
+    "read-pkg/type-fest": ["type-fest@5.7.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg=="],
+
+    "read-pkg/unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
+
+    "semantic-release/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
+
+    "semantic-release/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
+
+    "semantic-release/p-reduce": ["p-reduce@3.0.0", "", {}, "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q=="],
+
+    "signale/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
+
+    "signale/figures": ["figures@2.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA=="],
+
+    "tempy/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
+
+    "tempy/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@semantic-release/git/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "@semantic-release/git/execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "@semantic-release/git/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "@semantic-release/git/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "@semantic-release/git/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "@semantic-release/github/aggregate-error/clean-stack": ["clean-stack@5.3.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg=="],
+
+    "@semantic-release/github/aggregate-error/indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "@semantic-release/npm/aggregate-error/clean-stack": ["clean-stack@5.3.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg=="],
+
+    "@semantic-release/npm/aggregate-error/indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "@semantic-release/release-notes-generator/read-package-up/read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
+
+    "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
+    "cli-highlight/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
+    "cli-table3/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cli-table3/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "env-ci/execa/get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
+
+    "env-ci/execa/human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
+
+    "env-ci/execa/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
+
+    "env-ci/execa/npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
+
+    "env-ci/execa/onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
+
+    "env-ci/execa/strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "npm/minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "npm/minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "semantic-release/aggregate-error/clean-stack": ["clean-stack@5.3.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg=="],
+
+    "semantic-release/aggregate-error/indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "signale/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "signale/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+
+    "signale/figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
+
+    "@semantic-release/release-notes-generator/read-package-up/read-pkg/unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
+
+    "cli-highlight/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "cli-highlight/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cli-highlight/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "cli-highlight/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cli-highlight/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "env-ci/execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "env-ci/execa/onetime/mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
+
+    "npm/minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "npm/minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "signale/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
+    "cli-highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cli-highlight/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "cli-highlight/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "cli-highlight/yargs/cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "cli-highlight/yargs/cliui/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+  }
+}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+# Supply-chain hardening: ignore package versions published less than 3 days ago.
+minimumReleaseAge = 259200

--- a/package.json
+++ b/package.json
@@ -35,25 +35,23 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.9",
+    "@biomejs/biome": "^2.5.0",
+    "@clack/prompts": "^0.10.1",
+    "@dosu/api-types": "0.0.7",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@trpc/client": "11.8.0",
     "@trpc/server": "11.8.0",
-    "@types/bun": "^1.3.11",
-    "@vitest/coverage-v8": "^3.2.0",
-    "semantic-release": "^25.0.3",
-    "typescript": "^5.8.3",
-    "vitest": "^3.1.1"
-  },
-  "dependencies": {
-    "@clack/prompts": "^0.10.0",
-    "@dosu/api-types": "0.0.7",
+    "@types/bun": "^1.3.14",
+    "@vitest/coverage-v8": "^4.1.9",
     "commander": "^13.1.0",
-    "open": "^10.1.0",
+    "open": "^10.2.0",
     "picocolors": "^1.1.1",
+    "semantic-release": "^25.0.5",
     "superjson": "^2.2.6",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9",
     "write-file-atomic": "^5.0.1"
   }
 }

--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -506,4 +506,310 @@ describe("runAgentSetup", () => {
       reason: "not_found",
     });
   });
+
+  it("emits fetch_failed when loading deployments throws while resolving --deployment", async () => {
+    mockExchangeTicket.mockResolvedValue({
+      status: "authenticated",
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_in: 3600,
+    });
+    mockClient.getDeployments.mockRejectedValue(new Error("api down"));
+
+    const code = await runAgentSetup({
+      tool: "claude",
+      loginTicket: "tkt",
+      deploymentID: "dep-X",
+    });
+
+    expect(code).toBe(1);
+    const events = emittedEvents();
+    expect(events.at(-1)).toMatchObject({
+      step: "deployment",
+      status: "error",
+      reason: "fetch_failed",
+      agent_next_steps: expect.stringContaining("api down"),
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("emits fetch_failed when auto-resolving deployments throws", async () => {
+    mockExchangeTicket.mockResolvedValue({
+      status: "authenticated",
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_in: 3600,
+    });
+    mockClient.getDeployments.mockRejectedValue("boom");
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt" });
+
+    expect(code).toBe(1);
+    const events = emittedEvents();
+    expect(events.at(-1)).toMatchObject({
+      step: "deployment",
+      status: "error",
+      reason: "fetch_failed",
+      agent_next_steps: expect.stringContaining("boom"),
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("emits no_deployments when the account has no deployments at all", async () => {
+    mockExchangeTicket.mockResolvedValue({
+      status: "authenticated",
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_in: 3600,
+    });
+    mockClient.getDeployments.mockResolvedValue([]);
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt" });
+
+    expect(code).toBe(1);
+    const events = emittedEvents();
+    expect(events.at(-1)).toMatchObject({
+      step: "deployment",
+      status: "error",
+      reason: "no_deployments",
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("reuses a deployment already locked in from a previous run", async () => {
+    mockLoadConfig.mockReturnValue({
+      ...baseCfg,
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      deployment_id: "dep-locked",
+      deployment_name: "acme/locked",
+    });
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(false);
+    mockClient.createAPIKey.mockResolvedValue({
+      api_key: "sk_user_locked",
+      id: "k9",
+      name: "dosu-cli",
+      key_prefix: "sk_user_locked",
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(0);
+    const events = emittedEvents();
+    const depEvent = events.find((e) => e.step === "deployment");
+    expect(depEvent).toMatchObject({
+      step: "deployment",
+      status: "ok",
+      deployment_id: "dep-locked",
+      name: "acme/locked",
+    });
+    // Deployment was reused, not re-fetched.
+    expect(mockClient.getDeployments).not.toHaveBeenCalled();
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a still-valid API key without minting a new one", async () => {
+    mockLoadConfig.mockReturnValue({
+      ...baseCfg,
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      deployment_id: "dep-locked",
+      deployment_name: "acme/locked",
+      api_key: "sk_existing",
+    });
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(0);
+    const events = emittedEvents();
+    const keyEvent = events.find((e) => e.step === "api_key");
+    expect(keyEvent).toMatchObject({ step: "api_key", reused: true });
+    expect(mockClient.createAPIKey).not.toHaveBeenCalled();
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits create_failed when minting the API key throws", async () => {
+    mockLoadConfig.mockReturnValue({
+      ...baseCfg,
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      deployment_id: "dep-locked",
+      deployment_name: "acme/locked",
+    });
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(false);
+    mockClient.createAPIKey.mockRejectedValue(new Error("key service down"));
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    const events = emittedEvents();
+    expect(events.at(-1)).toMatchObject({
+      step: "api_key",
+      status: "error",
+      reason: "create_failed",
+      agent_next_steps: expect.stringContaining("key service down"),
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("emits install_failed when the provider install throws", async () => {
+    mockLoadConfig.mockReturnValue({
+      ...baseCfg,
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      deployment_id: "dep-locked",
+      deployment_name: "acme/locked",
+      api_key: "sk_existing",
+    });
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    (claudeProvider.install as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    const events = emittedEvents();
+    expect(events.at(-1)).toMatchObject({
+      step: "mcp_install",
+      status: "error",
+      reason: "install_failed",
+      agent_next_steps: expect.stringContaining("disk full"),
+    });
+  });
+
+  it("redeems a ticket whose response omits tokens, falling back to defaults", async () => {
+    mockExchangeTicket.mockResolvedValue({ status: "authenticated" });
+    mockClient.getDeployments.mockResolvedValue([
+      {
+        deployment_id: "dep-1",
+        name: "acme/main",
+        description: "",
+        provider_slug: "dosu_mcp",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-1",
+      },
+    ]);
+    mockClient.validateAPIKey.mockResolvedValue(false);
+    mockClient.createAPIKey.mockResolvedValue({
+      api_key: "sk_user_x",
+      id: "k1",
+      name: "dosu-cli",
+      key_prefix: "sk_user_x",
+    });
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt-good" });
+
+    expect(code).toBe(0);
+    const authSave = mockSaveConfig.mock.calls[0]?.[0] as {
+      access_token: string;
+      refresh_token: string;
+      expires_at: number;
+    };
+    expect(authSave.access_token).toBe("");
+    expect(authSave.refresh_token).toBe("");
+    expect(authSave.expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000) + 3000);
+  });
+
+  it("emits ticket_exchange_failed when redeeming a ticket throws", async () => {
+    mockExchangeTicket.mockRejectedValue(new Error("exchange boom"));
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt" });
+
+    expect(code).toBe(1);
+    expect(emittedEvents()).toEqual([
+      expect.objectContaining({
+        step: "auth",
+        status: "error",
+        reason: "ticket_exchange_failed",
+        agent_next_steps: expect.stringContaining("exchange boom"),
+      }),
+    ]);
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an expired token and continues when the raw probe is unauthorized", async () => {
+    mockLoadConfig
+      .mockReturnValueOnce({
+        ...baseCfg,
+        access_token: "stale",
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      })
+      .mockReturnValue({
+        ...baseCfg,
+        access_token: "fresh",
+        refresh_token: "ref2",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      });
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 401 }));
+    mockClient.refreshToken.mockResolvedValue(undefined);
+    mockClient.validateAPIKey.mockResolvedValue(true);
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(0);
+    expect(mockClient.refreshToken).toHaveBeenCalledTimes(1);
+    const events = emittedEvents();
+    expect(events.map((e) => e.step)).toContain("auth");
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("mints a ticket when the existing session is unauthorized and refresh fails", async () => {
+    mockLoadConfig.mockReturnValue({
+      ...baseCfg,
+      access_token: "stale",
+      refresh_token: "ref",
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    });
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 401 }));
+    mockClient.refreshToken.mockRejectedValue(new Error("refresh failed"));
+    mockMintTicket.mockResolvedValue({
+      ticket: "tkt-fresh",
+      expires_in: 600,
+      url: "https://app.dosu.dev/cli/auth?ticket=tkt-fresh",
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(0);
+    const events = emittedEvents();
+    expect(events.at(-1)).toMatchObject({
+      step: "auth",
+      status: "need_user_action",
+      ticket: "tkt-fresh",
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("emits ticket_mint_failed when minting a fresh ticket throws", async () => {
+    mockMintTicket.mockRejectedValue(new Error("mint boom"));
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(emittedEvents()).toEqual([
+      expect.objectContaining({
+        step: "auth",
+        status: "error",
+        reason: "ticket_mint_failed",
+        agent_next_steps: expect.stringContaining("mint boom"),
+      }),
+    ]);
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
 });

--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -49,7 +49,7 @@ vi.mock("../setup/flow", () => ({
 }));
 
 vi.mock("../client/client", () => ({
-  Client: vi.fn().mockImplementation((cfg: unknown) => {
+  Client: vi.fn().mockImplementation(function (cfg: unknown) {
     mockClientConstructor(cfg);
     return mockClient;
   }),
@@ -123,7 +123,7 @@ describe("runAgentSetup", () => {
   let stdioProvider: SetupProvider;
 
   function emittedEvents(): Array<Record<string, unknown>> {
-    return logSpy.mock.calls.map((c) => JSON.parse(c[0] as string));
+    return logSpy.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
   }
 
   beforeEach(() => {

--- a/src/agent/login-commands.test.ts
+++ b/src/agent/login-commands.test.ts
@@ -96,6 +96,26 @@ describe("runLoginRequest", () => {
       reason: "mint_failed",
     });
   });
+
+  it("prints a human-readable error when minting fails (no --json)", async () => {
+    mockMintTicket.mockRejectedValue(new Error("network down"));
+
+    const code = await runLoginRequest({ json: false });
+
+    expect(code).toBe(1);
+    const joined = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(joined).toContain("Failed to mint login ticket: network down");
+  });
+
+  it("stringifies non-Error rejections when minting fails (no --json)", async () => {
+    mockMintTicket.mockRejectedValue("boom");
+
+    const code = await runLoginRequest({ json: false });
+
+    expect(code).toBe(1);
+    const joined = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(joined).toContain("Failed to mint login ticket: boom");
+  });
 });
 
 describe("runLoginCheck", () => {
@@ -195,5 +215,96 @@ describe("runLoginCheck", () => {
     const joined = logSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
     expect(joined).toContain("Successfully authenticated");
     expect(joined).toContain("user@example.com");
+  });
+
+  it("emits a structured error when exchange throws (--json)", async () => {
+    mockExchangeTicket.mockRejectedValue(new Error("network down"));
+
+    const code = await runLoginCheck({ ticket: "tkt", json: true });
+
+    expect(code).toBe(1);
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+    const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+    expect(payload).toMatchObject({
+      step: "check",
+      status: "error",
+      reason: "exchange_failed",
+    });
+  });
+
+  it("prints a human-readable error when exchange throws (no --json)", async () => {
+    mockExchangeTicket.mockRejectedValue(new Error("network down"));
+
+    const code = await runLoginCheck({ ticket: "tkt", json: false });
+
+    expect(code).toBe(1);
+    const joined = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(joined).toContain("Ticket exchange failed: network down");
+  });
+
+  it("stringifies non-Error rejections when exchange throws (no --json)", async () => {
+    mockExchangeTicket.mockRejectedValue("boom");
+
+    const code = await runLoginCheck({ ticket: "tkt", json: false });
+
+    expect(code).toBe(1);
+    const joined = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(joined).toContain("Ticket exchange failed: boom");
+  });
+
+  it("falls back to defaults when authenticated response omits tokens", async () => {
+    mockExchangeTicket.mockResolvedValue({ status: "authenticated" });
+
+    const code = await runLoginCheck({ ticket: "tkt", json: true });
+
+    expect(code).toBe(0);
+    expect(mockSaveConfig).toHaveBeenCalledTimes(1);
+    const saved = mockSaveConfig.mock.calls[0]?.[0] as {
+      access_token: string;
+      refresh_token: string;
+      expires_at: number;
+    };
+    expect(saved.access_token).toBe("");
+    expect(saved.refresh_token).toBe("");
+    // 3600s fallback applied.
+    expect(saved.expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000) + 3000);
+  });
+
+  it("omits the email line in non-JSON mode when no email is returned", async () => {
+    mockExchangeTicket.mockResolvedValue({
+      status: "authenticated",
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_in: 3600,
+    });
+
+    const code = await runLoginCheck({ ticket: "tkt", json: false });
+
+    expect(code).toBe(0);
+    const joined = logSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(joined).toContain("Successfully authenticated");
+    expect(joined).not.toContain("Signed in as");
+  });
+
+  it("prints a human-readable pending message in non-JSON mode", async () => {
+    mockExchangeTicket.mockResolvedValue({ status: "pending" });
+
+    const code = await runLoginCheck({ ticket: "tkt", json: false });
+
+    expect(code).toBe(0);
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+    const joined = logSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(joined).toContain("Still waiting for the user to complete sign-in");
+  });
+
+  it("prints a human-readable expired message in non-JSON mode", async () => {
+    mockExchangeTicket.mockResolvedValue({ status: "expired" });
+
+    const code = await runLoginCheck({ ticket: "tkt", json: false });
+
+    expect(code).toBe(1);
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+    const joined = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(joined).toContain("Ticket has expired or was already used");
   });
 });

--- a/src/agent/login-commands.test.ts
+++ b/src/agent/login-commands.test.ts
@@ -76,7 +76,7 @@ describe("runLoginRequest", () => {
     const code = await runLoginRequest({ json: false });
 
     expect(code).toBe(0);
-    const joined = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    const joined = logSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
     expect(joined).toContain("https://app.dosu.dev/cli/auth?ticket=tkt-xyz");
     expect(joined).toContain("dosu login --check tkt-xyz");
     // No --json suffix when the user did not opt in.
@@ -192,7 +192,7 @@ describe("runLoginCheck", () => {
     const code = await runLoginCheck({ ticket: "tkt", json: false });
 
     expect(code).toBe(0);
-    const joined = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    const joined = logSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
     expect(joined).toContain("Successfully authenticated");
     expect(joined).toContain("user@example.com");
   });

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -108,7 +108,7 @@ async function run(...args: string[]) {
 }
 
 function allLogOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 function mockSuccessfulRefresh(accessToken: string, refreshToken: string): void {

--- a/src/client/trpc.test.ts
+++ b/src/client/trpc.test.ts
@@ -26,9 +26,9 @@ const { mockRefreshToken } = vi.hoisted(() => ({
   mockRefreshToken: vi.fn(),
 }));
 vi.mock("./client", () => ({
-  Client: vi.fn().mockImplementation(() => ({
-    refreshToken: mockRefreshToken,
-  })),
+  Client: vi.fn().mockImplementation(function () {
+    return { refreshToken: mockRefreshToken };
+  }),
 }));
 
 function makeConfig(overrides: Partial<Config> = {}): Config {

--- a/src/commands/analytics.test.ts
+++ b/src/commands/analytics.test.ts
@@ -38,7 +38,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/ask.test.ts
+++ b/src/commands/ask.test.ts
@@ -34,11 +34,11 @@ function jsonResponse(data: unknown, status = 200): Response {
 }
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 function allErrors(): string {
-  return errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/deployments.test.ts
+++ b/src/commands/deployments.test.ts
@@ -42,7 +42,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -63,7 +63,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 function jsonResponse(data: unknown, status = 200): Response {
@@ -1019,7 +1019,7 @@ describe("docs import", () => {
       new Error('{"detail":"An import operation is already in progress"}'),
     );
     await expect(run("import", "--json", "github", "--files", "f1")).rejects.toThrow("exit");
-    const errLine = errorSpy.mock.calls.map((c) => c[0]).join("\n");
+    const errLine = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
     const parsed = JSON.parse(errLine) as { error: string };
     expect(parsed.error).toContain("dosu docs import-status");
     expect(mockClackLogError).not.toHaveBeenCalled();
@@ -1029,7 +1029,7 @@ describe("docs import", () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockRejectedValueOnce(new Error('{"detail":"Something went wrong"}'));
     await expect(run("import", "--json", "github", "--files", "f1")).rejects.toThrow("exit");
-    const errLine = errorSpy.mock.calls.map((c) => c[0]).join("\n");
+    const errLine = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
     const parsed = JSON.parse(errLine) as { error: string };
     expect(parsed.error).toBe("Something went wrong");
     expect(mockClackLogError).not.toHaveBeenCalled();

--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -24,7 +24,9 @@ vi.mock("../config/config", async (importOriginal) => {
 });
 
 vi.mock("../client/client", () => ({
-  Client: vi.fn(() => ({ validateAPIKey: vi.fn(async () => true) })),
+  Client: vi.fn(function () {
+    return { validateAPIKey: vi.fn(async () => true) };
+  }),
 }));
 
 import { Client } from "../client/client";
@@ -599,9 +601,9 @@ describe("lifecycle commands", () => {
 
   it("doctor reports a backend failure when the API key is rejected", async () => {
     vi.mocked(loadConfig).mockReturnValue({ ...AUTHED });
-    vi.mocked(Client).mockImplementationOnce(
-      () => ({ validateAPIKey: vi.fn(async () => false) }) as unknown as Client,
-    );
+    vi.mocked(Client).mockImplementationOnce(function () {
+      return { validateAPIKey: vi.fn(async () => false) } as unknown as Client;
+    });
     await runInstall("claude-code", { dir });
     const checks = await collectDoctorChecks({ dir });
     expect(checks.find((c) => c.name === "backend")?.status).toBe("fail");

--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -30,11 +30,12 @@ vi.mock("../client/client", () => ({
 }));
 
 import { Client } from "../client/client";
-import { loadConfig } from "../config/config";
+import { loadConfig, MODE_OSS } from "../config/config";
 import { loadState, saveState, type TicketState } from "../hooks/state";
 import { requestCreateTicket, requestGetTicket, TicketHttpError } from "../hooks/ticket-client";
 import {
   collectDoctorChecks,
+  hooksCommand,
   runDoctor,
   runHookEntrypoint,
   runInstall,
@@ -158,6 +159,36 @@ describe("runUserPromptSubmit", () => {
     expect(saveState).not.toHaveBeenCalled();
     expect(stdout()).toBe("");
   });
+
+  it("no-ops when the prompt field is absent entirely", async () => {
+    await runUserPromptSubmit({ session_id: "sess" });
+    expect(requestCreateTicket).not.toHaveBeenCalled();
+    expect(stdout()).toBe("");
+  });
+
+  it("is silent when create rejects with a non-Error value", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    vi.mocked(requestCreateTicket).mockRejectedValue("boom-string");
+    await runUserPromptSubmit({ session_id: "sess", prompt: "x" });
+    expect(saveState).not.toHaveBeenCalled();
+    expect(stdout()).toBe("");
+  });
+
+  it("honors a valid DOSU_HOOK_TTL_MS override when setting expiresAt", async () => {
+    process.env.DOSU_HOOK_TTL_MS = "5000";
+    vi.mocked(loadState).mockReturnValue(null);
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_ttl",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+    await runUserPromptSubmit({ session_id: "sess", prompt: "p" }, 10_000);
+    expect(saveState).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresAt: 15_000 }), // 10_000 + 5000 override
+    );
+    delete process.env.DOSU_HOOK_TTL_MS;
+  });
 });
 
 describe("runPostToolUse", () => {
@@ -280,6 +311,36 @@ describe("runPostToolUse", () => {
     expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ lastCheckedAt: 50_000 }));
     expect(stdout()).toBe("");
   });
+
+  it("latches the server status (failed/expired) without injecting context", async () => {
+    for (const status of ["failed", "expired"] as const) {
+      vi.clearAllMocks();
+      vi.mocked(loadConfig).mockReturnValue({ ...AUTHED });
+      vi.mocked(loadState).mockReturnValue(pending());
+      vi.mocked(requestGetTicket).mockResolvedValue({
+        ticket_id: "kt_1",
+        status,
+        created_at: "x",
+        expires_at: "y",
+        result: null,
+        error: null,
+      });
+      await runPostToolUse({ session_id: "sess" }, 50_000);
+      expect(saveState).toHaveBeenCalledWith(
+        expect.objectContaining({ status, lastCheckedAt: 50_000 }),
+      );
+      expect(stdout()).toBe("");
+    }
+  });
+
+  it("honors a valid DOSU_HOOK_CHECK_COOLDOWN_MS override on the cooldown gate", async () => {
+    process.env.DOSU_HOOK_CHECK_COOLDOWN_MS = "10000";
+    vi.mocked(loadState).mockReturnValue(pending({ lastCheckedAt: 1000 }));
+    await runPostToolUse({ session_id: "sess" }, 5000); // 4000ms < 10000ms override
+    expect(requestGetTicket).not.toHaveBeenCalled();
+    expect(stdout()).toBe("");
+    delete process.env.DOSU_HOOK_CHECK_COOLDOWN_MS;
+  });
 });
 
 describe("runStop", () => {
@@ -374,6 +435,66 @@ describe("runStop", () => {
     await runStop({ session_id: "sess" }, 70_000);
     expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
   });
+
+  it("continues without polling when the ticket is in a terminal (non-pending) state", async () => {
+    vi.mocked(loadState).mockReturnValue(pending({ status: "delivered" }));
+    await runStop({ session_id: "sess" }, 70_000);
+    expect(requestGetTicket).not.toHaveBeenCalled();
+    expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
+  });
+
+  it("continues without polling when the pending ticket has expired", async () => {
+    vi.mocked(loadState).mockReturnValue(pending({ expiresAt: 100 }));
+    await runStop({ session_id: "sess" }, 70_000);
+    expect(requestGetTicket).not.toHaveBeenCalled();
+    expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
+  });
+
+  it("continues without polling when auth/deployment is missing", async () => {
+    vi.mocked(loadState).mockReturnValue(pending());
+    vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, api_key: undefined });
+    await runStop({ session_id: "sess" }, 70_000);
+    expect(requestGetTicket).not.toHaveBeenCalled();
+    expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
+  });
+
+  it("clamps a non-positive poll override back to the default interval", async () => {
+    // DOSU_HOOK_STOP_POLL_MS="0" is invalid (must be > 0), so stopPollMs() returns
+    // the 1000ms default; with wait=0 (beforeEach) maxWaits = floor(0/1000) = 0,
+    // so the loop polls once and never sleeps.
+    process.env.DOSU_HOOK_STOP_POLL_MS = "0";
+    vi.mocked(loadState).mockReturnValue(pending());
+    vi.mocked(requestGetTicket).mockResolvedValue({
+      ticket_id: "kt_1",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+      result: null,
+      error: null,
+    });
+    await runStop({ session_id: "sess" }, 70_000);
+    expect(requestGetTicket).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
+  });
+
+  it("falls back to the default stop-wait budget when the env override is unset", async () => {
+    // No DOSU_HOOK_STOP_WAIT_MS → default 8000ms; a huge poll interval keeps
+    // maxWaits at 0 so the loop polls once and never sleeps.
+    delete process.env.DOSU_HOOK_STOP_WAIT_MS;
+    process.env.DOSU_HOOK_STOP_POLL_MS = "999999"; // floor(8000/999999) = 0
+    vi.mocked(loadState).mockReturnValue(pending());
+    vi.mocked(requestGetTicket).mockResolvedValue({
+      ticket_id: "kt_1",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+      result: null,
+      error: null,
+    });
+    await runStop({ session_id: "sess" }, 70_000);
+    expect(requestGetTicket).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
+  });
 });
 
 describe("runStatus", () => {
@@ -393,6 +514,13 @@ describe("runStatus", () => {
   it("reports no active ticket when there is none", () => {
     runStatus({}, {});
     expect(stdout()).toContain("No active Dosu knowledge ticket");
+  });
+
+  it("prints Delivered: no for an undelivered ticket", () => {
+    vi.mocked(loadState).mockReturnValue(pending());
+    runStatus({ session_id: "sess" }, {}, 10);
+    expect(stdout()).toContain("Status: pending");
+    expect(stdout()).toContain("Delivered: no");
   });
 });
 
@@ -415,6 +543,13 @@ describe("runHookEntrypoint", () => {
 
   it("treats malformed stdin as empty and never throws", async () => {
     await expect(runHookEntrypoint("post-tool-use", "{not json")).resolves.toBeUndefined();
+    expect(stdout()).toBe("");
+  });
+
+  it("treats blank stdin as an empty input object", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    await expect(runHookEntrypoint("post-tool-use", "   ")).resolves.toBeUndefined();
+    expect(requestGetTicket).not.toHaveBeenCalled();
     expect(stdout()).toBe("");
   });
 
@@ -638,5 +773,145 @@ describe("lifecycle commands", () => {
     expect(steps).toEqual(
       expect.arrayContaining(["doctor-config", "doctor-hooks", "doctor-backend"]),
     );
+  });
+
+  it("install --json emits a machine-readable error for an unsupported agent", async () => {
+    await runInstall("cursor", { dir, json: true });
+    expect(process.exitCode).toBe(2);
+    const line = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "hooks-install", reason: "unsupported_agent" });
+  });
+
+  it("install --json emits a machine-readable error for an unsupported scope", async () => {
+    await runInstall("claude-code", { dir, scope: "project", json: true });
+    expect(process.exitCode).toBe(2);
+    const line = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "hooks-install", reason: "unsupported_scope" });
+  });
+
+  it("uninstall --json emits a machine-readable error for an unsupported agent", async () => {
+    await runUninstall("cursor", { dir, json: true });
+    expect(process.exitCode).toBe(2);
+    const line = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "hooks-uninstall", reason: "unsupported_agent" });
+  });
+
+  it("install codex --json emits a machine-readable step", async () => {
+    await runInstall("codex", { dir, json: true });
+    const line = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "hooks-install", agent: "codex" });
+    expect(line.events).toEqual(["UserPromptSubmit", "PostToolUse", "Stop"]);
+  });
+
+  it("install factory --json emits a machine-readable step", async () => {
+    await runInstall("factory", { dir, json: true });
+    const line = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "hooks-install", agent: "factory" });
+    expect(line.events).toEqual(["UserPromptSubmit", "PostToolUse", "Stop"]);
+  });
+
+  it("install --json surfaces a write failure as a machine-readable error", async () => {
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(join(dir, ".claude", "settings.local.json"), "{ broken");
+    await runInstall("claude-code", { dir, json: true });
+    expect(process.exitCode).toBe(1);
+    const line = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "hooks-install", reason: "write_failed" });
+  });
+
+  it("doctor flags an unparseable claude config as a failure", async () => {
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(join(dir, ".claude", "settings.local.json"), "{ broken");
+    const checks = await collectDoctorChecks({ dir });
+    expect(checks.find((c) => c.name === "config")?.status).toBe("fail");
+    expect(checks.find((c) => c.name === "config")?.detail).toContain("invalid JSON");
+  });
+
+  it("doctor flags an unparseable codex config and an installed-but-incomplete one", async () => {
+    // Unparseable codex hooks file.
+    mkdirSync(join(dir, ".codex"), { recursive: true });
+    writeFileSync(join(dir, ".codex", "hooks.json"), "{ broken");
+    let checks = await collectDoctorChecks({ dir });
+    expect(checks.find((c) => c.name === "codex-config")?.status).toBe("fail");
+
+    // Valid JSON, but Dosu hooks not installed.
+    writeFileSync(join(dir, ".codex", "hooks.json"), "{}");
+    checks = await collectDoctorChecks({ dir });
+    const codex = checks.find((c) => c.name === "codex-config");
+    expect(codex?.status).toBe("fail");
+    expect(codex?.detail).toContain("not both installed");
+  });
+
+  it("doctor flags an unparseable factory config and an installed-but-incomplete one", async () => {
+    mkdirSync(join(dir, ".factory"), { recursive: true });
+    writeFileSync(join(dir, ".factory", "hooks.json"), "{ broken");
+    let checks = await collectDoctorChecks({ dir });
+    expect(checks.find((c) => c.name === "factory-config")?.status).toBe("fail");
+
+    writeFileSync(join(dir, ".factory", "hooks.json"), "{}");
+    checks = await collectDoctorChecks({ dir });
+    const factory = checks.find((c) => c.name === "factory-config");
+    expect(factory?.status).toBe("fail");
+    expect(factory?.detail).toContain("not both installed");
+  });
+});
+
+describe("hooksCommand wiring", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dosu-hooks-wire-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("dispatches the install action through Commander", async () => {
+    await hooksCommand().parseAsync(["install", "claude-code", "--dir", dir], { from: "user" });
+    expect(stdout()).toContain("Installed Dosu hooks");
+  });
+
+  it("dispatches the uninstall action through Commander", async () => {
+    await hooksCommand().parseAsync(["install", "claude-code", "--dir", dir], { from: "user" });
+    logSpy.mockClear();
+    await hooksCommand().parseAsync(["uninstall", "claude-code", "--dir", dir], { from: "user" });
+    expect(stdout()).toContain("Removed Dosu hooks");
+  });
+
+  it("dispatches the doctor action through Commander", async () => {
+    await hooksCommand().parseAsync(["install", "claude-code", "--dir", dir], { from: "user" });
+    logSpy.mockClear();
+    await hooksCommand().parseAsync(["doctor", "--dir", dir, "--json"], { from: "user" });
+    const steps = logSpy.mock.calls.map((c) => JSON.parse(c[0]).step);
+    expect(steps).toEqual(expect.arrayContaining(["doctor-config"]));
+  });
+});
+
+describe("collectDoctorChecks deployment detail", () => {
+  it("defaults the project dir to cwd when none is passed (read-only inspection)", async () => {
+    // No `dir` → resolveDir falls back to process.cwd(); the repo cwd has no
+    // agent hook files, so this just inspects and reports without writing.
+    const checks = await collectDoctorChecks({});
+    expect(checks.some((c) => c.name === "config")).toBe(true);
+  });
+
+  it("falls back to deployment_id when no deployment_name is set", async () => {
+    vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, deployment_name: undefined });
+    const checks = await collectDoctorChecks({});
+    const deployment = checks.find((c) => c.name === "deployment");
+    expect(deployment?.status).toBe("ok");
+    expect(deployment?.detail).toBe("dep-1"); // deployment_id fallback
+  });
+
+  it("reports 'oss' for an OSS-mode config with no deployment id or name", async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      access_token: "at",
+      refresh_token: "rt",
+      expires_at: Date.now() + 3_600_000,
+      mode: MODE_OSS,
+    });
+    const checks = await collectDoctorChecks({});
+    const deployment = checks.find((c) => c.name === "deployment");
+    expect(deployment?.status).toBe("ok");
+    expect(deployment?.detail).toBe("oss"); // final fallback
   });
 });

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -166,7 +166,7 @@ afterEach(() => {
 });
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 function makeRunner(over: Partial<InsightsRunner> = {}): InsightsRunner {
@@ -480,7 +480,7 @@ describe("insightsCommand", () => {
 
     await expect(runCmd()).rejects.toThrow("exit");
     expect(errorSpy).toHaveBeenCalled();
-    const errOut = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    const errOut = errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
     expect(errOut).toContain("runner boom");
   });
 });

--- a/src/commands/integrations.test.ts
+++ b/src/commands/integrations.test.ts
@@ -38,7 +38,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/knowledge.test.ts
+++ b/src/commands/knowledge.test.ts
@@ -39,7 +39,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/members.test.ts
+++ b/src/commands/members.test.ts
@@ -38,7 +38,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/org.test.ts
+++ b/src/commands/org.test.ts
@@ -38,7 +38,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -37,7 +37,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -19,11 +19,11 @@ let tempDir: string;
 let origXDG: string | undefined;
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 function allErrors(): string {
-  return errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/sources.test.ts
+++ b/src/commands/sources.test.ts
@@ -38,7 +38,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/suggest.test.ts
+++ b/src/commands/suggest.test.ts
@@ -39,7 +39,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/tags.test.ts
+++ b/src/commands/tags.test.ts
@@ -38,7 +38,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/commands/threads.test.ts
+++ b/src/commands/threads.test.ts
@@ -38,7 +38,7 @@ const validConfig = {
 };
 
 function allOutput(): string {
-  return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
 
 async function run(...args: string[]) {

--- a/src/hooks/ticket-client.test.ts
+++ b/src/hooks/ticket-client.test.ts
@@ -5,7 +5,9 @@ const postWithApiKey = vi.fn();
 const getWithApiKey = vi.fn();
 
 vi.mock("../client/client", () => ({
-  Client: vi.fn(() => ({ postWithApiKey, getWithApiKey })),
+  Client: vi.fn(function () {
+    return { postWithApiKey, getWithApiKey };
+  }),
 }));
 
 import {

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -686,7 +686,9 @@ describe("runSetup integration", () => {
       connectGithubRepo: vi.fn().mockResolvedValue({ skipped: true, reason: "repo_not_installed" }),
       ...overrides,
     };
-    mockClient.mockImplementation(() => clientMethods as unknown as Client);
+    mockClient.mockImplementation(function () {
+      return clientMethods as unknown as Client;
+    });
     return clientMethods;
   }
 
@@ -1564,7 +1566,9 @@ describe("runSetup checkpoint behavior", () => {
       connectGithubRepo: vi.fn().mockResolvedValue({ skipped: true, reason: "repo_not_installed" }),
       ...overrides,
     };
-    mockClient.mockImplementation(() => methods as unknown as Client);
+    mockClient.mockImplementation(function () {
+      return methods as unknown as Client;
+    });
     return methods;
   }
 

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1941,3 +1941,504 @@ describe("runSetup checkpoint behavior", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// 8. Additional branch coverage for runSetup error/edge paths
+// ---------------------------------------------------------------------------
+
+describe("runSetup additional branches", () => {
+  const mockClient = vi.mocked(Client);
+
+  beforeEach(() => {
+    setupTempEnv();
+    vi.resetAllMocks();
+    installSetupStepDefaults();
+    installRemoteSetupDefaults();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+    installMultiselectDefault();
+    mockInstallSkill.mockResolvedValue({ success: true, sha: "test-sha" });
+  });
+  afterEach(teardownTempEnv);
+
+  function setupAuthed(overrides: Record<string, unknown> = {}) {
+    const methods = {
+      doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+      refreshToken: vi.fn(),
+      getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+      getDeployments: vi.fn().mockResolvedValue([makeDeployment()]),
+      validateAPIKey: vi.fn().mockResolvedValue(true),
+      createAPIKey: vi.fn().mockResolvedValue({ api_key: "new-key" }),
+      ...overrides,
+    };
+    mockClient.mockImplementation(function () {
+      return methods as unknown as Client;
+    });
+    return methods;
+  }
+
+  it("aborts when the cloud setup context fails to load (profile has no user_id)", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    // Profile without a user_id → resolveCloudSetupContext returns null.
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: null,
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith("Could not load your profile.");
+    // Never advanced to the one-shot confirm / outro.
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_failed" &&
+          e.properties?.reason === "cloud_setup_context_failed",
+      ),
+    ).toBe(true);
+  });
+
+  it("aborts when the cloud setup context query throws", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockRejectedValue(new Error("trpc down"));
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Could not load your onboarding state"),
+    );
+    expect(p.outro).not.toHaveBeenCalled();
+  });
+
+  it("aborts onboarding when no target org can be determined", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    // No accessible orgs → resolveOnboardingTargetOrg returns null.
+    mockTrpc.organization.getOrganizations.query.mockResolvedValue([]);
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith("Could not determine your onboarding organization.");
+    expect(p.outro).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the first accessible org when none has the OWNER role", async () => {
+    saveConfig(makeCfg());
+    setupAuthed({
+      getDeployments: vi.fn().mockResolvedValue([
+        makeDeployment({
+          deployment_id: "dep-member",
+          org_id: "member-org",
+          org_name: "Member Org",
+          space_id: "space-member",
+        }),
+      ]),
+    });
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    // No OWNER role anywhere → falls back to accessibleOrgs[0].
+    mockTrpc.organization.getOrganizations.query.mockResolvedValue([
+      { org_id: "member-org", name: "Member Org", user_role: "MEMBER" },
+    ]);
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.org_id).toBe("member-org");
+    expect(saved.deployment_id).toBe("dep-member");
+  });
+
+  it("aborts onboarding when no deployment exists for the target org", async () => {
+    saveConfig(makeCfg());
+    // Deployments exist but none belong to the onboarding org.
+    setupAuthed({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "dep-other", org_id: "other-org" })]),
+    });
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    mockTrpc.organization.getOrganizations.query.mockResolvedValue([
+      { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
+    ]);
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No MCP found for Owner Org"));
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_failed" &&
+          e.properties?.reason === "onboarding_deployment_failed",
+      ),
+    ).toBe(true);
+  });
+
+  it("picks the first org deployment when none matches the dosu_mcp provider slug", async () => {
+    saveConfig(makeCfg());
+    setupAuthed({
+      getDeployments: vi.fn().mockResolvedValue([
+        makeDeployment({
+          deployment_id: "dep-fallback",
+          org_id: "owner-org",
+          org_name: "Owner Org",
+          space_id: "space-fallback",
+          provider_slug: "some_other_provider",
+        }),
+      ]),
+    });
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    mockTrpc.organization.getOrganizations.query.mockResolvedValue([
+      { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
+    ]);
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.deployment_id).toBe("dep-fallback");
+  });
+
+  it("returns early when the one-shot confirm is cancelled", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    const cancelSymbol = Symbol("cancel");
+    // Cancel the one-shot confirm multiselect specifically.
+    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
+      const o = opts as { message: string; initialValues?: unknown[] };
+      if (
+        String(o.message ?? "")
+          .toLowerCase()
+          .includes("dosu will set")
+      ) {
+        return cancelSymbol as unknown as never;
+      }
+      return (o.initialValues ?? []) as unknown as never;
+    });
+    vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
+
+    await runSetup();
+
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_cancelled" && e.properties?.reason === "options_cancelled",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns early when the MCP tool selection is cancelled", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+
+    const cancelSymbol = Symbol("cancel");
+    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
+      const o = opts as { message: string; initialValues?: unknown[] };
+      if (
+        String(o.message ?? "")
+          .toLowerCase()
+          .includes("dosu will set")
+      ) {
+        return (o.initialValues ?? []) as unknown as never;
+      }
+      return cancelSymbol as unknown as never;
+    });
+    vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
+
+    await runSetup();
+
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_cancelled" &&
+          e.properties?.reason === "mcp_selection_cancelled",
+      ),
+    ).toBe(true);
+  });
+
+  it("aborts when the GitHub docs import step does not advance", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
+    // Docs import refuses to advance → tracks github_docs_import_failed and returns.
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: false });
+
+    await runSetup();
+
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_failed" &&
+          e.properties?.reason === "github_docs_import_failed",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns early and tracks cancellation when the GitHub connect step does not advance", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
+
+    await runSetup();
+
+    expect(mockStepImportGitHubDocs).not.toHaveBeenCalled();
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_cancelled" &&
+          e.properties?.reason === "github_connect_not_advanced",
+      ),
+    ).toBe(true);
+  });
+
+  it("persists a fresh space_id surfaced by the GitHub connect step", async () => {
+    // After binding the onboarding deployment cfg has no space_id, and the
+    // connect step returns one → the `connectResult.space_id && !cfg.space_id`
+    // branch saves it.
+    saveConfig(makeCfg({ space_id: undefined }));
+    // Bound deployment carries no space_id so cfg.space_id stays empty until
+    // the connect step supplies one.
+    setupAuthed({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ org_id: "o1", space_id: undefined })]),
+    });
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({
+      advance: true,
+      has_connected_repo: false,
+      space_id: "space-from-connect",
+    });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.space_id).toBe("space-from-connect");
+  });
+
+  it("switches mode from OSS to Cloud when --mode cloud is passed over an OSS config", async () => {
+    saveConfig(makeCfg({ mode: "oss" }));
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup({ mode: "cloud" });
+
+    const saved = loadConfig();
+    expect(saved.mode).toBeUndefined();
+  });
+
+  it("treats docs import with no imported count as not activated", async () => {
+    // imported is true but imported_count is absent → the `(imported_count ?? 0)
+    // > 0` guard is false, so docsImported stays false (no activation event).
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
+    mockStepImportGitHubDocs.mockResolvedValue({ advance: true, imported: true });
+
+    await runSetup();
+
+    const events = trackedCliOnboardingEvents().map((input) => input.event);
+    expect(events).not.toContain("cli_onboarding_docs_imported");
+    expect(events).not.toContain("cli_onboarding_activated");
+  });
+
+  it("defaults the failed count to zero in the docs-imported tracking events", async () => {
+    // docsImported is true (imported_count > 0) but failed_count is absent, so
+    // the `failed_count ?? 0` fallbacks are exercised.
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
+    mockStepImportGitHubDocs.mockResolvedValue({
+      advance: true,
+      imported: true,
+      imported_count: 2,
+      task_id: "task-x",
+    });
+
+    await runSetup();
+
+    expect(trackedCliOnboardingEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "cli_onboarding_docs_imported",
+          properties: expect.objectContaining({ imported_count: 2, failed_count: 0 }),
+        }),
+        expect.objectContaining({
+          event: "cli_onboarding_activated",
+          properties: expect.objectContaining({ imported_count: 2, failed_count: 0 }),
+        }),
+      ]),
+    );
+  });
+
+  it("continues to the outro when the skill install reports failure", async () => {
+    // skillCompleted is false → the `if (skillCompleted)` tracking branch is
+    // skipped, but the flow still completes (MCP/docs unaffected).
+    saveConfig(makeCfg());
+    setupAuthed();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockInstallSkill.mockResolvedValue({ success: false });
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Failed to install skill"));
+    const skillEvents = trackedCliOnboardingEvents().map((e) => e.event);
+    expect(skillEvents).not.toContain("cli_onboarding_skill_installed");
+  });
+
+  it("neither installs nor removes a detected tool that is unconfigured and left unticked", async () => {
+    // Cursor is detected but not configured, so it starts unticked. The default
+    // multiselect leaves it unticked → it lands in neither toInstall nor
+    // toRemove (the else arm of `else if (isConfigured)`).
+    saveConfig(makeCfg());
+    setupAuthed();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    // Accept the one-shot confirm and the (preselected = none, since
+    // unconfigured) tool selection as-is.
+    installMultiselectDefault();
+
+    await runSetup();
+
+    // Nothing written to disk for cursor (not installed, not removed).
+    expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
+  });
+
+  it("returns no org when the org selection resolves to an unknown id", async () => {
+    // p.select returns a value that doesn't match any org → `orgs.find(...) ??
+    // null` takes the null arm and the deployment never gets saved.
+    saveConfig(makeCfg({ deployment_id: undefined, deployment_name: undefined }));
+    setupAuthed({
+      getOrgs: vi.fn().mockResolvedValue([
+        { org_id: "o1", name: "Org1" },
+        { org_id: "o2", name: "Org2" },
+      ]),
+    });
+    vi.mocked(p.select).mockResolvedValueOnce("does-not-exist");
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.deployment_id).toBeUndefined();
+    expect(p.outro).not.toHaveBeenCalled();
+  });
+
+  it("returns no deployment when the MCP selection resolves to an unknown id", async () => {
+    // p.select returns a value that matches no deployment → `deployments.find(...)
+    // ?? null` takes the null arm.
+    saveConfig(makeCfg({ deployment_id: undefined, deployment_name: undefined }));
+    setupAuthed({
+      getDeployments: vi.fn().mockResolvedValue([
+        { deployment_id: "d1", name: "D1", org_id: "o1", org_name: "Org1" },
+        { deployment_id: "d2", name: "D2", org_id: "o1", org_name: "Org1" },
+      ]),
+    });
+    vi.mocked(p.select).mockResolvedValueOnce("nope");
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.deployment_id).toBeUndefined();
+    expect(p.outro).not.toHaveBeenCalled();
+  });
+
+  it("shows the docs-imported 'Try it out' prompt when MCP and GitHub onboarding both ran", async () => {
+    // Configure an MCP tool (so mcpConfiguredThisRun is true) AND complete the
+    // GitHub onboarding step → showTryItOutPrompt is invoked with docsImported
+    // = `choices.connectGitHub && githubOnboardingDone` = true.
+    saveConfig(makeCfg());
+    setupAuthed();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: true });
+    mockStepImportGitHubDocs.mockResolvedValue({
+      advance: true,
+      imported: true,
+      imported_count: 1,
+      failed_count: 0,
+    });
+
+    await runSetup();
+
+    expect(p.log.message).toHaveBeenCalledWith(
+      expect.stringContaining("summarize the most important docs"),
+    );
+  });
+});

--- a/src/setup/github-doc-import-prompt.test.ts
+++ b/src/setup/github-doc-import-prompt.test.ts
@@ -303,4 +303,363 @@ describe("GitHubDocsImportPrompt", () => {
     const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
     expect(rendered).toContain("All docs already imported");
   });
+
+  it("renders and closes via the readline hook when state finalizes", () => {
+    const prompt = makePrompt();
+    let renderCalls = 0;
+    let closed = false;
+    // Simulate an attached readline interface so handleRawKeypress exercises
+    // the `rl`-guarded render + close paths.
+    (prompt as unknown as { rl: unknown }).rl = { line: "", cursor: 0 };
+    (prompt as unknown as { render: () => void }).render = () => {
+      renderCalls += 1;
+    };
+    (prompt as unknown as { close: () => void }).close = () => {
+      closed = true;
+    };
+
+    // A non-finalizing key triggers a render but no close.
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    expect(renderCalls).toBe(1);
+    expect(closed).toBe(false);
+
+    // Enter in repo mode finalizes (state=submit) and closes.
+    prompt.handleRawKeypress(undefined, { name: "return" });
+    expect(prompt.state).toBe("submit");
+    expect(renderCalls).toBe(2);
+    expect(closed).toBe(true);
+  });
+
+  it("invokes the constructor render hook when the prompt renders through readline", () => {
+    const prompt = makePrompt();
+    (prompt as unknown as { rl: unknown }).rl = { line: "", cursor: 0 };
+    // Capture stdout writes so the real @clack render does not leak escapes
+    // into the test reporter, then drive a render through the rl hook.
+    const original = process.stdout.write.bind(process.stdout);
+    (process.stdout as unknown as { write: () => boolean }).write = () => true;
+    try {
+      prompt.handleRawKeypress(undefined, { name: "down" });
+    } finally {
+      (process.stdout as unknown as { write: typeof original }).write = original;
+    }
+    expect(prompt.fileCursor).toBe(0);
+  });
+
+  it("ignores non-printable multi-character keys in file mode", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    const before = prompt.searchQuery;
+    // A multi-character key (e.g. a function key sequence) is not printable and
+    // must not be appended to the search query.
+    prompt.handleRawKeypress("[A", undefined);
+    expect(prompt.searchQuery).toBe(before);
+    expect(prompt.searchActive).toBe(false);
+  });
+
+  it("does nothing when moving the repo cursor with no repositories", () => {
+    const prompt = new GitHubDocsImportPrompt({ repositories: [] });
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    expect(prompt.repoCursor).toBe(0);
+    expect(prompt.state).toBe("initial");
+  });
+
+  it("does not enter a repository when none exists", () => {
+    const prompt = new GitHubDocsImportPrompt({ repositories: [] });
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    expect(prompt.mode).toBe("repos");
+  });
+
+  it("does not toggle a repository when none exists", () => {
+    const prompt = new GitHubDocsImportPrompt({ repositories: [] });
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    expect(prompt.value).toEqual([]);
+  });
+
+  it("falls back to 'Files' title and empty file list when the repo cursor is out of range", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    // Force file mode with an out-of-range cursor so currentRepository is undefined.
+    (prompt as unknown as { repoCursor: number }).repoCursor = 99;
+    expect(prompt.filteredFiles).toEqual([]);
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("Files");
+    expect(rendered).toContain("No docs match your search.");
+  });
+
+  it("selects an unselected file when toggled on", () => {
+    const prompt = makePrompt();
+    // Start with nothing selected so the first toggle is an "add".
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    expect(prompt.value).toEqual([]);
+
+    prompt.handleRawKeypress(undefined, { name: "up" });
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    expect(prompt.value).toEqual(["f-1"]);
+  });
+
+  it("does not toggle-all when there are no selectable visible files", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/core",
+          files: [{ id: "f-1", path: "README.md", is_synced: true }],
+        },
+      ],
+    });
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress("a", undefined);
+    expect(prompt.value).toEqual([]);
+  });
+
+  it("toggle-all selects every visible file when not all are selected", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    // Deselect everything in this repo, then toggle-all to re-select.
+    prompt.handleRawKeypress("a", undefined);
+    expect(prompt.value).toEqual(["f-4"]);
+    prompt.handleRawKeypress("a", undefined);
+    expect(prompt.value.sort()).toEqual(["f-1", "f-2", "f-4"]);
+  });
+
+  it("renders inactive repo rows with plain labels and no hint", () => {
+    const prompt = makePrompt();
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    // The second repo is inactive (cursor is on the first) and not locked, so
+    // it renders a plain slug with no '(All docs already imported)' hint.
+    const coreLine = rendered.split("\n").find((line) => line.includes("acme/core"));
+    expect(coreLine).toBeDefined();
+    expect(coreLine).not.toContain("All docs already imported");
+  });
+
+  it("renders a top ellipsis when scrolled past the start of a long repo list", () => {
+    // Repo mode has no per-mode item cap, so the visible window is derived from
+    // the terminal height; pin it small enough to force windowing + ellipsis.
+    const original = process.stdout.rows;
+    Object.defineProperty(process.stdout, "rows", { value: 18, configurable: true });
+    try {
+      const prompt = new GitHubDocsImportPrompt({
+        repositories: Array.from({ length: 30 }, (_, index) => ({
+          slug: `acme/repo-${index + 1}`,
+          files: [{ id: `r${index + 1}-f1`, path: "docs/a.md", is_synced: false }],
+        })),
+      });
+      for (let i = 0; i < 20; i += 1) {
+        prompt.handleRawKeypress(undefined, { name: "down" });
+      }
+      const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+      expect(rendered).toContain("...");
+    } finally {
+      Object.defineProperty(process.stdout, "rows", { value: original, configurable: true });
+    }
+  });
+
+  it("shows the 'type to filter' placeholder, then an empty active-search field", () => {
+    const prompt = makePrompt();
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    let rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("type to filter");
+
+    // Activating search with no query yet renders neither the placeholder nor a query.
+    prompt.handleRawKeypress("/", undefined);
+    rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).not.toContain("type to filter");
+    expect(prompt.searchActive).toBe(true);
+    expect(prompt.searchQuery).toBe("");
+
+    // Typing a query renders the query text.
+    prompt.handleRawKeypress("d", undefined);
+    rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("Search: d");
+  });
+
+  it("renders synced rows (active and inactive) and selected rows in file mode", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/mixed",
+          files: [
+            { id: "f-1", path: "docs/synced-a.md", is_synced: true },
+            { id: "f-2", path: "docs/synced-b.md", is_synced: true },
+            { id: "f-3", path: "docs/selectable.md", is_synced: false },
+          ],
+        },
+      ],
+    });
+    prompt.handleRawKeypress(undefined, { name: "right" });
+
+    // Cursor on the first synced row: active synced marker + label.
+    let rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("docs/synced-a.md");
+    expect(rendered).toContain("docs/synced-b.md");
+    expect(rendered).toContain("(Already imported)");
+    expect(rendered).toContain("docs/selectable.md");
+
+    // Move cursor onto the selectable (selected) row: active selected marker.
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    prompt.handleRawKeypress(undefined, { name: "down" });
+    expect(prompt.fileCursor).toBe(2);
+    rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    // Inactive synced rows and an inactive-vs-active selectable row are now rendered.
+    expect(rendered).toContain("docs/synced-a.md");
+    expect(rendered).toContain("docs/selectable.md");
+
+    // Deselect the selectable row so the inactive/active unselected branches render.
+    prompt.handleRawKeypress(undefined, { name: "space" });
+    expect(prompt.value).toEqual([]);
+    rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("docs/selectable.md");
+
+    // Move cursor off the selectable row so an inactive unselected row renders.
+    prompt.handleRawKeypress(undefined, { name: "up" });
+    rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("docs/selectable.md");
+  });
+
+  it("renders all repository marker states for both active and inactive rows", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/all",
+          files: [{ id: "a-1", path: "docs/a.md", is_synced: false }],
+        },
+        {
+          slug: "acme/partial",
+          files: [
+            { id: "p-1", path: "docs/p1.md", is_synced: false },
+            { id: "p-2", path: "docs/p2.md", is_synced: false },
+          ],
+        },
+        {
+          slug: "acme/none",
+          files: [{ id: "n-1", path: "docs/n.md", is_synced: false }],
+        },
+        {
+          slug: "acme/locked",
+          files: [{ id: "l-1", path: "README.md", is_synced: true }],
+        },
+      ],
+    });
+
+    // Make the second repo partial and the third repo "none".
+    prompt.handleRawKeypress(undefined, { name: "down" }); // -> acme/partial
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    prompt.handleRawKeypress(undefined, { name: "space" }); // deselect first file -> partial
+    prompt.handleRawKeypress(undefined, { name: "left" });
+    expect(prompt.getRepositorySelectionState(prompt.repositories[1])).toBe("partial");
+
+    prompt.handleRawKeypress(undefined, { name: "down" }); // -> acme/none
+    prompt.handleRawKeypress(undefined, { name: "space" }); // deselect all -> none
+    expect(prompt.getRepositorySelectionState(prompt.repositories[2])).toBe("none");
+
+    // Render with cursor on the "none" repo: all/partial/locked rows are inactive,
+    // and the active row is "none".
+    let rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("acme/all");
+    expect(rendered).toContain("acme/partial");
+    expect(rendered).toContain("acme/none");
+    expect(rendered).toContain("All docs already imported");
+
+    // Now move the cursor across each repo so the active branch of every
+    // marker state is exercised.
+    prompt.handleRawKeypress(undefined, { name: "up" }); // -> acme/partial (active partial)
+    rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(prompt.repoCursor).toBe(1);
+
+    prompt.handleRawKeypress(undefined, { name: "up" }); // -> acme/all (active all)
+    rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(prompt.repoCursor).toBe(0);
+
+    prompt.handleRawKeypress(undefined, { name: "up" }); // -> acme/locked (active locked)
+    rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(prompt.repoCursor).toBe(3);
+    expect(rendered).toContain("All docs already imported");
+  });
+
+  it("renders a plural submit label when multiple docs are selected", () => {
+    const prompt = makePrompt();
+    (prompt as unknown as { state: string }).state = "submit";
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    expect(rendered).toContain("3 docs selected");
+  });
+
+  it("derives the visible window from the terminal height when rows is set", () => {
+    const original = process.stdout.rows;
+    Object.defineProperty(process.stdout, "rows", { value: 30, configurable: true });
+    try {
+      const prompt = new GitHubDocsImportPrompt({
+        repositories: [
+          {
+            slug: "acme/api",
+            files: Array.from({ length: 40 }, (_, index) => ({
+              id: `f-${index + 1}`,
+              path: `docs/topic-${index + 1}.md`,
+              is_synced: false,
+            })),
+          },
+        ],
+      });
+      prompt.handleRawKeypress(undefined, { name: "right" });
+      const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+      const visibleDocLines = rendered
+        .split("\n")
+        .filter((line) => line.includes("docs/topic-") || line.includes("..."));
+      // 30 rows - 8 = 22 visible window, capped at MAX_VISIBLE_FILE_ITEMS (15).
+      expect(visibleDocLines.length).toBeLessThanOrEqual(15);
+    } finally {
+      Object.defineProperty(process.stdout, "rows", { value: original, configurable: true });
+    }
+  });
+
+  it("scrolls the file window down so the lower bound branch is taken", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/api",
+          files: Array.from({ length: 25 }, (_, index) => ({
+            id: `f-${index + 1}`,
+            path: `docs/topic-${index + 1}.md`,
+            is_synced: false,
+          })),
+        },
+      ],
+    });
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    for (let i = 0; i < 20; i += 1) {
+      prompt.handleRawKeypress(undefined, { name: "down" });
+    }
+    expect(prompt.fileCursor).toBe(20);
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    // Window has scrolled; the late topic is visible and a top ellipsis is shown.
+    expect(rendered).toContain("docs/topic-21.md");
+    expect(rendered).toContain("...");
+  });
+
+  it("keeps the window pinned to the top while the cursor sits in the middle band", () => {
+    const prompt = new GitHubDocsImportPrompt({
+      repositories: [
+        {
+          slug: "acme/api",
+          files: Array.from({ length: 25 }, (_, index) => ({
+            id: `f-${index + 1}`,
+            path: `docs/topic-${index + 1}.md`,
+            is_synced: false,
+          })),
+        },
+      ],
+    });
+    prompt.handleRawKeypress(undefined, { name: "right" });
+    // Cursor in the middle band (>= 2 and well below the lower-bound trigger):
+    // neither windowing branch fires, so the window stays anchored at the top.
+    for (let i = 0; i < 5; i += 1) {
+      prompt.handleRawKeypress(undefined, { name: "down" });
+    }
+    expect(prompt.fileCursor).toBe(5);
+    const rendered = (prompt as unknown as { renderPrompt: () => string }).renderPrompt();
+    // Top item still visible (no top ellipsis), but a bottom ellipsis is present.
+    expect(rendered).toContain("docs/topic-1.md");
+    expect(rendered).toContain("...");
+  });
 });

--- a/src/setup/github-doc-import-step.test.ts
+++ b/src/setup/github-doc-import-step.test.ts
@@ -603,4 +603,514 @@ describe("stepImportGitHubDocs", () => {
     expect(mockPromptGitHubDocsImport).not.toHaveBeenCalled();
     expect(result.advance).toBe(true);
   });
+
+  it("returns advance=false when the user cancels at the scan timeout", async () => {
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([]);
+    vi.mocked(p.isCancel).mockReturnValue(true);
+
+    const resultPromise = stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+    await vi.advanceTimersByTimeAsync(60_000);
+    const result = await resultPromise;
+
+    expect(result.advance).toBe(false);
+    expect(mockPromptGitHubDocsImport).not.toHaveBeenCalled();
+  });
+
+  it("returns advance=false when the doc import selection is cancelled", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(Symbol("cancel"));
+    vi.mocked(p.isCancel).mockReturnValue(true);
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.knowledgeStore.getBySpaceId.query).not.toHaveBeenCalled();
+    expect(mockTrpc.docImports.importGithubFiles.mutate).not.toHaveBeenCalled();
+  });
+
+  it("returns advance=false when no knowledge store is found for the deployment", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.knowledgeStore.getBySpaceId.query.mockResolvedValue(null);
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(result.advance).toBe(false);
+    expect(p.log.error).toHaveBeenCalledWith("No knowledge store found for this deployment.");
+    expect(mockTrpc.docImports.importGithubFiles.mutate).not.toHaveBeenCalled();
+  });
+
+  it("returns advance=false when loading the knowledge store throws", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.knowledgeStore.getBySpaceId.query.mockRejectedValue(new Error("db down"));
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(result.advance).toBe(false);
+    expect(p.log.error).toHaveBeenCalledWith(
+      "Could not load the knowledge store for this deployment.",
+    );
+    expect(mockTrpc.docImports.importGithubFiles.mutate).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing task_id as a queued background import", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.importGithubFiles.mutate.mockResolvedValue(null);
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(p.log.success).toHaveBeenCalledWith("Import task started.");
+    expect(p.log.info).toHaveBeenCalledWith("Your docs should finish importing in a few minutes.");
+    expect(mockTrpc.docImports.getImportStatus.query).not.toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+    expect(result.imported).toBe(false);
+    expect(result.imported_count).toBe(0);
+    expect(result.queued).toBe(true);
+  });
+
+  it("returns advance=false when starting the import task throws", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.importGithubFiles.mutate.mockRejectedValue(new Error("kaboom"));
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(p.log.error).toHaveBeenCalledWith("Could not start the GitHub doc import.");
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.docImports.getImportStatus.query).not.toHaveBeenCalled();
+  });
+
+  it("stops watching after repeated null status responses", async () => {
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.getImportStatus.query.mockResolvedValue(null);
+
+    const resultPromise = stepImportGitHubDocs(makeCfg());
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await resultPromise;
+
+    const spinnerInstance = vi.mocked(p.spinner).mock.results.at(-1)?.value;
+    expect(spinnerInstance?.stop).toHaveBeenCalledWith("Stopped watching import progress");
+    expect(result.advance).toBe(true);
+    expect(result.queued).toBe(true);
+    expect(result.task_id).toBe("task-1");
+  });
+
+  it("shows a zero-progress message when status arrives without detail, then completes", async () => {
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.getImportStatus.query
+      .mockResolvedValueOnce({
+        task_id: "task-1",
+        state: "PROGRESS",
+        detail: null,
+        created_at: "2026-04-24T00:00:00Z",
+        updated_at: null,
+      })
+      .mockResolvedValueOnce({
+        task_id: "task-1",
+        state: "SUCCESS",
+        detail: {
+          message: "COMPLETED",
+          knowledge_store_id: "ks-1",
+          provider: "github",
+          total: 1,
+          completed: 1,
+          failed: 0,
+          documents: [{ id: "file-1", title: "docs/setup.md", status: "SUCCESS" }],
+        },
+        created_at: "2026-04-24T00:00:00Z",
+        updated_at: "2026-04-24T00:00:02Z",
+      });
+
+    const resultPromise = stepImportGitHubDocs(makeCfg());
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await resultPromise;
+
+    const spinnerInstance = vi.mocked(p.spinner).mock.results.at(-1)?.value;
+    expect(spinnerInstance?.message).toHaveBeenCalledWith("Importing documents... 0/1 complete");
+    expect(result.advance).toBe(true);
+  });
+
+  it("appends the failed suffix to the in-progress message while importing", async () => {
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/a.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+      {
+        id: "file-2",
+        file_path: "docs/b.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1", "file-2"]);
+    mockTrpc.docImports.getImportStatus.query
+      .mockResolvedValueOnce({
+        task_id: "task-1",
+        state: "PROGRESS",
+        detail: {
+          message: "IN_PROGRESS",
+          knowledge_store_id: "ks-1",
+          provider: "github",
+          total: 2,
+          completed: 0,
+          failed: 1,
+          documents: [],
+        },
+        created_at: "2026-04-24T00:00:00Z",
+        updated_at: null,
+      })
+      .mockResolvedValueOnce({
+        task_id: "task-1",
+        state: "SUCCESS",
+        detail: {
+          message: "COMPLETED",
+          knowledge_store_id: "ks-1",
+          provider: "github",
+          total: 2,
+          completed: 2,
+          failed: 0,
+          documents: [],
+        },
+        created_at: "2026-04-24T00:00:00Z",
+        updated_at: "2026-04-24T00:00:02Z",
+      });
+
+    const resultPromise = stepImportGitHubDocs(makeCfg());
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await resultPromise;
+
+    const spinnerInstance = vi.mocked(p.spinner).mock.results.at(-1)?.value;
+    expect(spinnerInstance?.message).toHaveBeenCalledWith(
+      "Importing documents... 1/2 complete, 1 failed",
+    );
+    expect(result.advance).toBe(true);
+  });
+
+  it("handles a completed task whose final status has no detail", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.getImportStatus.query.mockResolvedValue({
+      task_id: "task-1",
+      state: "SUCCESS",
+      detail: null,
+      created_at: "2026-04-24T00:00:00Z",
+      updated_at: "2026-04-24T00:00:02Z",
+    });
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    const spinnerInstance = vi.mocked(p.spinner).mock.results.at(-1)?.value;
+    expect(spinnerInstance?.stop).toHaveBeenCalledWith("Import complete");
+    expect(p.log.success).toHaveBeenCalledWith(
+      "Imported 0 docs.\nYour GitHub docs are ready, and onboarding is complete.",
+    );
+    expect(result.advance).toBe(true);
+    expect(result.imported).toBe(false);
+    expect(result.imported_count).toBe(0);
+    expect(result.failed_count).toBe(0);
+  });
+
+  it("groups files without a repository slug under 'unknown'", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/orphan.md",
+        repository_slug: null,
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue([]);
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(mockPromptGitHubDocsImport).toHaveBeenCalledWith({
+      repositories: [
+        {
+          slug: "unknown",
+          files: [{ id: "file-1", path: "docs/orphan.md", is_synced: false }],
+        },
+      ],
+    });
+    expect(result.advance).toBe(true);
+  });
+
+  it("keeps scanning when listing data sources throws (legacy wait path)", async () => {
+    vi.useFakeTimers();
+    mockTrpc.dataSource.list.query.mockRejectedValue(new Error("data source list failed"));
+    mockTrpc.docImports.listImportableGithubFiles.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([
+        {
+          id: "file-1",
+          file_path: "docs/setup.md",
+          repository_slug: "acme/api",
+          is_synced: false,
+        },
+      ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+
+    const resultPromise = stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await resultPromise;
+
+    expect(mockPromptGitHubDocsImport).toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+  });
+
+  it("treats a failed importable-files query as an empty list", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockRejectedValue(
+      new Error("list importable failed"),
+    );
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(mockPromptGitHubDocsImport).not.toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+    expect(result.imported).toBe(false);
+    expect(result.imported_count).toBe(0);
+  });
+
+  it("handles a non-Error thrown while loading the knowledge store", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.knowledgeStore.getBySpaceId.query.mockRejectedValue("string failure");
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(result.advance).toBe(false);
+    expect(p.log.error).toHaveBeenCalledWith(
+      "Could not load the knowledge store for this deployment.",
+    );
+  });
+
+  it("handles a non-Error thrown while starting the import task", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.importGithubFiles.mutate.mockRejectedValue("string failure");
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(result.advance).toBe(false);
+    expect(p.log.error).toHaveBeenCalledWith("Could not start the GitHub doc import.");
+  });
+
+  it("handles a non-Error thrown while polling import status", async () => {
+    vi.useFakeTimers();
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.getImportStatus.query.mockRejectedValue("string failure");
+
+    const resultPromise = stepImportGitHubDocs(makeCfg());
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await resultPromise;
+
+    expect(result.advance).toBe(true);
+    expect(result.queued).toBe(true);
+  });
+
+  it("handles a non-Error thrown while listing data sources (legacy wait path)", async () => {
+    vi.useFakeTimers();
+    mockTrpc.dataSource.list.query.mockRejectedValue("string failure");
+    mockTrpc.docImports.listImportableGithubFiles.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([
+        {
+          id: "file-1",
+          file_path: "docs/setup.md",
+          repository_slug: "acme/api",
+          is_synced: false,
+        },
+      ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+
+    const resultPromise = stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await resultPromise;
+
+    expect(mockPromptGitHubDocsImport).toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+  });
+
+  it("handles a non-Error thrown while listing importable files", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockRejectedValue("string failure");
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(mockPromptGitHubDocsImport).not.toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+  });
+
+  it("uses the singular doc form when a single-doc import partially fails", async () => {
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+    mockTrpc.docImports.getImportStatus.query.mockResolvedValue({
+      task_id: "task-1",
+      state: "FAILURE",
+      detail: {
+        message: "COMPLETED_WITH_ERRORS",
+        knowledge_store_id: "ks-1",
+        provider: "github",
+        total: 1,
+        completed: 0,
+        failed: 1,
+        documents: [{ id: "file-1", title: "docs/setup.md", status: "FAILED", error: "boom" }],
+      },
+      created_at: "2026-04-24T00:00:00Z",
+      updated_at: "2026-04-24T00:00:02Z",
+    });
+
+    const result = await stepImportGitHubDocs(makeCfg());
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      "Imported 0 of 1 doc; 1 failed.\nYou can review the failed docs later, but onboarding is complete.",
+    );
+    expect(result.advance).toBe(true);
+    expect(result.failed_count).toBe(1);
+  });
+
+  it("loops back to a fresh scan when the user chooses retry after a timeout", async () => {
+    vi.useFakeTimers();
+    // Never any docs and never indexed -> each scan runs the full timeout.
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { provider_slug: "github", is_indexed: false },
+    ]);
+    // First timeout -> retry (loop again); second timeout -> skip (exit).
+    vi.mocked(p.select).mockResolvedValueOnce("retry").mockResolvedValueOnce("skip");
+
+    const resultPromise = stepImportGitHubDocs(makeCfg(), { waitForFreshDocs: true });
+    await vi.advanceTimersByTimeAsync(120_000);
+    const result = await resultPromise;
+
+    expect(p.select).toHaveBeenCalledTimes(2);
+    expect(mockPromptGitHubDocsImport).not.toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+  });
+
+  it("ignores data source rows without an id when waiting on expected ids", async () => {
+    vi.useFakeTimers();
+    mockTrpc.dataSource.list.query
+      .mockResolvedValueOnce([
+        { provider_slug: "github", is_indexed: false },
+        { data_source_id: "ds-fresh", provider_slug: "github", is_indexed: false },
+      ])
+      .mockResolvedValueOnce([
+        { provider_slug: "github", is_indexed: false },
+        { data_source_id: "ds-fresh", provider_slug: "github", is_indexed: true },
+      ]);
+    mockTrpc.docImports.listImportableGithubFiles.query.mockResolvedValue([
+      {
+        id: "file-1",
+        file_path: "docs/setup.md",
+        repository_slug: "acme/api",
+        is_synced: false,
+      },
+    ]);
+    mockPromptGitHubDocsImport.mockResolvedValue(["file-1"]);
+
+    const resultPromise = stepImportGitHubDocs(makeCfg(), {
+      waitForFreshDocs: true,
+      expectedDataSourceIds: ["ds-fresh"],
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    const result = await resultPromise;
+
+    expect(mockPromptGitHubDocsImport).toHaveBeenCalled();
+    expect(result.advance).toBe(true);
+  });
 });

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -87,7 +87,7 @@ vi.mock("../client/trpc", () => ({
 
 import * as p from "@clack/prompts";
 import type { Config } from "../config/config";
-import { detectGitRepo, stepConnectGitHubRepo } from "./github-step";
+import { detectGitRepo, stepConnectGitHubRepo, verifyDataSourcesPersist } from "./github-step";
 
 // Skip the post-connect verify-poll budget so each test resolves in real
 // time without needing fake timers to coexist with the install-flow promise
@@ -140,6 +140,13 @@ describe("detectGitRepo", () => {
 
   it("returns null for non-GitHub origin", () => {
     mockExecSync.mockReturnValue(Buffer.from("git@gitlab.com:foo/bar.git\n"));
+    expect(detectGitRepo()).toBeNull();
+  });
+
+  it("returns null when the origin url is empty", () => {
+    // git exits 0 with empty stdout when remote.origin.url is unset — covers
+    // the `if (!url) return null` guard.
+    mockExecSync.mockReturnValue(Buffer.from("   \n"));
     expect(detectGitRepo()).toBeNull();
   });
 });
@@ -728,6 +735,244 @@ describe("stepConnectGitHubRepo", () => {
     ]);
   });
 
+  it("keeps the prior repo list when a post-install poll returns empty", async () => {
+    // A non-zero refresh budget lets the poll loop body run. The poll returns
+    // an empty list while the previous list was non-empty, so the
+    // `polledRepos.length === 0 && previousRepos.length > 0` ternary keeps the
+    // previous repos rather than wiping them.
+    mockTrpc.githubRepository.listForOrg.query
+      .mockResolvedValueOnce([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+      ])
+      .mockResolvedValue([]); // every poll comes back empty
+    mockPromptGitHubRepositories
+      .mockResolvedValueOnce("__add_repositories__")
+      .mockResolvedValueOnce([]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, {
+      verify: { timeoutMs: 0, intervalMs: 0 },
+      refresh: { timeoutMs: 5, intervalMs: 0 },
+    });
+
+    // Second prompt still shows the original repo — the empty poll was ignored.
+    const secondArgs = mockPromptGitHubRepositories.mock.calls[1][0] as {
+      options: { kind?: string; value?: string }[];
+    };
+    expect(secondArgs.options.filter((o) => o.kind === "repo").map((o) => o.value)).toEqual([
+      "acme/api",
+    ]);
+    expect(result.advance).toBe(true);
+  });
+
+  it("treats listForOrg failures as an empty list (catch path)", async () => {
+    // The pre-flight `fetchListForOrg` swallows errors and returns []. With no
+    // repos and an empty selection the step advances. Covers the catch block
+    // in fetchListForOrg.
+    mockTrpc.githubRepository.listForOrg.query.mockRejectedValue(new Error("network down"));
+    mockPromptGitHubRepositories.mockResolvedValue([]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null);
+
+    expect(result.advance).toBe(true);
+    expect(mockTrpc.workspaces.create.mutate).not.toHaveBeenCalled();
+  });
+
+  it("treats a non-Error listForOrg rejection as an empty list", async () => {
+    // A bare string rejection exercises the `String(err)` side of the catch's
+    // `instanceof Error` ternary in fetchListForOrg.
+    mockTrpc.githubRepository.listForOrg.query.mockRejectedValue("offline");
+    mockPromptGitHubRepositories.mockResolvedValue([]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null);
+
+    expect(result.advance).toBe(true);
+  });
+
+  it("falls back to a manual URL message when the browser fails to open", async () => {
+    // `open` throwing should not abort the install flow — it logs a manual URL
+    // and keeps waiting for the callback. Covers the openGitHubInstallFlow
+    // open-failure catch block.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockOpenDefault.mockRejectedValueOnce(new Error("no browser"));
+    mockPromptGitHubRepositories
+      .mockResolvedValueOnce("__add_repositories__")
+      .mockResolvedValueOnce([]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_REFRESH);
+
+    const infoCalls = vi.mocked(p.log.info).mock.calls.map((c) => String(c[0]));
+    expect(infoCalls.some((s) => s.includes("Could not open browser"))).toBe(true);
+    expect(result.advance).toBe(true);
+  });
+
+  it("falls back to a manual URL message when open rejects with a non-Error", async () => {
+    // A non-Error rejection from `open` takes the `String(err)` branch of the
+    // open-failure catch ternary.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockOpenDefault.mockRejectedValueOnce("spawn EACCES");
+    mockPromptGitHubRepositories
+      .mockResolvedValueOnce("__add_repositories__")
+      .mockResolvedValueOnce([]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_REFRESH);
+
+    const infoCalls = vi.mocked(p.log.info).mock.calls.map((c) => String(c[0]));
+    expect(infoCalls.some((s) => s.includes("Could not open browser"))).toBe(true);
+    expect(result.advance).toBe(true);
+  });
+
+  it("rolls back when workspaces.create returns no deployment_id", async () => {
+    // A null/empty deployment from workspaces.create must short-circuit
+    // createDeploymentForRepo without creating a data_source. With the only
+    // selected repo failing, `created` is empty so the step reports failure.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/api"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue(null);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.dataSource.create.mutate).not.toHaveBeenCalled();
+    const warnCalls = vi.mocked(p.log.warn).mock.calls.map((c) => String(c[0]));
+    expect(warnCalls.some((m) => m.includes("Could not connect any repos"))).toBe(false);
+  });
+
+  it("swallows tRPC errors mid-wireup and reports the repo as failed", async () => {
+    // A throw from any mutate inside createDeploymentForRepo (here:
+    // syncDataSource) is caught and logged, yielding null for that repo.
+    // With the only repo failing, `created` is empty → no survivors → failure.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/api"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-api" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-api" });
+    mockTrpc.dataSource.syncDataSource.mutate.mockRejectedValue(new Error("trpc 500"));
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(false);
+    const errorCalls = vi.mocked(p.log.error).mock.calls.map((c) => String(c[0]));
+    expect(errorCalls.some((m) => m.includes("Could not connect any repos"))).toBe(true);
+  });
+
+  it("swallows a non-Error tRPC rejection mid-wireup", async () => {
+    // A non-Error rejection from a mutate inside createDeploymentForRepo takes
+    // the `String(err)` side of that catch's `instanceof Error` ternary.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/api"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-api" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-api" });
+    mockTrpc.dataSource.syncDataSource.mutate.mockRejectedValue("trpc exploded");
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(false);
+  });
+
+  it("tolerates an orphan-deployment delete that throws (Error)", async () => {
+    // The single connected repo is dropped by backend sync, triggering an
+    // orphan delete. `workspaces.delete.mutate` rejecting must be swallowed
+    // (best-effort cleanup) — covers the deleteOrphanDeployment catch.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "stale", slug: "acme/stale", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/stale"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-stale" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-stale" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-stale" }]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([]); // already GC'd
+    mockTrpc.workspaces.delete.mutate.mockRejectedValue(new Error("delete failed"));
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.workspaces.delete.mutate).toHaveBeenCalledWith("dep-stale");
+  });
+
+  it("tolerates an orphan-deployment delete that throws (non-Error)", async () => {
+    // Same path, but the delete rejects with a bare string — takes the
+    // `String(err)` side of the deleteOrphanDeployment catch ternary.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "stale", slug: "acme/stale", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/stale"]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-stale" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-stale" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-stale" }]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([]); // already GC'd
+    mockTrpc.workspaces.delete.mutate.mockRejectedValue("delete blew up");
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.workspaces.delete.mutate).toHaveBeenCalledWith("dep-stale");
+  });
+
+  it("skips selected slugs that are no longer in the repo list", async () => {
+    // The prompt returns a slug that's vanished from `repos` (e.g. removed
+    // between prompt render and selection). `repos.find` misses → `continue`.
+    // Nothing gets created, so the step fails with the no-reverts error.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/ghost"]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(false);
+    expect(mockTrpc.workspaces.create.mutate).not.toHaveBeenCalled();
+    const errorCalls = vi.mocked(p.log.error).mock.calls.map((c) => String(c[0]));
+    expect(errorCalls.some((m) => m.includes("Could not connect any repos"))).toBe(true);
+  });
+
+  it("reports skipped + connected counts when some repos survive and others are reverted", async () => {
+    // Two survive, two are reverted → exercises the plural `repo${...}s`
+    // branches in both the spinner "· N skipped" stop label and the warn line,
+    // and the `reverted.length > 0` summary branch.
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "a", slug: "acme/a", is_deployed: false },
+      { repository_id: 2, name: "b", slug: "acme/b", is_deployed: false },
+      { repository_id: 3, name: "c", slug: "acme/c", is_deployed: false },
+      { repository_id: 4, name: "d", slug: "acme/d", is_deployed: false },
+    ]);
+    mockPromptGitHubRepositories.mockResolvedValue(["acme/a", "acme/b", "acme/c", "acme/d"]);
+    mockTrpc.workspaces.create.mutate
+      .mockResolvedValueOnce({ deployment_id: "dep-a" })
+      .mockResolvedValueOnce({ deployment_id: "dep-b" })
+      .mockResolvedValueOnce({ deployment_id: "dep-c" })
+      .mockResolvedValueOnce({ deployment_id: "dep-d" });
+    mockTrpc.dataSource.create.mutate
+      .mockResolvedValueOnce({ data_source_id: "ds-a" })
+      .mockResolvedValueOnce({ data_source_id: "ds-b" })
+      .mockResolvedValueOnce({ data_source_id: "ds-c" })
+      .mockResolvedValueOnce({ data_source_id: "ds-d" });
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-a" }]);
+    mockTrpc.deploymentDataSource.create.mutate.mockResolvedValue({});
+    // ds-a and ds-b survive; ds-c and ds-d were GC'd by the backend.
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-a", provider_slug: "github", is_indexed: false },
+      { data_source_id: "ds-b", provider_slug: "github", is_indexed: false },
+    ]);
+
+    const result = await stepConnectGitHubRepo(makeCfg(), null, NO_WAIT_VERIFY);
+
+    expect(result.advance).toBe(true);
+    expect(result.created_data_source_ids).toEqual(["ds-a", "ds-b"]);
+    expect(mockTrpc.workspaces.delete.mutate).toHaveBeenCalledWith("dep-c");
+    expect(mockTrpc.workspaces.delete.mutate).toHaveBeenCalledWith("dep-d");
+    const warnCalls = vi.mocked(p.log.warn).mock.calls.map((c) => String(c[0]));
+    expect(warnCalls.some((m) => m.includes("acme/c") && m.includes("acme/d"))).toBe(true);
+  });
+
   it("returns advance=false when user cancels the multiselect", async () => {
     mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
       { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
@@ -740,5 +985,106 @@ describe("stepConnectGitHubRepo", () => {
 
     expect(result.advance).toBe(false);
     expect(mockTrpc.workspaces.create.mutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("verifyDataSourcesPersist", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("short-circuits with empty sets when there are no expected ids", async () => {
+    // Empty expected set never touches the network — covers the early return.
+    const result = await verifyDataSourcesPersist(mockTrpc, "org-1", []);
+
+    expect(result.alive.size).toBe(0);
+    expect(result.dropped.size).toBe(0);
+    expect(mockTrpc.dataSource.list.query).not.toHaveBeenCalled();
+  });
+
+  it("uses the default poll budget and exits on the first dropped id", async () => {
+    // No opts → exercises the `timeoutMs ??` / `intervalMs ??` default
+    // branches. A drop on the first poll triggers the `dropped.size > 0` early
+    // return, so the real 10s default budget is never actually waited on.
+    mockTrpc.dataSource.list.query.mockResolvedValue([{ data_source_id: "ds-1" }]);
+
+    const result = await verifyDataSourcesPersist(mockTrpc, "org-1", ["ds-1", "ds-2"]);
+
+    expect([...result.alive]).toEqual(["ds-1"]);
+    expect([...result.dropped]).toEqual(["ds-2"]);
+    expect(mockTrpc.dataSource.list.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports dropped ids and exits on the first poll that misses one", async () => {
+    mockTrpc.dataSource.list.query.mockResolvedValue([{ data_source_id: "ds-1" }]);
+
+    const result = await verifyDataSourcesPersist(mockTrpc, "org-1", ["ds-1", "ds-2"], {
+      timeoutMs: 0,
+      intervalMs: 0,
+    });
+
+    expect([...result.alive]).toEqual(["ds-1"]);
+    expect([...result.dropped]).toEqual(["ds-2"]);
+  });
+
+  it("treats a list query failure as no rows present and retries within budget", async () => {
+    // First poll throws (caught + logged → listed stays []), so both ids look
+    // dropped and we exit immediately. Covers the dataSource.list catch block.
+    mockTrpc.dataSource.list.query.mockRejectedValue(new Error("transient 503"));
+
+    const result = await verifyDataSourcesPersist(mockTrpc, "org-1", ["ds-1"], {
+      timeoutMs: 0,
+      intervalMs: 0,
+    });
+
+    expect(result.alive.size).toBe(0);
+    expect([...result.dropped]).toEqual(["ds-1"]);
+  });
+
+  it("handles a non-Error rejection from the list query", async () => {
+    // A thrown non-Error value (e.g. a bare string) takes the `String(err)`
+    // side of the catch's `instanceof Error` ternary.
+    mockTrpc.dataSource.list.query.mockRejectedValue("boom");
+
+    const result = await verifyDataSourcesPersist(mockTrpc, "org-1", ["ds-1"], {
+      timeoutMs: 0,
+      intervalMs: 0,
+    });
+
+    expect(result.alive.size).toBe(0);
+    expect([...result.dropped]).toEqual(["ds-1"]);
+  });
+
+  it("breaks after a single poll when timeoutMs is 0 and nothing is dropped", async () => {
+    // All expected present and timeoutMs === 0 → the `if (timeoutMs === 0)
+    // break` exit fires after the first iteration without sleeping.
+    mockTrpc.dataSource.list.query.mockResolvedValue([{ data_source_id: "ds-1" }]);
+
+    const result = await verifyDataSourcesPersist(mockTrpc, "org-1", ["ds-1"], {
+      timeoutMs: 0,
+      intervalMs: 0,
+    });
+
+    expect([...result.alive]).toEqual(["ds-1"]);
+    expect(result.dropped.size).toBe(0);
+    expect(mockTrpc.dataSource.list.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps polling past the first iteration when timeoutMs is non-zero", async () => {
+    // A small non-zero budget with zero interval: nothing is ever dropped, so
+    // the `timeoutMs === 0` break is skipped and the loop sleeps and re-polls
+    // until the while-condition budget elapses. Exercises the non-zero
+    // timeout path through the loop without burning real time.
+    mockTrpc.dataSource.list.query.mockResolvedValue([{ data_source_id: "ds-1" }]);
+
+    const result = await verifyDataSourcesPersist(mockTrpc, "org-1", ["ds-1"], {
+      timeoutMs: 25,
+      intervalMs: 0,
+    });
+
+    expect([...result.alive]).toEqual(["ds-1"]);
+    expect(result.dropped.size).toBe(0);
+    // Looped more than once (re-polled after sleeping) before the budget ran out.
+    expect(mockTrpc.dataSource.list.query.mock.calls.length).toBeGreaterThan(1);
   });
 });

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -225,9 +225,9 @@ describe("runTUI", () => {
     mockIsCancel.mockReturnValue(false);
 
     const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 200 });
-    vi.mocked(Client).mockImplementation(
-      () => ({ doRequestRaw: mockDoRequestRaw }) as unknown as Client,
-    );
+    vi.mocked(Client).mockImplementation(function () {
+      return { doRequestRaw: mockDoRequestRaw } as unknown as Client;
+    });
 
     mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
 
@@ -243,10 +243,12 @@ describe("runTUI", () => {
 
     const mockRefreshToken = vi.fn().mockResolvedValue(undefined);
     const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 401 });
-    vi.mocked(Client).mockImplementation(
-      () =>
-        ({ doRequestRaw: mockDoRequestRaw, refreshToken: mockRefreshToken }) as unknown as Client,
-    );
+    vi.mocked(Client).mockImplementation(function () {
+      return {
+        doRequestRaw: mockDoRequestRaw,
+        refreshToken: mockRefreshToken,
+      } as unknown as Client;
+    });
 
     mockSelect.mockResolvedValueOnce("auth").mockResolvedValueOnce("exit");
 
@@ -261,10 +263,12 @@ describe("runTUI", () => {
 
     const mockRefreshToken = vi.fn().mockRejectedValue(new Error("refresh failed"));
     const mockDoRequestRaw = vi.fn().mockResolvedValue({ status: 401 });
-    vi.mocked(Client).mockImplementation(
-      () =>
-        ({ doRequestRaw: mockDoRequestRaw, refreshToken: mockRefreshToken }) as unknown as Client,
-    );
+    vi.mocked(Client).mockImplementation(function () {
+      return {
+        doRequestRaw: mockDoRequestRaw,
+        refreshToken: mockRefreshToken,
+      } as unknown as Client;
+    });
 
     // User declines to open browser
     mockConfirm.mockResolvedValueOnce(false);
@@ -281,9 +285,9 @@ describe("runTUI", () => {
     mockIsCancel.mockReturnValue(false);
 
     const mockDoRequestRaw = vi.fn().mockRejectedValue(new Error("network error"));
-    vi.mocked(Client).mockImplementation(
-      () => ({ doRequestRaw: mockDoRequestRaw }) as unknown as Client,
-    );
+    vi.mocked(Client).mockImplementation(function () {
+      return { doRequestRaw: mockDoRequestRaw } as unknown as Client;
+    });
 
     // User declines to open browser
     mockConfirm.mockResolvedValueOnce(false);


### PR DESCRIPTION
## Summary

Dependency, packaging, and tooling work. No source/runtime behavior changes — every edit is packaging, CI, tests, or docs.

**6 commits:** `build(deps)` · `ci: provenance` · `test: Vitest 4 migration` · `ci: --frozen-lockfile` · `test: restore coverage` · `docs`

### Supply-chain hardening
- **Commit `bun.lock`** for reproducible installs (un-ignored in `.gitignore`).
- **`bunfig.toml` `minimumReleaseAge=259200`** — `bun install`/`update` ignore versions published in the last 3 days.
- **`--frozen-lockfile` in CI** — all 6 `bun install` steps now fail on any `package.json`↔`bun.lock` drift instead of silently re-resolving. Kept as a CLI flag (not `bunfig.toml`) so local dev still updates the lockfile normally.
- **Zero-dependency publish** — the npm bundle (`bin/dosu.js`) inlines every dependency, so all deps moved to `devDependencies` and the published package now declares **no runtime dependencies**. `npm install @dosu/cli` pulls zero transitive packages.
  - Verified: bundle runs from a dir with no `node_modules`; `npm pack` tarball is 3 files; `bun install --frozen-lockfile` clean from scratch.
- **npm provenance** — release job gets `id-token: write` + `NPM_CONFIG_PROVENANCE=true`, so each publish carries a signed attestation linking it to the source commit + Actions run.

### Dependency upgrades
- `bun update` (Biome 2.5, semantic-release, `@types/bun`, `@clack/prompts`, `open`, …).
- **TypeScript 5 → 6** — clean, no code changes.
- **Vitest 3 → 4** — a real migration:
  - Vitest 4 can't `new` an arrow ⇒ converted all mocked-class (`Client`) implementations to regular `function`s. (Single root cause behind the initial 67 failures.)
  - Annotated `spy.mock.calls.map((c: unknown[]) => …)` where Vitest 4's mock types dropped the contextual type.
  - `biome.json`: migrated to the 2.5 schema and disabled `useArrowFunction` for `*.test.ts` so `biome --write` can't revert the constructor mocks.

### Coverage (Vitest 4)
`@vitest/coverage-v8` v4 uses AST-aware remapping by default (the opt-out was removed) — a stricter meter that dropped aggregate coverage below the 95/90/95 gate (branches 90 → 86.76) with **no real loss of testing**. Rather than lower the thresholds, added **127 tests** across the seven highest-impact files to hold the line:
- branches 86.76% → **93.57%** · statements 94.26% → **97.71%** · lines 94.74% → **98.12%**
- Remaining uncovered arms are defensive (non-`Error` catch fallbacks) or unreachable through public entry points.

### Docs
- Rewrote `README.md`; expanded `AGENTS.md` (Dependencies & Packaging; Vitest 4 mocked-class convention).

## Verification
`bun run typecheck` ✅ · `bun run check` ✅ · `bunx vitest run --coverage` ✅ (1326 tests, all thresholds met). All CI jobs green.

> Note: `bun run test` does **not** collect coverage; use `bunx vitest run --coverage` to match CI.

## Notes
- **No release triggered.** All commits are `build`/`ci`/`test`/`docs`, so semantic-release won't bump the version — the zero-dep publish and provenance take effect automatically on the **next** release. To ship a patch now, retype the packaging commit as `fix:`.
- **Deferred:** the runtime majors (`commander` 13→15, `open` 10→11, `@clack/prompts` 0.10→1, `write-file-atomic` 5→8) all raise the minimum Node version above the declared `engines: >=18`; parked pending a Node-floor decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)