### PR TITLE
[codex] Track CLI install channel in onboarding analytics

### DIFF
--- a/src/setup/analytics.test.ts
+++ b/src/setup/analytics.test.ts
@@ -95,6 +95,7 @@ describe("setup analytics", () => {
       event: "cli_onboarding_completed",
       properties: expect.objectContaining({
         onboarding_run_id: "run-1",
+        install_channel: "npm",
         mode: "oss",
         org_id: "org-1",
         deployment_id: "dep-1",
@@ -145,6 +146,7 @@ describe("setup analytics", () => {
       event: "cli_onboarding_auth_started",
       onboarding_run_id: "run-2",
       properties: expect.objectContaining({
+        install_channel: "npm",
         mode: "cloud",
         source: "setup",
       }),

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -4,7 +4,7 @@ import { type AppRouter, createTypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
 import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
-import { VERSION } from "../version/version";
+import { INSTALL_CHANNEL, VERSION } from "../version/version";
 
 type CliOnboardingEvent =
   | "cli_onboarding_auth_completed"
@@ -104,6 +104,7 @@ export async function trackCliOnboardingPreAuthEvent(
 function baseProperties(cfg: Config): CliOnboardingProperties {
   return {
     cli_version: VERSION,
+    install_channel: INSTALL_CHANNEL,
     platform: process.platform,
     arch: process.arch,
     mode: cfg.mode ?? "cloud",


### PR DESCRIPTION
## Summary

- add the build-time `INSTALL_CHANNEL` value to CLI onboarding analytics base properties
- cover authenticated and pre-auth setup telemetry payloads in focused tests
- support the PostHog install-channel dashboard tiles that now split CLI onboarding by `npm`, `homebrew`, `binary`, or `unknown`

## Testing

- `bunx vitest run src/setup/analytics.test.ts`
- `git diff --check`

## Notes

Opened as a draft for review and testing. Do not merge until the release/test path is confirmed.
