### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,11 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+run_mode = "nonconcurrent"
+setup = "$CONDUCTOR_ROOT_PATH/conductor-setup.sh"
+
+[tasks.Run]
+available_in = "local"
+command = "$CONDUCTOR_WORKSPACE_PATH/conductor-run.sh"
+default = true
+icon = "play"

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,0 @@
-{
-  "scripts": {
-    "setup": "$CONDUCTOR_ROOT_PATH/conductor-setup.sh",
-    "run": "$CONDUCTOR_WORKSPACE_PATH/conductor-run.sh"
-  },
-  "runScriptMode": "nonconcurrent"
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.