### PR TITLE
feat: add audit command with repo-sync enforcement and non-blocking PR generation

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -7,6 +7,7 @@ import { Command } from "commander";
 import { Client } from "../client/client";
 import { analyticsCommand } from "../commands/analytics";
 import { askCommand } from "../commands/ask";
+import { auditCommand } from "../commands/audit";
 import { deploymentsCommand } from "../commands/deployments";
 import { docsCommand } from "../commands/docs";
 import { hooksCommand } from "../commands/hooks";
@@ -32,6 +33,7 @@ import {
 } from "../config/config";
 import { logger } from "../debug/logger";
 import { allProviders, getProvider, type Provider } from "../mcp/providers";
+import { checkForReadyTasks } from "../version/pending-tasks-check";
 import { checkForSkillUpdates } from "../version/skill-update-check";
 import { checkForUpdates } from "../version/update-check";
 import { getVersionString } from "../version/version";
@@ -61,6 +63,7 @@ export function createProgram(): Command {
       if (!isHookEntrypointInvocation(process.argv)) {
         checkForUpdates();
         checkForSkillUpdates();
+        checkForReadyTasks();
       }
     })
     .action(async () => {
@@ -298,6 +301,7 @@ export function createProgram(): Command {
   // Agent-facing commands
   program.addCommand(analyticsCommand());
   program.addCommand(askCommand());
+  program.addCommand(auditCommand());
   program.addCommand(deploymentsCommand());
   program.addCommand(docsCommand());
   program.addCommand(hooksCommand());

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -1,0 +1,537 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── tRPC client ──
+const mockQuery = vi.fn();
+const mockMutate = vi.fn();
+function createMockProxy(path: string[] = []): unknown {
+  return new Proxy(() => {}, {
+    get(_, prop: string) {
+      if (prop === "query") return (input: unknown) => mockQuery(path.join("."), input);
+      if (prop === "mutate") return (input: unknown) => mockMutate(path.join("."), input);
+      return createMockProxy([...path, prop]);
+    },
+  });
+}
+vi.mock("../client/trpc", () => ({
+  createTypedClient: vi.fn().mockImplementation(() => createMockProxy()),
+}));
+
+// ── config ──
+const mockLoadConfig = vi.fn();
+vi.mock("../config/config", () => ({
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+}));
+
+// ── github-step ──
+const mockDetectGitRepo = vi.fn();
+const mockStepConnect = vi.fn();
+vi.mock("../setup/github-step", () => ({
+  detectGitRepo: (...a: unknown[]) => mockDetectGitRepo(...a),
+  stepConnectGitHubRepo: (...a: unknown[]) => mockStepConnect(...a),
+}));
+
+// ── pending-tasks cache ──
+const mockAddPendingTask = vi.fn();
+vi.mock("../version/pending-tasks-check", () => ({
+  addPendingTask: (...a: unknown[]) => mockAddPendingTask(...a),
+}));
+
+// ── fs (findings file) ──
+const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
+vi.mock("node:fs", () => ({
+  existsSync: (...a: unknown[]) => mockExistsSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
+}));
+
+// ── clack ──
+const mockConfirm = vi.fn();
+const mockMultiselect = vi.fn();
+const mockIsCancel = vi.fn().mockReturnValue(false);
+const mockSpinner = { start: vi.fn(), stop: vi.fn(), message: vi.fn() };
+vi.mock("@clack/prompts", () => ({
+  confirm: (...a: unknown[]) => mockConfirm(...a),
+  multiselect: (...a: unknown[]) => mockMultiselect(...a),
+  isCancel: (...a: unknown[]) => mockIsCancel(...a),
+  spinner: () => mockSpinner,
+  log: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("../debug/logger", () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { auditCommand } from "./audit";
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+// biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
+let exitSpy: any;
+
+const validConfig = {
+  access_token: "t",
+  refresh_token: "r",
+  expires_at: 0,
+  api_key: "sk_user_test",
+  org_id: "org1",
+  space_id: "sp1",
+};
+
+const detected = { owner: "o", name: "r", slug: "o/r" };
+
+const findings = {
+  version: 1,
+  generated_at: "2026-01-01T00:00:00Z",
+  repo: { remote: "git@github.com:o/r.git", slug: "o/r" },
+  items: [
+    {
+      task: "generate-agents-md",
+      type: "agents",
+      file: "AGENTS.md",
+      status: "missing",
+      action: "create",
+      can_help: true,
+      confidence: "high",
+      rationale: "no agents file",
+      evidence: ["e1"],
+    },
+    {
+      task: "generate-readme",
+      type: "readme",
+      file: "README.md",
+      status: "present_ok",
+      action: "skip",
+      can_help: true,
+      confidence: "low",
+      rationale: "looks fine",
+      evidence: [],
+    },
+    {
+      task: "unsupported-thing",
+      type: "deps",
+      file: "DEPS.md",
+      status: "missing",
+      action: "create",
+      can_help: true,
+      confidence: "high",
+      rationale: "n/a",
+      evidence: [],
+    },
+  ],
+};
+
+const capabilities = {
+  tasks: [
+    { id: "generate-agents-md", label: "AGENTS.md", description: "", doc_type: "agents" },
+    { id: "generate-readme", label: "README", description: "", doc_type: "readme" },
+  ],
+};
+
+function jsonResp(data: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => data,
+  } as unknown as Response;
+}
+
+interface FetchInit {
+  method?: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function fetchCalls(): [string, FetchInit][] {
+  return mockFetch.mock.calls as unknown as [string, FetchInit][];
+}
+
+function postCalls(): [string, FetchInit][] {
+  return fetchCalls().filter((c) => c[1]?.method === "POST");
+}
+
+function setFindings(obj: unknown): void {
+  mockExistsSync.mockReturnValue(true);
+  mockReadFileSync.mockReturnValue(JSON.stringify(obj));
+}
+
+async function run(...args: string[]) {
+  const cmd = auditCommand();
+  cmd.exitOverride();
+  await cmd.parseAsync(["node", "test", ...args]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsCancel.mockReturnValue(false);
+  mockLoadConfig.mockReturnValue(validConfig);
+  mockDetectGitRepo.mockReturnValue(detected);
+  process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api.example.test";
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("exit");
+  }) as never);
+});
+
+afterEach(() => {
+  delete process.env.DOSU_BACKEND_URL_OVERRIDE;
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+  exitSpy.mockRestore();
+});
+
+describe("config guard", () => {
+  it("exits when api_key missing", async () => {
+    mockLoadConfig.mockReturnValue({ ...validConfig, api_key: undefined });
+    await expect(run()).rejects.toThrow("exit");
+  });
+
+  it("exits when org_id missing", async () => {
+    mockLoadConfig.mockReturnValue({ ...validConfig, org_id: undefined });
+    await expect(run()).rejects.toThrow("exit");
+  });
+
+  it("exits when not logged in", async () => {
+    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    await expect(run()).rejects.toThrow("exit");
+  });
+});
+
+describe("repo enforcement", () => {
+  it("exits when not a git repo", async () => {
+    mockDetectGitRepo.mockReturnValue(null);
+    await expect(run()).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.join(" ")).toContain("Not a GitHub repo");
+  });
+
+  it("prompts to connect when no matching data source, exits on decline", async () => {
+    mockQuery.mockResolvedValueOnce([]); // dataSource.list — no match
+    mockConfirm.mockResolvedValue(false);
+    await expect(run()).rejects.toThrow("exit");
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(mockStepConnect).not.toHaveBeenCalled();
+  });
+
+  it("connects when accepted, then proceeds", async () => {
+    // list #1 no match → confirm yes → connect → list #2 indexed match
+    mockQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+      ]);
+    mockConfirm.mockResolvedValue(true);
+    mockStepConnect.mockResolvedValue({ has_connected_repo: true });
+    setFindings(findings);
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities)) // GET /cli/tasks
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" })); // POST
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+
+    await run();
+
+    expect(mockStepConnect).toHaveBeenCalledWith(validConfig, detected);
+    expect(mockAddPendingTask).toHaveBeenCalled();
+  });
+
+  it("polls until indexed when matched but not indexed", async () => {
+    mockQuery
+      .mockResolvedValueOnce([
+        { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: false },
+      ])
+      .mockResolvedValueOnce([
+        { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+      ]);
+    setFindings(findings);
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+
+    await run();
+
+    // Two list calls = initial (not indexed) + one poll (indexed).
+    const listCalls = mockQuery.mock.calls.filter((c) => c[0] === "dataSource.list");
+    expect(listCalls.length).toBeGreaterThanOrEqual(2);
+    expect(mockAddPendingTask).toHaveBeenCalled();
+  });
+
+  it("--data-source-id skips auto-match entirely", async () => {
+    setFindings(findings);
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+
+    await run("--data-source-id", "ds-explicit");
+
+    expect(mockQuery).not.toHaveBeenCalled();
+    const postCall = postCalls()[0];
+    const body = JSON.parse(postCall[1].body);
+    expect(body.data_source_id).toBe("ds-explicit");
+  });
+});
+
+describe("findings loading", () => {
+  beforeEach(() => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+  });
+
+  it("exits when findings file missing", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await expect(run()).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.join(" ")).toContain("Dosu audit");
+  });
+
+  it("exits when version is not 1", async () => {
+    setFindings({ ...findings, version: 2 });
+    await expect(run()).rejects.toThrow("exit");
+  });
+
+  it("exits on invalid JSON", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("NOT JSON{{{");
+    await expect(run()).rejects.toThrow("exit");
+  });
+});
+
+describe("capability intersection + selection", () => {
+  beforeEach(() => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    setFindings(findings);
+  });
+
+  it("only offers items that match a capability", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResp(capabilities));
+    mockMultiselect.mockResolvedValue([]);
+    await run();
+    const opts = mockMultiselect.mock.calls[0][0].options as { value: string }[];
+    const values = opts.map((o) => o.value);
+    expect(values).toContain("generate-agents-md");
+    expect(values).toContain("generate-readme");
+    expect(values).not.toContain("unsupported-thing");
+  });
+
+  it("preselects can_help && action !== skip", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResp(capabilities));
+    mockMultiselect.mockResolvedValue([]);
+    await run();
+    const initial = mockMultiselect.mock.calls[0][0].initialValues as string[];
+    expect(initial).toEqual(["generate-agents-md"]); // readme is skip
+  });
+
+  it("posts correct payload per selected item", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+
+    await run();
+
+    const postCall = postCalls()[0];
+    expect(postCall[0]).toBe("https://api.example.test/v1/cli/task/generate-agents-md");
+    expect(postCall[1].headers["X-Dosu-API-Key"]).toBe("sk_user_test");
+    const body = JSON.parse(postCall[1].body);
+    expect(body.data_source_id).toBe("ds1");
+    expect(body.repo).toBe("o/r");
+    expect(body.findings.task).toBe("generate-agents-md");
+    expect(mockAddPendingTask).toHaveBeenCalledWith({
+      task_id: "task-1",
+      doc_types: ["agents"],
+      repo: "o/r",
+    });
+  });
+
+  it("--yes selects all can_help && action !== skip without prompting", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+
+    await run("--yes");
+
+    expect(mockMultiselect).not.toHaveBeenCalled();
+    const posts = postCalls();
+    expect(posts).toHaveLength(1); // only agents (readme is skip)
+    expect(posts[0][0]).toContain("generate-agents-md");
+  });
+
+  it("returns early when nothing selected", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResp(capabilities));
+    mockMultiselect.mockResolvedValue([]);
+    await run();
+    const posts = postCalls();
+    expect(posts).toHaveLength(0);
+    expect(mockAddPendingTask).not.toHaveBeenCalled();
+  });
+
+  it("handles cancelled multiselect", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResp(capabilities));
+    mockMultiselect.mockResolvedValue(Symbol("cancel"));
+    mockIsCancel.mockReturnValue(true);
+    await run();
+    const posts = postCalls();
+    expect(posts).toHaveLength(0);
+  });
+
+  it("info message when no findings intersect capabilities", async () => {
+    setFindings({ ...findings, items: [findings.items[2]] }); // only unsupported
+    mockFetch.mockResolvedValueOnce(jsonResp(capabilities));
+    await run();
+    expect(mockMultiselect).not.toHaveBeenCalled();
+  });
+});
+
+describe("--tasks (agent-driven, non-interactive)", () => {
+  beforeEach(() => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    setFindings(findings);
+  });
+
+  it("fires exactly the requested subset without prompting", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+
+    await run("--tasks", "generate-agents-md");
+
+    expect(mockMultiselect).not.toHaveBeenCalled();
+    const posts = postCalls();
+    expect(posts).toHaveLength(1);
+    expect(posts[0][0]).toContain("generate-agents-md");
+  });
+
+  it("ignores task ids the audit did not offer", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+
+    await run("--tasks", "generate-agents-md,nope-not-real");
+
+    const posts = postCalls();
+    expect(posts).toHaveLength(1);
+    expect(posts[0][0]).toContain("generate-agents-md");
+  });
+
+  it("never prompts or connects when the repo is unconnected; exits non-zero", async () => {
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue([]); // no matching data source
+    await expect(run("--tasks", "generate-agents-md")).rejects.toThrow("exit");
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockStepConnect).not.toHaveBeenCalled();
+  });
+});
+
+describe("--json output", () => {
+  beforeEach(() => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    setFindings(findings);
+  });
+
+  it("emits task_ids and does NOT poll (non-blocking)", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+
+    await run("--yes", "--json");
+
+    const out = JSON.parse(logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n"));
+    expect(out.task_ids).toEqual(["task-1"]);
+    // No GET /cli/task/run/* call — generation is fire-and-forget.
+    const runPolls = fetchCalls().filter((c) => String(c[0]).includes("/cli/task/run/"));
+    expect(runPolls).toHaveLength(0);
+  });
+
+  it("emits empty task_ids when nothing intersects", async () => {
+    setFindings({ ...findings, items: [findings.items[2]] });
+    mockFetch.mockResolvedValueOnce(jsonResp(capabilities));
+    await run("--json");
+    const out = JSON.parse(logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n"));
+    expect(out.task_ids).toEqual([]);
+  });
+});
+
+describe("error branches", () => {
+  beforeEach(() => {
+    setFindings(findings);
+  });
+
+  it("exits when backend URL is not configured", async () => {
+    delete process.env.DOSU_BACKEND_URL_OVERRIDE;
+    delete process.env.DOSU_BACKEND_URL;
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    await expect(run()).rejects.toThrow("exit");
+  });
+
+  it("throws a friendly error when GET /cli/tasks fails", async () => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    mockFetch.mockResolvedValueOnce(jsonResp({ detail: "capabilities down" }, false));
+    await expect(run()).rejects.toThrow("capabilities down");
+  });
+
+  it("throws when POST /cli/task fails", async () => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ detail: "task rejected" }, false));
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+    await expect(run()).rejects.toThrow("task rejected");
+  });
+
+  it("skips items where the POST returns no task_id", async () => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    mockFetch.mockResolvedValueOnce(jsonResp(capabilities)).mockResolvedValueOnce(jsonResp({})); // no task_id
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+    await run();
+    expect(mockAddPendingTask).not.toHaveBeenCalled();
+  });
+
+  it("exits when connect succeeds but no match appears", async () => {
+    mockQuery.mockResolvedValueOnce([]).mockResolvedValueOnce([]); // never matches
+    mockConfirm.mockResolvedValue(true);
+    mockStepConnect.mockResolvedValue({ has_connected_repo: true });
+    await expect(run()).rejects.toThrow("exit");
+  });
+
+  it("exits when stepConnect reports no connected repo", async () => {
+    mockQuery.mockResolvedValueOnce([]);
+    mockConfirm.mockResolvedValue(true);
+    mockStepConnect.mockResolvedValue({ has_connected_repo: false });
+    await expect(run()).rejects.toThrow("exit");
+  });
+
+  it("emits empty task_ids in --json when selection is empty", async () => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    mockFetch.mockResolvedValueOnce(jsonResp(capabilities));
+    mockMultiselect.mockResolvedValue([]);
+    await run("--json");
+    const out = JSON.parse(logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n"));
+    expect(out.task_ids).toEqual([]);
+  });
+
+  it("exits when matched data source has no id after indexing", async () => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: undefined, provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    await expect(run()).rejects.toThrow("exit");
+  });
+});

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -360,6 +360,16 @@ describe("indexing poll (fake timers)", () => {
     await assertion;
     expect(mockSpinner.start).not.toHaveBeenCalled(); // quiet poll: no spinner
   });
+
+  it("treats a transient dataSource.list failure during polling as still-indexing", async () => {
+    mockQuery
+      .mockResolvedValueOnce(notIndexed) // initial check
+      .mockRejectedValueOnce(new Error("network blip")); // poll throws → caught
+    const assertion = expect(run()).rejects.toThrow("exit");
+    await vi.advanceTimersByTimeAsync(3_000);
+    await assertion;
+    expect(mockSpinner.stop).toHaveBeenCalledWith("Still indexing");
+  });
 });
 
 describe("capability intersection + selection", () => {
@@ -554,6 +564,20 @@ describe("error branches", () => {
       .mockResolvedValueOnce(jsonResp({ detail: "task rejected" }, false));
     mockMultiselect.mockResolvedValue(["generate-agents-md"]);
     await expect(run()).rejects.toThrow("task rejected");
+  });
+
+  it("falls back to a status message when the error body isn't JSON", async () => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => {
+        throw new Error("not json");
+      },
+    } as unknown as Response);
+    await expect(run()).rejects.toThrow("Request failed with status 503");
   });
 
   it("skips items where the POST returns no task_id", async () => {

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -215,6 +215,12 @@ describe("repo enforcement", () => {
     expect(mockStepConnect).not.toHaveBeenCalled();
   });
 
+  it("handles a null dataSource.list result as no data sources", async () => {
+    mockQuery.mockResolvedValue(null); // dataSource.list → null → `?? []`
+    await expect(run("--tasks", "generate-agents-md")).rejects.toThrow("exit");
+    expect(mockStepConnect).not.toHaveBeenCalled();
+  });
+
   it("connects when accepted, then proceeds", async () => {
     // list #1 no match → confirm yes → connect → list #2 indexed match
     mockQuery
@@ -370,6 +376,14 @@ describe("indexing poll (fake timers)", () => {
     await assertion;
     expect(mockSpinner.stop).toHaveBeenCalledWith("Still indexing");
   });
+
+  it("handles a non-Error rejection during polling", async () => {
+    mockQuery.mockResolvedValueOnce(notIndexed).mockRejectedValueOnce("string failure"); // non-Error → String(err) branch
+    const assertion = expect(run()).rejects.toThrow("exit");
+    await vi.advanceTimersByTimeAsync(3_000);
+    await assertion;
+    expect(mockSpinner.stop).toHaveBeenCalledWith("Still indexing");
+  });
 });
 
 describe("capability intersection + selection", () => {
@@ -455,6 +469,12 @@ describe("capability intersection + selection", () => {
   it("info message when no findings intersect capabilities", async () => {
     setFindings({ ...findings, items: [findings.items[2]] }); // only unsupported
     mockFetch.mockResolvedValueOnce(jsonResp(capabilities));
+    await run();
+    expect(mockMultiselect).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing tasks array in the capabilities response as none", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResp({})); // no `tasks` key → `?? []`
     await run();
     expect(mockMultiselect).not.toHaveBeenCalled();
   });
@@ -578,6 +598,14 @@ describe("error branches", () => {
       },
     } as unknown as Response);
     await expect(run()).rejects.toThrow("Request failed with status 503");
+  });
+
+  it("uses the status message when the error JSON has no detail field", async () => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    mockFetch.mockResolvedValueOnce(jsonResp({}, false)); // valid JSON, no `detail`
+    await expect(run()).rejects.toThrow("Request failed with status 500");
   });
 
   it("skips items where the POST returns no task_id", async () => {

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -297,6 +297,69 @@ describe("findings loading", () => {
     mockReadFileSync.mockReturnValue("NOT JSON{{{");
     await expect(run()).rejects.toThrow("exit");
   });
+
+  it("exits when findings JSON is valid but null", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("null");
+    await expect(run()).rejects.toThrow("exit");
+  });
+
+  it("exits when findings items is not an array", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: 1, items: "nope" }));
+    await expect(run()).rejects.toThrow("exit");
+  });
+});
+
+describe("indexing poll (fake timers)", () => {
+  const notIndexed = [
+    { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: false },
+  ];
+  const indexed = [
+    { data_source_id: "ds1", provider_slug: "github", name: "o/r", is_indexed: true },
+  ];
+
+  beforeEach(() => {
+    setFindings(findings);
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("polls through a not-indexed cycle, then proceeds once indexed", async () => {
+    mockQuery
+      .mockResolvedValueOnce(notIndexed) // initial check in ensureSyncedRepo
+      .mockResolvedValueOnce(notIndexed) // poll iteration 1 → sleep
+      .mockResolvedValueOnce(indexed); // poll iteration 2 → indexed
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+
+    const pr = run();
+    await vi.advanceTimersByTimeAsync(6_000);
+    await pr;
+
+    expect(mockSpinner.stop).toHaveBeenCalledWith("Repo indexed");
+    expect(mockAddPendingTask).toHaveBeenCalled();
+  });
+
+  it("exits when indexing never finishes (interactive shows spinner)", async () => {
+    mockQuery.mockResolvedValue(notIndexed);
+    const assertion = expect(run()).rejects.toThrow("exit");
+    await vi.advanceTimersByTimeAsync(130_000);
+    await assertion;
+    expect(mockSpinner.stop).toHaveBeenCalledWith("Still indexing");
+  });
+
+  it("--tasks exits non-interactively when indexing never finishes (no spinner)", async () => {
+    mockQuery.mockResolvedValue(notIndexed);
+    const assertion = expect(run("--tasks", "generate-agents-md")).rejects.toThrow("exit");
+    await vi.advanceTimersByTimeAsync(130_000);
+    await assertion;
+    expect(mockSpinner.start).not.toHaveBeenCalled(); // quiet poll: no spinner
+  });
 });
 
 describe("capability intersection + selection", () => {

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -278,6 +278,42 @@ describe("repo enforcement", () => {
     const body = JSON.parse(postCall[1].body);
     expect(body.data_source_id).toBe("ds-explicit");
   });
+
+  it("matches a data source named by the bare repo name (not the full slug)", async () => {
+    // Repos connected via the dashboard/older flows are named just "r", not
+    // "o/r". detected.slug is "o/r"; the match must still find it.
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds-bare", provider_slug: "github", name: "r", is_indexed: true },
+    ]);
+    setFindings(findings);
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+
+    await run();
+
+    expect(mockStepConnect).not.toHaveBeenCalled();
+    const body = JSON.parse(postCalls()[0][1].body);
+    expect(body.data_source_id).toBe("ds-bare");
+  });
+
+  it("prefers an exact slug match over a bare-name match", async () => {
+    mockQuery.mockResolvedValue([
+      { data_source_id: "ds-bare", provider_slug: "github", name: "r", is_indexed: true },
+      { data_source_id: "ds-slug", provider_slug: "github", name: "o/r", is_indexed: true },
+    ]);
+    setFindings(findings);
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+    mockMultiselect.mockResolvedValue(["generate-agents-md"]);
+
+    await run();
+
+    const body = JSON.parse(postCalls()[0][1].body);
+    expect(body.data_source_id).toBe("ds-slug");
+  });
 });
 
 describe("findings loading", () => {
@@ -314,6 +350,28 @@ describe("findings loading", () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue(JSON.stringify({ version: 1, items: "nope" }));
     await expect(run()).rejects.toThrow("exit");
+  });
+
+  it("refuses to publish to a repo other than the one the audit ran on", async () => {
+    // detected repo is o/r; findings say the audit ran on a different repo.
+    setFindings({
+      ...findings,
+      repo: { remote: "git@github.com:other/repo.git", slug: "other/repo" },
+    });
+    await expect(run()).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.join(" ")).toContain("Audit was run on other/repo");
+  });
+
+  it("allows a repo mismatch when --data-source-id is given explicitly", async () => {
+    setFindings({
+      ...findings,
+      repo: { remote: "git@github.com:other/repo.git", slug: "other/repo" },
+    });
+    mockFetch
+      .mockResolvedValueOnce(jsonResp(capabilities))
+      .mockResolvedValueOnce(jsonResp({ task_id: "task-1" }));
+    await run("--data-source-id", "ds-explicit", "--tasks", "generate-agents-md");
+    expect(postCalls()).toHaveLength(1); // override bypasses the audited-repo guard
   });
 });
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -243,28 +243,32 @@ async function ensureSyncedRepo(
 }
 
 function loadFindings(findingsPath: string): AuditFindings {
+  const fail = (): never => {
+    console.error(
+      pc.red("Run the Dosu audit in your coding agent first (it writes .dosu/audit.json)."),
+    );
+    process.exit(1);
+  };
   if (!existsSync(findingsPath)) {
-    console.error(
-      pc.red("Run the Dosu audit in your coding agent first (it writes .dosu/audit.json)."),
-    );
-    process.exit(1);
+    fail();
   }
-  let parsed: AuditFindings;
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(readFileSync(findingsPath, "utf-8")) as AuditFindings;
+    parsed = JSON.parse(readFileSync(findingsPath, "utf-8"));
   } catch {
-    console.error(
-      pc.red("Run the Dosu audit in your coding agent first (it writes .dosu/audit.json)."),
-    );
-    process.exit(1);
+    fail();
   }
-  if (parsed.version !== 1) {
-    console.error(
-      pc.red("Run the Dosu audit in your coding agent first (it writes .dosu/audit.json)."),
-    );
-    process.exit(1);
+  // Guard against valid-JSON-but-wrong-shape (e.g. `null`, a primitive, or a
+  // missing/!==1 version, or non-array items) — accessing fields would throw.
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as AuditFindings).version !== 1 ||
+    !Array.isArray((parsed as AuditFindings).items)
+  ) {
+    fail();
   }
-  return parsed;
+  return parsed as AuditFindings;
 }
 
 /** Intersect findings with capabilities, keyed by `item.task` === capability `id`. */

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -76,15 +76,16 @@ function requireConfig(): Config & { api_key: string; org_id: string } {
   return cfg as Config & { api_key: string; org_id: string };
 }
 
-async function backendGet(path: string, apiKey: string): Promise<unknown> {
+function requireBackendURL(): string {
   const backendURL = getBackendURL();
   if (!backendURL) {
     console.error(pc.red("Backend URL not configured."));
     process.exit(1);
   }
-  const resp = await fetch(`${backendURL}${path}`, {
-    headers: { "X-Dosu-API-Key": apiKey },
-  });
+  return backendURL;
+}
+
+async function parseBackendResponse(resp: Response): Promise<unknown> {
   if (!resp.ok) {
     let detail = `Request failed with status ${resp.status}`;
     try {
@@ -96,30 +97,24 @@ async function backendGet(path: string, apiKey: string): Promise<unknown> {
   return await resp.json();
 }
 
+async function backendGet(path: string, apiKey: string): Promise<unknown> {
+  const resp = await fetch(`${requireBackendURL()}${path}`, {
+    headers: { "X-Dosu-API-Key": apiKey },
+  });
+  return parseBackendResponse(resp);
+}
+
 async function backendPost(
   path: string,
   apiKey: string,
   body: Record<string, unknown>,
 ): Promise<unknown> {
-  const backendURL = getBackendURL();
-  if (!backendURL) {
-    console.error(pc.red("Backend URL not configured."));
-    process.exit(1);
-  }
-  const resp = await fetch(`${backendURL}${path}`, {
+  const resp = await fetch(`${requireBackendURL()}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json", "X-Dosu-API-Key": apiKey },
     body: JSON.stringify(body),
   });
-  if (!resp.ok) {
-    let detail = `Request failed with status ${resp.status}`;
-    try {
-      const errBody = (await resp.json()) as { detail?: string };
-      detail = errBody.detail ?? detail;
-    } catch {}
-    throw new Error(detail);
-  }
-  return await resp.json();
+  return parseBackendResponse(resp);
 }
 
 async function listDataSources(client: TypedClient, orgId: string): Promise<DataSourceLike[]> {

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -126,7 +126,14 @@ async function listDataSources(client: TypedClient, orgId: string): Promise<Data
 }
 
 function findMatch(sources: DataSourceLike[], detected: DetectedRepo): DataSourceLike | undefined {
-  return sources.find((ds) => ds.provider_slug === "github" && ds.name === detected.slug);
+  const github = sources.filter((ds) => ds.provider_slug === "github");
+  // Prefer an exact "owner/repo" slug match (how the CLI's own connect flow
+  // names data sources), but fall back to the bare repo name — repos connected
+  // via the dashboard or older flows are named just the repo (e.g. "repo", not
+  // "owner/repo").
+  return (
+    github.find((ds) => ds.name === detected.slug) ?? github.find((ds) => ds.name === detected.name)
+  );
 }
 
 function sleep(ms: number): Promise<void> {
@@ -319,9 +326,21 @@ export function auditCommand(): Command {
           nonInteractive,
         );
 
-        // 2. Load findings.
+        // 2. Load findings, then guarantee the PR targets the repo the audit
+        // skill actually ran on (recorded in findings.repo.slug) — never a
+        // different repo than the one audited, unless --data-source-id overrides.
         const findingsPath = opts.findings ?? join(process.cwd(), ".dosu", "audit.json");
         const findings = loadFindings(findingsPath);
+
+        if (!opts.dataSourceId && findings.repo?.slug && findings.repo.slug !== detected.slug) {
+          console.error(
+            pc.red(
+              `Audit was run on ${findings.repo.slug}, but the current repo is ${detected.slug}. ` +
+                `Run 'dosu audit' from ${findings.repo.slug} so the PR targets the audited repo.`,
+            ),
+          );
+          process.exit(1);
+        }
 
         // 3. Fetch capabilities.
         const capsResp = (await backendGet("/v1/cli/tasks", apiKey)) as CapabilitiesResponse;

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,0 +1,421 @@
+/**
+ * `dosu audit` — consume a coding-agent's `.dosu/audit.json`, ensure the repo is
+ * connected + indexed in Dosu, then fire server-side doc-generation tasks
+ * NON-BLOCKING. The resulting PR is surfaced on a later CLI run via the
+ * pending-tasks notifier (see `src/version/pending-tasks-check.ts`).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as p from "@clack/prompts";
+import { Command } from "commander";
+import pc from "picocolors";
+import { createTypedClient, type TypedClient } from "../client/trpc";
+import type { Config } from "../config/config";
+import { getBackendURL } from "../config/constants";
+import { logger } from "../debug/logger";
+import { type DetectedRepo, detectGitRepo, stepConnectGitHubRepo } from "../setup/github-step";
+import { addPendingTask } from "../version/pending-tasks-check";
+import { requireAPIKey, requireLoginConfig } from "./auth";
+import { printResult } from "./output";
+
+const INDEX_POLL_INTERVAL_MS = 2_000;
+const INDEX_POLL_TIMEOUT_MS = 120_000;
+
+/** A data source as returned by `dataSource.list` (subset we rely on). */
+interface DataSourceLike {
+  data_source_id?: string;
+  provider_slug?: string;
+  name?: string;
+  is_indexed?: boolean;
+  status?: string;
+}
+
+/** A capability as returned by `GET /v1/cli/tasks`. */
+interface Capability {
+  id: string;
+  label: string;
+  description: string;
+  doc_type: string;
+}
+
+interface CapabilitiesResponse {
+  tasks: Capability[];
+}
+
+/** A single finding inside `.dosu/audit.json`. */
+interface AuditItem {
+  task: string;
+  type: string;
+  file: string;
+  status: "missing" | "outdated" | "present_ok";
+  action: "create" | "update" | "skip";
+  can_help: boolean;
+  confidence: "high" | "medium" | "low";
+  rationale: string;
+  evidence: string[];
+}
+
+interface AuditFindings {
+  version: number;
+  generated_at: string;
+  repo: { remote: string; slug: string };
+  items: AuditItem[];
+}
+
+function requireConfig(): Config & { api_key: string; org_id: string } {
+  const cfg = requireLoginConfig();
+  if (!cfg.api_key) {
+    console.error(pc.red("API key not configured. Run 'dosu setup' first."));
+    process.exit(1);
+  }
+  if (!cfg.org_id) {
+    console.error(pc.red("Missing org config. Run 'dosu setup' to reconfigure."));
+    process.exit(1);
+  }
+  return cfg as Config & { api_key: string; org_id: string };
+}
+
+async function backendGet(path: string, apiKey: string): Promise<unknown> {
+  const backendURL = getBackendURL();
+  if (!backendURL) {
+    console.error(pc.red("Backend URL not configured."));
+    process.exit(1);
+  }
+  const resp = await fetch(`${backendURL}${path}`, {
+    headers: { "X-Dosu-API-Key": apiKey },
+  });
+  if (!resp.ok) {
+    let detail = `Request failed with status ${resp.status}`;
+    try {
+      const errBody = (await resp.json()) as { detail?: string };
+      detail = errBody.detail ?? detail;
+    } catch {}
+    throw new Error(detail);
+  }
+  return await resp.json();
+}
+
+async function backendPost(
+  path: string,
+  apiKey: string,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const backendURL = getBackendURL();
+  if (!backendURL) {
+    console.error(pc.red("Backend URL not configured."));
+    process.exit(1);
+  }
+  const resp = await fetch(`${backendURL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-Dosu-API-Key": apiKey },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    let detail = `Request failed with status ${resp.status}`;
+    try {
+      const errBody = (await resp.json()) as { detail?: string };
+      detail = errBody.detail ?? detail;
+    } catch {}
+    throw new Error(detail);
+  }
+  return await resp.json();
+}
+
+async function listDataSources(client: TypedClient, orgId: string): Promise<DataSourceLike[]> {
+  const result = (await client.dataSource.list.query({
+    org_id: orgId,
+    excluded_provider_slugs: [],
+  })) as DataSourceLike[] | null;
+  return result ?? [];
+}
+
+function findMatch(sources: DataSourceLike[], detected: DetectedRepo): DataSourceLike | undefined {
+  return sources.find((ds) => ds.provider_slug === "github" && ds.name === detected.slug);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll `dataSource.list` until the matched data source for `detected` is
+ * indexed. Returns the indexed data source, or `null` on timeout.
+ */
+async function waitForIndexed(
+  client: TypedClient,
+  orgId: string,
+  detected: DetectedRepo,
+  quiet = false,
+): Promise<DataSourceLike | null> {
+  const spinner = quiet ? null : p.spinner();
+  spinner?.start("Waiting for Dosu to finish indexing the repo...");
+  const startedAt = Date.now();
+  try {
+    while (Date.now() - startedAt < INDEX_POLL_TIMEOUT_MS) {
+      const sources = await listDataSources(client, orgId);
+      const match = findMatch(sources, detected);
+      if (match?.is_indexed === true) {
+        spinner?.stop("Repo indexed");
+        return match;
+      }
+      await sleep(INDEX_POLL_INTERVAL_MS);
+    }
+  } catch (err: unknown) {
+    /* v8 ignore next 2 -- transient list failures bubble up rarely */
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("audit", `dataSource.list during index poll failed: ${msg}`);
+  }
+  spinner?.stop("Still indexing");
+  return null;
+}
+
+/**
+ * Resolve the data_source_id for the detected repo, connecting + indexing it if
+ * necessary. Exits the process on any blocking condition. Returns the
+ * data_source_id on success.
+ */
+async function ensureSyncedRepo(
+  cfg: Config & { org_id: string },
+  client: TypedClient,
+  detected: DetectedRepo,
+  explicitDataSourceId: string | undefined,
+  nonInteractive: boolean,
+): Promise<string> {
+  if (explicitDataSourceId) {
+    return explicitDataSourceId;
+  }
+
+  let sources = await listDataSources(client, cfg.org_id);
+  let match = findMatch(sources, detected);
+
+  if (!match) {
+    // In non-interactive (agent-driven) mode never prompt or open a browser —
+    // fail with a clear message the caller can relay and exit non-zero.
+    if (nonInteractive) {
+      console.error(
+        pc.red(`${detected.slug} isn't connected to Dosu. Run 'dosu setup' to connect it first.`),
+      );
+      process.exit(1);
+    }
+    const connect = await p.confirm({
+      message: `${detected.slug} isn't connected to Dosu. Connect and sync it now?`,
+    });
+    if (p.isCancel(connect) || !connect) {
+      console.error(
+        pc.red(`Repo not connected. Run 'dosu setup' to connect ${detected.slug}, then retry.`),
+      );
+      process.exit(1);
+    }
+    const result = await stepConnectGitHubRepo(cfg, detected);
+    if (!result.has_connected_repo) {
+      console.error(pc.red(`Could not connect ${detected.slug}. Run 'dosu setup' and retry.`));
+      process.exit(1);
+    }
+    sources = await listDataSources(client, cfg.org_id);
+    match = findMatch(sources, detected);
+    if (!match) {
+      console.error(pc.red(`Could not find ${detected.slug} after connecting. Retry shortly.`));
+      process.exit(1);
+    }
+  }
+
+  if (match.is_indexed !== true) {
+    const indexed = await waitForIndexed(client, cfg.org_id, detected, nonInteractive);
+    if (!indexed) {
+      if (nonInteractive) {
+        console.error(pc.red(`${detected.slug} is still indexing. Re-run once indexing finishes.`));
+        process.exit(1);
+      }
+      p.log.info(
+        `${detected.slug} is still indexing. Re-run 'dosu audit' in a few minutes once it's ready.`,
+      );
+      process.exit(0);
+    }
+    match = indexed;
+  }
+
+  if (!match.data_source_id) {
+    console.error(pc.red("Matched data source has no id. Run 'dosu setup' and retry."));
+    process.exit(1);
+  }
+  return match.data_source_id;
+}
+
+function loadFindings(findingsPath: string): AuditFindings {
+  if (!existsSync(findingsPath)) {
+    console.error(
+      pc.red("Run the Dosu audit in your coding agent first (it writes .dosu/audit.json)."),
+    );
+    process.exit(1);
+  }
+  let parsed: AuditFindings;
+  try {
+    parsed = JSON.parse(readFileSync(findingsPath, "utf-8")) as AuditFindings;
+  } catch {
+    console.error(
+      pc.red("Run the Dosu audit in your coding agent first (it writes .dosu/audit.json)."),
+    );
+    process.exit(1);
+  }
+  if (parsed.version !== 1) {
+    console.error(
+      pc.red("Run the Dosu audit in your coding agent first (it writes .dosu/audit.json)."),
+    );
+    process.exit(1);
+  }
+  return parsed;
+}
+
+/** Intersect findings with capabilities, keyed by `item.task` === capability `id`. */
+function intersectActionable(items: AuditItem[], capabilities: Capability[]): AuditItem[] {
+  const known = new Set(capabilities.map((c) => c.id));
+  return items.filter((item) => known.has(item.task));
+}
+
+function isPreselected(item: AuditItem): boolean {
+  return item.can_help && item.action !== "skip";
+}
+
+export function auditCommand(): Command {
+  const cmd = new Command("audit")
+    .description("Generate docs from a coding-agent audit (.dosu/audit.json)")
+    .option("--data-source-id <id>", "Skip auto-match and use this data source ID")
+    .option("--findings <path>", "Path to the audit findings JSON")
+    .option(
+      "--tasks <ids>",
+      "Comma-separated task ids to generate (non-interactive; for agent-driven use)",
+    )
+    .option("--yes", "Skip the prompt and select all suggested items")
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: {
+        dataSourceId?: string;
+        findings?: string;
+        tasks?: string;
+        yes?: boolean;
+        json?: boolean;
+      }) => {
+        const cfg = requireConfig();
+        const apiKey = requireAPIKey(cfg);
+
+        // 1. Enforce a synced repo (block otherwise).
+        const detected = detectGitRepo();
+        if (!detected) {
+          console.error(pc.red("Not a GitHub repo. Run 'dosu audit' from a GitHub repository."));
+          process.exit(1);
+        }
+
+        // `--tasks` is the agent-driven path: fire a specific subset without any
+        // interactive prompt. Treat it as non-interactive so the connect/index
+        // steps never block on a clack prompt or open a browser.
+        const nonInteractive = Boolean(opts.tasks);
+
+        const client = createTypedClient(cfg);
+        const dataSourceId = await ensureSyncedRepo(
+          cfg,
+          client,
+          detected,
+          opts.dataSourceId,
+          nonInteractive,
+        );
+
+        // 2. Load findings.
+        const findingsPath = opts.findings ?? join(process.cwd(), ".dosu", "audit.json");
+        const findings = loadFindings(findingsPath);
+
+        // 3. Fetch capabilities.
+        const capsResp = (await backendGet("/v1/cli/tasks", apiKey)) as CapabilitiesResponse;
+        const capabilities = capsResp.tasks ?? [];
+
+        // 4. Intersect findings with capabilities.
+        const actionable = intersectActionable(findings.items, capabilities);
+        if (actionable.length === 0) {
+          if (opts.json) {
+            printResult({ task_ids: [] }, opts);
+            return;
+          }
+          p.log.info("Nothing to generate — no audit findings match Dosu's capabilities.");
+          return;
+        }
+
+        // 5. Select items.
+        let selected: AuditItem[];
+        if (opts.tasks) {
+          // Agent-driven: fire exactly the requested task ids (the agent already
+          // presented the picks to the user). Warn on any that aren't offerable.
+          const want = new Set(
+            opts.tasks
+              .split(",")
+              .map((t) => t.trim())
+              .filter(Boolean),
+          );
+          selected = actionable.filter((item) => want.has(item.task));
+          const unknown = [...want].filter((t) => !actionable.some((item) => item.task === t));
+          if (unknown.length > 0) {
+            logger.warn("audit", `Ignoring tasks not offered by the audit: ${unknown.join(", ")}`);
+          }
+        } else if (opts.yes) {
+          selected = actionable.filter(isPreselected);
+        } else {
+          const choice = await p.multiselect({
+            message: "Which docs should Dosu generate?",
+            options: actionable.map((item) => ({
+              value: item.task,
+              label: `${item.file} ${pc.dim(`(${item.type})`)}`,
+              hint: `${item.status} — ${item.rationale}`,
+            })),
+            initialValues: actionable.filter(isPreselected).map((item) => item.task),
+            required: false,
+          });
+          if (p.isCancel(choice)) {
+            p.log.info("Cancelled.");
+            return;
+          }
+          const chosen = new Set(choice as string[]);
+          selected = actionable.filter((item) => chosen.has(item.task));
+        }
+
+        if (selected.length === 0) {
+          if (opts.json) {
+            printResult({ task_ids: [] }, opts);
+            return;
+          }
+          p.log.info("Nothing selected.");
+          return;
+        }
+
+        // 6. Fire tasks NON-BLOCKING.
+        const taskIds: string[] = [];
+        for (const item of selected) {
+          const result = (await backendPost(`/v1/cli/task/${item.task}`, apiKey, {
+            data_source_id: dataSourceId,
+            repo: detected.slug,
+            findings: item,
+          })) as { task_id?: string };
+          const taskId = result?.task_id;
+          if (!taskId) {
+            logger.warn("audit", `No task_id returned for ${item.task}`);
+            continue;
+          }
+          taskIds.push(taskId);
+          // 7. Cache the pending task so a later CLI run surfaces the PR.
+          addPendingTask({
+            task_id: taskId,
+            doc_types: [item.type],
+            repo: detected.slug,
+          });
+        }
+
+        if (opts.json) {
+          printResult({ task_ids: taskIds }, opts);
+          return;
+        }
+        p.log.success(
+          "Dosu is generating your docs — you'll be notified here when the PR is ready.",
+        );
+      },
+    );
+
+  return cmd;
+}

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -648,6 +648,19 @@ describe("showTryItOutPrompt", () => {
       expect.stringContaining("summarize the most important docs"),
     );
   });
+
+  it("points to the codebase audit in cloud mode", () => {
+    showTryItOutPrompt({ docsImported: false, hasAgentsMd: false });
+
+    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("audit this repo"));
+    expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("dosu audit"));
+  });
+
+  it("omits the audit pointer in OSS mode", () => {
+    showTryItOutPrompt({ mode: MODE_OSS });
+
+    expect(p.log.message).not.toHaveBeenCalledWith(expect.stringContaining("audit this repo"));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -907,4 +907,13 @@ export function showTryItOutPrompt(
     return `Ask Dosu to draft an AGENTS.md for this project.`;
   })();
   p.log.message(`Try it out! Paste this into your agent:\n\n${info(prompt)}`);
+
+  // Surface the codebase audit as a next step (cloud mode only — it acts on the
+  // user's own repo). The agent runs the audit skill; `dosu audit` is the
+  // terminal-only fallback.
+  if (opts.mode !== MODE_OSS) {
+    p.log.message(
+      `See what docs Dosu can generate for this repo:\n\n${info("Ask Dosu to audit this repo and show what docs it can generate.")}\n\nOr run ${info("dosu audit")} after your agent writes the audit.`,
+    );
+  }
 }

--- a/src/version/pending-tasks-check.test.ts
+++ b/src/version/pending-tasks-check.test.ts
@@ -311,4 +311,25 @@ describe("checkForReadyTasks — polling", () => {
     checkForReadyTasks();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("does not poll when the backend URL is not configured", () => {
+    delete process.env.DOSU_BACKEND_URL_OVERRIDE;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+    checkForReadyTasks();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows unexpected errors during the check (never throws on the hot path)", () => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // A pending task gets past the early-return, then loadConfig blows up.
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+    mockLoadConfig.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    expect(() => checkForReadyTasks()).not.toThrow();
+  });
 });

--- a/src/version/pending-tasks-check.test.ts
+++ b/src/version/pending-tasks-check.test.ts
@@ -242,6 +242,57 @@ describe("checkForReadyTasks — polling", () => {
     });
   });
 
+  it("falls back to a placeholder url when SUCCESS has no pr_url", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ state: "SUCCESS" }) });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+
+    checkForReadyTasks();
+    await vi.waitFor(() => {
+      const task = readCacheFile().tasks[0] as { prUrl?: string };
+      expect(task.prUrl).toBe("(no URL returned)");
+    });
+  });
+
+  it("falls back to a generic error when FAILURE has no detail message", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ state: "FAILURE" }) });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+
+    checkForReadyTasks();
+    await vi.waitFor(() => {
+      const task = readCacheFile().tasks[0] as { error?: string };
+      expect(task.error).toBe("generation failed");
+    });
+  });
+
+  it("leaves a task in-flight on PROGRESS (only bumps lastCheck)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ state: "PROGRESS" }) });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+
+    checkForReadyTasks();
+    await vi.waitFor(() => {
+      const task = readCacheFile().tasks[0] as {
+        prUrl?: string;
+        error?: string;
+        lastCheck: number;
+      };
+      expect(task.prUrl).toBeUndefined();
+      expect(task.error).toBeUndefined();
+      expect(task.lastCheck).toBeGreaterThan(0);
+    });
+  });
+
   it("does not poll a fresh in-flight task", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/src/version/pending-tasks-check.test.ts
+++ b/src/version/pending-tasks-check.test.ts
@@ -332,4 +332,28 @@ describe("checkForReadyTasks — polling", () => {
     });
     expect(() => checkForReadyTasks()).not.toThrow();
   });
+
+  it("ignores a poll result when the task is no longer cached", async () => {
+    let resolveFetch: (v: unknown) => void = () => {};
+    const fetchMock = vi.fn().mockReturnValue(
+      new Promise((r) => {
+        resolveFetch = r;
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+
+    checkForReadyTasks(); // dispatches the poll (still pending)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The task disappears (e.g. pruned by a concurrent run) before it resolves.
+    writeCacheFile([]);
+    resolveFetch({ ok: true, json: async () => ({ state: "SUCCESS", pr_url: "x" }) });
+
+    await vi.waitFor(() => {
+      // pollTask re-reads the cache, finds no matching task, and returns early.
+      expect(readCacheFile().tasks).toHaveLength(0);
+    });
+  });
 });

--- a/src/version/pending-tasks-check.test.ts
+++ b/src/version/pending-tasks-check.test.ts
@@ -1,0 +1,263 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoadConfig = vi.fn();
+vi.mock("../config/config", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+  };
+});
+
+import {
+  addPendingTask,
+  checkForReadyTasks,
+  fetchTaskRun,
+  readPendingTasks,
+  writePendingTasks,
+} from "./pending-tasks-check";
+
+let tempDir: string;
+let origXDG: string | undefined;
+let origBackend: string | undefined;
+
+function cachePath(): string {
+  return join(tempDir, "dosu-cli", "pending-tasks.json");
+}
+
+function writeCacheFile(tasks: unknown[]): void {
+  const { mkdirSync } = require("node:fs");
+  mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+  writeFileSync(cachePath(), JSON.stringify({ tasks }));
+}
+
+function readCacheFile(): { tasks: unknown[] } {
+  return JSON.parse(readFileSync(cachePath(), "utf-8"));
+}
+
+beforeEach(() => {
+  origXDG = process.env.XDG_CONFIG_HOME;
+  origBackend = process.env.DOSU_BACKEND_URL_OVERRIDE;
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-pending-test-"));
+  process.env.XDG_CONFIG_HOME = tempDir;
+  process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api.example.test";
+  mockLoadConfig.mockReturnValue({ api_key: "sk_user_test" });
+});
+
+afterEach(() => {
+  if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
+  else delete process.env.XDG_CONFIG_HOME;
+  if (origBackend !== undefined) process.env.DOSU_BACKEND_URL_OVERRIDE = origBackend;
+  else delete process.env.DOSU_BACKEND_URL_OVERRIDE;
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("readPendingTasks / writePendingTasks", () => {
+  it("returns empty list when no cache exists", () => {
+    expect(readPendingTasks()).toEqual({ tasks: [] });
+  });
+
+  it("round-trips tasks through write + read", () => {
+    writePendingTasks({
+      tasks: [{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 5 }],
+    });
+    const cache = readPendingTasks();
+    expect(cache.tasks).toHaveLength(1);
+    expect(cache.tasks[0].task_id).toBe("t1");
+  });
+
+  it("returns empty on corrupt cache", () => {
+    writeCacheFile([]);
+    writeFileSync(cachePath(), "NOT JSON{{{");
+    expect(readPendingTasks()).toEqual({ tasks: [] });
+  });
+
+  it("returns empty when tasks is not an array", () => {
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(join(tempDir, "dosu-cli"), { recursive: true });
+    writeFileSync(cachePath(), JSON.stringify({ tasks: "nope" }));
+    expect(readPendingTasks()).toEqual({ tasks: [] });
+  });
+});
+
+describe("addPendingTask", () => {
+  it("appends a task with lastCheck=0", () => {
+    addPendingTask({ task_id: "t1", doc_types: ["readme"], repo: "o/r" });
+    const cache = readCacheFile();
+    expect(cache.tasks).toHaveLength(1);
+    expect(cache.tasks[0]).toMatchObject({
+      task_id: "t1",
+      doc_types: ["readme"],
+      repo: "o/r",
+      lastCheck: 0,
+    });
+  });
+
+  it("appends to existing tasks", () => {
+    addPendingTask({ task_id: "t1", doc_types: ["readme"], repo: "o/r" });
+    addPendingTask({ task_id: "t2", doc_types: ["agents"], repo: "o/r" });
+    expect(readCacheFile().tasks).toHaveLength(2);
+  });
+});
+
+describe("fetchTaskRun", () => {
+  it("returns parsed response on ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: async () => ({ state: "SUCCESS", pr_url: "u" }) }),
+    );
+    const res = await fetchTaskRun("https://api.example.test", "k", "t1");
+    expect(res).toEqual({ state: "SUCCESS", pr_url: "u" });
+  });
+
+  it("sends the API key header", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ state: "PROGRESS" }) });
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchTaskRun("https://api.example.test", "secret", "t9");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.example.test/v1/cli/task/run/t9");
+    expect(init.headers["X-Dosu-API-Key"]).toBe("secret");
+  });
+
+  it("returns null on non-ok", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    expect(await fetchTaskRun("https://api.example.test", "k", "t1")).toBeNull();
+  });
+
+  it("returns null when state missing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+    expect(await fetchTaskRun("https://api.example.test", "k", "t1")).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
+    expect(await fetchTaskRun("https://api.example.test", "k", "t1")).toBeNull();
+  });
+});
+
+describe("checkForReadyTasks — display latch", () => {
+  it("no-ops with empty cache", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn());
+    checkForReadyTasks();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("prints a ready PR once and prunes it", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn());
+    writeCacheFile([
+      {
+        task_id: "t1",
+        doc_types: ["agents"],
+        repo: "o/r",
+        lastCheck: Date.now(),
+        prUrl: "https://pr",
+      },
+    ]);
+    checkForReadyTasks();
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0]).toContain("https://pr");
+    // Finished + displayed → pruned.
+    expect(readCacheFile().tasks).toHaveLength(0);
+  });
+
+  it("prints a failure note", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn());
+    writeCacheFile([
+      { task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: Date.now(), error: "kaboom" },
+    ]);
+    checkForReadyTasks();
+    expect(spy.mock.calls[0][0]).toContain("kaboom");
+    expect(readCacheFile().tasks).toHaveLength(0);
+  });
+
+  it("does not re-display an already-displayed task", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn());
+    // displayedAt set but with prUrl → already shown last run; should prune silently.
+    writeCacheFile([
+      {
+        task_id: "t1",
+        doc_types: ["agents"],
+        repo: "o/r",
+        lastCheck: Date.now(),
+        prUrl: "https://pr",
+        displayedAt: Date.now() - 1000,
+      },
+    ]);
+    checkForReadyTasks();
+    expect(spy).not.toHaveBeenCalled();
+    expect(readCacheFile().tasks).toHaveLength(0);
+  });
+
+  it("handles corrupt cache without throwing", () => {
+    writeCacheFile([]);
+    writeFileSync(cachePath(), "NOT JSON{{{");
+    expect(() => checkForReadyTasks()).not.toThrow();
+  });
+});
+
+describe("checkForReadyTasks — polling", () => {
+  it("polls a stale in-flight task and stores prUrl on SUCCESS", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ state: "SUCCESS", pr_url: "https://pr/1" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+
+    checkForReadyTasks();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.waitFor(() => {
+      const task = readCacheFile().tasks[0] as { prUrl?: string };
+      expect(task.prUrl).toBe("https://pr/1");
+    });
+  });
+
+  it("stores error on FAILURE", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ state: "FAILURE", detail: { message: "no perms" } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+
+    checkForReadyTasks();
+    await vi.waitFor(() => {
+      const task = readCacheFile().tasks[0] as { error?: string };
+      expect(task.error).toBe("no perms");
+    });
+  });
+
+  it("does not poll a fresh in-flight task", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: Date.now() }]);
+    checkForReadyTasks();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not poll when api key is missing", () => {
+    mockLoadConfig.mockReturnValue({});
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeCacheFile([{ task_id: "t1", doc_types: ["agents"], repo: "o/r", lastCheck: 0 }]);
+    checkForReadyTasks();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/version/pending-tasks-check.ts
+++ b/src/version/pending-tasks-check.ts
@@ -112,9 +112,10 @@ export async function fetchTaskRun(
 }
 
 function displayTask(task: PendingTask): void {
+  // Only ever called for a finished task (prUrl set, else an error).
   if (task.prUrl) {
     console.error(`\n${pc.green(`✓ Dosu PR ready (${task.repo}): ${task.prUrl}`)}\n`);
-  } else if (task.error) {
+  } else {
     console.error(`\n${pc.yellow(`✗ Dosu doc generation failed (${task.repo}): ${task.error}`)}\n`);
   }
 }
@@ -150,8 +151,9 @@ export function checkForReadyTasks(): void {
     const apiKey = cfg.api_key;
     if (backendURL && apiKey) {
       const now = Date.now();
+      // Only in-flight tasks remain here — finished ones were displayed and
+      // pruned above — so we just skip those polled too recently.
       for (const task of cache.tasks) {
-        if (task.prUrl || task.error) continue;
         if (now - task.lastCheck < CHECK_INTERVAL_MS) continue;
         pollTask(backendURL, apiKey, task.task_id);
       }

--- a/src/version/pending-tasks-check.ts
+++ b/src/version/pending-tasks-check.ts
@@ -1,0 +1,194 @@
+/**
+ * Non-blocking PR-ready notifier for `dosu audit`.
+ *
+ * Uses the same "check now, display next run" pattern as `update-check.ts`:
+ * 1. On startup, reads cached pending tasks from disk.
+ * 2. For any task that already has a `prUrl` (or `error`) and hasn't been shown
+ *    yet, prints a notice to stderr and latches it (`displayedAt`). Finished +
+ *    displayed tasks are pruned from the cache.
+ * 3. For tasks still in flight whose `lastCheck` is stale (>60 s), fires a
+ *    background `GET /v1/cli/task/run/{task_id}` (not awaited) and records the
+ *    result so the next CLI run can surface it.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import pc from "picocolors";
+import { getConfigDir, loadConfig } from "../config/config";
+import { getBackendURL } from "../config/constants";
+import { logger } from "../debug/logger";
+
+const CACHE_FILENAME = "pending-tasks.json";
+const CHECK_INTERVAL_MS = 60_000; // 60s between polls per task
+const FETCH_TIMEOUT_MS = 5_000;
+
+export interface PendingTask {
+  task_id: string;
+  doc_types: string[];
+  repo: string;
+  lastCheck: number;
+  prUrl?: string;
+  error?: string;
+  displayedAt?: number;
+}
+
+interface PendingTasksCache {
+  tasks: PendingTask[];
+}
+
+type TaskRunState = "PROGRESS" | "SUCCESS" | "FAILURE";
+
+interface TaskRunResponse {
+  state: TaskRunState;
+  detail?: Record<string, unknown>;
+  pr_url?: string;
+}
+
+function getCachePath(): string {
+  return join(getConfigDir(), CACHE_FILENAME);
+}
+
+export function readPendingTasks(): PendingTasksCache {
+  try {
+    const path = getCachePath();
+    if (!existsSync(path)) return { tasks: [] };
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    if (Array.isArray(data?.tasks)) {
+      return { tasks: data.tasks as PendingTask[] };
+    }
+    return { tasks: [] };
+  } catch {
+    return { tasks: [] };
+  }
+}
+
+export function writePendingTasks(cache: PendingTasksCache): void {
+  try {
+    const dir = getConfigDir();
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    writeFileSync(getCachePath(), JSON.stringify(cache), { mode: 0o600 });
+  } catch {
+    // Graceful degradation — cache write failure is non-fatal
+  }
+}
+
+/** Append a pending task to the cache. Used by `dosu audit` after firing tasks. */
+export function addPendingTask(task: { task_id: string; doc_types: string[]; repo: string }): void {
+  const cache = readPendingTasks();
+  cache.tasks.push({
+    task_id: task.task_id,
+    doc_types: task.doc_types,
+    repo: task.repo,
+    // 0 → immediately stale so the next CLI run polls it.
+    lastCheck: 0,
+  });
+  writePendingTasks(cache);
+}
+
+/** Fetch a task's run status from the backend. Never throws. */
+export async function fetchTaskRun(
+  backendURL: string,
+  apiKey: string,
+  taskId: string,
+): Promise<TaskRunResponse | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(`${backendURL}/v1/cli/task/run/${taskId}`, {
+      headers: { "X-Dosu-API-Key": apiKey },
+      signal: controller.signal,
+    });
+    if (!resp.ok) return null;
+    const data = (await resp.json()) as TaskRunResponse;
+    if (typeof data?.state !== "string") return null;
+    return data;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function displayTask(task: PendingTask): void {
+  if (task.prUrl) {
+    console.error(`\n${pc.green(`✓ Dosu PR ready (${task.repo}): ${task.prUrl}`)}\n`);
+  } else if (task.error) {
+    console.error(`\n${pc.yellow(`✗ Dosu doc generation failed (${task.repo}): ${task.error}`)}\n`);
+  }
+}
+
+/**
+ * Surface ready PRs and poll in-flight tasks — called synchronously from the
+ * preAction hook.
+ */
+export function checkForReadyTasks(): void {
+  try {
+    const cache = readPendingTasks();
+    if (cache.tasks.length === 0) return;
+
+    let mutated = false;
+
+    // 1. Display any finished-but-undisplayed tasks, then prune them.
+    for (const task of cache.tasks) {
+      if ((task.prUrl || task.error) && !task.displayedAt) {
+        displayTask(task);
+        task.displayedAt = Date.now();
+        mutated = true;
+      }
+    }
+    const remaining = cache.tasks.filter((t) => !((t.prUrl || t.error) && t.displayedAt));
+    if (remaining.length !== cache.tasks.length) {
+      cache.tasks = remaining;
+      mutated = true;
+    }
+
+    // 2. Fire background polls for stale, in-flight tasks.
+    const cfg = loadConfig();
+    const backendURL = getBackendURL();
+    const apiKey = cfg.api_key;
+    if (backendURL && apiKey) {
+      const now = Date.now();
+      for (const task of cache.tasks) {
+        if (task.prUrl || task.error) continue;
+        if (now - task.lastCheck < CHECK_INTERVAL_MS) continue;
+        pollTask(backendURL, apiKey, task.task_id);
+      }
+    }
+
+    if (mutated) {
+      writePendingTasks(cache);
+    }
+  } catch (err) {
+    logger.error("pending-tasks", `Pending-tasks check failed: ${err}`);
+  }
+}
+
+/**
+ * Fire-and-forget poll. Re-reads + re-writes the cache inside the `.then` so a
+ * concurrent write from `checkForReadyTasks` (step 1 pruning) isn't clobbered.
+ */
+function pollTask(backendURL: string, apiKey: string, taskId: string): void {
+  fetchTaskRun(backendURL, apiKey, taskId)
+    .then((result) => {
+      const cache = readPendingTasks();
+      const task = cache.tasks.find((t) => t.task_id === taskId);
+      if (!task) return;
+      task.lastCheck = Date.now();
+      if (result?.state === "SUCCESS") {
+        task.prUrl = result.pr_url ?? "(no URL returned)";
+      } else if (result?.state === "FAILURE") {
+        const detail = result.detail;
+        const message =
+          detail && typeof detail.message === "string" ? detail.message : "generation failed";
+        task.error = message;
+      }
+      writePendingTasks(cache);
+    })
+    .catch(
+      /* v8 ignore next 3 -- fetchTaskRun never rejects */ (err) => {
+        logger.error("pending-tasks", `Background task poll failed: ${err}`);
+      },
+    );
+}


### PR DESCRIPTION
### Summary

Adds `dosu audit`: consume a coding-agent's `.dosu/audit.json`, ensure the current repo is connected + indexed in Dosu, then fire server-side doc-generation tasks **non-blocking**. The resulting PR is surfaced on a later CLI run via a notifier — the same "check now, display next run" pattern as the update notice.

### What's included

- **`src/commands/audit.ts`** — auth guard → repo-sync enforcement (`detectGitRepo` → `dataSource.list` match → `stepConnectGitHubRepo` if missing → index poll) → capability intersection (`GET /v1/cli/tasks`) → selection → `POST /v1/cli/task/{task}`.
  - Interactive: clack multiselect (pre-selects confident, actionable items, shows status + rationale).
  - `--tasks <ids>`: agent-driven, **non-interactive** firing — never prompts or opens a browser; exits non-zero with a clear message if the repo isn't connected/indexed.
  - Also `--json`, `--yes`, `--data-source-id`, `--findings`.
- **`src/version/pending-tasks-check.ts`** — preAction notifier; surfaces `✓ Dosu PR ready: <url>` once on stderr and polls fire-and-forget. Guarded out of hook entrypoints so the agent hot path stays clean.
- **Setup** points users to the audit in the next-steps prompt (cloud mode).

### Testing

Full suite **1406 pass**; coverage within the enforced gate (95/90/80/95). `typecheck` + Biome clean.

### Related

Pairs with the Dosu skill (writes `.dosu/audit.json`) and the backend `/v1/cli` task API (generates docs + opens the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
