### PR TITLE
chore: sync vendored CLI contract (f5c0727a7884)

### DIFF
--- a/src/client/contract.ts
+++ b/src/client/contract.ts
@@ -1,2 +1,2 @@
 export const CLI_CONTRACT_HASH: typeof import("../generated/dosu-api-types").CLI_CONTRACT_HASH =
-  "888669da10bd";
+  "f5c0727a7884";

--- a/src/generated/dosu-api-types.d.ts
+++ b/src/generated/dosu-api-types.d.ts
@@ -289,7 +289,7 @@ export type CliProviderSlug =
 	| 'teams'
 	| 'azure_devops'
 
-export declare const CLI_CONTRACT_HASH: '888669da10bd'
+export declare const CLI_CONTRACT_HASH: 'f5c0727a7884'
 
 export type AnalyticsGetUsageStatsInput = {
 	days?: number
@@ -626,7 +626,7 @@ export type PageCreateInput = {
 	id?: string
 	knowledge_store_id: string
 	page_type?: 'document' | 'answer' | 'changelog' | 'template' | 'topic'
-	pending_status?: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED'
+	pending_status?: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'PENDING_MERGE' | 'DECLINED'
 	published?: boolean
 	title?: string
 }
@@ -685,7 +685,7 @@ export type PageGetOutput = {
 	md5_hash: string
 	origin: 'manual_update' | 'llm_generated' | 'sync_upstream' | 'api_update'
 	page_version_id: string
-	pending_status: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED' | null
+	pending_status: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED' | 'PENDING_MERGE' | null
 	published: boolean
 	resolved_relative_links?: Record<string, string>
 	restored_from: number | null
@@ -723,7 +723,7 @@ export type PageListVersionsOutput = Array<{
 		sync_provider: 'github' | 'coda' | 'confluence' | 'notion' | 'gitlab' | 'azure_devops' | null
 		synced_from_document_source_id: string | null
 	} | null
-	pending_status: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED' | null
+	pending_status: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED' | 'PENDING_MERGE' | null
 	published: boolean
 	restored_from: number | null
 	title: string
@@ -764,7 +764,7 @@ export type PageListWithTagsOutput = {
 		md5_hash: string
 		origin: 'manual_update' | 'llm_generated' | 'sync_upstream' | 'api_update'
 		page_version_id: string
-		pending_status: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED' | null
+		pending_status: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED' | 'PENDING_MERGE' | null
 		published: boolean
 		repository_slug?: string
 		resolved_relative_links?: Record<string, string>
@@ -816,7 +816,7 @@ export type PageRestoreVersionOutput = {
 	id: string
 	origin: 'manual_update' | 'llm_generated' | 'sync_upstream' | 'api_update'
 	page_id: string
-	pending_status: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED' | null
+	pending_status: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED' | 'PENDING_MERGE' | null
 	published: boolean
 	restored_from: number | null
 	reviewed_at: string | null
@@ -842,7 +842,7 @@ export type PageUpdateInput = {
 	body?: string
 	id: string
 	knowledge_store_id: string
-	pending_status?: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'DECLINED'
+	pending_status?: 'PENDING_REVIEW' | 'PENDING_SYNC' | 'PENDING_MERGE' | 'DECLINED'
 	published?: boolean
 	title?: string
 	version?: number


### PR DESCRIPTION
Automated sync of the vendored CLI contract from dosu-ai/dosu@3273ad9de87a7d4f71ba5565f183bb944a2846d4 (contract hash `f5c0727a7884`).

- `src/generated/dosu-api-types.d.ts` — full copy of `frontend/packages/api/generated/cli-contract.d.ts`
- `src/client/contract.ts` — pinned `CLI_CONTRACT_HASH` updated to match

**Green CI** on this PR means the contract change is compatible with current CLI code — safe to merge.
**Red typecheck** means the CLI needs adapting before this can land.