### PR TITLE
chore: sync vendored CLI contract (888669da10bd)

### DIFF
--- a/src/client/contract.ts
+++ b/src/client/contract.ts
@@ -1,2 +1,2 @@
 export const CLI_CONTRACT_HASH: typeof import("../generated/dosu-api-types").CLI_CONTRACT_HASH =
-  "8d9ba113842a";
+  "888669da10bd";

--- a/src/generated/dosu-api-types.d.ts
+++ b/src/generated/dosu-api-types.d.ts
@@ -41,7 +41,6 @@
 // - thread.list
 // - topic.getPagesByTopicId
 // - topic.listTopicsByKnowledgeStore
-// - topic.removeFromPage
 // - user.getCliOnboardingContext
 // - user.trackCliOnboardingEvent
 // - user.trackCliOnboardingPreAuthEvent
@@ -290,7 +289,7 @@ export type CliProviderSlug =
 	| 'teams'
 	| 'azure_devops'
 
-export declare const CLI_CONTRACT_HASH: '8d9ba113842a'
+export declare const CLI_CONTRACT_HASH: '888669da10bd'
 
 export type AnalyticsGetUsageStatsInput = {
 	days?: number
@@ -617,6 +616,7 @@ export type OrganizationGetOrganizationsOutput = Array<{
 	customer_id: string | null
 	name: string
 	org_id: string
+	pro_trial_ends_at: string | null
 	user_id: string
 	user_role: 'OWNER' | 'ADMIN' | 'MEMBER'
 }>
@@ -985,13 +985,6 @@ export type TopicListTopicsByKnowledgeStoreInput = {
 
 export type TopicListTopicsByKnowledgeStoreOutput = any
 
-export type TopicRemoveFromPageInput = {
-	page_id: string
-	topic_id: string
-}
-
-export type TopicRemoveFromPageOutput = any
-
 export type UserGetCliOnboardingContextInput = undefined
 
 export type UserGetCliOnboardingContextOutput = any
@@ -1263,7 +1256,6 @@ export interface CliApiClient {
 			TopicListTopicsByKnowledgeStoreInput,
 			TopicListTopicsByKnowledgeStoreOutput
 		>
-		removeFromPage: MutationProcedure<TopicRemoveFromPageInput, TopicRemoveFromPageOutput>
 	}
 	user: {
 		getCliOnboardingContext: QueryProcedure<undefined, UserGetCliOnboardingContextOutput>


### PR DESCRIPTION
Automated sync of the vendored CLI contract from dosu-ai/dosu@ce9432519e51f5a7cb74de41bc51cee40621964c (contract hash `888669da10bd`).

- `src/generated/dosu-api-types.d.ts` — full copy of `frontend/packages/api/generated/cli-contract.d.ts`
- `src/client/contract.ts` — pinned `CLI_CONTRACT_HASH` updated to match

**Green CI** on this PR means the contract change is compatible with current CLI code — safe to merge.
**Red typecheck** means the CLI needs adapting before this can land.