### PR TITLE
feat: per-channel update hints for npm, binary, and Homebrew installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:local": "DOSU_DEV=true bun run src/index.ts",
     "build": "bun --env-file=.env.production run scripts/build-compile.ts",
     "build:dev": "bun --env-file=.env.development run scripts/build-compile.ts",
-    "build:npm": "bun --env-file=.env.production run scripts/build-npm.ts",
+    "build:npm": "DOSU_INSTALL_CHANNEL=npm bun --env-file=.env.production run scripts/build-npm.ts",
     "build:all": "bun --env-file=.env.production run scripts/build-all.ts",
     "test": "bunx vitest run",
     "test:watch": "bunx vitest",

--- a/scripts/build-all.test.ts
+++ b/scripts/build-all.test.ts
@@ -29,11 +29,13 @@ describe("buildDefines", () => {
     envBackup.DOSU_BACKEND_URL = process.env.DOSU_BACKEND_URL;
     envBackup.SUPABASE_URL = process.env.SUPABASE_URL;
     envBackup.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+    envBackup.DOSU_INSTALL_CHANNEL = process.env.DOSU_INSTALL_CHANNEL;
     delete process.env.DOSU_VERSION;
     delete process.env.DOSU_WEB_APP_URL;
     delete process.env.DOSU_BACKEND_URL;
     delete process.env.SUPABASE_URL;
     delete process.env.SUPABASE_ANON_KEY;
+    delete process.env.DOSU_INSTALL_CHANNEL;
   });
 
   afterEach(() => {
@@ -63,6 +65,7 @@ describe("buildDefines", () => {
     process.env.DOSU_BACKEND_URL = "https://api.test.dev";
     process.env.SUPABASE_URL = "https://db.test.dev";
     process.env.SUPABASE_ANON_KEY = "anon-test-key";
+    process.env.DOSU_INSTALL_CHANNEL = "homebrew";
 
     const defines = buildDefines();
     expect(defines).toEqual([
@@ -76,6 +79,8 @@ describe("buildDefines", () => {
       'process.env.SUPABASE_URL="https://db.test.dev"',
       "--define",
       'process.env.SUPABASE_ANON_KEY="anon-test-key"',
+      "--define",
+      'process.env.DOSU_INSTALL_CHANNEL="homebrew"',
     ]);
   });
 
@@ -85,15 +90,21 @@ describe("buildDefines", () => {
     expect(defines[1]).toBe('process.env.DOSU_VERSION="has\\"quotes"');
   });
 
-  it("should return exactly 10 elements (5 pairs of --define + value)", () => {
+  it("should return exactly 12 elements (6 pairs of --define + value)", () => {
     const defines = buildDefines();
-    expect(defines).toHaveLength(10);
+    expect(defines).toHaveLength(12);
     expect(defines.filter((_, i) => i % 2 === 0)).toEqual([
       "--define",
       "--define",
       "--define",
       "--define",
       "--define",
+      "--define",
     ]);
+  });
+
+  it("should default INSTALL_CHANNEL to npm when env var is not set", () => {
+    const defines = buildDefines();
+    expect(defines).toContain('process.env.DOSU_INSTALL_CHANNEL="npm"');
   });
 });

--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -44,6 +44,7 @@ export function buildDefines(): string[] {
   const backendURL = process.env.DOSU_BACKEND_URL ?? "";
   const supabaseURL = process.env.SUPABASE_URL ?? "";
   const supabaseAnonKey = process.env.SUPABASE_ANON_KEY ?? "";
+  const installChannel = process.env.DOSU_INSTALL_CHANNEL ?? "npm";
 
   return [
     "--define",
@@ -56,6 +57,8 @@ export function buildDefines(): string[] {
     `process.env.SUPABASE_URL=${JSON.stringify(supabaseURL)}`,
     "--define",
     `process.env.SUPABASE_ANON_KEY=${JSON.stringify(supabaseAnonKey)}`,
+    "--define",
+    `process.env.DOSU_INSTALL_CHANNEL=${JSON.stringify(installChannel)}`,
   ];
 }
 
@@ -64,9 +67,16 @@ async function main() {
   if (!existsSync(distDir)) mkdirSync(distDir, { recursive: true });
 
   const defines = buildDefines();
-  console.log(`Building for ${TARGETS.length} platforms...\n`);
+  const outputSuffix = process.env.DOSU_OUTPUT_SUFFIX ?? "";
+  console.log(
+    `Building for ${TARGETS.length} platforms...${outputSuffix ? ` (suffix: ${outputSuffix})` : ""}\n`,
+  );
 
-  for (const { target, output } of TARGETS) {
+  for (const { target, output: baseOutput } of TARGETS) {
+    // Insert suffix before the file extension (.exe) or append to the end.
+    const output = baseOutput.includes(".")
+      ? baseOutput.replace(/(\.[^.]+)$/, `${outputSuffix}$1`)
+      : `${baseOutput}${outputSuffix}`;
     const outPath = join(distDir, output);
     console.log(`  Building ${target} → ${output}`);
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -7,8 +7,16 @@ DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 echo "==> Building release v${VERSION} (${COMMIT})"
 
-# Build cross-platform binaries
+rm -rf dist
+
+# Build cross-platform binaries for direct GitHub release downloads
 DOSU_VERSION="$VERSION" DOSU_COMMIT="$COMMIT" DOSU_DATE="$DATE" \
+  DOSU_INSTALL_CHANNEL=binary \
+  bun --env-file=.env.production run scripts/build-all.ts
+
+# Build Homebrew-specific binaries (same targets, channel baked as "homebrew")
+DOSU_VERSION="$VERSION" DOSU_COMMIT="$COMMIT" DOSU_DATE="$DATE" \
+  DOSU_INSTALL_CHANNEL=homebrew DOSU_OUTPUT_SUFFIX=-homebrew \
   bun --env-file=.env.production run scripts/build-all.ts
 
 # Create archives

--- a/src/version/update-check.test.ts
+++ b/src/version/update-check.test.ts
@@ -2,7 +2,30 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { checkForUpdates, fetchLatestVersion, isNewerVersion } from "./update-check";
+import {
+  buildUpdateHint,
+  checkForUpdates,
+  fetchLatestVersion,
+  isNewerVersion,
+} from "./update-check";
+
+describe("buildUpdateHint", () => {
+  it("returns npm update command for npm channel", () => {
+    expect(buildUpdateHint("npm")).toBe('Run "npm update -g @dosu/cli"');
+  });
+
+  it("returns brew upgrade command for homebrew channel", () => {
+    expect(buildUpdateHint("homebrew")).toBe('Run "brew upgrade dosu"');
+  });
+
+  it("returns GitHub releases download link for binary channel", () => {
+    expect(buildUpdateHint("binary")).toContain("github.com/dosu-ai/dosu-cli/releases");
+  });
+
+  it("falls back to npm hint for unknown channel", () => {
+    expect(buildUpdateHint("unknown")).toBe('Run "npm update -g @dosu/cli"');
+  });
+});
 
 describe("isNewerVersion", () => {
   it("returns true when latest is a higher major", () => {

--- a/src/version/update-check.ts
+++ b/src/version/update-check.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import pc from "picocolors";
 import { getConfigDir } from "../config/config";
 import { logger } from "../debug/logger";
-import { VERSION } from "./version";
+import { INSTALL_CHANNEL, VERSION } from "./version";
 
 const CACHE_FILENAME = "update-check.json";
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -90,10 +90,16 @@ export async function fetchLatestVersion(): Promise<string | null> {
   }
 }
 
+export function buildUpdateHint(channel: string): string {
+  if (channel === "homebrew") return 'Run "brew upgrade dosu"';
+  if (channel === "binary") return "Download from https://github.com/dosu-ai/dosu-cli/releases";
+  return 'Run "npm update -g @dosu/cli"';
+}
+
 function displayNotice(current: string, latest: string): void {
   const msg =
     `\n${pc.yellow(`  Update available: ${current} → ${latest}`)}\n` +
-    `${pc.dim('  Run "npm update -g @dosu/cli" or visit https://github.com/dosu-ai/dosu-cli/releases')}\n`;
+    `${pc.dim(`  ${buildUpdateHint(INSTALL_CHANNEL)}`)}\n`;
   console.error(msg);
 }
 

--- a/src/version/version.test.ts
+++ b/src/version/version.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getVersionString, VERSION } from "./version";
+import { getVersionString, INSTALL_CHANNEL, VERSION } from "./version";
 
 describe("version", () => {
   it("should read version from package.json in dev mode", () => {
@@ -10,5 +10,9 @@ describe("version", () => {
   it("should return clean version string", () => {
     const result = getVersionString();
     expect(result).toMatch(/^v\d+\.\d+\.\d+/);
+  });
+
+  it("should default INSTALL_CHANNEL to npm in dev/source mode", () => {
+    expect(INSTALL_CHANNEL).toBe("npm");
   });
 });

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -14,6 +14,9 @@ function readPackageVersion(): string {
 
 export const VERSION = process.env.DOSU_VERSION ?? readPackageVersion();
 
+/** Distribution channel baked in at build time. One of: "npm", "binary", "homebrew". */
+export const INSTALL_CHANNEL = process.env.DOSU_INSTALL_CHANNEL ?? "npm";
+
 /**
  * Returns a formatted version string, e.g. "dosu v0.3.1".
  */


### PR DESCRIPTION
Bake DOSU_INSTALL_CHANNEL into each build so the update notice shows the right upgrade command: 
`npm update -g`, 
`brew upgrade dosu`, 
or a direct link to GitHub releases. 

build-release.sh now runs two passes. One with `DOSU_INSTALL_CHANNEL=binary` for GitHub release tarballs and one with `DOSU_INSTALL_CHANNEL=homebrew `+ `DOSU_OUTPUT_SUFFIX=-homebrew` for Homebrew-specific tarballs.