### PR TITLE
fix(review): migrate `dosu review list` to the opaque {id, kind} contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",
         "@clack/prompts": "^1.6.0",
-        "@dosu/api-types": "^0.0.24",
+        "@dosu/api-types": "0.0.33",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
@@ -71,7 +71,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@dosu/api-types": ["@dosu/api-types@0.0.24", "", { "peerDependencies": { "@trpc/server": "^11.17.0" } }, "sha512-F+QLZsm2cSz6wI2F3XBsayfXY9i4uivcRmOCGtzV/MdeZTA0EWgO1vHKIm5gmM8vgvtfQyOWaOtqXIXyQtLEzw=="],
+    "@dosu/api-types": ["@dosu/api-types@0.0.33", "", { "peerDependencies": { "@trpc/server": "^11.17.0" } }, "sha512-kpxEHFb8pE/FzNdMQoiSQTph4SOr5Q0sBB6cUjebdZP+0W5qOhnOJt2Uyf9jK49TMZssWr+6SAYIOr9CiljpGw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@clack/prompts": "^1.6.0",
-    "@dosu/api-types": "0.0.24",
+    "@dosu/api-types": "0.0.33",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -66,7 +66,8 @@ afterEach(() => {
 
 describe("review list", () => {
   const pendingItem = {
-    pageVersionId: "pv-abcdef12",
+    id: "pv-abcdef12",
+    kind: "doc_change",
     pageId: "pg-1",
     title: "API Guide",
     version: 3,
@@ -91,6 +92,7 @@ describe("review list", () => {
       knowledgeStoreId: "ks1",
     });
     expect(allOutput()).toContain("pv-abcde");
+    expect(allOutput()).toContain("doc_change");
     expect(allOutput()).toContain("API Guide");
     // origin enum is humanized to match the MCP tool / dashboard
     expect(allOutput()).toContain("Synced from source");
@@ -106,7 +108,8 @@ describe("review list", () => {
 
     const output = JSON.parse(allOutput());
     expect(output).toHaveLength(1);
-    expect(output[0].pageVersionId).toBe("pv-abcdef12");
+    expect(output[0].id).toBe("pv-abcdef12");
+    expect(output[0].kind).toBe("doc_change");
     // --json is the machine surface — raw enum, not humanized
     expect(output[0].origin).toBe("sync_upstream");
   });
@@ -255,6 +258,7 @@ describe("review approve", () => {
 
     const output = JSON.parse(allOutput());
     expect(output.success).toBe(true);
+    expect(output.id).toBe("pv-1");
     expect(output.action).toBe("accept");
   });
 });

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -72,9 +72,10 @@ export function reviewCommand(): Command {
       }
 
       printTable(
-        ["Version ID", "Title", "Source", "Status", "Created"],
+        ["ID", "Kind", "Title", "Source", "Status", "Created"],
         items.map((i) => [
-          i.pageVersionId.slice(0, 8),
+          i.id.slice(0, 8),
+          i.kind,
           truncate(i.title ?? "(untitled)", 40),
           humanizeSource(i.origin, i.version),
           i.pendingStatus,
@@ -130,22 +131,23 @@ export function reviewCommand(): Command {
     cmd
       .command(name)
       .description(description)
-      .argument("<page-version-id>", "Page version ID")
+      .argument("<id>", "Review item ID (from `dosu review list`)")
       .option("--json", "Output as JSON")
-      .action(async (pageVersionId: string, opts: { json?: boolean }) => {
+      .action(async (id: string, opts: { json?: boolean }) => {
         const cfg = requireConfig();
         const client = createTypedClient(cfg);
 
+        // For the only kind today (doc_change) the opaque id is the page version id.
         await client.page.updatePublicationStatus.mutate({
-          page_version_id: pageVersionId,
+          page_version_id: id,
           action,
         });
 
         if (opts.json) {
-          printResult({ success: true, page_version_id: pageVersionId, action }, opts);
+          printResult({ success: true, id, action }, opts);
           return;
         }
-        console.log(pc.green(`Review ${name}: ${pageVersionId.slice(0, 8)}`));
+        console.log(pc.green(`Review ${name}: ${id.slice(0, 8)}`));
       });
   }
 


### PR DESCRIPTION
## Why (regression)

The contract-freeze ([dosu-ai/dosu#11362](https://github.com/dosu-ai/dosu/pull/11362), [ENG-520](https://linear.app/dosu/issue/ENG-520)) changed `review.listPending` to return the opaque `{ id, kind: "doc_change", … }` envelope **instead of** `pageVersionId`. The deployed backend now serves that shape, but the released `dosu review list` ([ENG-501](https://linear.app/dosu/issue/ENG-501)) still read `pageVersionId` — so it rendered blank version IDs and broke the `list → approve/reject` handoff against the live API. This is a field regression and lands ahead of the W2 feature work.

## What changed

- Bump `@dosu/api-types` `0.0.24` → `0.0.33` (post-#11362 release; `PendingReviewItem` now carries `id` + `kind` in place of `pageVersionId`).
- `dosu review list`: `item.pageVersionId` → `item.id`; surface the new `kind` column (only `doc_change` today).
- Verbs (`approve`/`reject`/`revert`): argument `<page-version-id>` → `<id>`; the opaque id is passed through to `page.updatePublicationStatus` (input unchanged — for `doc_change` the id *is* the page version id), consistent with the MCP tool. `--json` payload emits `id` instead of `page_version_id`.
- Tests updated to the `{ id, kind }` shape.

This is a rename + api-types bump — no new design.

## Out of scope

0.0.33 also adds a server-provided `source: string` field, but the CLI still humanizes `origin` locally via `humanizeSource`. Removing that duplication is the W2 `getChange` work ([ENG-521](https://linear.app/dosu/issue/ENG-521)/[ENG-522](https://linear.app/dosu/issue/ENG-522)).

## Acceptance

`dosu review list` shows real IDs again and the listed `id` round-trips through the review verbs against the deployed contract. `--json` reflects the `{ id, kind, … }` shape.

Closes [ENG-536](https://linear.app/dosu/issue/ENG-536).

🤖 Generated with [Claude Code](https://claude.com/claude-code)