### PR TITLE
chore: update dependencies and require Node.js 22+

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run `dosu` with no arguments any time to open the interactive menu.
 
 ### npx / npm (Recommended)
 
-Requires Node.js 18+.
+Requires Node.js 22+.
 
 ```bash
 npx @dosu/cli setup

--- a/bun.lock
+++ b/bun.lock
@@ -6,23 +6,23 @@
       "name": "@dosu/cli",
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",
-        "@clack/prompts": "^0.10.1",
-        "@dosu/api-types": "0.0.10",
+        "@clack/prompts": "^1.6.0",
+        "@dosu/api-types": "0.0.11",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
-        "@trpc/client": "11.17.0",
-        "@trpc/server": "11.17.0",
+        "@trpc/client": "11.18.0",
+        "@trpc/server": "11.18.0",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
-        "commander": "^13.1.0",
-        "open": "^10.2.0",
+        "commander": "^15.0.0",
+        "open": "^11.0.0",
         "picocolors": "^1.1.1",
         "semantic-release": "^25.0.5",
         "superjson": "^2.2.6",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
-        "write-file-atomic": "^5.0.1",
+        "write-file-atomic": "^8.0.0",
       },
     },
   },
@@ -65,13 +65,13 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
 
-    "@clack/core": ["@clack/core@0.4.2", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg=="],
+    "@clack/core": ["@clack/core@1.4.2", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ=="],
 
-    "@clack/prompts": ["@clack/prompts@0.10.1", "", { "dependencies": { "@clack/core": "0.4.2", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw=="],
+    "@clack/prompts": ["@clack/prompts@1.6.0", "", { "dependencies": { "@clack/core": "1.4.2", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@dosu/api-types": ["@dosu/api-types@0.0.10", "", { "dependencies": { "@trpc/server": "11.17.0" } }, "sha512-SrzJJt11P+dqaVe0YxffIqYwipCk4l1Yk+EmzRsVleoMHqJSuKGd6HXXaA171CFkS0OvECxJ/1H/Up0EPFJGkA=="],
+    "@dosu/api-types": ["@dosu/api-types@0.0.11", "", { "dependencies": { "@trpc/server": "11.17.0" } }, "sha512-/ZGvM+daxr9MmfzmgJy1S7DeiQEGyI5nnxE6ZVYNhkU9nlq/EHwinekoBCxmnicFS6S7bgimA6km08hGkm+qYg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -235,9 +235,9 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@trpc/client": ["@trpc/client@11.17.0", "", { "peerDependencies": { "@trpc/server": "11.17.0", "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-KpJBFrbKTDeVCFv/3ckL1XBBH5Yssn8hethI/rUy7GIpTj+VzjtPjykDqJpzobuVOz+d26cXCSu1t4I6MYI5Zg=="],
+    "@trpc/client": ["@trpc/client@11.18.0", "", { "peerDependencies": { "@trpc/server": "11.18.0", "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-wOqeg3Fvl25V1ZisQhUD3K8G60ZJDlSGJNSyeXrLH24xAo5w6GSR2Kzb1cSNY9Y+IQ2YZvYGZstBU+V/ulo/ow=="],
 
-    "@trpc/server": ["@trpc/server@11.17.0", "", { "peerDependencies": { "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw=="],
+    "@trpc/server": ["@trpc/server@11.18.0", "", { "peerDependencies": { "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-JAvXOuNTxgXjIDfQaOvDq1j66LMNfDJUH1IU7Slfn8EvRv2EkH6ehu3A7zpYhjO0syHHiYg77v2lG2JFJgvw7Q=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -319,7 +319,7 @@
 
     "color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
-    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
 
@@ -391,6 +391,12 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
@@ -443,8 +449,6 @@
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
-    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
-
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
@@ -458,6 +462,8 @@
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
 
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
@@ -573,7 +579,7 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "p-each-series": ["p-each-series@3.0.0", "", {}, "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw=="],
 
@@ -620,6 +626,8 @@
     "pkg-conf": ["pkg-conf@2.1.0", "", { "dependencies": { "find-up": "^2.0.0", "load-json-file": "^4.0.0" } }, "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
@@ -779,9 +787,9 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
+    "write-file-atomic": ["write-file-atomic@8.0.0", "", { "dependencies": { "signal-exit": "^4.0.1" } }, "sha512-dYwyZredl67GyLLIHJnRM3h2PcOmN5SkcgC7eM5DPDEOEl6dLFqVrMg3F1Ea32usj4VSVZtd2H4MtKTNOf6nPg=="],
 
-    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -796,6 +804,8 @@
     "@actions/http-client/undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@dosu/api-types/@trpc/server": ["@trpc/server@11.17.0", "", { "peerDependencies": { "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 

--- a/package.json
+++ b/package.json
@@ -32,26 +32,26 @@
     "prepack": "bun run build:npm"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
-    "@clack/prompts": "^0.10.1",
-    "@dosu/api-types": "0.0.10",
+    "@clack/prompts": "^1.6.0",
+    "@dosu/api-types": "0.0.11",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
-    "@trpc/client": "11.17.0",
-    "@trpc/server": "11.17.0",
+    "@trpc/client": "11.18.0",
+    "@trpc/server": "11.18.0",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
-    "commander": "^13.1.0",
-    "open": "^10.2.0",
+    "commander": "^15.0.0",
+    "open": "^11.0.0",
     "picocolors": "^1.1.1",
     "semantic-release": "^25.0.5",
     "superjson": "^2.2.6",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
-    "write-file-atomic": "^5.0.1"
+    "write-file-atomic": "^8.0.0"
   }
 }

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -2,6 +2,15 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import type { Config } from "../config/config";
 import { Client, SessionExpiredError } from "./client";
 
+// Mock saveConfig to avoid filesystem writes (hoisted; applies to the whole file)
+vi.mock("../config/config", async () => {
+  const actual = await vi.importActual("../config/config");
+  return {
+    ...actual,
+    saveConfig: vi.fn(),
+  };
+});
+
 // Mock fetch globally
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -78,14 +87,6 @@ describe("Client", () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ data: "success" }));
 
       const cfg = makeConfig();
-      // Mock saveConfig to avoid filesystem writes
-      vi.mock("../config/config", async () => {
-        const actual = await vi.importActual("../config/config");
-        return {
-          ...actual,
-          saveConfig: vi.fn(),
-        };
-      });
 
       const client = new Client(cfg);
       const resp = await client.get("/test");

--- a/src/setup/github-doc-import-prompt.test.ts
+++ b/src/setup/github-doc-import-prompt.test.ts
@@ -421,7 +421,7 @@ describe("GitHubDocsImportPrompt", () => {
     prompt.handleRawKeypress("a", undefined);
     expect(prompt.value).toEqual(["f-4"]);
     prompt.handleRawKeypress("a", undefined);
-    expect(prompt.value.sort()).toEqual(["f-1", "f-2", "f-4"]);
+    expect(prompt.value?.sort()).toEqual(["f-1", "f-2", "f-4"]);
   });
 
   it("renders inactive repo rows with plain labels and no hint", () => {

--- a/src/setup/github-doc-import-prompt.test.ts
+++ b/src/setup/github-doc-import-prompt.test.ts
@@ -421,7 +421,7 @@ describe("GitHubDocsImportPrompt", () => {
     prompt.handleRawKeypress("a", undefined);
     expect(prompt.value).toEqual(["f-4"]);
     prompt.handleRawKeypress("a", undefined);
-    expect(prompt.value?.sort()).toEqual(["f-1", "f-2", "f-4"]);
+    expect(prompt.value?.toSorted()).toEqual(["f-1", "f-2", "f-4"]);
   });
 
   it("renders inactive repo rows with plain labels and no hint", () => {

--- a/src/setup/github-doc-import-prompt.ts
+++ b/src/setup/github-doc-import-prompt.ts
@@ -47,7 +47,7 @@ export async function promptGitHubDocsImport({
 }
 /* v8 ignore stop */
 
-export class GitHubDocsImportPrompt extends Prompt {
+export class GitHubDocsImportPrompt extends Prompt<string[]> {
   repositories: GitHubImportRepositoryOption[];
   mode: PromptMode = "repos";
   repoCursor = 0;

--- a/src/setup/github-repo-prompt.test.ts
+++ b/src/setup/github-repo-prompt.test.ts
@@ -121,9 +121,9 @@ describe("GitHubRepoPrompt", () => {
     const options = [ACTION_OPTION, ...repoOptions("a/b", "c/d", "e/f")];
     const prompt = makePrompt(options);
     prompt.emit("cursor", "down");
-    prompt.emit("key", "a");
+    prompt.emit("key", "a", {});
     expect(prompt.value).toEqual(["a/b", "c/d", "e/f"]);
-    prompt.emit("key", "a");
+    prompt.emit("key", "a", {});
     expect(prompt.value).toEqual([]);
   });
 
@@ -131,7 +131,7 @@ describe("GitHubRepoPrompt", () => {
     const options = [ACTION_OPTION, ...repoOptions("a/b")];
     const prompt = makePrompt(options);
     prompt.emit("cursor", "down");
-    prompt.emit("key", "z");
+    prompt.emit("key", "z", {});
     expect(prompt.value).toEqual([]);
   });
 

--- a/src/setup/github-repo-prompt.ts
+++ b/src/setup/github-repo-prompt.ts
@@ -61,7 +61,7 @@ export async function promptGitHubRepositories({
 }
 /* v8 ignore stop */
 
-export class GitHubRepoPrompt extends Prompt {
+export class GitHubRepoPrompt extends Prompt<ActionValue | string[]> {
   options: PromptOption[];
   message: string;
   maxItems?: number;

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -88,6 +88,10 @@ beforeEach(() => {
     start: vi.fn(),
     stop: vi.fn(),
     message: vi.fn(),
+    cancel: vi.fn(),
+    error: vi.fn(),
+    clear: vi.fn(),
+    isCancelled: false,
   } as ReturnType<typeof p.spinner>);
   vi.spyOn(console, "log").mockImplementation(() => {});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "esModuleInterop": true,


### PR DESCRIPTION
## What changed

Bumps the CLI's dependency tree and raises the supported Node.js floor.

**Dependencies (devDependencies + bundled tree):**
- `@clack/prompts` `^0.10.1` → `^1.6.0` (pulls in `@clack/core` 1.x, new `fast-string-width` / `fast-wrap-ansi` deps)
- `@dosu/api-types` `0.0.10` → `0.0.11`
- `@trpc/client` & `@trpc/server` `11.17.0` → `11.18.0`
- `commander` `^13.1.0` → `^15.0.0`
- `open` `^10.2.0` → `^11.0.0`
- `write-file-atomic` `^5.0.1` → `^8.0.0` (drops the `imurmurhash` transitive dep)
- `bun.lock` regenerated to match

**Node version:**
- `engines.node` `>=18` → `>=22`
- README install note updated to "Requires Node.js 22+"

**Source/test adjustments for the new `@clack/core` API:**
- `GitHubDocsImportPrompt` / `GitHubRepoPrompt` now extend the generic `Prompt<T>` (`Prompt<string[]>` and `Prompt<ActionValue | string[]>`), so `value` is properly typed/nullable
- `github-repo-prompt.test.ts` updated key-event emits to the new `(key, value)` signature
- `tui.test.ts` spinner mock extended with `cancel`/`error`/`clear`/`isCancelled` to match the new spinner shape
- `client.test.ts` hoisted the `saveConfig` `vi.mock` to module scope (mock factories must be hoisted)

## Why

Routine dependency maintenance to stay current and pull in upstream fixes. The major bumps (`@clack/prompts`, `commander`, `open`, `write-file-atomic`) require Node 22, hence the `engines` floor bump.

## Test notes

- The published npm package inlines all deps into `bin/dosu.js`, so these stay in `devDependencies`.
- `bunfig.toml`'s 3-day `minimumReleaseAge` gate applies to any future `bun update`.
- Recommend CI confirm `bun run test`, `bun run typecheck`, and `bun run check` pass against the new tree before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)