### PR TITLE
chore: sync vendored CLI contract (8d9ba113842a)

### DIFF
--- a/src/client/contract.ts
+++ b/src/client/contract.ts
@@ -1,2 +1,2 @@
 export const CLI_CONTRACT_HASH: typeof import("../generated/dosu-api-types").CLI_CONTRACT_HASH =
-  "140d68a8c401";
+  "8d9ba113842a";

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -243,7 +243,7 @@ export function reviewCommand(): Command {
       // Docs are knowledge-store-scoped; drafts are deployment-scoped. Passing
       // deploymentId merges draft replies into the list (ENG-524) — omit it and
       // the server returns doc changes only.
-      const items = await client.review.listPending.query({
+      const items: ReviewListItem[] = await client.review.listPending.query({
         knowledgeStoreId: ksId,
         deploymentId: cfg.deployment_id,
       });

--- a/src/generated/dosu-api-types.d.ts
+++ b/src/generated/dosu-api-types.d.ts
@@ -20,9 +20,16 @@
 // - invitations.invite
 // - invitations.rejectInvitation
 // - knowledgeStore.getBySpaceId
+// - messages.deleteMessage
+// - messages.getMessage
 // - messages.list
+// - messages.publishMessage
+// - messages.saveDraft
 // - nango.getConnection
+// - page.updateReview
+// - review.getChange
 // - review.getThreadContext
+// - review.listPending
 // - search.getMentions
 // - slackChannel.getAll
 // - slackChannel.join
@@ -283,7 +290,7 @@ export type CliProviderSlug =
 	| 'teams'
 	| 'azure_devops'
 
-export declare const CLI_CONTRACT_HASH: '140d68a8c401'
+export declare const CLI_CONTRACT_HASH: '8d9ba113842a'
 
 export type AnalyticsGetUsageStatsInput = {
 	days?: number
@@ -535,6 +542,14 @@ export type KnowledgeStoreGetBySpaceIdInput = {
 
 export type KnowledgeStoreGetBySpaceIdOutput = any
 
+export type MessagesDeleteMessageInput = string
+
+export type MessagesDeleteMessageOutput = any
+
+export type MessagesGetMessageInput = string
+
+export type MessagesGetMessageOutput = any
+
 export type MessagesListInput = {
 	cursor?: number
 	expand_body_tree?: boolean
@@ -544,6 +559,20 @@ export type MessagesListInput = {
 }
 
 export type MessagesListOutput = any
+
+export type MessagesPublishMessageInput = {
+	body?: string
+	postId: string
+}
+
+export type MessagesPublishMessageOutput = any
+
+export type MessagesSaveDraftInput = {
+	body: string
+	messageId: string
+}
+
+export type MessagesSaveDraftOutput = any
 
 export type NangoGetConnectionInput = {
 	orgId: string
@@ -830,11 +859,32 @@ export type PageUpdatePublicationStatusOutput = {
 	page_version_id: string
 }
 
+export type PageUpdateReviewInput = {
+	body?: string
+	page_version_id: string
+	title?: string
+}
+
+export type PageUpdateReviewOutput = any
+
+export type ReviewGetChangeInput = {
+	id: string
+}
+
+export type ReviewGetChangeOutput = any
+
 export type ReviewGetThreadContextInput = {
 	thread_id: string
 }
 
 export type ReviewGetThreadContextOutput = any
+
+export type ReviewListPendingInput = {
+	deploymentId?: string
+	knowledgeStoreId: string
+}
+
+export type ReviewListPendingOutput = any
 
 export type SearchGetMentionsInput = {
 	dataSourceIds: Array<string>
@@ -1147,7 +1197,11 @@ export interface CliApiClient {
 		getBySpaceId: QueryProcedure<KnowledgeStoreGetBySpaceIdInput, KnowledgeStoreGetBySpaceIdOutput>
 	}
 	messages: {
+		deleteMessage: MutationProcedure<MessagesDeleteMessageInput, MessagesDeleteMessageOutput>
+		getMessage: QueryProcedure<MessagesGetMessageInput, MessagesGetMessageOutput>
 		list: QueryProcedure<MessagesListInput, MessagesListOutput>
+		publishMessage: MutationProcedure<MessagesPublishMessageInput, MessagesPublishMessageOutput>
+		saveDraft: MutationProcedure<MessagesSaveDraftInput, MessagesSaveDraftOutput>
 	}
 	nango: {
 		getConnection: QueryProcedure<NangoGetConnectionInput, NangoGetConnectionOutput>
@@ -1176,9 +1230,12 @@ export interface CliApiClient {
 			PageUpdatePublicationStatusInput,
 			PageUpdatePublicationStatusOutput
 		>
+		updateReview: MutationProcedure<PageUpdateReviewInput, PageUpdateReviewOutput>
 	}
 	review: {
+		getChange: QueryProcedure<ReviewGetChangeInput, ReviewGetChangeOutput>
 		getThreadContext: QueryProcedure<ReviewGetThreadContextInput, ReviewGetThreadContextOutput>
+		listPending: QueryProcedure<ReviewListPendingInput, ReviewListPendingOutput>
 	}
 	search: {
 		getMentions: QueryProcedure<SearchGetMentionsInput, SearchGetMentionsOutput>


### PR DESCRIPTION
Automated sync of the vendored CLI contract from dosu-ai/dosu@5143115d3c4f2c7cebee6794a1c937edef1585a9 (contract hash `8d9ba113842a`).

- `src/generated/dosu-api-types.d.ts` — full copy of `frontend/packages/api/generated/cli-contract.d.ts`
- `src/client/contract.ts` — pinned `CLI_CONTRACT_HASH` updated to match

**Green CI** on this PR means the contract change is compatible with current CLI code — safe to merge.
**Red typecheck** means the CLI needs adapting before this can land.