### PR TITLE
feat(review): add `dosu review edit <page-version-id>`

### DIFF
--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { TRPCClientError } from "@trpc/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -233,6 +236,59 @@ describe("review diff", () => {
 
     await expect(run("diff", "pv-missing")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
+  });
+});
+
+describe("review edit", () => {
+  it("calls page.updateReview with title and body", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockResolvedValueOnce(undefined);
+
+    await run("edit", "pv-abcdef12", "--title", "New Title", "--body", "# Body");
+
+    expect(mockMutate).toHaveBeenCalledWith("page.updateReview", {
+      page_version_id: "pv-abcdef12",
+      title: "New Title",
+      body: "# Body",
+    });
+    expect(allOutput()).toContain("Review edited: pv-abcde");
+  });
+
+  it("reads body from --body-file", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockResolvedValueOnce(undefined);
+    const dir = mkdtempSync(join(tmpdir(), "dosu-review-test-"));
+    const file = join(dir, "body.md");
+    try {
+      writeFileSync(file, "# From file\n", "utf-8");
+      await run("edit", "pv-abcdef12", "--body-file", file);
+      expect(mockMutate).toHaveBeenCalledWith("page.updateReview", {
+        page_version_id: "pv-abcdef12",
+        title: undefined,
+        body: "# From file\n",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("errors when neither title nor body is given", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+
+    await expect(run("edit", "pv-abcdef12")).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("Nothing to edit");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("outputs JSON with --json", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockResolvedValueOnce(undefined);
+
+    await run("edit", "--json", "pv-abcdef12", "--title", "T");
+
+    const output = JSON.parse(allOutput());
+    expect(output.success).toBe(true);
+    expect(output.id).toBe("pv-abcdef12");
   });
 });
 

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -280,6 +280,26 @@ describe("review edit", () => {
     expect(mockMutate).not.toHaveBeenCalled();
   });
 
+  it("errors when both --body and --body-file are given", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+
+    await expect(run("edit", "pv-abcdef12", "--body", "x", "--body-file", "f.md")).rejects.toThrow(
+      "exit",
+    );
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("only one of --body or --body-file");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("errors gracefully when --body-file cannot be read", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+
+    await expect(run("edit", "pv-abcdef12", "--body-file", "/no/such/file.md")).rejects.toThrow(
+      "exit",
+    );
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("Failed to read --body-file");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce(undefined);

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -300,6 +300,18 @@ describe("review edit", () => {
     expect(mockMutate).not.toHaveBeenCalled();
   });
 
+  it("prints a clear message for an unknown or non-pending page-version id", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockRejectedValueOnce(
+      new TRPCClientError("not found", {
+        result: { error: { code: -32004, message: "not found", data: { code: "NOT_FOUND" } } },
+      }),
+    );
+
+    await expect(run("edit", "pv-missing", "--title", "T")).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("No pending review item found");
+  });
+
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce(undefined);

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -2,6 +2,7 @@
  * `dosu review` — document review workflow.
  */
 
+import { readFileSync } from "node:fs";
 import * as p from "@clack/prompts";
 import type { RouterOutputs } from "@dosu/api-types";
 import { isTRPCClientError } from "@trpc/client";
@@ -166,6 +167,44 @@ export function reviewCommand(): Command {
       // "(No textual changes…)" notice — distinguished by isNewDoc / hasChanges.
       console.log(change.diff);
     });
+
+  // In-place edit of a pending version's body/title via page.updateReview
+  // (PENDING_REVIEW-guarded server-side). After editing, `dosu review approve` publishes.
+  cmd
+    .command("edit")
+    .description("Edit a pending document version's body/title in place")
+    .argument("<page-version-id>", "Page version ID (from `dosu review list`)")
+    .option("--title <title>", "New title")
+    .option("--body <markdown>", "New body (markdown)")
+    .option("--body-file <path>", "Read body from file")
+    .option("--json", "Output as JSON")
+    .action(
+      async (
+        id: string,
+        opts: { title?: string; body?: string; bodyFile?: string; json?: boolean },
+      ) => {
+        const cfg = requireConfig();
+        const client = createTypedClient(cfg);
+
+        const body = opts.bodyFile ? readFileSync(opts.bodyFile, "utf-8") : opts.body;
+        if (body === undefined && opts.title === undefined) {
+          console.error(pc.red("Nothing to edit. Pass --title and/or --body/--body-file."));
+          process.exit(1);
+        }
+
+        await client.page.updateReview.mutate({
+          page_version_id: id,
+          title: opts.title,
+          body,
+        });
+
+        if (opts.json) {
+          printResult({ success: true, id }, opts);
+          return;
+        }
+        console.log(pc.green(`Review edited: ${id.slice(0, 8)}`));
+      },
+    );
 
   cmd
     .command("context")

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -186,7 +186,21 @@ export function reviewCommand(): Command {
         const cfg = requireConfig();
         const client = createTypedClient(cfg);
 
-        const body = opts.bodyFile ? readFileSync(opts.bodyFile, "utf-8") : opts.body;
+        if (opts.body !== undefined && opts.bodyFile !== undefined) {
+          console.error(pc.red("Pass only one of --body or --body-file."));
+          process.exit(1);
+        }
+
+        let body: string | undefined = opts.body;
+        if (opts.bodyFile) {
+          try {
+            body = readFileSync(opts.bodyFile, "utf-8");
+          } catch (err) {
+            console.error(pc.red(`Failed to read --body-file: ${(err as Error).message}`));
+            process.exit(1);
+          }
+        }
+
         if (body === undefined && opts.title === undefined) {
           console.error(pc.red("Nothing to edit. Pass --title and/or --body/--body-file."));
           process.exit(1);

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -206,11 +206,26 @@ export function reviewCommand(): Command {
           process.exit(1);
         }
 
-        await client.page.updateReview.mutate({
-          page_version_id: id,
-          title: opts.title,
-          body,
-        });
+        try {
+          await client.page.updateReview.mutate({
+            page_version_id: id,
+            title: opts.title,
+            body,
+          });
+        } catch (err) {
+          if (
+            isTRPCClientError(err) &&
+            (err.data as { code?: string } | null)?.code === "NOT_FOUND"
+          ) {
+            console.error(
+              pc.red(
+                `No pending review item found for '${id}'. Run 'dosu review list' to see editable items.`,
+              ),
+            );
+            process.exit(1);
+          }
+          throw err;
+        }
 
         if (opts.json) {
           printResult({ success: true, id }, opts);


### PR DESCRIPTION
## What

Adds `dosu review edit <page-version-id> [--title …] [--body <md>] [--body-file <f>] [--json]` — an in-place edit of a pending document version's body/title.

```
dosu review edit pv-abcdef12 --body-file new-body.md
dosu review edit pv-abcdef12 --title "Updated title"
```

## Why

Part of the [ENG-520](https://linear.app/dosu/issue/ENG-520) review-parity epic ([ENG-523](https://linear.app/dosu/issue/ENG-523), W3 Phase 1). Brings the CLI to parity with the MCP edit path ([ENG-518](https://linear.app/dosu/issue/ENG-518)) for editing review suggestions before approval.

## How

- Calls the **existing** `page.updateReview` mutation — no backend dependency. It's PENDING_REVIEW-guarded server-side. After editing, `dosu review approve` publishes.
- Body-file handling mirrors `dosu docs` (`--body` inline or `--body-file <path>`).
- Errors if neither `--title` nor a body is given.

## Notes for reviewers

- No confirm-gate: unlike `approve`/`reject`, `edit` doesn't publish, so it's non-destructive like `revert`.
- `package.json` was already on `@dosu/api-types` 0.0.33 (≥ the 0.0.24 that introduced `page.updateReview`), so no self-bump was needed.
- 4 tests added; full suite + typecheck + Biome pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)