### PR TITLE
feat(review): add `dosu review list` for the pending review queue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",
         "@clack/prompts": "^1.6.0",
-        "@dosu/api-types": "0.0.11",
+        "@dosu/api-types": "^0.0.24",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
@@ -71,7 +71,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@dosu/api-types": ["@dosu/api-types@0.0.11", "", { "dependencies": { "@trpc/server": "11.17.0" } }, "sha512-/ZGvM+daxr9MmfzmgJy1S7DeiQEGyI5nnxE6ZVYNhkU9nlq/EHwinekoBCxmnicFS6S7bgimA6km08hGkm+qYg=="],
+    "@dosu/api-types": ["@dosu/api-types@0.0.24", "", { "peerDependencies": { "@trpc/server": "^11.17.0" } }, "sha512-F+QLZsm2cSz6wI2F3XBsayfXY9i4uivcRmOCGtzV/MdeZTA0EWgO1vHKIm5gmM8vgvtfQyOWaOtqXIXyQtLEzw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -804,8 +804,6 @@
     "@actions/http-client/undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@dosu/api-types/@trpc/server": ["@trpc/server@11.17.0", "", { "peerDependencies": { "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@clack/prompts": "^1.6.0",
-    "@dosu/api-types": "0.0.11",
+    "@dosu/api-types": "0.0.24",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -71,7 +71,7 @@ describe("review list", () => {
     title: "API Guide",
     version: 3,
     type: "document",
-    origin: "github_pr",
+    origin: "sync_upstream",
     externalTriggerUrl: "https://github.com/org/repo/pull/42",
     pendingStatus: "pending_review",
     createdAt: "2026-06-24T19:18:50.002Z",

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -92,6 +92,9 @@ describe("review list", () => {
     });
     expect(allOutput()).toContain("pv-abcde");
     expect(allOutput()).toContain("API Guide");
+    // origin enum is humanized to match the MCP tool / dashboard
+    expect(allOutput()).toContain("Synced from source");
+    expect(allOutput()).not.toContain("sync_upstream");
   });
 
   it("outputs valid JSON with --json", async () => {
@@ -104,6 +107,24 @@ describe("review list", () => {
     const output = JSON.parse(allOutput());
     expect(output).toHaveLength(1);
     expect(output[0].pageVersionId).toBe("pv-abcdef12");
+    // --json is the machine surface — raw enum, not humanized
+    expect(output[0].origin).toBe("sync_upstream");
+  });
+
+  it.each([
+    ["manual_update", 1, "User created"],
+    ["manual_update", 2, "User updated"],
+    ["llm_generated", 1, "AI generated"],
+    ["api_update", 1, "Created via API"],
+    ["future_origin", 1, "future_origin"], // unknown enum falls through to raw value
+  ])("humanizes source %s (v%i) as %s", async (origin, version, expected) => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ks1" });
+    mockQuery.mockResolvedValueOnce([{ ...pendingItem, origin, version }]);
+
+    await run("list");
+
+    expect(allOutput()).toContain(expected);
   });
 
   it("falls back to (untitled) when title is missing", async () => {

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -106,6 +106,16 @@ describe("review list", () => {
     expect(output[0].pageVersionId).toBe("pv-abcdef12");
   });
 
+  it("falls back to (untitled) when title is missing", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ks1" });
+    mockQuery.mockResolvedValueOnce([{ ...pendingItem, title: null }]);
+
+    await run("list");
+
+    expect(allOutput()).toContain("(untitled)");
+  });
+
   it("prints message for empty queue", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce({ id: "ks1" });

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -34,6 +34,7 @@ const validConfig = {
   refresh_token: "r",
   expires_at: 0,
   api_key: "sk_user_test",
+  space_id: "sp1",
 };
 
 function allOutput(): string {
@@ -61,6 +62,70 @@ afterEach(() => {
   logSpy.mockRestore();
   errorSpy.mockRestore();
   exitSpy.mockRestore();
+});
+
+describe("review list", () => {
+  const pendingItem = {
+    pageVersionId: "pv-abcdef12",
+    pageId: "pg-1",
+    title: "API Guide",
+    version: 3,
+    type: "document",
+    origin: "github_pr",
+    externalTriggerUrl: "https://github.com/org/repo/pull/42",
+    pendingStatus: "pending_review",
+    createdAt: "2026-06-24T19:18:50.002Z",
+  };
+
+  it("resolves space→KS then calls review.listPending", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ks1" }); // knowledgeStore.getBySpaceId
+    mockQuery.mockResolvedValueOnce([pendingItem]);
+
+    await run("list");
+
+    expect(mockQuery).toHaveBeenNthCalledWith(1, "knowledgeStore.getBySpaceId", {
+      space_id: "sp1",
+    });
+    expect(mockQuery).toHaveBeenNthCalledWith(2, "review.listPending", {
+      knowledgeStoreId: "ks1",
+    });
+    expect(allOutput()).toContain("pv-abcde");
+    expect(allOutput()).toContain("API Guide");
+  });
+
+  it("outputs valid JSON with --json", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ks1" });
+    mockQuery.mockResolvedValueOnce([pendingItem]);
+
+    await run("list", "--json");
+
+    const output = JSON.parse(allOutput());
+    expect(output).toHaveLength(1);
+    expect(output[0].pageVersionId).toBe("pv-abcdef12");
+  });
+
+  it("prints message for empty queue", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ks1" });
+    mockQuery.mockResolvedValueOnce([]);
+
+    await run("list");
+
+    expect(allOutput()).toContain("No pending review items");
+  });
+
+  it("exits when space_id is missing", async () => {
+    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    await expect(run("list")).rejects.toThrow("exit");
+  });
+
+  it("exits when no knowledge store is found", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(null); // knowledgeStore.getBySpaceId
+    await expect(run("list")).rejects.toThrow("exit");
+  });
 });
 
 describe("review context", () => {

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -53,7 +53,7 @@ export function reviewCommand(): Command {
         ["Version ID", "Title", "Origin", "Status", "Created"],
         items.map((i) => [
           i.pageVersionId.slice(0, 8),
-          truncate(i.title, 40),
+          truncate(i.title ?? "(untitled)", 40),
           i.origin,
           i.pendingStatus,
           formatDate(i.createdAt),

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -12,6 +12,23 @@ function requireConfig() {
   return requireLoginConfig();
 }
 
+// ponytail: mirrors _humanize_origin in dosu's backend/public_api/mcp/tools/review.py —
+// keep in sync so the CLI, MCP tool, and dashboard show the same source labels.
+function humanizeSource(origin: string, version: number): string {
+  switch (origin) {
+    case "manual_update":
+      return version <= 1 ? "User created" : "User updated";
+    case "llm_generated":
+      return "AI generated";
+    case "sync_upstream":
+      return "Synced from source";
+    case "api_update":
+      return "Created via API";
+    default:
+      return origin;
+  }
+}
+
 async function getKnowledgeStoreId(client: TypedClient, spaceId: string): Promise<string> {
   const store = await client.knowledgeStore.getBySpaceId.query({ space_id: spaceId });
   if (!store) {
@@ -50,11 +67,11 @@ export function reviewCommand(): Command {
       }
 
       printTable(
-        ["Version ID", "Title", "Origin", "Status", "Created"],
+        ["Version ID", "Title", "Source", "Status", "Created"],
         items.map((i) => [
           i.pageVersionId.slice(0, 8),
           truncate(i.title ?? "(untitled)", 40),
-          i.origin,
+          humanizeSource(i.origin, i.version),
           i.pendingStatus,
           formatDate(i.createdAt),
         ]),

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -2,6 +2,7 @@
  * `dosu review` — document review workflow.
  */
 
+import type { RouterOutputs } from "@dosu/api-types";
 import { Command } from "commander";
 import pc from "picocolors";
 import { createTypedClient, type TypedClient } from "../client/trpc";
@@ -12,9 +13,13 @@ function requireConfig() {
   return requireLoginConfig();
 }
 
+// Pinned to the published API enum so the case labels are checked against the real
+// origin union (RouterOutputs derives it from `review.listPending`).
+type ReviewOrigin = RouterOutputs["review"]["listPending"][number]["origin"];
+
 // ponytail: mirrors _humanize_origin in dosu's backend/public_api/mcp/tools/review.py —
 // keep in sync so the CLI, MCP tool, and dashboard show the same source labels.
-function humanizeSource(origin: string, version: number): string {
+function humanizeSource(origin: ReviewOrigin, version: number): string {
   switch (origin) {
     case "manual_update":
       return version <= 1 ? "User created" : "User updated";

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -4,16 +4,63 @@
 
 import { Command } from "commander";
 import pc from "picocolors";
-import { createTypedClient } from "../client/trpc";
+import { createTypedClient, type TypedClient } from "../client/trpc";
 import { requireLoginConfig } from "./auth";
-import { printInfo, printResult } from "./output";
+import { formatDate, printInfo, printResult, printTable, truncate } from "./output";
 
 function requireConfig() {
   return requireLoginConfig();
 }
 
+async function getKnowledgeStoreId(client: TypedClient, spaceId: string): Promise<string> {
+  const store = await client.knowledgeStore.getBySpaceId.query({ space_id: spaceId });
+  if (!store) {
+    console.error(pc.red("No knowledge store found for this deployment."));
+    process.exit(1);
+  }
+  return store.id;
+}
+
 export function reviewCommand(): Command {
   const cmd = new Command("review").description("Document review workflow");
+
+  cmd
+    .command("list")
+    .description("List pending document review items")
+    .option("--json", "Output as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const cfg = requireConfig();
+      if (!cfg.space_id) {
+        console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
+        process.exit(1);
+      }
+      const client = createTypedClient(cfg);
+      const ksId = await getKnowledgeStoreId(client, cfg.space_id);
+
+      const items = await client.review.listPending.query({ knowledgeStoreId: ksId });
+
+      if (opts.json) {
+        printResult(items, opts);
+        return;
+      }
+
+      if (!items || items.length === 0) {
+        console.log(pc.dim("No pending review items."));
+        return;
+      }
+
+      printTable(
+        ["Version ID", "Title", "Origin", "Status", "Created"],
+        items.map((i) => [
+          i.pageVersionId.slice(0, 8),
+          truncate(i.title, 40),
+          i.origin,
+          i.pendingStatus,
+          formatDate(i.createdAt),
+        ]),
+        { rawData: items },
+      );
+    });
 
   cmd
     .command("context")


### PR DESCRIPTION
Closes ENG-501

Part of [ENG-501](https://linear.app/dosu/issue/ENG-501/expose-the-document-review-queue-in-dosu-cli-skill) — the **dosu-cli** task: expose the document review queue via `dosu review list`.

## What

- Bump `@dosu/api-types` `0.0.11 → 0.0.24`, which adds the `review.listPending` procedure. The 3-day install gate doesn't apply — `bunfig.toml` already excludes `@dosu/api-types` via `minimumReleaseAgeExcludes`.
- Add `dosu review list [--json]`: resolves space → knowledge store (`knowledgeStore.getBySpaceId`, same pattern as `dosu suggest`), calls `review.listPending`, and prints a table (Version ID / Title / Source / Status / Created) or raw JSON. The `Source` column is humanized to match the MCP review tool / dashboard (e.g. `sync_upstream` → "Synced from source"); in `--json`, `origin` stays the raw enum (machine surface — the skill keys off it).

`context` / `approve` / `reject` / `revert` already existed.

## CLI usage

```bash
dosu review list                 # human table
dosu review list --json          # machine-readable (what the skill consumes)

# act on a specific page version (IDs come from `list`)
dosu review approve <page-version-id>    # accept → publishes
dosu review reject  <page-version-id>    # decline
dosu review revert  <page-version-id>    # back to pending
```

```console
$ dosu review list
Version ID  Title              Source             Status          Created
a3f9c1d2    API Authentication Synced from source pending_review  Jun 24, 2026
b7e4f8a0    Billing Overview   AI generated       pending_review  Jun 25, 2026

$ dosu review approve a3f9c1d2
Review approve: a3f9c1d2
```

## Scope note

A `dosu review diff` command was prototyped here but **pulled** — rendering the diff client-side duplicated the backend's `_render_change` and could only key off page-id (latest pending version). It will ship correctly via the server-rendered `review.getChange` follow-up (keyed on page-version-id) — [ENG-521](https://linear.app/dosu/issue/ENG-521) (backend) → [ENG-522](https://linear.app/dosu/issue/ENG-522) (CLI). Whole plan in the epic [ENG-520](https://linear.app/dosu/issue/ENG-520). This PR is intentionally the clean `list` deliverable ([ENG-501](https://linear.app/dosu/issue/ENG-501)) so it can merge first.

## Tests

`review.test.ts` — 24 cases: `list` success path (space→KS→listPending), `--json` (raw enum preserved), source humanization across all origins, missing-title fallback, empty queue, missing `space_id`, no knowledge store.

- `bun run typecheck` ✓
- `bun run check` (Biome) ✓
- `bunx vitest run src/commands/review` — 24/24 ✓

Not exercised live (this dev env isn't authenticated); the command is structurally identical to the proven `suggest list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

