### PR TITLE
feat(review): gate `review approve`/`reject` behind diff preview + --confirm

### DIFF
--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -17,6 +17,11 @@ vi.mock("../client/trpc", () => ({
   createTypedClient: vi.fn().mockImplementation(() => createMockProxy()),
 }));
 
+const mockConfirm = vi.fn();
+vi.mock("@clack/prompts", () => ({
+  confirm: (...args: unknown[]) => mockConfirm(...args),
+}));
+
 const mockLoadConfig = vi.fn();
 vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
@@ -237,50 +242,157 @@ describe("review context", () => {
   });
 });
 
+const changeView = {
+  id: "pv-1",
+  kind: "doc_change",
+  title: "API Guide",
+  source: "Synced from source",
+  version: 3,
+  publishedVersion: 2,
+  isNewDoc: false,
+  hasChanges: true,
+  diff: "@@ -1,2 +1,2 @@\n context line\n-old line\n+new line",
+};
+
 describe("review approve", () => {
-  it("calls page.updatePublicationStatus with action=accept", async () => {
+  it("previews the diff and applies with --confirm", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(changeView); // review.getChange
     mockMutate.mockResolvedValueOnce({});
 
-    await run("approve", "pv-1");
+    await run("approve", "--confirm", "pv-1");
 
+    expect(mockQuery).toHaveBeenCalledWith("review.getChange", { id: "pv-1" });
     expect(mockMutate).toHaveBeenCalledWith("page.updatePublicationStatus", {
       page_version_id: "pv-1",
       action: "accept",
     });
+    // the diff preview is shown before applying
+    const out = allOutput();
+    expect(out).toContain("API Guide");
+    expect(out).toContain("new line");
+    expect(out).toContain("Review approve: pv-1");
   });
 
-  it("outputs JSON with --json", async () => {
+  it("does not mutate without --confirm in non-interactive mode", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(changeView);
+
+    await run("approve", "pv-1");
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(allOutput()).toContain("Re-run with --confirm");
+  });
+
+  it("outputs JSON with --json --confirm", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(changeView);
     mockMutate.mockResolvedValueOnce({});
 
-    await run("approve", "--json", "pv-1");
+    await run("approve", "--json", "--confirm", "pv-1");
 
     const output = JSON.parse(allOutput());
     expect(output.success).toBe(true);
     expect(output.id).toBe("pv-1");
     expect(output.action).toBe("accept");
   });
+
+  it("returns the change preview as JSON without --confirm and does not mutate", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(changeView);
+
+    await run("approve", "--json", "pv-1");
+
+    const output = JSON.parse(allOutput());
+    expect(output.confirmRequired).toBe(true);
+    expect(output.applied).toBe(false);
+    expect(output.diff).toContain("new line");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
 });
 
 describe("review reject", () => {
-  it("calls page.updatePublicationStatus with action=decline", async () => {
+  it("applies with --confirm", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(changeView);
     mockMutate.mockResolvedValueOnce({});
+
+    await run("reject", "--confirm", "pv-123456");
+
+    expect(mockMutate).toHaveBeenCalledWith("page.updatePublicationStatus", {
+      page_version_id: "pv-123456",
+      action: "decline",
+    });
+    expect(allOutput()).toContain("Review reject: pv-12345");
+  });
+
+  it("shows 'No content changes' when hasChanges is false", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ ...changeView, hasChanges: false });
 
     await run("reject", "pv-1");
 
+    expect(allOutput()).toContain("No content changes");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("review approve (interactive prompt)", () => {
+  let ttyDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    ttyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  });
+
+  afterEach(() => {
+    if (ttyDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", ttyDescriptor);
+    } else {
+      // restore the original "absent" state so later tests stay non-interactive
+      Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+    }
+  });
+
+  it("applies when the user confirms y/N", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(changeView);
+    mockMutate.mockResolvedValueOnce({});
+    mockConfirm.mockResolvedValueOnce(true);
+
+    await run("approve", "pv-1");
+
+    expect(mockConfirm).toHaveBeenCalled();
     expect(mockMutate).toHaveBeenCalledWith("page.updatePublicationStatus", {
       page_version_id: "pv-1",
-      action: "decline",
+      action: "accept",
     });
   });
 
-  it("prints human-readable confirmation", async () => {
+  it("aborts when the user declines (or cancels)", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockResolvedValueOnce({});
-    await run("reject", "pv-123456");
-    expect(allOutput()).toContain("Review reject: pv-12345");
+    mockQuery.mockResolvedValueOnce(changeView);
+    mockConfirm.mockResolvedValueOnce(false);
+
+    await run("approve", "pv-1");
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(allOutput()).toContain("Aborted");
+  });
+
+  it("renders a new-doc preview (no published version)", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({
+      ...changeView,
+      isNewDoc: true,
+      publishedVersion: null,
+      version: 1,
+    });
+    mockConfirm.mockResolvedValueOnce(false);
+
+    await run("approve", "pv-1");
+
+    expect(allOutput()).toContain("1 (new)");
   });
 });
 

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -20,6 +20,7 @@ vi.mock("../client/trpc", () => ({
 const mockConfirm = vi.fn();
 vi.mock("@clack/prompts", () => ({
   confirm: (...args: unknown[]) => mockConfirm(...args),
+  isCancel: (value: unknown) => value === Symbol.for("clack:cancel"),
 }));
 
 const mockLoadConfig = vi.fn();
@@ -369,7 +370,7 @@ describe("review approve (interactive prompt)", () => {
     });
   });
 
-  it("aborts when the user declines (or cancels)", async () => {
+  it("aborts when the user declines", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce(changeView);
     mockConfirm.mockResolvedValueOnce(false);
@@ -378,6 +379,17 @@ describe("review approve (interactive prompt)", () => {
 
     expect(mockMutate).not.toHaveBeenCalled();
     expect(allOutput()).toContain("Aborted");
+  });
+
+  it("handles cancellation gracefully", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(changeView);
+    mockConfirm.mockResolvedValueOnce(Symbol.for("clack:cancel"));
+
+    await run("approve", "pv-1");
+
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(allOutput()).toContain("Cancelled");
   });
 
   it("renders a new-doc preview (no published version)", async () => {

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -2,12 +2,16 @@
  * `dosu review` — document review workflow.
  */
 
+import * as p from "@clack/prompts";
 import type { RouterOutputs } from "@dosu/api-types";
 import { Command } from "commander";
 import pc from "picocolors";
 import { createTypedClient, type TypedClient } from "../client/trpc";
 import { requireLoginConfig } from "./auth";
 import { formatDate, printInfo, printResult, printTable, truncate } from "./output";
+
+// The server-rendered change view consumed by the approve/reject confirm-gate.
+type ChangeView = RouterOutputs["review"]["getChange"];
 
 function requireConfig() {
   return requireLoginConfig();
@@ -32,6 +36,39 @@ function humanizeSource(origin: ReviewOrigin, version: number): string {
     default:
       return origin;
   }
+}
+
+// Colorize a unified diff so the preview reads like one. + green, - red, hunk headers dim.
+function colorizeDiff(diff: string): string {
+  return diff
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("+")) return pc.green(line);
+      if (line.startsWith("-")) return pc.red(line);
+      if (line.startsWith("@@")) return pc.cyan(line);
+      return pc.dim(line);
+    })
+    .join("\n");
+}
+
+// Render the change view preview shown before an approve/reject confirmation.
+function printChangePreview(change: ChangeView): void {
+  printInfo([
+    ["Title", change.title],
+    ["Source", change.source],
+    [
+      "Version",
+      change.isNewDoc
+        ? `${change.version} (new)`
+        : `${change.publishedVersion ?? "?"} → ${change.version}`,
+    ],
+  ]);
+  if (!change.hasChanges) {
+    console.log(pc.dim("No content changes."));
+    return;
+  }
+  console.log();
+  console.log(colorizeDiff(change.diff));
 }
 
 async function getKnowledgeStoreId(client: TypedClient, spaceId: string): Promise<string> {
@@ -117,27 +154,47 @@ export function reviewCommand(): Command {
       ]);
     });
 
-  const actions = [
-    { name: "approve", action: "accept" as const, description: "Approve a document version" },
-    { name: "reject", action: "decline" as const, description: "Reject a document version" },
-    {
-      name: "revert",
-      action: "revert_to_pending" as const,
-      description: "Revert to pending review",
-    },
+  // approve/reject mutate published content, so they're gated behind a diff
+  // preview + explicit confirmation — mirroring the MCP tool's confirm-gated
+  // accept/decline. `--confirm` (or an interactive y/N) is required to apply.
+  const gated = [
+    { name: "approve", action: "accept" as const, verb: "Approve" },
+    { name: "reject", action: "decline" as const, verb: "Reject" },
   ];
 
-  for (const { name, action, description } of actions) {
+  for (const { name, action, verb } of gated) {
     cmd
       .command(name)
-      .description(description)
+      .description(`${verb} a document version (shows the diff, requires --confirm)`)
       .argument("<id>", "Review item ID (from `dosu review list`)")
+      .option("--confirm", "Apply without the interactive prompt")
       .option("--json", "Output as JSON")
-      .action(async (id: string, opts: { json?: boolean }) => {
+      .action(async (id: string, opts: { json?: boolean; confirm?: boolean }) => {
         const cfg = requireConfig();
         const client = createTypedClient(cfg);
 
         // For the only kind today (doc_change) the opaque id is the page version id.
+        const change = await client.review.getChange.query({ id });
+        if (!opts.json) printChangePreview(change);
+
+        let proceed = opts.confirm === true;
+        if (!proceed && !opts.json && process.stdin?.isTTY) {
+          const answer = await p.confirm({
+            message: `${verb} this change?`,
+            initialValue: false,
+          });
+          proceed = answer === true;
+        }
+
+        if (!proceed) {
+          if (opts.json) {
+            printResult({ ...change, applied: false, confirmRequired: true }, opts);
+          } else {
+            console.log(pc.dim("Aborted. Re-run with --confirm to apply."));
+          }
+          return;
+        }
+
         await client.page.updatePublicationStatus.mutate({
           page_version_id: id,
           action,
@@ -150,6 +207,28 @@ export function reviewCommand(): Command {
         console.log(pc.green(`Review ${name}: ${id.slice(0, 8)}`));
       });
   }
+
+  // revert just re-opens an item for review (non-destructive), so it stays ungated.
+  cmd
+    .command("revert")
+    .description("Revert to pending review")
+    .argument("<id>", "Review item ID (from `dosu review list`)")
+    .option("--json", "Output as JSON")
+    .action(async (id: string, opts: { json?: boolean }) => {
+      const cfg = requireConfig();
+      const client = createTypedClient(cfg);
+
+      await client.page.updatePublicationStatus.mutate({
+        page_version_id: id,
+        action: "revert_to_pending",
+      });
+
+      if (opts.json) {
+        printResult({ success: true, id, action: "revert_to_pending" }, opts);
+        return;
+      }
+      console.log(pc.green(`Review revert: ${id.slice(0, 8)}`));
+    });
 
   return cmd;
 }

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -183,6 +183,10 @@ export function reviewCommand(): Command {
             message: `${verb} this change?`,
             initialValue: false,
           });
+          if (p.isCancel(answer)) {
+            console.log(pc.dim("Cancelled."));
+            return;
+          }
           proceed = answer === true;
         }
 


### PR DESCRIPTION
## What

`dosu review approve` / `reject` now show the server-rendered diff and require explicit confirmation before mutating published content — mirroring the MCP tool's confirm-gated `accept` / `decline`.

- Fetch `review.getChange({ id })` and print a colorized unified-diff preview (title, source, version transition, `+`/`-`/hunk colors).
- Gate the mutation behind `--confirm` **or** an interactive y/N prompt.
- `revert` is non-destructive (re-opens an item for review) and stays ungated.

### Confirmation matrix
| Mode | Behavior |
|---|---|
| `--confirm` | applies immediately |
| TTY, no flag | shows diff, prompts y/N |
| non-TTY / piped, no flag | shows diff, prints "Re-run with --confirm", no mutation |
| `--json`, no `--confirm` | emits the change preview with `confirmRequired: true`, no mutation |
| `--json --confirm` | applies, emits `{ success, id, action }` |

The `--json` no-confirm path returns the change preview so an agent can inspect the diff and re-call with `--confirm` — matching how the MCP gate returns the diff before a confirmed second call.

## Why

Approve/reject mutate published documentation with no preview today. This brings the CLI to parity with the MCP confirm-gate so reviewers see what they're publishing/rejecting first. Can be relaxed later (e.g. a `--yes` bypass) if the gate proves annoying.

## Notes for reviewers

- Part of the ENG-520 review-parity epic (W2). Closes ENG-527; consumes `review.getChange` from ENG-521 (shipped in `@dosu/api-types` 0.0.33).
- Tests: 29 in `review.test.ts` (interactive confirm/decline, `--confirm`, non-interactive abort, JSON preview, new-doc + no-changes previews). Full suite green (1369), coverage thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)