### PR TITLE
fix(review): dispatch draft review items by id prefix (ENG-547)

### DIFF
--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -57,6 +57,17 @@ function notFound() {
   });
 }
 
+// A tRPC UNPROCESSABLE_CONTENT error — what review.getChange surfaces for a
+// malformed (non-UUID) id, since the change-view endpoint types its path param
+// as a UUID and FastAPI 422s before any lookup.
+function unprocessable() {
+  return new TRPCClientError("invalid id", {
+    result: {
+      error: { code: -32600, message: "invalid id", data: { code: "UNPROCESSABLE_CONTENT" } },
+    },
+  });
+}
+
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 }
@@ -282,6 +293,14 @@ describe("review diff", () => {
     mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → unknown doc
 
     await expect(run("diff", "missing")).rejects.toThrow("exit");
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
+  });
+
+  it("prints a clear message for a malformed (non-UUID) id instead of crashing", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockRejectedValueOnce(unprocessable()); // review.getChange → 422, not 404
+
+    await expect(run("diff", "not-a-uuid")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
   });
 

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -48,9 +48,9 @@ const validConfig = {
   deployment_id: "dep1",
 };
 
-// A tRPC NOT_FOUND error, as the client surfaces it. doc_change ids resolve via
-// review.getChange; a draft_message id 404s there — that 404 routes the verb to
-// the draft path.
+// A tRPC NOT_FOUND error, as the client surfaces it. Verbs route by the opaque
+// id's prefix (draft_message:<uuid> → draft, bare uuid → doc_change), so a
+// NOT_FOUND now only signals a genuinely unknown/inaccessible doc-change id.
 function notFound() {
   return new TRPCClientError("not found", {
     result: { error: { code: -32004, message: "not found", data: { code: "NOT_FOUND" } } },
@@ -163,7 +163,9 @@ describe("review list", () => {
   });
 
   const draftItem = {
-    id: "msg-abcdef12",
+    // listPending prefixes draft ids (ENG-547) — the CLI prints them verbatim so
+    // they're copyable straight into the verbs, which strip the prefix.
+    id: "draft_message:msg-abcdef12",
     kind: "draft_message",
     title: "Re: how do I configure X?",
     body: "You can configure X by…",
@@ -182,6 +184,8 @@ describe("review list", () => {
     expect(out).toContain("doc_change");
     expect(out).toContain("draft_message");
     expect(out).toContain("Re: how do I configure X?");
+    // the full prefixed id must print so it can be pasted into approve/reject/edit
+    expect(out).toContain("draft_message:msg-abcdef12");
     // drafts have no origin/version/pendingStatus — they render fixed labels
     expect(out).toContain("Draft reply");
     expect(out).toContain("draft");
@@ -273,22 +277,23 @@ describe("review diff", () => {
     expect(output.diff).toContain("@@");
   });
 
-  it("prints a clear message for an id that is neither a doc change nor a draft", async () => {
+  it("prints a clear message for an unknown bare (doc) id", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → not a doc
-    mockQuery.mockResolvedValueOnce(null); // messages.getMessage → not a draft
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → unknown doc
 
     await expect(run("diff", "missing")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
   });
 
-  it("shows the body for a draft id (getChange 404s → draft path)", async () => {
+  it("shows the body for a prefixed draft id (no getChange probe)", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange
-    mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "the answer" });
+    mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "the answer" }); // getMessage
 
-    await run("diff", "msg-1");
+    await run("diff", "draft_message:msg-1");
 
+    // Prefix routing goes straight to the draft path — getChange is never probed.
+    expect(mockQuery).toHaveBeenCalledWith("messages.getMessage", "msg-1");
+    expect(mockQuery).not.toHaveBeenCalledWith("review.getChange", expect.anything());
     const out = allOutput();
     expect(out).toContain("Re: q");
     expect(out).toContain("Draft reply");
@@ -297,10 +302,9 @@ describe("review diff", () => {
 
   it("passes the draft through with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound());
     mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "the answer" });
 
-    await run("diff", "--json", "msg-1");
+    await run("diff", "--json", "draft_message:msg-1");
 
     const output = JSON.parse(allOutput());
     expect(output.kind).toBe("draft_message");
@@ -308,14 +312,13 @@ describe("review diff", () => {
   });
 });
 
-// resolveChange resolves a doc-change id (any truthy ChangeView) so edit/approve
-// take the doc path; a rejection routes to the draft path.
+// A truthy ChangeView returned by review.getChange, for the approve/reject/revert
+// doc paths that resolve a diff preview before mutating.
 const docChange = { kind: "doc_change" };
 
 describe("review edit", () => {
   it("calls page.updateReview with title and body", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce(docChange); // review.getChange → doc
     mockMutate.mockResolvedValueOnce(undefined);
 
     await run("edit", "pv-abcdef12", "--title", "New Title", "--body", "# Body");
@@ -330,7 +333,6 @@ describe("review edit", () => {
 
   it("reads body from --body-file", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce(docChange);
     mockMutate.mockResolvedValueOnce(undefined);
     const dir = mkdtempSync(join(tmpdir(), "dosu-review-test-"));
     const file = join(dir, "body.md");
@@ -347,36 +349,36 @@ describe("review edit", () => {
     }
   });
 
-  it("saves a new draft revision for a draft id (body only)", async () => {
+  it("strips the prefix and saves a new draft revision for a draft id (body only)", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → draft
     mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "old" }); // getMessage
     mockMutate.mockResolvedValueOnce(undefined);
 
-    await run("edit", "msg-1", "--body", "new body");
+    await run("edit", "draft_message:msg-1", "--body", "new body");
 
+    // saveDraft gets the BARE message id — the draft_message: prefix is stripped.
     expect(mockMutate).toHaveBeenCalledWith("messages.saveDraft", {
       messageId: "msg-1",
       body: "new body",
     });
-    expect(allOutput()).toContain("Review edited: msg-1");
+    expect(allOutput()).toContain("Review edited: draft_me");
   });
 
   it("rejects --title for a draft id (saveDraft is body-only)", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → draft
 
-    await expect(run("edit", "msg-1", "--title", "T", "--body", "b")).rejects.toThrow("exit");
+    await expect(run("edit", "draft_message:msg-1", "--title", "T", "--body", "b")).rejects.toThrow(
+      "exit",
+    );
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("--body only");
     expect(mockMutate).not.toHaveBeenCalled();
   });
 
   it("prints a clear message for an unknown draft id", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → not a doc
     mockQuery.mockResolvedValueOnce(null); // getMessage → not a draft
 
-    await expect(run("edit", "missing", "--body", "b")).rejects.toThrow("exit");
+    await expect(run("edit", "draft_message:missing", "--body", "b")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
     expect(mockMutate).not.toHaveBeenCalled();
   });
@@ -409,9 +411,8 @@ describe("review edit", () => {
     expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  it("prints a clear message for a doc that left review between resolve and update", async () => {
+  it("prints a clear message for a doc that left review before update", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce(docChange); // review.getChange → doc
     mockMutate.mockRejectedValueOnce(notFound()); // page.updateReview → no longer pending
 
     await expect(run("edit", "pv-missing", "--title", "T")).rejects.toThrow("exit");
@@ -420,7 +421,6 @@ describe("review edit", () => {
 
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce(docChange);
     mockMutate.mockResolvedValueOnce(undefined);
 
     await run("edit", "--json", "pv-abcdef12", "--title", "T");
@@ -604,39 +604,39 @@ describe("review reject", () => {
 describe("review approve/reject (draft messages)", () => {
   const draftRow = { id: "msg-1", title: "Re: how do I configure X?", body: "Configure it like…" };
 
-  it("previews the draft and publishes it on approve --confirm", async () => {
+  it("strips the prefix and publishes on approve --confirm", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → draft
     mockQuery.mockResolvedValueOnce(draftRow); // messages.getMessage
     mockMutate.mockResolvedValueOnce(undefined);
 
-    await run("approve", "--confirm", "msg-1");
+    await run("approve", "--confirm", "draft_message:msg-1");
 
     const out = allOutput();
     expect(out).toContain("Re: how do I configure X?"); // preview shown
     expect(out).toContain("Configure it like…");
+    // publishMessage gets the BARE id, and getChange is never probed for a draft.
+    expect(mockQuery).not.toHaveBeenCalledWith("review.getChange", expect.anything());
+    expect(mockQuery).toHaveBeenCalledWith("messages.getMessage", "msg-1");
     expect(mockMutate).toHaveBeenCalledWith("messages.publishMessage", { postId: "msg-1" });
-    expect(out).toContain("Review approve: msg-1");
+    expect(out).toContain("Review approve: draft_me");
   });
 
-  it("discards the draft on reject --confirm", async () => {
+  it("strips the prefix and discards the draft on reject --confirm", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound());
     mockQuery.mockResolvedValueOnce(draftRow);
     mockMutate.mockResolvedValueOnce(undefined);
 
-    await run("reject", "--confirm", "msg-1");
+    await run("reject", "--confirm", "draft_message:msg-1");
 
     expect(mockMutate).toHaveBeenCalledWith("messages.deleteMessage", "msg-1");
-    expect(allOutput()).toContain("Review reject: msg-1");
+    expect(allOutput()).toContain("Review reject: draft_me");
   });
 
   it("returns a draft confirmRequired payload as JSON without --confirm", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound());
     mockQuery.mockResolvedValueOnce(draftRow);
 
-    await run("approve", "--json", "msg-1");
+    await run("approve", "--json", "draft_message:msg-1");
 
     const output = JSON.parse(allOutput());
     expect(output.kind).toBe("draft_message");
@@ -649,10 +649,9 @@ describe("review approve/reject (draft messages)", () => {
 
   it("exits with a clear message when the draft id resolves to nothing", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound());
     mockQuery.mockResolvedValueOnce(null); // messages.getMessage → missing
 
-    await expect(run("approve", "--confirm", "missing")).rejects.toThrow("exit");
+    await expect(run("approve", "--confirm", "draft_message:missing")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
     expect(mockMutate).not.toHaveBeenCalled();
   });
@@ -760,20 +759,18 @@ describe("review revert", () => {
     expect(output.action).toBe("revert_to_pending");
   });
 
-  it("rejects revert for a draft id (resolveChange 404s → draft path)", async () => {
+  it("rejects revert for a prefixed draft id", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → draft
     mockQuery.mockResolvedValueOnce({ id: "msg-1" }); // messages.getMessage exists
 
-    await expect(run("revert", "msg-1")).rejects.toThrow("exit");
+    await expect(run("revert", "draft_message:msg-1")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("not supported for draft replies");
     expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  it("exits with a clear message for an id that is neither a doc change nor a draft", async () => {
+  it("exits with a clear message for an unknown bare (doc) id", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → not a doc
-    mockQuery.mockResolvedValueOnce(null); // messages.getMessage → not a draft
+    mockQuery.mockRejectedValueOnce(notFound()); // review.getChange → unknown doc
 
     await expect(run("revert", "missing")).rejects.toThrow("exit");
     expect(errorSpy.mock.calls.flat().join(" ")).toContain("No review item found");
@@ -801,7 +798,6 @@ describe("review error propagation", () => {
 
   it("rethrows a non-NOT_FOUND error from page.updateReview", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce(docChange); // review.getChange → doc
     mockMutate.mockRejectedValueOnce(new Error("boom"));
 
     await expect(run("edit", "pv-1", "--body", "x")).rejects.toThrow("boom");

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -361,7 +361,8 @@ describe("review edit", () => {
       messageId: "msg-1",
       body: "new body",
     });
-    expect(allOutput()).toContain("Review edited: draft_me");
+    // confirmation shows the bare message id, not the shared draft_message: prefix
+    expect(allOutput()).toContain("Review edited: msg-1");
   });
 
   it("rejects --title for a draft id (saveDraft is body-only)", async () => {
@@ -618,7 +619,7 @@ describe("review approve/reject (draft messages)", () => {
     expect(mockQuery).not.toHaveBeenCalledWith("review.getChange", expect.anything());
     expect(mockQuery).toHaveBeenCalledWith("messages.getMessage", "msg-1");
     expect(mockMutate).toHaveBeenCalledWith("messages.publishMessage", { postId: "msg-1" });
-    expect(out).toContain("Review approve: draft_me");
+    expect(out).toContain("Review approve: msg-1");
   });
 
   it("strips the prefix and discards the draft on reject --confirm", async () => {
@@ -629,7 +630,7 @@ describe("review approve/reject (draft messages)", () => {
     await run("reject", "--confirm", "draft_message:msg-1");
 
     expect(mockMutate).toHaveBeenCalledWith("messages.deleteMessage", "msg-1");
-    expect(allOutput()).toContain("Review reject: draft_me");
+    expect(allOutput()).toContain("Review reject: msg-1");
   });
 
   it("returns a draft confirmRequired payload as JSON without --confirm", async () => {

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -26,6 +26,17 @@ function isNotFound(err: unknown): boolean {
   return isTRPCClientError(err) && (err.data as { code?: string } | null)?.code === "NOT_FOUND";
 }
 
+// The change-view endpoint types its id as a UUID, so a malformed/non-UUID id
+// (a typo, or a mangled draft prefix) fails FastAPI validation with 422 → tRPC
+// UNPROCESSABLE_CONTENT rather than 404. Treat it like NOT_FOUND so a bad id reads
+// as a clean "no such review item" instead of an uncaught crash.
+function isInvalidId(err: unknown): boolean {
+  return (
+    isTRPCClientError(err) &&
+    (err.data as { code?: string } | null)?.code === "UNPROCESSABLE_CONTENT"
+  );
+}
+
 // Prefix on draft-message review-item ids from `review.listPending` (ENG-547,
 // dosu-ai/dosu#11451). Mirror of DRAFT_MESSAGE_ID_PREFIX in dosu's
 // frontend/packages/api/src/routers/review.ts and DRAFT_MESSAGE_PREFIX in
@@ -57,12 +68,13 @@ function truncateId(id: string): string {
 }
 
 // Fetch the doc-change view for a bare page-version id, or exit with a clear
-// message if it's unknown/inaccessible (getChange 404s). Non-404s propagate.
+// message if it's unknown (404), inaccessible, or a malformed id (422). Other
+// errors propagate.
 async function requireChange(client: TypedClient, id: string): Promise<ChangeView> {
   try {
     return await client.review.getChange.query({ id });
   } catch (err) {
-    if (isNotFound(err)) {
+    if (isNotFound(err) || isInvalidId(err)) {
       console.error(
         pc.red(`No review item found for '${id}'. Run 'dosu review list' to see pending items.`),
       );

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -26,22 +26,51 @@ function isNotFound(err: unknown): boolean {
   return isTRPCClientError(err) && (err.data as { code?: string } | null)?.code === "NOT_FOUND";
 }
 
-// Resolve the kind behind an opaque review-item id (ENG-524). doc_change items are
-// page versions (resolved by review.getChange); a draft_message id lives in the
-// message table, so getChange 404s — that 404 is how the verbs route by kind
-// without a separate flag. Returns the ChangeView for docs, null for drafts.
-async function resolveChange(client: TypedClient, id: string): Promise<ChangeView | null> {
+// Prefix on draft-message review-item ids from `review.listPending` (ENG-547,
+// dosu-ai/dosu#11451). Mirror of DRAFT_MESSAGE_ID_PREFIX in dosu's
+// frontend/packages/api/src/routers/review.ts and DRAFT_MESSAGE_PREFIX in
+// backend/public_api/mcp/tools/review.py — keep all three in sync. Prefixing makes
+// the opaque id identical across MCP and tRPC/CLI so the same token is portable.
+const DRAFT_MESSAGE_ID_PREFIX = "draft_message:";
+
+// Route an opaque review-item id to its kind, mirroring the MCP tool's
+// `_parse_item_id`: a prefixed id is a draft_message, a bare id is a doc_change
+// page-version UUID. We dispatch on the prefix rather than probing review.getChange
+// (the old ENG-524 approach) because the change-view endpoint types its id as a UUID
+// and now 422s — not 404s — on a prefixed id, so a 404-probe can no longer route drafts.
+function isDraftId(id: string): boolean {
+  return id.startsWith(DRAFT_MESSAGE_ID_PREFIX);
+}
+
+// Strip the draft prefix to recover the bare message UUID the `messages.*`
+// procedures expect (they're otherwise called by the web with bare, web-controlled
+// ids). Only called on ids already confirmed as drafts by isDraftId, so the prefix
+// is always present.
+function bareMessageId(id: string): string {
+  return id.slice(DRAFT_MESSAGE_ID_PREFIX.length);
+}
+
+// Fetch the doc-change view for a bare page-version id, or exit with a clear
+// message if it's unknown/inaccessible (getChange 404s). Non-404s propagate.
+async function requireChange(client: TypedClient, id: string): Promise<ChangeView> {
   try {
     return await client.review.getChange.query({ id });
   } catch (err) {
-    if (isNotFound(err)) return null;
+    if (isNotFound(err)) {
+      console.error(
+        pc.red(`No review item found for '${id}'. Run 'dosu review list' to see pending items.`),
+      );
+      process.exit(1);
+    }
     throw err;
   }
 }
 
 // Fetch the message row behind a draft id, or exit with a clear message if missing.
+// `messages.getMessage` wants the bare UUID, so strip the prefix for the lookup while
+// still echoing the id the user passed in any error.
 async function requireDraft(client: TypedClient, id: string): Promise<DraftMessageRow> {
-  const draft = await client.messages.getMessage.query(id);
+  const draft = await client.messages.getMessage.query(bareMessageId(id));
   if (!draft) {
     console.error(
       pc.red(`No review item found for '${id}'. Run 'dosu review list' to see pending items.`),
@@ -198,9 +227,8 @@ export function reviewCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      // A draft_message id 404s on getChange → render its body instead of a diff.
-      const change = await resolveChange(client, id);
-      if (!change) {
+      // Route by the opaque id's prefix: a draft renders its body, a doc renders a diff.
+      if (isDraftId(id)) {
         const draft = await requireDraft(client, id);
         if (opts.json) {
           printResult({ id, kind: "draft_message", title: draft.title, body: draft.body }, opts);
@@ -213,6 +241,7 @@ export function reviewCommand(): Command {
         return;
       }
 
+      const change = await requireChange(client, id);
       if (opts.json) {
         printResult(change, opts);
         return;
@@ -269,9 +298,8 @@ export function reviewCommand(): Command {
           process.exit(1);
         }
 
-        // A draft_message id 404s on getChange → route to saveDraft (body only).
-        const change = await resolveChange(client, id);
-        if (!change) {
+        // Route by prefix: a draft saves a new revision (body only), a doc edits in place.
+        if (isDraftId(id)) {
           // saveDraft takes body only; --title is doc-only. (Past the generic
           // "nothing to edit" check above, body is guaranteed set when title isn't.)
           if (opts.title !== undefined) {
@@ -279,7 +307,10 @@ export function reviewCommand(): Command {
             process.exit(1);
           }
           await requireDraft(client, id);
-          await client.messages.saveDraft.mutate({ messageId: id, body: body as string });
+          await client.messages.saveDraft.mutate({
+            messageId: bareMessageId(id),
+            body: body as string,
+          });
         } else {
           try {
             await client.page.updateReview.mutate({
@@ -361,9 +392,9 @@ export function reviewCommand(): Command {
         const cfg = requireConfig();
         const client = createTypedClient(cfg);
 
-        // Route by kind behind the opaque id: docs resolve via getChange; a draft
-        // message 404s there, so we preview the draft body instead (ENG-524).
-        const change = await resolveChange(client, id);
+        // Route by the opaque id's prefix: a doc resolves its diff via getChange;
+        // a draft previews its stored body instead (ENG-524 / ENG-547).
+        const change = isDraftId(id) ? null : await requireChange(client, id);
         const draft = change ? null : await requireDraft(client, id);
         const noun = change ? "change" : "draft reply";
 
@@ -404,10 +435,10 @@ export function reviewCommand(): Command {
           await client.page.updatePublicationStatus.mutate({ page_version_id: id, action });
         } else if (action === "accept") {
           // Publish the draft (latest stored body) to its originating thread.
-          await client.messages.publishMessage.mutate({ postId: id });
+          await client.messages.publishMessage.mutate({ postId: bareMessageId(id) });
         } else {
           // Reject = discard the draft reply.
-          await client.messages.deleteMessage.mutate(id);
+          await client.messages.deleteMessage.mutate(bareMessageId(id));
         }
 
         if (opts.json) {
@@ -420,7 +451,7 @@ export function reviewCommand(): Command {
 
   // revert just re-opens a doc change for review (non-destructive), so it stays
   // ungated. Drafts have no revert — a rejected draft is regenerated on the next
-  // agent run — so a draft id 404s here and we say so (ENG-524).
+  // agent run — so a draft-prefixed id is refused here (ENG-524).
   cmd
     .command("revert")
     .description("Revert a doc change to pending review (not supported for draft replies)")
@@ -430,11 +461,10 @@ export function reviewCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      // Resolve kind like the other verbs rather than catching the mutation's 404:
-      // a draft id 404s on getChange, and requireDraft turns a truly-unknown id into
-      // a clean "no review item" error instead of a misleading "not supported" one.
-      const change = await resolveChange(client, id);
-      if (!change) {
+      // Route by prefix: drafts have no revert. requireDraft turns a truly-unknown
+      // id into a clean "no review item" error instead of a misleading "not
+      // supported" one; requireChange does the same for an unknown doc id.
+      if (isDraftId(id)) {
         await requireDraft(client, id);
         console.error(
           pc.red(
@@ -443,6 +473,7 @@ export function reviewCommand(): Command {
         );
         process.exit(1);
       }
+      await requireChange(client, id);
 
       await client.page.updatePublicationStatus.mutate({
         page_version_id: id,

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -50,6 +50,12 @@ function bareMessageId(id: string): string {
   return id.slice(DRAFT_MESSAGE_ID_PREFIX.length);
 }
 
+// Short id for confirmation messages — strip the draft prefix first so a draft
+// shows its message id (`msg-1`), not the shared prefix (`draft_me`).
+function truncateId(id: string): string {
+  return (isDraftId(id) ? bareMessageId(id) : id).slice(0, 8);
+}
+
 // Fetch the doc-change view for a bare page-version id, or exit with a clear
 // message if it's unknown/inaccessible (getChange 404s). Non-404s propagate.
 async function requireChange(client: TypedClient, id: string): Promise<ChangeView> {
@@ -335,7 +341,7 @@ export function reviewCommand(): Command {
           printResult({ success: true, id }, opts);
           return;
         }
-        console.log(pc.green(`Review edited: ${id.slice(0, 8)}`));
+        console.log(pc.green(`Review edited: ${truncateId(id)}`));
       },
     );
 
@@ -445,7 +451,7 @@ export function reviewCommand(): Command {
           printResult({ success: true, id, action }, opts);
           return;
         }
-        console.log(pc.green(`Review ${name}: ${id.slice(0, 8)}`));
+        console.log(pc.green(`Review ${name}: ${truncateId(id)}`));
       });
   }
 
@@ -484,7 +490,7 @@ export function reviewCommand(): Command {
         printResult({ success: true, id, action: "revert_to_pending" }, opts);
         return;
       }
-      console.log(pc.green(`Review revert: ${id.slice(0, 8)}`));
+      console.log(pc.green(`Review revert: ${truncateId(id)}`));
     });
 
   return cmd;


### PR DESCRIPTION
Follow-on to **dosu-ai/dosu#11451** ([ENG-547](https://linear.app/dosu/issue/ENG-547)) in the backend/tRPC repo.

### Background

dosu#11451 reconciled the kind-discriminated review contract so `review.listPending` now emits draft-message ids **prefixed** as `draft_message:<uuid>` (matching the MCP tool), instead of bare message uuids. That PR's own follow-on note flags this repo:

> **Follow-on (dosu-cli repo):** the CLI must strip `DRAFT_MESSAGE_ID_PREFIX` before calling the draft `message.*` procedures, since `listPending` draft ids are now prefixed.

### The actual problem is bigger than "strip the prefix"

The CLI verbs (`diff`, `edit`, `approve`, `reject`, `revert`) routed **draft vs. doc** by *probing* `review.getChange` and treating a `NOT_FOUND` (404) as "this is a draft". That worked only because a bare draft uuid is a *valid* UUID that the change-view lookup 404s on.

A prefixed `draft_message:<uuid>` id is **not** a valid UUID, and the change-view endpoint types its path param as `UUID` (`backend/public_api/pages/router.py`), so it now returns **422**, not 404. `isNotFound` doesn't match a 422 → the probe rethrows → **every draft verb crashes** once the backend change ships.

### Fix

Dispatch on the prefix, mirroring the MCP tool's `_parse_item_id`, and strip it before the `messages.*` calls (which want the bare uuid — they're otherwise called by the web with bare, web-controlled ids):

- `isDraftId(id)` decides the kind up front (no getChange probe for drafts — also saves a doomed round-trip + a backend 422).
- `bareMessageId(id)` feeds `publishMessage` / `deleteMessage` / `saveDraft` / `getMessage`.
- `doc_change` ids stay bare page-version UUIDs; the doc path still resolves the diff via `getChange` and now surfaces a clean "No review item found" on an unknown id.
- New `DRAFT_MESSAGE_ID_PREFIX` constant mirrors the TS `DRAFT_MESSAGE_ID_PREFIX` (dosu review.ts) and Python `DRAFT_MESSAGE_PREFIX`, with a keep-in-sync comment.

No `@dosu/api-types` bump needed — `listPending`'s type shape is unchanged (`id` is still `string`); only the value gained a prefix.

### Testing

- `bun run test` — 1471 pass; `review.ts` coverage 100% stmts / 95.7% branch / 100% funcs+lines.
- `bun run typecheck`, `bun run check` — clean.
- Draft-routing tests updated to pass prefixed ids and assert the **bare** id reaches the `messages.*` procedures + that `getChange` is never probed for a draft.

> ⚠️ Depends on dosu#11451 being deployed. Until then `listPending` returns bare draft ids, which this routes as `doc_change` → a clean "not found" (the two are meant to ship together per ENG-547).

🤖 Generated with [Claude Code](https://claude.com/claude-code)