### PR TITLE
feat(review): surface draft messages in `dosu review` (ENG-524)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",
         "@clack/prompts": "^1.6.0",
-        "@dosu/api-types": "0.0.33",
+        "@dosu/api-types": "0.0.36",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
@@ -71,7 +71,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@dosu/api-types": ["@dosu/api-types@0.0.33", "", { "peerDependencies": { "@trpc/server": "^11.17.0" } }, "sha512-kpxEHFb8pE/FzNdMQoiSQTph4SOr5Q0sBB6cUjebdZP+0W5qOhnOJt2Uyf9jK49TMZssWr+6SAYIOr9CiljpGw=="],
+    "@dosu/api-types": ["@dosu/api-types@0.0.36", "", { "peerDependencies": { "@trpc/server": "^11.17.0" } }, "sha512-XVY6cTbA4fqxBwX8T21MgQH+yUqV16zQCiQP1DbT+FSFxHnLcqsDvEt/Ft3rvzCPROrW8bT+/NMaCzRke8jIcw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@clack/prompts": "^1.6.0",
-    "@dosu/api-types": "0.0.33",
+    "@dosu/api-types": "0.0.36",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -639,6 +639,8 @@ describe("review approve/reject (draft messages)", () => {
 
     const output = JSON.parse(allOutput());
     expect(output.kind).toBe("draft_message");
+    expect(output.title).toBe(draftRow.title);
+    expect(output.body).toBe(draftRow.body);
     expect(output.confirmRequired).toBe(true);
     expect(output.applied).toBe(false);
     expect(mockMutate).not.toHaveBeenCalled();
@@ -728,6 +730,7 @@ describe("review approve (interactive prompt)", () => {
 describe("review revert", () => {
   it("calls page.updatePublicationStatus with action=revert_to_pending", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(docChange); // review.getChange → doc
     mockMutate.mockResolvedValueOnce({});
 
     await run("revert", "pv-1");
@@ -740,6 +743,7 @@ describe("review revert", () => {
 
   it("prints human-readable confirmation", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(docChange);
     mockMutate.mockResolvedValueOnce({});
     await run("revert", "pv-123456");
     expect(allOutput()).toContain("Review revert: pv-12345");
@@ -747,6 +751,7 @@ describe("review revert", () => {
 
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(docChange);
     mockMutate.mockResolvedValueOnce({});
     await run("revert", "--json", "pv-1");
     const output = JSON.parse(allOutput());
@@ -754,16 +759,29 @@ describe("review revert", () => {
     expect(output.action).toBe("revert_to_pending");
   });
 
-  it("rejects revert for a draft id (mutation 404s → unsupported message)", async () => {
+  it("rejects revert for a draft id (resolveChange 404s → draft path)", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockRejectedValueOnce(notFound());
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → draft
+    mockQuery.mockResolvedValueOnce({ id: "msg-1" }); // messages.getMessage exists
 
     await expect(run("revert", "msg-1")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("not supported for draft replies");
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  it("rethrows a non-NOT_FOUND error from revert", async () => {
+  it("exits with a clear message for an id that is neither a doc change nor a draft", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → not a doc
+    mockQuery.mockResolvedValueOnce(null); // messages.getMessage → not a draft
+
+    await expect(run("revert", "missing")).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("rethrows an error from the revert mutation", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(docChange); // review.getChange → doc
     mockMutate.mockRejectedValueOnce(new Error("boom"));
 
     await expect(run("revert", "pv-1")).rejects.toThrow("boom");

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -45,7 +45,17 @@ const validConfig = {
   expires_at: 0,
   api_key: "sk_user_test",
   space_id: "sp1",
+  deployment_id: "dep1",
 };
+
+// A tRPC NOT_FOUND error, as the client surfaces it. doc_change ids resolve via
+// review.getChange; a draft_message id 404s there — that 404 routes the verb to
+// the draft path.
+function notFound() {
+  return new TRPCClientError("not found", {
+    result: { error: { code: -32004, message: "not found", data: { code: "NOT_FOUND" } } },
+  });
+}
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -100,6 +110,7 @@ describe("review list", () => {
     });
     expect(mockQuery).toHaveBeenNthCalledWith(2, "review.listPending", {
       knowledgeStoreId: "ks1",
+      deploymentId: "dep1",
     });
     expect(allOutput()).toContain("pv-abcde");
     expect(allOutput()).toContain("doc_change");
@@ -144,6 +155,41 @@ describe("review list", () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce({ id: "ks1" });
     mockQuery.mockResolvedValueOnce([{ ...pendingItem, title: null }]);
+
+    await run("list");
+
+    expect(allOutput()).toContain("(untitled)");
+  });
+
+  const draftItem = {
+    id: "msg-abcdef12",
+    kind: "draft_message",
+    title: "Re: how do I configure X?",
+    body: "You can configure X by…",
+    threadId: "th-1",
+    createdAt: "2026-06-25T10:00:00.000Z",
+  };
+
+  it("renders draft_message items alongside doc changes", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ks1" });
+    mockQuery.mockResolvedValueOnce([pendingItem, draftItem]);
+
+    await run("list");
+
+    const out = allOutput();
+    expect(out).toContain("doc_change");
+    expect(out).toContain("draft_message");
+    expect(out).toContain("Re: how do I configure X?");
+    // drafts have no origin/version/pendingStatus — they render fixed labels
+    expect(out).toContain("Draft reply");
+    expect(out).toContain("draft");
+  });
+
+  it("falls back to (untitled) for a draft with an empty title", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ks1" });
+    mockQuery.mockResolvedValueOnce([{ ...draftItem, title: "" }]);
 
     await run("list");
 
@@ -226,22 +272,49 @@ describe("review diff", () => {
     expect(output.diff).toContain("@@");
   });
 
-  it("prints a clear message for an unknown page-version id", async () => {
+  it("prints a clear message for an id that is neither a doc change nor a draft", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(
-      new TRPCClientError("not found", {
-        result: { error: { code: -32004, message: "not found", data: { code: "NOT_FOUND" } } },
-      }),
-    );
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → not a doc
+    mockQuery.mockResolvedValueOnce(null); // messages.getMessage → not a draft
 
-    await expect(run("diff", "pv-missing")).rejects.toThrow("exit");
+    await expect(run("diff", "missing")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
   });
+
+  it("shows the body for a draft id (getChange 404s → draft path)", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange
+    mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "the answer" });
+
+    await run("diff", "msg-1");
+
+    const out = allOutput();
+    expect(out).toContain("Re: q");
+    expect(out).toContain("Draft reply");
+    expect(out).toContain("the answer");
+  });
+
+  it("passes the draft through with --json", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound());
+    mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "the answer" });
+
+    await run("diff", "--json", "msg-1");
+
+    const output = JSON.parse(allOutput());
+    expect(output.kind).toBe("draft_message");
+    expect(output.body).toBe("the answer");
+  });
 });
+
+// resolveChange resolves a doc-change id (any truthy ChangeView) so edit/approve
+// take the doc path; a rejection routes to the draft path.
+const docChange = { kind: "doc_change" };
 
 describe("review edit", () => {
   it("calls page.updateReview with title and body", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(docChange); // review.getChange → doc
     mockMutate.mockResolvedValueOnce(undefined);
 
     await run("edit", "pv-abcdef12", "--title", "New Title", "--body", "# Body");
@@ -256,6 +329,7 @@ describe("review edit", () => {
 
   it("reads body from --body-file", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(docChange);
     mockMutate.mockResolvedValueOnce(undefined);
     const dir = mkdtempSync(join(tmpdir(), "dosu-review-test-"));
     const file = join(dir, "body.md");
@@ -270,6 +344,40 @@ describe("review edit", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("saves a new draft revision for a draft id (body only)", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → draft
+    mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "old" }); // getMessage
+    mockMutate.mockResolvedValueOnce(undefined);
+
+    await run("edit", "msg-1", "--body", "new body");
+
+    expect(mockMutate).toHaveBeenCalledWith("messages.saveDraft", {
+      messageId: "msg-1",
+      body: "new body",
+    });
+    expect(allOutput()).toContain("Review edited: msg-1");
+  });
+
+  it("rejects --title for a draft id (saveDraft is body-only)", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → draft
+
+    await expect(run("edit", "msg-1", "--title", "T", "--body", "b")).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("--body only");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("prints a clear message for an unknown draft id", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → not a doc
+    mockQuery.mockResolvedValueOnce(null); // getMessage → not a draft
+
+    await expect(run("edit", "missing", "--body", "b")).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
   it("errors when neither title nor body is given", async () => {
@@ -300,13 +408,10 @@ describe("review edit", () => {
     expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  it("prints a clear message for an unknown or non-pending page-version id", async () => {
+  it("prints a clear message for a doc that left review between resolve and update", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockRejectedValueOnce(
-      new TRPCClientError("not found", {
-        result: { error: { code: -32004, message: "not found", data: { code: "NOT_FOUND" } } },
-      }),
-    );
+    mockQuery.mockResolvedValueOnce(docChange); // review.getChange → doc
+    mockMutate.mockRejectedValueOnce(notFound()); // page.updateReview → no longer pending
 
     await expect(run("edit", "pv-missing", "--title", "T")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("No pending review item found");
@@ -314,6 +419,7 @@ describe("review edit", () => {
 
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(docChange);
     mockMutate.mockResolvedValueOnce(undefined);
 
     await run("edit", "--json", "pv-abcdef12", "--title", "T");
@@ -494,6 +600,61 @@ describe("review reject", () => {
   });
 });
 
+describe("review approve/reject (draft messages)", () => {
+  const draftRow = { id: "msg-1", title: "Re: how do I configure X?", body: "Configure it like…" };
+
+  it("previews the draft and publishes it on approve --confirm", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → draft
+    mockQuery.mockResolvedValueOnce(draftRow); // messages.getMessage
+    mockMutate.mockResolvedValueOnce(undefined);
+
+    await run("approve", "--confirm", "msg-1");
+
+    const out = allOutput();
+    expect(out).toContain("Re: how do I configure X?"); // preview shown
+    expect(out).toContain("Configure it like…");
+    expect(mockMutate).toHaveBeenCalledWith("messages.publishMessage", { postId: "msg-1" });
+    expect(out).toContain("Review approve: msg-1");
+  });
+
+  it("discards the draft on reject --confirm", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound());
+    mockQuery.mockResolvedValueOnce(draftRow);
+    mockMutate.mockResolvedValueOnce(undefined);
+
+    await run("reject", "--confirm", "msg-1");
+
+    expect(mockMutate).toHaveBeenCalledWith("messages.deleteMessage", "msg-1");
+    expect(allOutput()).toContain("Review reject: msg-1");
+  });
+
+  it("returns a draft confirmRequired payload as JSON without --confirm", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound());
+    mockQuery.mockResolvedValueOnce(draftRow);
+
+    await run("approve", "--json", "msg-1");
+
+    const output = JSON.parse(allOutput());
+    expect(output.kind).toBe("draft_message");
+    expect(output.confirmRequired).toBe(true);
+    expect(output.applied).toBe(false);
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("exits with a clear message when the draft id resolves to nothing", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(notFound());
+    mockQuery.mockResolvedValueOnce(null); // messages.getMessage → missing
+
+    await expect(run("approve", "--confirm", "missing")).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});
+
 describe("review approve (interactive prompt)", () => {
   let ttyDescriptor: PropertyDescriptor | undefined;
 
@@ -591,6 +752,40 @@ describe("review revert", () => {
     const output = JSON.parse(allOutput());
     expect(output.success).toBe(true);
     expect(output.action).toBe("revert_to_pending");
+  });
+
+  it("rejects revert for a draft id (mutation 404s → unsupported message)", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockRejectedValueOnce(notFound());
+
+    await expect(run("revert", "msg-1")).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("not supported for draft replies");
+  });
+
+  it("rethrows a non-NOT_FOUND error from revert", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(run("revert", "pv-1")).rejects.toThrow("boom");
+  });
+});
+
+// Errors other than NOT_FOUND are not kind-routing signals — they propagate.
+describe("review error propagation", () => {
+  it("rethrows a non-NOT_FOUND error from getChange (kind resolution)", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(new Error("boom")); // review.getChange
+
+    await expect(run("approve", "--confirm", "pv-1")).rejects.toThrow("boom");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("rethrows a non-NOT_FOUND error from page.updateReview", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(docChange); // review.getChange → doc
+    mockMutate.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(run("edit", "pv-1", "--body", "x")).rejects.toThrow("boom");
   });
 });
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -387,7 +387,12 @@ export function reviewCommand(): Command {
 
         if (!proceed) {
           if (opts.json) {
-            const preview = change ?? { id, kind: "draft_message" };
+            const preview = change ?? {
+              id,
+              kind: "draft_message",
+              title: draft?.title,
+              body: draft?.body,
+            };
             printResult({ ...preview, applied: false, confirmRequired: true }, opts);
           } else {
             console.log(pc.dim("Aborted. Re-run with --confirm to apply."));
@@ -425,22 +430,24 @@ export function reviewCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      try {
-        await client.page.updatePublicationStatus.mutate({
-          page_version_id: id,
-          action: "revert_to_pending",
-        });
-      } catch (err) {
-        if (isNotFound(err)) {
-          console.error(
-            pc.red(
-              "Revert is not supported for draft replies. A rejected draft is regenerated on the next agent run.",
-            ),
-          );
-          process.exit(1);
-        }
-        throw err;
+      // Resolve kind like the other verbs rather than catching the mutation's 404:
+      // a draft id 404s on getChange, and requireDraft turns a truly-unknown id into
+      // a clean "no review item" error instead of a misleading "not supported" one.
+      const change = await resolveChange(client, id);
+      if (!change) {
+        await requireDraft(client, id);
+        console.error(
+          pc.red(
+            "Revert is not supported for draft replies. A rejected draft is regenerated on the next agent run.",
+          ),
+        );
+        process.exit(1);
       }
+
+      await client.page.updatePublicationStatus.mutate({
+        page_version_id: id,
+        action: "revert_to_pending",
+      });
 
       if (opts.json) {
         printResult({ success: true, id, action: "revert_to_pending" }, opts);

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,5 +1,5 @@
 /**
- * `dosu review` — document review workflow.
+ * `dosu review` — review workflow for pending doc changes and draft replies.
  */
 
 import { readFileSync } from "node:fs";
@@ -15,13 +15,51 @@ import { formatDate, printInfo, printResult, printTable, truncate } from "./outp
 // The server-rendered change view consumed by the approve/reject confirm-gate.
 type ChangeView = RouterOutputs["review"]["getChange"];
 
+// The raw message row behind a draft id (used to preview a draft in the gate).
+type DraftMessageRow = NonNullable<RouterOutputs["messages"]["getMessage"]>;
+
 function requireConfig() {
   return requireLoginConfig();
 }
 
+function isNotFound(err: unknown): boolean {
+  return isTRPCClientError(err) && (err.data as { code?: string } | null)?.code === "NOT_FOUND";
+}
+
+// Resolve the kind behind an opaque review-item id (ENG-524). doc_change items are
+// page versions (resolved by review.getChange); a draft_message id lives in the
+// message table, so getChange 404s — that 404 is how the verbs route by kind
+// without a separate flag. Returns the ChangeView for docs, null for drafts.
+async function resolveChange(client: TypedClient, id: string): Promise<ChangeView | null> {
+  try {
+    return await client.review.getChange.query({ id });
+  } catch (err) {
+    if (isNotFound(err)) return null;
+    throw err;
+  }
+}
+
+// Fetch the message row behind a draft id, or exit with a clear message if missing.
+async function requireDraft(client: TypedClient, id: string): Promise<DraftMessageRow> {
+  const draft = await client.messages.getMessage.query(id);
+  if (!draft) {
+    console.error(
+      pc.red(`No review item found for '${id}'. Run 'dosu review list' to see pending items.`),
+    );
+    process.exit(1);
+  }
+  return draft;
+}
+
 // Pinned to the published API enum so the case labels are checked against the real
 // origin union (RouterOutputs derives it from `review.listPending`).
-type ReviewOrigin = RouterOutputs["review"]["listPending"][number]["origin"];
+// `origin` is unique to the doc-change member of the listPending union (drafts
+// have none), so extract on its presence rather than on `kind` — the doc member's
+// kind is the broad ReviewItemKind, not a literal, so a kind-extract yields never.
+type ReviewOrigin = Extract<
+  RouterOutputs["review"]["listPending"][number],
+  { origin: string }
+>["origin"];
 
 // ponytail: mirrors _humanize_origin in dosu's backend/public_api/mcp/tools/review.py —
 // keep in sync so the CLI, MCP tool, and dashboard show the same source labels.
@@ -73,6 +111,16 @@ function printChangePreview(change: ChangeView): void {
   console.log(colorizeDiff(change.diff));
 }
 
+// A draft reply has no published baseline to diff against — preview is title + body.
+function printDraftPreview(draft: DraftMessageRow): void {
+  printInfo([
+    ["Title", draft.title ?? "(untitled)"],
+    ["Source", "Draft reply"],
+  ]);
+  console.log();
+  console.log(draft.body ?? "");
+}
+
 async function getKnowledgeStoreId(client: TypedClient, spaceId: string): Promise<string> {
   const store = await client.knowledgeStore.getBySpaceId.query({ space_id: spaceId });
   if (!store) {
@@ -83,11 +131,11 @@ async function getKnowledgeStoreId(client: TypedClient, spaceId: string): Promis
 }
 
 export function reviewCommand(): Command {
-  const cmd = new Command("review").description("Document review workflow");
+  const cmd = new Command("review").description("Review workflow (doc changes and draft replies)");
 
   cmd
     .command("list")
-    .description("List pending document review items")
+    .description("List pending review items (doc changes and draft replies)")
     .option("--json", "Output as JSON")
     .action(async (opts: { json?: boolean }) => {
       const cfg = requireConfig();
@@ -98,7 +146,13 @@ export function reviewCommand(): Command {
       const client = createTypedClient(cfg);
       const ksId = await getKnowledgeStoreId(client, cfg.space_id);
 
-      const items = await client.review.listPending.query({ knowledgeStoreId: ksId });
+      // Docs are knowledge-store-scoped; drafts are deployment-scoped. Passing
+      // deploymentId merges draft replies into the list (ENG-524) — omit it and
+      // the server returns doc changes only.
+      const items = await client.review.listPending.query({
+        knowledgeStoreId: ksId,
+        deploymentId: cfg.deployment_id,
+      });
 
       if (opts.json) {
         printResult(items, opts);
@@ -112,43 +166,51 @@ export function reviewCommand(): Command {
 
       printTable(
         ["ID", "Kind", "Title", "Source", "Status", "Created"],
-        items.map((i) => [
-          i.id.slice(0, 8),
-          i.kind,
-          truncate(i.title ?? "(untitled)", 40),
-          humanizeSource(i.origin, i.version),
-          i.pendingStatus,
-          formatDate(i.createdAt),
-        ]),
+        items.map((i) =>
+          i.kind === "draft_message"
+            ? [
+                i.id.slice(0, 8),
+                i.kind,
+                truncate(i.title || "(untitled)", 40),
+                "Draft reply",
+                "draft",
+                formatDate(i.createdAt),
+              ]
+            : [
+                i.id.slice(0, 8),
+                i.kind,
+                truncate(i.title ?? "(untitled)", 40),
+                humanizeSource(i.origin, i.version),
+                i.pendingStatus,
+                formatDate(i.createdAt),
+              ],
+        ),
         { rawData: items },
       );
     });
 
   cmd
     .command("diff")
-    .description("Show the server-rendered diff for a pending document version")
-    .argument("<page-version-id>", "Page version ID (from `dosu review list`)")
+    .description("Show a pending review item (doc-change diff or draft reply body)")
+    .argument("<id>", "Review item ID (from `dosu review list`)")
     .option("--json", "Output as JSON")
     .action(async (id: string, opts: { json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      let change: RouterOutputs["review"]["getChange"];
-      try {
-        change = await client.review.getChange.query({ id });
-      } catch (err) {
-        if (
-          isTRPCClientError(err) &&
-          (err.data as { code?: string } | null)?.code === "NOT_FOUND"
-        ) {
-          console.error(
-            pc.red(
-              `No review item found for '${id}'. Run 'dosu review list' to see pending items.`,
-            ),
-          );
-          process.exit(1);
+      // A draft_message id 404s on getChange → render its body instead of a diff.
+      const change = await resolveChange(client, id);
+      if (!change) {
+        const draft = await requireDraft(client, id);
+        if (opts.json) {
+          printResult({ id, kind: "draft_message", title: draft.title, body: draft.body }, opts);
+          return;
         }
-        throw err;
+        console.log(pc.bold(draft.title ?? "(untitled)"));
+        console.log(pc.dim("Draft reply"));
+        console.log("");
+        console.log(draft.body ?? "");
+        return;
       }
 
       if (opts.json) {
@@ -168,12 +230,13 @@ export function reviewCommand(): Command {
       console.log(change.diff);
     });
 
-  // In-place edit of a pending version's body/title via page.updateReview
-  // (PENDING_REVIEW-guarded server-side). After editing, `dosu review approve` publishes.
+  // In-place edit of a pending review item. doc changes go through page.updateReview
+  // (PENDING_REVIEW-guarded); draft replies save a new draft revision via
+  // message.saveDraft (body only). After editing, `dosu review approve` publishes.
   cmd
     .command("edit")
-    .description("Edit a pending document version's body/title in place")
-    .argument("<page-version-id>", "Page version ID (from `dosu review list`)")
+    .description("Edit a pending review item in place (doc body/title, or draft reply body)")
+    .argument("<id>", "Review item ID (from `dosu review list`)")
     .option("--title <title>", "New title")
     .option("--body <markdown>", "New body (markdown)")
     .option("--body-file <path>", "Read body from file")
@@ -206,25 +269,35 @@ export function reviewCommand(): Command {
           process.exit(1);
         }
 
-        try {
-          await client.page.updateReview.mutate({
-            page_version_id: id,
-            title: opts.title,
-            body,
-          });
-        } catch (err) {
-          if (
-            isTRPCClientError(err) &&
-            (err.data as { code?: string } | null)?.code === "NOT_FOUND"
-          ) {
-            console.error(
-              pc.red(
-                `No pending review item found for '${id}'. Run 'dosu review list' to see editable items.`,
-              ),
-            );
+        // A draft_message id 404s on getChange → route to saveDraft (body only).
+        const change = await resolveChange(client, id);
+        if (!change) {
+          // saveDraft takes body only; --title is doc-only. (Past the generic
+          // "nothing to edit" check above, body is guaranteed set when title isn't.)
+          if (opts.title !== undefined) {
+            console.error(pc.red("Draft replies support --body only (no --title)."));
             process.exit(1);
           }
-          throw err;
+          await requireDraft(client, id);
+          await client.messages.saveDraft.mutate({ messageId: id, body: body as string });
+        } else {
+          try {
+            await client.page.updateReview.mutate({
+              page_version_id: id,
+              title: opts.title,
+              body,
+            });
+          } catch (err) {
+            if (isNotFound(err)) {
+              console.error(
+                pc.red(
+                  `No pending review item found for '${id}'. Run 'dosu review list' to see editable items.`,
+                ),
+              );
+              process.exit(1);
+            }
+            throw err;
+          }
         }
 
         if (opts.json) {
@@ -278,7 +351,9 @@ export function reviewCommand(): Command {
   for (const { name, action, verb } of gated) {
     cmd
       .command(name)
-      .description(`${verb} a document version (shows the diff, requires --confirm)`)
+      .description(
+        `${verb} a review item (doc change or draft reply; shows a preview, requires --confirm)`,
+      )
       .argument("<id>", "Review item ID (from `dosu review list`)")
       .option("--confirm", "Apply without the interactive prompt")
       .option("--json", "Output as JSON")
@@ -286,14 +361,21 @@ export function reviewCommand(): Command {
         const cfg = requireConfig();
         const client = createTypedClient(cfg);
 
-        // For the only kind today (doc_change) the opaque id is the page version id.
-        const change = await client.review.getChange.query({ id });
-        if (!opts.json) printChangePreview(change);
+        // Route by kind behind the opaque id: docs resolve via getChange; a draft
+        // message 404s there, so we preview the draft body instead (ENG-524).
+        const change = await resolveChange(client, id);
+        const draft = change ? null : await requireDraft(client, id);
+        const noun = change ? "change" : "draft reply";
+
+        if (!opts.json) {
+          if (change) printChangePreview(change);
+          else printDraftPreview(draft as DraftMessageRow);
+        }
 
         let proceed = opts.confirm === true;
         if (!proceed && !opts.json && process.stdin?.isTTY) {
           const answer = await p.confirm({
-            message: `${verb} this change?`,
+            message: `${verb} this ${noun}?`,
             initialValue: false,
           });
           if (p.isCancel(answer)) {
@@ -305,17 +387,23 @@ export function reviewCommand(): Command {
 
         if (!proceed) {
           if (opts.json) {
-            printResult({ ...change, applied: false, confirmRequired: true }, opts);
+            const preview = change ?? { id, kind: "draft_message" };
+            printResult({ ...preview, applied: false, confirmRequired: true }, opts);
           } else {
             console.log(pc.dim("Aborted. Re-run with --confirm to apply."));
           }
           return;
         }
 
-        await client.page.updatePublicationStatus.mutate({
-          page_version_id: id,
-          action,
-        });
+        if (change) {
+          await client.page.updatePublicationStatus.mutate({ page_version_id: id, action });
+        } else if (action === "accept") {
+          // Publish the draft (latest stored body) to its originating thread.
+          await client.messages.publishMessage.mutate({ postId: id });
+        } else {
+          // Reject = discard the draft reply.
+          await client.messages.deleteMessage.mutate(id);
+        }
 
         if (opts.json) {
           printResult({ success: true, id, action }, opts);
@@ -325,20 +413,34 @@ export function reviewCommand(): Command {
       });
   }
 
-  // revert just re-opens an item for review (non-destructive), so it stays ungated.
+  // revert just re-opens a doc change for review (non-destructive), so it stays
+  // ungated. Drafts have no revert — a rejected draft is regenerated on the next
+  // agent run — so a draft id 404s here and we say so (ENG-524).
   cmd
     .command("revert")
-    .description("Revert to pending review")
+    .description("Revert a doc change to pending review (not supported for draft replies)")
     .argument("<id>", "Review item ID (from `dosu review list`)")
     .option("--json", "Output as JSON")
     .action(async (id: string, opts: { json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      await client.page.updatePublicationStatus.mutate({
-        page_version_id: id,
-        action: "revert_to_pending",
-      });
+      try {
+        await client.page.updatePublicationStatus.mutate({
+          page_version_id: id,
+          action: "revert_to_pending",
+        });
+      } catch (err) {
+        if (isNotFound(err)) {
+          console.error(
+            pc.red(
+              "Revert is not supported for draft replies. A rejected draft is regenerated on the next agent run.",
+            ),
+          );
+          process.exit(1);
+        }
+        throw err;
+      }
 
       if (opts.json) {
         printResult({ success: true, id, action: "revert_to_pending" }, opts);


### PR DESCRIPTION
Fixes [ENG-524](https://linear.app/dosu/issue/ENG-524). Part 2 (dosu-cli) of the ENG-520 review-parity epic. Backend half merged in [dosu-ai/dosu#11378](https://github.com/dosu-ai/dosu/pull/11378).

## What

Surface deployment-wide **draft replies** in `dosu review` and route them through the existing verbs — **dispatched by `kind` behind the opaque id**, with no parallel `messages` command tree (the ENG-520 contract requirement that keeps the eventual `review_item` refactor an internal swap).

| verb | doc_change | draft_message |
|---|---|---|
| `list` | (existing) | render kind/title, fixed `Draft reply`/`draft` labels |
| `diff` | server diff | show the draft body |
| `approve` | `page.updatePublicationStatus(accept)` | `messages.publishMessage({postId})` |
| `reject` | `page.updatePublicationStatus(decline)` | `messages.deleteMessage(id)` |
| `edit` | `page.updateReview` | `messages.saveDraft({messageId, body})` (body only) |
| `revert` | `updatePublicationStatus(revert)` | unsupported → clear message |

## How it dispatches

`review.getChange` **is** the kind discriminator: a `doc_change` id is a page-version (resolves); a `draft_message` id lives in the `message` table, so `getChange` 404s — that 404 routes the verb to the draft path. One mechanism across `diff`/`approve`/`reject`/`edit`; `revert` lets the doc-only mutation 404 and translates it.

- `list` passes `deploymentId: cfg.deployment_id` to merge drafts (omit → docs only, backwards compatible).
- approve/reject keep the confirm-gate, previewing the draft title + body.
- Help text generalized from "document version" → "review item (doc change or draft reply)" (F5).
- Bumps `@dosu/api-types` 0.0.33 → 0.0.36 (kind-discriminated `listPending`).

## Reviewer notes

- The plan said `edit→editMessage`; that procedure doesn't exist. The real one is `messages.saveDraft` (body only, no title), which is what the MCP draft-edit path also calls (`editMessage` bridge). The api-types router key is `messages` (plural).
- Draft preview body comes from `messages.getMessage` (the CREATE head row). If a draft was edited via `saveDraft`, edits land as child rows, so the **preview** body can lag — flagged with a `ponytail:` comment. Publish always uses the server's latest body, so only preview text could be stale. Can add child-row resolution later if that matters.

## Tests

Existing cases updated for the getChange-first resolution; added draft coverage for every verb (list rendering, diff, approve/reject/edit/revert, error propagation). `review.ts` at 100% lines / 95.6% branches; full suite **1396 passing**, global coverage 98.0/93.8/98.4. Typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)