### PR TITLE
feat(integrations): report Azure DevOps connection status

### DIFF
--- a/src/commands/integrations.test.ts
+++ b/src/commands/integrations.test.ts
@@ -158,16 +158,16 @@ describe("integrations status", () => {
 });
 
 describe("integrations status azure_devops", () => {
-  it("reports connected via PAT and short-circuits before the OAuth probe", async () => {
+  it("reports connected via OAuth (primary) and short-circuits before the PAT probe", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({ id: "ado-pat" });
+    mockQuery.mockResolvedValueOnce({ id: "ado-oauth" });
 
     await run("status", "azure_devops");
 
     expect(mockQuery).toHaveBeenCalledTimes(1);
     expect(mockQuery.mock.calls[0][1]).toMatchObject({
-      provider: "azure_devops",
-      providerConfigKey: "azure-devops",
+      provider: "microsoft-entra-id",
+      providerConfigKey: "microsoft-entra-id",
     });
     const output = allOutput();
     expect(output).toContain("connected");
@@ -175,18 +175,18 @@ describe("integrations status azure_devops", () => {
     expect(output).not.toContain("not connected");
   });
 
-  it("falls back to the OAuth probe when PAT is not connected", async () => {
+  it("falls back to the PAT probe when OAuth is not connected", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery
-      .mockResolvedValueOnce(null) // PAT - not connected
-      .mockResolvedValueOnce({ id: "ado-oauth" }); // OAuth - connected
+      .mockResolvedValueOnce(null) // OAuth - not connected
+      .mockResolvedValueOnce({ id: "ado-pat" }); // PAT - connected
 
     await run("status", "azure_devops");
 
     expect(mockQuery).toHaveBeenCalledTimes(2);
     expect(mockQuery.mock.calls[1][1]).toMatchObject({
-      provider: "microsoft-entra-id",
-      providerConfigKey: "microsoft-entra-id",
+      provider: "azure_devops",
+      providerConfigKey: "azure-devops",
     });
     const output = allOutput();
     expect(output).toContain("connected");
@@ -206,8 +206,8 @@ describe("integrations status azure_devops", () => {
   it("continues past a probe that throws", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery
-      .mockRejectedValueOnce(new Error("boom")) // PAT throws
-      .mockResolvedValueOnce({ id: "ado-oauth" }); // OAuth - connected
+      .mockRejectedValueOnce(new Error("boom")) // OAuth throws
+      .mockResolvedValueOnce({ id: "ado-pat" }); // PAT - connected
 
     await run("status", "azure_devops");
 

--- a/src/commands/integrations.test.ts
+++ b/src/commands/integrations.test.ts
@@ -65,16 +65,18 @@ afterEach(() => {
 });
 
 describe("integrations list", () => {
+  // `list` probes platforms in parallel, so the mock keys off the query input
+  // (providerConfigKey) rather than a fixed call order.
+  function mockConnectedKeys(...connectedKeys: string[]) {
+    const set = new Set(connectedKeys);
+    mockQuery.mockImplementation((_path: string, input: { providerConfigKey: string }) =>
+      Promise.resolve(set.has(input.providerConfigKey) ? { id: input.providerConfigKey } : null),
+    );
+  }
+
   it("queries nango platforms and shows connection status", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    // Query order: gitlab, azure_devops (PAT), azure_devops (OAuth), confluence, notion, coda
-    mockQuery
-      .mockResolvedValueOnce(null) // gitlab - not connected
-      .mockResolvedValueOnce(null) // azure_devops PAT - not connected
-      .mockResolvedValueOnce(null) // azure_devops OAuth - not connected
-      .mockResolvedValueOnce({ id: "conn2" }) // confluence - connected
-      .mockResolvedValueOnce(null) // notion - not connected
-      .mockResolvedValueOnce(null); // coda - not connected
+    mockConnectedKeys("confluence"); // only confluence connected
 
     await run("list");
 
@@ -87,31 +89,38 @@ describe("integrations list", () => {
 
   it("outputs valid JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    for (let i = 0; i < 6; i++) mockQuery.mockResolvedValueOnce(null);
+    mockQuery.mockResolvedValue(null); // nothing connected, any number of probes
 
     await run("list", "--json");
 
     const output = JSON.parse(allOutput());
     expect(Array.isArray(output)).toBe(true);
+    // DISPLAY_PLATFORMS: github, gitlab, azure_devops, slack, confluence, notion, coda, teams
+    expect(output).toHaveLength(8);
     expect(output[0]).toHaveProperty("platform");
     expect(output[0]).toHaveProperty("connected");
   });
 
   it("includes azure_devops connected via OAuth", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery
-      .mockResolvedValueOnce(null) // gitlab
-      .mockResolvedValueOnce(null) // azure_devops PAT - not connected
-      .mockResolvedValueOnce({ id: "ado-oauth" }) // azure_devops OAuth - connected
-      .mockResolvedValueOnce(null) // confluence
-      .mockResolvedValueOnce(null) // notion
-      .mockResolvedValueOnce(null); // coda
+    mockConnectedKeys("microsoft-entra-id"); // ADO connected via OAuth only
 
     await run("list", "--json");
 
     const output = JSON.parse(allOutput());
     const ado = output.find((r: { platform: string }) => r.platform === "azure_devops");
     expect(ado.connected).toBe(true);
+  });
+
+  it("reports gitlab connected when only a PAT connection exists", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockConnectedKeys("gitlab-pat"); // GitLab connected via PAT, not OAuth
+
+    await run("list", "--json");
+
+    const output = JSON.parse(allOutput());
+    const gitlab = output.find((r: { platform: string }) => r.platform === "gitlab");
+    expect(gitlab.connected).toBe(true);
   });
 });
 
@@ -208,6 +217,34 @@ describe("integrations status azure_devops", () => {
     expect(output.platform).toBe("azure_devops");
     expect(output.connected).toBe(true);
     expect(output.connection).toBeTruthy();
+  });
+});
+
+describe("integrations status gitlab (multi-auth)", () => {
+  it("detects a GitLab PAT connection via the fallback probe", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery
+      .mockResolvedValueOnce(null) // gitlab OAuth - not connected
+      .mockResolvedValueOnce({ id: "gl-pat" }); // gitlab-pat - connected
+
+    await run("status", "gitlab");
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery.mock.calls[1][1]).toMatchObject({ provider: "gitlab-pat" });
+    const output = allOutput();
+    expect(output).toContain("connected");
+    expect(output).not.toContain("not connected");
+  });
+
+  it("still supports `status gitlab-pat` as a standalone platform", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "gl-pat" });
+
+    await run("status", "gitlab-pat");
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0][1]).toMatchObject({ provider: "gitlab-pat" });
+    expect(allOutput()).toContain("connected");
   });
 });
 

--- a/src/commands/integrations.test.ts
+++ b/src/commands/integrations.test.ts
@@ -67,9 +67,11 @@ afterEach(() => {
 describe("integrations list", () => {
   it("queries nango platforms and shows connection status", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    // Only nango-supported platforms are queried: gitlab, confluence, notion, coda
+    // Query order: gitlab, azure_devops (PAT), azure_devops (OAuth), confluence, notion, coda
     mockQuery
       .mockResolvedValueOnce(null) // gitlab - not connected
+      .mockResolvedValueOnce(null) // azure_devops PAT - not connected
+      .mockResolvedValueOnce(null) // azure_devops OAuth - not connected
       .mockResolvedValueOnce({ id: "conn2" }) // confluence - connected
       .mockResolvedValueOnce(null) // notion - not connected
       .mockResolvedValueOnce(null); // coda - not connected
@@ -78,13 +80,14 @@ describe("integrations list", () => {
 
     const output = allOutput();
     expect(output).toContain("github");
+    expect(output).toContain("azure_devops");
     expect(output).toContain("connected");
     expect(output).toContain("not connected");
   });
 
   it("outputs valid JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    for (let i = 0; i < 4; i++) mockQuery.mockResolvedValueOnce(null);
+    for (let i = 0; i < 6; i++) mockQuery.mockResolvedValueOnce(null);
 
     await run("list", "--json");
 
@@ -92,6 +95,23 @@ describe("integrations list", () => {
     expect(Array.isArray(output)).toBe(true);
     expect(output[0]).toHaveProperty("platform");
     expect(output[0]).toHaveProperty("connected");
+  });
+
+  it("includes azure_devops connected via OAuth", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery
+      .mockResolvedValueOnce(null) // gitlab
+      .mockResolvedValueOnce(null) // azure_devops PAT - not connected
+      .mockResolvedValueOnce({ id: "ado-oauth" }) // azure_devops OAuth - connected
+      .mockResolvedValueOnce(null) // confluence
+      .mockResolvedValueOnce(null) // notion
+      .mockResolvedValueOnce(null); // coda
+
+    await run("list", "--json");
+
+    const output = JSON.parse(allOutput());
+    const ado = output.find((r: { platform: string }) => r.platform === "azure_devops");
+    expect(ado.connected).toBe(true);
   });
 });
 
@@ -121,6 +141,96 @@ describe("integrations status", () => {
     await run("status", "confluence");
 
     expect(allOutput()).toContain("not connected");
+  });
+});
+
+describe("integrations status azure_devops", () => {
+  it("reports connected via PAT and short-circuits before the OAuth probe", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ado-pat" });
+
+    await run("status", "azure_devops");
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0][1]).toMatchObject({ provider: "azure_devops" });
+    const output = allOutput();
+    expect(output).toContain("connected");
+    // "not connected" contains the substring "connected", so assert it is absent
+    expect(output).not.toContain("not connected");
+  });
+
+  it("falls back to the OAuth probe when PAT is not connected", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery
+      .mockResolvedValueOnce(null) // PAT - not connected
+      .mockResolvedValueOnce({ id: "ado-oauth" }); // OAuth - connected
+
+    await run("status", "azure_devops");
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery.mock.calls[1][1]).toMatchObject({ provider: "microsoft-entra-id" });
+    const output = allOutput();
+    expect(output).toContain("connected");
+    expect(output).not.toContain("not connected");
+  });
+
+  it("reports not connected when neither probe returns a connection", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+    await run("status", "azure_devops");
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(allOutput()).toContain("not connected");
+  });
+
+  it("continues past a probe that throws", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery
+      .mockRejectedValueOnce(new Error("boom")) // PAT throws
+      .mockResolvedValueOnce({ id: "ado-oauth" }); // OAuth - connected
+
+    await run("status", "azure_devops");
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const output = allOutput();
+    expect(output).toContain("connected");
+    expect(output).not.toContain("not connected");
+  });
+
+  it("outputs JSON with the connection payload when connected", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ id: "ado-pat" });
+
+    await run("status", "--json", "azure_devops");
+
+    const output = JSON.parse(allOutput());
+    expect(output.platform).toBe("azure_devops");
+    expect(output.connected).toBe(true);
+    expect(output.connection).toBeTruthy();
+  });
+});
+
+describe("integrations status (not queryable via nango)", () => {
+  it("reports github as not connected without issuing a nango query", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+
+    await run("status", "github");
+
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(allOutput()).toContain("not connected");
+  });
+
+  it("outputs a JSON note for a not-queryable platform", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+
+    await run("status", "--json", "github");
+
+    const output = JSON.parse(allOutput());
+    expect(output.platform).toBe("github");
+    expect(output.connected).toBe(false);
+    expect(output.note).toContain("not queryable");
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 });
 

--- a/src/commands/integrations.test.ts
+++ b/src/commands/integrations.test.ts
@@ -161,7 +161,10 @@ describe("integrations status azure_devops", () => {
     await run("status", "azure_devops");
 
     expect(mockQuery).toHaveBeenCalledTimes(1);
-    expect(mockQuery.mock.calls[0][1]).toMatchObject({ provider: "azure_devops" });
+    expect(mockQuery.mock.calls[0][1]).toMatchObject({
+      provider: "azure_devops",
+      providerConfigKey: "azure-devops",
+    });
     const output = allOutput();
     expect(output).toContain("connected");
     // "not connected" contains the substring "connected", so assert it is absent
@@ -177,7 +180,10 @@ describe("integrations status azure_devops", () => {
     await run("status", "azure_devops");
 
     expect(mockQuery).toHaveBeenCalledTimes(2);
-    expect(mockQuery.mock.calls[1][1]).toMatchObject({ provider: "microsoft-entra-id" });
+    expect(mockQuery.mock.calls[1][1]).toMatchObject({
+      provider: "microsoft-entra-id",
+      providerConfigKey: "microsoft-entra-id",
+    });
     const output = allOutput();
     expect(output).toContain("connected");
     expect(output).not.toContain("not connected");
@@ -230,7 +236,10 @@ describe("integrations status gitlab (multi-auth)", () => {
     await run("status", "gitlab");
 
     expect(mockQuery).toHaveBeenCalledTimes(2);
-    expect(mockQuery.mock.calls[1][1]).toMatchObject({ provider: "gitlab-pat" });
+    expect(mockQuery.mock.calls[1][1]).toMatchObject({
+      provider: "gitlab",
+      providerConfigKey: "gitlab-pat",
+    });
     const output = allOutput();
     expect(output).toContain("connected");
     expect(output).not.toContain("not connected");
@@ -243,7 +252,10 @@ describe("integrations status gitlab (multi-auth)", () => {
     await run("status", "gitlab-pat");
 
     expect(mockQuery).toHaveBeenCalledTimes(1);
-    expect(mockQuery.mock.calls[0][1]).toMatchObject({ provider: "gitlab-pat" });
+    expect(mockQuery.mock.calls[0][1]).toMatchObject({
+      provider: "gitlab",
+      providerConfigKey: "gitlab-pat",
+    });
     expect(allOutput()).toContain("connected");
   });
 });

--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -22,9 +22,13 @@ type NangoProvider = NangoGetConnectionInput["provider"];
 
 /**
  * Nango probes per platform. A platform can be connectable under more than one
- * Nango provider — Azure DevOps, for example, connects via PAT (`azure_devops`)
- * or OAuth (`microsoft-entra-id`). A repo may be linked under either, so we
- * probe every provider and report connected if ANY probe returns a row.
+ * Nango provider, and a connection may exist under any of them:
+ *   - GitLab: OAuth (`gitlab`) or PAT (`gitlab-pat`)
+ *   - Confluence: OAuth (`confluence`) or Basic auth (`confluence-basic`)
+ *   - Azure DevOps: PAT (`azure_devops`) or OAuth (`microsoft-entra-id`)
+ * So each platform lists every provider to probe; we report connected if ANY
+ * probe returns a row. `gitlab-pat`/`confluence-basic` are also kept as
+ * standalone keys so `status gitlab-pat` / `status confluence-basic` still work.
  * `nango.getConnection` filters on provider AND providerConfigKey together;
  * prod uses bare config keys, so provider === providerConfigKey === the bare name.
  */
@@ -32,9 +36,15 @@ const NANGO_PROBES: Record<
   string,
   readonly { provider: NangoProvider; providerConfigKey: string }[]
 > = {
-  gitlab: [{ provider: "gitlab", providerConfigKey: "gitlab" }],
+  gitlab: [
+    { provider: "gitlab", providerConfigKey: "gitlab" },
+    { provider: "gitlab-pat", providerConfigKey: "gitlab-pat" },
+  ],
   "gitlab-pat": [{ provider: "gitlab-pat", providerConfigKey: "gitlab-pat" }],
-  confluence: [{ provider: "confluence", providerConfigKey: "confluence" }],
+  confluence: [
+    { provider: "confluence", providerConfigKey: "confluence" },
+    { provider: "confluence-basic", providerConfigKey: "confluence-basic" },
+  ],
   "confluence-basic": [{ provider: "confluence-basic", providerConfigKey: "confluence-basic" }],
   notion: [{ provider: "notion", providerConfigKey: "notion" }],
   coda: [{ provider: "coda", providerConfigKey: "coda" }],
@@ -99,12 +109,16 @@ export function integrationsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      const results: Array<{ platform: string; connected: boolean }> = [];
-      for (const platform of DISPLAY_PLATFORMS) {
-        // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        const { connected } = await probeConnection(client, cfg.org_id!, platform);
-        results.push({ platform, connected });
-      }
+      // Probe platforms in parallel — each is independent — so the command
+      // isn't gated on the sum of every platform's network round-trips.
+      // Promise.all preserves order, so the table still follows DISPLAY_PLATFORMS.
+      const results = await Promise.all(
+        DISPLAY_PLATFORMS.map(async (platform) => {
+          // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
+          const { connected } = await probeConnection(client, cfg.org_id!, platform);
+          return { platform, connected };
+        }),
+      );
 
       if (opts.json) {
         printResult(results, opts);

--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -22,15 +22,21 @@ type NangoProvider = NangoGetConnectionInput["provider"];
 
 /**
  * Nango probes per platform. A platform can be connectable under more than one
- * Nango provider, and a connection may exist under any of them:
- *   - GitLab: OAuth (`gitlab`) or PAT (`gitlab-pat`)
- *   - Confluence: OAuth (`confluence`) or Basic auth (`confluence-basic`)
- *   - Azure DevOps: PAT (`azure_devops`) or OAuth (`microsoft-entra-id`)
- * So each platform lists every provider to probe; we report connected if ANY
- * probe returns a row. `gitlab-pat`/`confluence-basic` are also kept as
- * standalone keys so `status gitlab-pat` / `status confluence-basic` still work.
- * `nango.getConnection` filters on provider AND providerConfigKey together;
- * prod uses bare config keys, so provider === providerConfigKey === the bare name.
+ * Nango provider, and a connection may exist under any of them; we report
+ * connected if ANY probe returns a row.
+ *
+ * `nango.getConnection` exact-matches BOTH `provider` (the Nango DB provider
+ * value) and `providerConfigKey` (the Nango integration id). These differ for
+ * the alternate-auth integrations — the integration id is a distinct base, and
+ * the DB provider stays the platform's canonical value:
+ *   - GitLab: OAuth `{gitlab, gitlab}`, PAT `{gitlab, gitlab-pat}`
+ *   - Confluence: OAuth `{confluence, confluence}`, Basic `{confluence, confluence-basic}`
+ *   - Azure DevOps: PAT `{azure_devops, azure-devops}`, OAuth `{microsoft-entra-id, microsoft-entra-id}`
+ * (Note `azure_devops` the DB provider vs `azure-devops` the integration id.)
+ *
+ * `gitlab-pat`/`confluence-basic` are also kept as standalone keys so
+ * `status gitlab-pat` / `status confluence-basic` still work. Prod uses bare
+ * integration ids (no env suffix), which is what the shipped CLI targets.
  */
 const NANGO_PROBES: Record<
   string,
@@ -38,18 +44,18 @@ const NANGO_PROBES: Record<
 > = {
   gitlab: [
     { provider: "gitlab", providerConfigKey: "gitlab" },
-    { provider: "gitlab-pat", providerConfigKey: "gitlab-pat" },
+    { provider: "gitlab", providerConfigKey: "gitlab-pat" },
   ],
-  "gitlab-pat": [{ provider: "gitlab-pat", providerConfigKey: "gitlab-pat" }],
+  "gitlab-pat": [{ provider: "gitlab", providerConfigKey: "gitlab-pat" }],
   confluence: [
     { provider: "confluence", providerConfigKey: "confluence" },
-    { provider: "confluence-basic", providerConfigKey: "confluence-basic" },
+    { provider: "confluence", providerConfigKey: "confluence-basic" },
   ],
-  "confluence-basic": [{ provider: "confluence-basic", providerConfigKey: "confluence-basic" }],
+  "confluence-basic": [{ provider: "confluence", providerConfigKey: "confluence-basic" }],
   notion: [{ provider: "notion", providerConfigKey: "notion" }],
   coda: [{ provider: "coda", providerConfigKey: "coda" }],
   azure_devops: [
-    { provider: "azure_devops", providerConfigKey: "azure_devops" },
+    { provider: "azure_devops", providerConfigKey: "azure-devops" },
     { provider: "microsoft-entra-id", providerConfigKey: "microsoft-entra-id" },
   ],
 };

--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -4,7 +4,8 @@
 
 import { Command } from "commander";
 import pc from "picocolors";
-import { createTypedClient } from "../client/trpc";
+import { createTypedClient, type TypedClient } from "../client/trpc";
+import type { NangoGetConnectionInput } from "../generated/dosu-api-types";
 import { requireLoginConfig } from "./auth";
 import { printResult, printTable } from "./output";
 
@@ -17,26 +18,75 @@ function requireConfig() {
   return cfg;
 }
 
-/** Platforms supported by `nango.getConnection` */
-const NANGO_PLATFORMS = [
-  "confluence",
-  "notion",
-  "coda",
-  "gitlab",
-  "gitlab-pat",
-  "confluence-basic",
-] as const;
+type NangoProvider = NangoGetConnectionInput["provider"];
+
+/**
+ * Nango probes per platform. A platform can be connectable under more than one
+ * Nango provider — Azure DevOps, for example, connects via PAT (`azure_devops`)
+ * or OAuth (`microsoft-entra-id`). A repo may be linked under either, so we
+ * probe every provider and report connected if ANY probe returns a row.
+ * `nango.getConnection` filters on provider AND providerConfigKey together;
+ * prod uses bare config keys, so provider === providerConfigKey === the bare name.
+ */
+const NANGO_PROBES: Record<
+  string,
+  readonly { provider: NangoProvider; providerConfigKey: string }[]
+> = {
+  gitlab: [{ provider: "gitlab", providerConfigKey: "gitlab" }],
+  "gitlab-pat": [{ provider: "gitlab-pat", providerConfigKey: "gitlab-pat" }],
+  confluence: [{ provider: "confluence", providerConfigKey: "confluence" }],
+  "confluence-basic": [{ provider: "confluence-basic", providerConfigKey: "confluence-basic" }],
+  notion: [{ provider: "notion", providerConfigKey: "notion" }],
+  coda: [{ provider: "coda", providerConfigKey: "coda" }],
+  azure_devops: [
+    { provider: "azure_devops", providerConfigKey: "azure_devops" },
+    { provider: "microsoft-entra-id", providerConfigKey: "microsoft-entra-id" },
+  ],
+};
 
 /** All display platforms including those checked via other means */
 const DISPLAY_PLATFORMS = [
   "github",
   "gitlab",
+  "azure_devops",
   "slack",
   "confluence",
   "notion",
   "coda",
   "teams",
 ] as const;
+
+/**
+ * Probe a platform's Nango connection state. Platforms absent from
+ * `NANGO_PROBES` (github, slack, teams) are reported as `queryable: false`.
+ * Otherwise every probe is tried in order, short-circuiting on the first
+ * connection found; a throwing probe is swallowed so the next one still runs.
+ */
+async function probeConnection(
+  client: TypedClient,
+  orgId: string,
+  platform: string,
+): Promise<{ queryable: boolean; connected: boolean; connection: unknown }> {
+  const probes = NANGO_PROBES[platform];
+  if (!probes) {
+    return { queryable: false, connected: false, connection: null };
+  }
+  for (const probe of probes) {
+    try {
+      const conn = await client.nango.getConnection.query({
+        provider: probe.provider,
+        providerConfigKey: probe.providerConfigKey,
+        orgId,
+      });
+      if (conn != null) {
+        return { queryable: true, connected: true, connection: conn };
+      }
+    } catch {
+      // Swallow and try the next probe.
+    }
+  }
+  return { queryable: true, connected: false, connection: null };
+}
 
 export function integrationsCommand(): Command {
   const cmd = new Command("integrations").description("Manage integrations");
@@ -51,24 +101,9 @@ export function integrationsCommand(): Command {
 
       const results: Array<{ platform: string; connected: boolean }> = [];
       for (const platform of DISPLAY_PLATFORMS) {
-        // Only nango-supported platforms can be queried via getConnection
-        const nangoProvider = NANGO_PLATFORMS.find((p) => p === platform);
-        if (nangoProvider) {
-          try {
-            const conn = await client.nango.getConnection.query({
-              provider: nangoProvider,
-              providerConfigKey: nangoProvider,
-              // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-              orgId: cfg.org_id!,
-            });
-            results.push({ platform, connected: conn !== null });
-          } catch {
-            results.push({ platform, connected: false });
-          }
-        } else {
-          // github, slack, teams — not queryable via nango
-          results.push({ platform, connected: false });
-        }
+        // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
+        const { connected } = await probeConnection(client, cfg.org_id!, platform);
+        results.push({ platform, connected });
       }
 
       if (opts.json) {
@@ -94,9 +129,15 @@ export function integrationsCommand(): Command {
     .action(async (platform: string, opts: { json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
-      const nangoProvider = NANGO_PLATFORMS.find((p) => p === platform);
+      const { queryable, connected, connection } = await probeConnection(
+        client,
+        // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
+        cfg.org_id!,
+        platform,
+      );
 
-      if (!nangoProvider) {
+      if (!queryable) {
+        // github, slack, teams — not queryable via nango
         if (opts.json) {
           printResult({ platform, connected: false, note: "not queryable via nango" }, opts);
           return;
@@ -105,27 +146,11 @@ export function integrationsCommand(): Command {
         return;
       }
 
-      try {
-        const conn = await client.nango.getConnection.query({
-          provider: nangoProvider,
-          providerConfigKey: nangoProvider,
-          // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-          orgId: cfg.org_id!,
-        });
-
-        const connected = conn !== null;
-        if (opts.json) {
-          printResult({ platform, connected, connection: conn }, opts);
-          return;
-        }
-        console.log(`${platform}: ${connected ? pc.green("connected") : pc.dim("not connected")}`);
-      } catch {
-        if (opts.json) {
-          printResult({ platform, connected: false }, opts);
-          return;
-        }
-        console.log(`${platform}: ${pc.dim("not connected")}`);
+      if (opts.json) {
+        printResult({ platform, connected, connection }, opts);
+        return;
       }
+      console.log(`${platform}: ${connected ? pc.green("connected") : pc.dim("not connected")}`);
     });
 
   cmd

--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -28,10 +28,12 @@ type NangoProvider = NangoGetConnectionInput["provider"];
  * `nango.getConnection` exact-matches BOTH `provider` (the Nango DB provider
  * value) and `providerConfigKey` (the Nango integration id). These differ for
  * the alternate-auth integrations — the integration id is a distinct base, and
- * the DB provider stays the platform's canonical value:
+ * the DB provider stays the platform's canonical value. The primary auth method
+ * (OAuth) is listed first so the common case short-circuits on the first probe;
+ * the alternate (PAT / Basic) is the fallback:
  *   - GitLab: OAuth `{gitlab, gitlab}`, PAT `{gitlab, gitlab-pat}`
  *   - Confluence: OAuth `{confluence, confluence}`, Basic `{confluence, confluence-basic}`
- *   - Azure DevOps: PAT `{azure_devops, azure-devops}`, OAuth `{microsoft-entra-id, microsoft-entra-id}`
+ *   - Azure DevOps: OAuth `{microsoft-entra-id, microsoft-entra-id}`, PAT `{azure_devops, azure-devops}`
  * (Note `azure_devops` the DB provider vs `azure-devops` the integration id.)
  *
  * `gitlab-pat`/`confluence-basic` are also kept as standalone keys so
@@ -55,8 +57,8 @@ const NANGO_PROBES: Record<
   notion: [{ provider: "notion", providerConfigKey: "notion" }],
   coda: [{ provider: "coda", providerConfigKey: "coda" }],
   azure_devops: [
-    { provider: "azure_devops", providerConfigKey: "azure-devops" },
     { provider: "microsoft-entra-id", providerConfigKey: "microsoft-entra-id" },
+    { provider: "azure_devops", providerConfigKey: "azure-devops" },
   ],
 };
 


### PR DESCRIPTION
## Summary

Azure DevOps CLI parity (ENG-504). Adds `azure_devops` to `dosu integrations list` and makes `dosu integrations status azure_devops` work.

Azure DevOps can be connected under two Nango providers — OAuth (`microsoft-entra-id`, the primary/recommended method) and PAT (`azure_devops`) — and a repo may be linked under either. This replaces the flat `NANGO_PLATFORMS` list with a `NANGO_PROBES` map plus a `probeConnection` helper that tries each provider for a platform, short-circuits on the first connection found, and swallows per-probe errors so one failing probe doesn't block the next. `status`/`list` report **connected if any probe returns a row**. The primary auth (OAuth) is probed first so the common case short-circuits on the first request.

The same grouping fixes GitLab and Confluence too: `status gitlab` / `status confluence` (and `list`) now detect connections made via PAT (`gitlab-pat`) or Basic auth (`confluence-basic`), which the previous flat list never probed. `getConnection` exact-matches both `provider` and `providerConfigKey`, so each probe pairs the canonical DB provider with the right integration id (e.g. Azure DevOps PAT is `{azure_devops, azure-devops}`).

No API change needed — the generated client types already include both Azure DevOps providers, and `providerConfigKey` is a free string.

## Changes

- `src/commands/integrations.ts` — `NANGO_PROBES` map (GitLab OAuth+PAT, Confluence OAuth+Basic, Azure DevOps OAuth+PAT, OAuth probed first), `probeConnection` helper, `azure_devops` added to the displayed platforms. `list` probes run in parallel (`Promise.all`, order preserved) instead of sequentially.
- `src/commands/integrations.test.ts` — coverage for the multi-probe fallback, Azure DevOps connected/not-connected/JSON paths, OAuth-primary short-circuit + PAT fallback, GitLab-via-PAT detection, standalone `status gitlab-pat`, and not-queryable platforms (github/slack/teams).

## Testing

**Automated:** `bun run test` (integrations 30/30; full suite 1554 passed), `bun run typecheck`, `bun run check` — all green.

**Manual (verified live against a local stack):**
- `integrations list` renders all platforms including the new `azure_devops` row.
- `status azure_devops` connects via the **OAuth** probe (primary) on the first request against a real Entra connection; the **PAT** probe was likewise confirmed to match a real PAT connection. Ordering (OAuth-primary short-circuit, PAT fallback) and error branches are covered by unit tests.
- `status github` reports "not queryable via nango" with no request issued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)