### PR TITLE
fix(review): print full review item IDs in `dosu review list` (#102)

### DIFF
--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -112,7 +112,8 @@ describe("review list", () => {
       knowledgeStoreId: "ks1",
       deploymentId: "dep1",
     });
-    expect(allOutput()).toContain("pv-abcde");
+    // full id must print — verbs (diff/approve/reject/edit) need the whole id (#102)
+    expect(allOutput()).toContain("pv-abcdef12");
     expect(allOutput()).toContain("doc_change");
     expect(allOutput()).toContain("API Guide");
     // origin enum is humanized to match the MCP tool / dashboard

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -169,7 +169,7 @@ export function reviewCommand(): Command {
         items.map((i) =>
           i.kind === "draft_message"
             ? [
-                i.id.slice(0, 8),
+                i.id,
                 i.kind,
                 truncate(i.title || "(untitled)", 40),
                 "Draft reply",
@@ -177,7 +177,7 @@ export function reviewCommand(): Command {
                 formatDate(i.createdAt),
               ]
             : [
-                i.id.slice(0, 8),
+                i.id,
                 i.kind,
                 truncate(i.title ?? "(untitled)", 40),
                 humanizeSource(i.origin, i.version),

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,17 @@ process.on("SIGINT", () => process.exit(0));
 
 execute().catch((err) => {
   console.error(err.message ?? err);
+  // A masked server message (e.g. "[object Object]" from a stringified 422
+  // detail) is useless on its own — surface the tRPC code/path/status if the
+  // error carries them so the failure is at least diagnosable.
+  const data = err?.data;
+  if (data && (data.code || data.path || data.httpStatus)) {
+    const parts = [
+      data.code && `code=${data.code}`,
+      data.path && `path=${data.path}`,
+      data.httpStatus && `status=${data.httpStatus}`,
+    ].filter(Boolean);
+    console.error(parts.join(" "));
+  }
   process.exit(1);
 });


### PR DESCRIPTION
Fixes #102.

## What changed

- **The bug** — `review list` rendered the ID column as `i.id.slice(0, 8)` ([src/commands/review.ts](src/commands/review.ts)). It now prints the full `i.id`.
- **Hardening** — the top-level error handler in [src/index.ts](src/index.ts) printed only `err.message`. It now also surfaces the tRPC `code`/`path`/`status` when present.
- Tightened the list table test to assert the full UUID prints (it previously only checked an 8-char prefix, which truncation also satisfied).

## Why

`review diff|approve|reject|edit` all require the full `page_version_id` UUID. Copy-pasting the 8-char ID that `list` printed always failed: the truncated value isn't a valid UUID, so the Python route returns a 422, which got masked as a bare `[object Object]`. Only `list` worked — the rest of the CLI review track was unusable as documented.

## Notes for reviewer

- The `[object Object]` stringification itself originates in `parseBackendError` in the dosu frontend repo (not this one); per the issue that's tracked separately. The ID truncation here was the actual blocker.
- 57 review tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)