### PR TITLE
feat(setup): route first-run onboarding through the web wizard

### DIFF
--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -39,6 +39,7 @@ function createMockServer(): CallbackServer {
   return {
     port: 12345,
     close: mockClose,
+    setNext: vi.fn(),
   };
 }
 
@@ -272,5 +273,57 @@ describe("startOAuthFlow", () => {
     resolveToken({ access_token: "a", refresh_token: "r", expires_in: 1 });
     const r = await flowPromise;
     expect(r).toMatchObject({ browserOpened: true });
+  });
+
+  it("holdNext keeps the server open and hands it over on the result", async () => {
+    const token: TokenResponse = { access_token: "tok", refresh_token: "ref", expires_in: 3600 };
+
+    const flowPromise = startOAuthFlow(undefined, "/cli/auth", {}, undefined, { holdNext: true });
+    await flowReady();
+
+    resolveToken(token);
+    const result = await flowPromise;
+
+    expect(result).toMatchObject({ browserOpened: true, token });
+    expect((result as { server?: CallbackServer }).server).toBe(mockServer);
+    // Server ownership transferred to the caller — not closed here.
+    expect(mockClose).not.toHaveBeenCalled();
+    expect(mockStartCallbackServer).toHaveBeenCalledWith(
+      expect.objectContaining({ nextHold: true }),
+    );
+  });
+
+  it("holdNext still closes the server on failure (no handover happened)", async () => {
+    const flowPromise = startOAuthFlow(undefined, "/cli/auth", {}, undefined, { holdNext: true });
+    await flowReady();
+
+    rejectToken(new Error("boom"));
+    await flowPromise.catch(() => {});
+
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it("suppressBrowserOpen completes the flow without opening a browser", async () => {
+    const token: TokenResponse = { access_token: "tok", refresh_token: "ref", expires_in: 3600 };
+
+    const flowPromise = startOAuthFlow(undefined, "/onboarding/connections", {}, undefined, {
+      suppressBrowserOpen: true,
+      successVariant: "onboarding",
+    });
+    // flowReady() waits on open(), which never fires here — wait on the
+    // callback server instead, plus a macrotask barrier for the race arming.
+    await vi.waitFor(() => expect(mockStartCallbackServer).toHaveBeenCalled());
+    await new Promise((r) => setImmediate(r));
+
+    resolveToken(token);
+    const result = await flowPromise;
+
+    expect(result).toMatchObject({ browserOpened: true, token });
+    expect(mockOpenDefault).not.toHaveBeenCalled();
+    expect(mockStartCallbackServer).toHaveBeenCalledWith(
+      expect.objectContaining({ successVariant: "onboarding" }),
+    );
+    // No holdNext → the flow still owns and closes the server.
+    expect(mockClose).toHaveBeenCalledOnce();
   });
 });

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -4,10 +4,15 @@
 
 import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
-import { startCallbackServer, type TokenResponse } from "./server";
+import {
+  type CallbackServer,
+  type SuccessVariant,
+  startCallbackServer,
+  type TokenResponse,
+} from "./server";
 
 export type OAuthFlowResult =
-  | { browserOpened: true; token: TokenResponse }
+  | { browserOpened: true; token: TokenResponse; server?: CallbackServer }
   | { browserOpened: false };
 
 export interface OAuthFlowOptions {
@@ -19,6 +24,20 @@ export interface OAuthFlowOptions {
    * failed browser open returns { browserOpened: false } immediately.
    */
   waitWithoutBrowser?: boolean;
+  /**
+   * Keep the callback server alive after the token arrives and return it on
+   * the result, so the caller can steer the success page's tab onward via
+   * `server.setNext(url)`. The caller owns closing the server.
+   */
+  holdNext?: boolean;
+  /**
+   * Don't open a browser — the caller navigates an already-open tab to the
+   * auth URL itself (e.g. via a previous server's `setNext`). `onAuthURL`
+   * still fires so the caller has the URL.
+   */
+  suppressBrowserOpen?: boolean;
+  /** Success-page copy variant served on the callback. Defaults to "auth". */
+  successVariant?: SuccessVariant;
 }
 
 /**
@@ -43,9 +62,13 @@ export async function startOAuthFlow(
   onAuthURL?: (url: string) => void,
   options: OAuthFlowOptions = {},
 ): Promise<OAuthFlowResult> {
-  const { server, tokenPromise } = await startCallbackServer();
+  const { server, tokenPromise } = await startCallbackServer({
+    nextHold: options.holdNext,
+    successVariant: options.successVariant,
+  });
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let handedOver = false;
 
   try {
     const callbackURL = `http://localhost:${server.port}/callback`;
@@ -54,19 +77,25 @@ export async function startOAuthFlow(
     logger.info("auth.flow", `Auth URL: ${authURL}`);
     options.onAuthURL?.(authURL);
 
-    // Open browser — dynamic import to avoid bundling issues
-    const open = await import("open");
     let browserOpened = false;
-    try {
-      await open.default(authURL);
+    if (options.suppressBrowserOpen) {
+      // The caller navigates an existing tab to authURL itself.
       browserOpened = true;
-      logger.info("auth.flow", "Browser open command executed");
-      onAuthURL?.(authURL);
-    } catch (openErr) {
-      logger.warn(
-        "auth.flow",
-        `Could not open browser automatically: ${openErr instanceof Error ? openErr.message : String(openErr)}`,
-      );
+      logger.info("auth.flow", "Browser open suppressed — caller steers an existing tab");
+    } else {
+      // Open browser — dynamic import to avoid bundling issues
+      const open = await import("open");
+      try {
+        await open.default(authURL);
+        browserOpened = true;
+        logger.info("auth.flow", "Browser open command executed");
+        onAuthURL?.(authURL);
+      } catch (openErr) {
+        logger.warn(
+          "auth.flow",
+          `Could not open browser automatically: ${openErr instanceof Error ? openErr.message : String(openErr)}`,
+        );
+      }
     }
 
     if (!browserOpened && !options.waitWithoutBrowser) {
@@ -102,11 +131,18 @@ export async function startOAuthFlow(
 
     const token = await Promise.race([tokenPromise, timeout, abort]);
     logger.info("auth.flow", "Token received");
+    if (options.holdNext) {
+      // Caller takes over the server to steer the tab (and close it).
+      handedOver = true;
+      return { browserOpened: true, token, server };
+    }
     return { browserOpened: true, token };
   } finally {
     clearTimeout(timeoutId);
-    server.close();
-    logger.debug("auth.flow", "Cleaning up: timeout cleared, server closed");
+    if (!handedOver) {
+      server.close();
+      logger.debug("auth.flow", "Cleaning up: timeout cleared, server closed");
+    }
   }
 }
 

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -273,3 +273,80 @@ describe("auth callback server", () => {
     expect(token.refresh_token).toBe("");
   });
 });
+
+describe("auth callback server — nextHold tab steering", () => {
+  let server: CallbackServer | null = null;
+
+  afterEach(() => {
+    if (server) {
+      server.close();
+      server = null;
+    }
+  });
+
+  it("serves the /next poll script on the success page only when nextHold is set", async () => {
+    const held = await startCallbackServer({ nextHold: true });
+    server = held.server;
+    const heldResp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
+    const heldHtml = await heldResp.text();
+    expect(heldHtml).toContain("fetch('/next')");
+    // Steered tabs announce the next step instead of "close this tab".
+    expect(heldHtml).toContain("Hang tight");
+    expect(heldHtml).toContain("ready to connect your data sources");
+    expect(heldHtml).toContain("Redirecting...");
+    await held.tokenPromise;
+    server.close();
+
+    const plain = await startCallbackServer();
+    server = plain.server;
+    const plainResp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
+    expect(await plainResp.text()).not.toContain("fetch('/next')");
+    await plain.tokenPromise;
+  });
+
+  it("answers /next: 204 while undecided, 200 with the URL after setNext, 410 after dismissal", async () => {
+    const result = await startCallbackServer({ nextHold: true });
+    server = result.server;
+    const base = `http://localhost:${server.port}`;
+
+    const undecided = await fetch(`${base}/next`);
+    expect(undecided.status).toBe(204);
+
+    server.setNext("https://app.test/onboarding/connections?source=cli");
+    const decided = await fetch(`${base}/next`);
+    expect(decided.status).toBe(200);
+    expect(await decided.json()).toEqual({
+      url: "https://app.test/onboarding/connections?source=cli",
+    });
+
+    server.setNext(null);
+    const dismissed = await fetch(`${base}/next`);
+    expect(dismissed.status).toBe(410);
+  });
+
+  it("keeps /next a 404 when the server was started without nextHold", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+    const resp = await fetch(`http://localhost:${server.port}/next`);
+    expect(resp.status).toBe(404);
+  });
+
+  it("serves onboarding-specific success copy for the onboarding variant", async () => {
+    const result = await startCallbackServer({ successVariant: "onboarding" });
+    server = result.server;
+    const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
+    const html = await resp.text();
+    expect(html).toContain("Onboarding Complete");
+    expect(html).toContain("Dosu is finishing your setup");
+    expect(html).not.toContain("Authentication Successful");
+    await result.tokenPromise;
+  });
+
+  it("defaults to the auth success copy", async () => {
+    const result = await startCallbackServer({ nextHold: true });
+    server = result.server;
+    const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
+    expect(await resp.text()).toContain("Authentication Successful");
+    await result.tokenPromise;
+  });
+});

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -135,7 +135,82 @@ if (hash) {
 </body>
 </html>`;
 
-function buildSuccessHtml(email?: string): string {
+/**
+ * Success-page copy variants. "auth" is the classic login confirmation;
+ * "onboarding" is served when the web onboarding wizard hands control back
+ * to the terminal, so the page should say setup finished — not "authentication".
+ */
+export type SuccessVariant = "auth" | "onboarding";
+
+const SUCCESS_COPY: Record<SuccessVariant, { title: string; heading: string; close: string }> = {
+  auth: {
+    title: "Dosu CLI - Authentication Successful",
+    heading: "Authentication Successful",
+    close: "You can close this tab and return to your terminal.",
+  },
+  onboarding: {
+    title: "Dosu CLI - Onboarding Complete",
+    heading: "Onboarding Complete",
+    close: "You're all set — return to your terminal, Dosu is finishing your setup there.",
+  },
+};
+
+/**
+ * Injected when the server was started with `nextHold`: the success page
+ * polls GET /next so the CLI can steer this same tab onward (e.g. into the
+ * web onboarding wizard) instead of opening a second one. Polling stops on
+ * 410 (CLI decided there's nowhere to go — the page then tells the user the
+ * tab can be closed) or after ~3 minutes. Transient fetch errors are
+ * tolerated: the budget, not a single hiccup, ends the loop, because giving
+ * up early would strand a handoff the CLI is still preparing (it may spend
+ * several network round-trips deciding before calling setNext).
+ *
+ * When the steer arrives (200), the page announces the next step — first-run
+ * users are about to see the data-source connection wizard, so saying
+ * "authentication successful, close this tab" right before that would be
+ * confusing — then navigates.
+ */
+const NEXT_POLL_SCRIPT = `<script>
+(function () {
+  var tries = 0;
+  var setCopy = function (heading, msg) {
+    var h = document.getElementById('heading');
+    var m = document.getElementById('close-msg');
+    if (h && heading) h.textContent = heading;
+    if (m && msg) m.textContent = msg;
+  };
+  var timer = setInterval(function () {
+    tries += 1;
+    if (tries > 720) { clearInterval(timer); setCopy(null, ${JSON.stringify(SUCCESS_COPY.auth.close)}); return; }
+    fetch('/next').then(function (res) {
+      if (res.status === 200) {
+        clearInterval(timer);
+        res.json().then(function (body) {
+          if (body && body.url) {
+            setCopy("You're ready to connect your data sources", 'Redirecting...');
+            window.location.replace(body.url);
+          }
+        });
+      } else if (res.status === 410) {
+        clearInterval(timer);
+        setCopy(null, ${JSON.stringify(SUCCESS_COPY.auth.close)});
+      }
+    }).catch(function () {});
+  }, 250);
+})();
+</script>`;
+
+function buildSuccessHtml(
+  email?: string,
+  variant: SuccessVariant = "auth",
+  withNextPoll = false,
+): string {
+  const copy = SUCCESS_COPY[variant];
+  // While the /next poller is live, don't invite the user to close the tab —
+  // the CLI may be about to steer it onward. The poll script swaps in the
+  // regular close message once the CLI dismisses the hold (410) or the
+  // budget runs out.
+  const closeMsg = withNextPoll ? "Hang tight — this tab will continue automatically." : copy.close;
   const emailLine = email
     ? `<p class="email">Signed in as <strong>${email.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")}</strong></p>`
     : "";
@@ -144,7 +219,7 @@ function buildSuccessHtml(email?: string): string {
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Dosu CLI - Authentication Successful</title>
+<title>${copy.title}</title>
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
@@ -246,15 +321,16 @@ h1 {
         <path d="M0.348633 85.4946C0.348633 85.4946 29.4856 85.8309 34.809 85.698C44.8337 85.4477 51.2872 84.402 57.5269 78.9724C62.8129 74.3727 75.1342 59.6836 75.1342 59.6836" stroke="black" stroke-width="6.16482"/>
         </svg>
     </div>
-    <h1>Authentication Successful</h1>
+    <h1 id="heading">${copy.heading}</h1>
     ${emailLine}
-    <p class="close-msg">You can close this tab and return to your terminal.</p>
+    <p class="close-msg" id="close-msg">${closeMsg}</p>
 </div>
 <div class="tip">
     <div class="tip-rule" aria-hidden="true"><span class="tip-dot"></span></div>
     <span class="tip-label">Did you know?</span>
     You can use Dosu to make your coding agents faster and cheaper. Just ask your agent to use Dosu to update your AGENTS.md.
 </div>
+${withNextPoll ? NEXT_POLL_SCRIPT : ""}
 </body>
 </html>`;
 }
@@ -262,13 +338,30 @@ h1 {
 export interface CallbackServer {
   port: number;
   close: () => void;
+  /**
+   * Steer the success page's tab onward (requires `nextHold`): a URL makes
+   * the page navigate there in place; `null` tells it to stop polling and
+   * stay put. No-op when the page never polls (server started without
+   * `nextHold`) or already navigated.
+   */
+  setNext: (url: string | null) => void;
+}
+
+export interface CallbackServerOptions {
+  /**
+   * Serve the success page with the /next poller so the CLI can redirect
+   * the tab afterwards via `server.setNext(url)`.
+   */
+  nextHold?: boolean;
+  /** Success-page copy variant. Defaults to "auth". */
+  successVariant?: SuccessVariant;
 }
 
 /**
  * Starts a local HTTP server to receive the OAuth callback.
  * Returns a promise that resolves with the token when received.
  */
-export async function startCallbackServer(): Promise<{
+export async function startCallbackServer(opts: CallbackServerOptions = {}): Promise<{
   server: CallbackServer;
   tokenPromise: Promise<TokenResponse>;
 }> {
@@ -279,6 +372,9 @@ export async function startCallbackServer(): Promise<{
     resolveToken = resolve;
     rejectToken = reject;
   });
+
+  // undefined = undecided (keep polling), string = navigate, null = dismissed.
+  let nextTarget: string | null | undefined;
 
   const http = require("node:http") as typeof import("node:http");
 
@@ -291,6 +387,21 @@ export async function startCallbackServer(): Promise<{
       "auth.server",
       `Request: ${req.method} ${url.pathname} cookie-len=${cookieLen} ua=${ua} has-token=${url.searchParams.has("access_token")}`,
     );
+
+    if (opts.nextHold && url.pathname === "/next") {
+      if (nextTarget === undefined) {
+        res.writeHead(204);
+        res.end();
+      } else if (nextTarget === null) {
+        res.writeHead(410);
+        res.end();
+      } else {
+        logger.info("auth.server", "Handing tab onward via /next");
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ url: nextTarget }));
+      }
+      return;
+    }
 
     if (url.pathname !== "/callback") {
       logger.debug("auth.server", `404: ${url.pathname}`);
@@ -353,20 +464,35 @@ export async function startCallbackServer(): Promise<{
 
     logger.info("auth.server", "Served success HTML");
     res.writeHead(200, { "Content-Type": "text/html" });
-    res.end(buildSuccessHtml(email ?? undefined));
+    res.end(
+      buildSuccessHtml(email ?? undefined, opts.successVariant ?? "auth", Boolean(opts.nextHold)),
+    );
   });
 
   // Listen on random port and wait for it to be ready
   await new Promise<void>((resolve) => {
     httpServer.listen(0, "localhost", () => resolve());
   });
+  // Never let this server keep the process alive on its own: the flows that
+  // wait on it always hold a ref'd timer, and a leaked server (error path
+  // that skipped close) must not turn into a hung CLI at exit.
+  httpServer.unref();
   const addr = httpServer.address() as import("node:net").AddressInfo;
   logger.info("auth.server", `Callback server listening on port ${addr.port}`);
 
   return {
     server: {
       port: addr.port,
-      close: () => httpServer.close(),
+      close: () => {
+        httpServer.close();
+        // The success page's /next poller keeps a keep-alive socket open;
+        // plain close() would wait for it to drain. Sever it so close
+        // completes promptly.
+        httpServer.closeAllConnections?.();
+      },
+      setNext: (url) => {
+        nextTarget = url;
+      },
     },
     tokenPromise,
   };

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -159,9 +159,11 @@ const SUCCESS_COPY: Record<SuccessVariant, { title: string; heading: string; clo
  * Injected when the server was started with `nextHold`: the success page
  * polls GET /next so the CLI can steer this same tab onward (e.g. into the
  * web onboarding wizard) instead of opening a second one. Polling stops on
- * 410 (CLI decided there's nowhere to go — the page then tells the user the
- * tab can be closed) or after ~3 minutes. Transient fetch errors are
- * tolerated: the budget, not a single hiccup, ends the loop, because giving
+ * 410 (CLI decided there's nowhere to go — the page then settles to
+ * `settleMsg`, the variant's regular close message), after ~3 minutes, or
+ * once the server is clearly gone (several consecutive fetch failures —
+ * covers both a closed server and a 410 whose response was cut off
+ * mid-flush). A single transient error never ends the loop, because giving
  * up early would strand a handoff the CLI is still preparing (it may spend
  * several network round-trips deciding before calling setNext).
  *
@@ -170,19 +172,23 @@ const SUCCESS_COPY: Record<SuccessVariant, { title: string; heading: string; clo
  * "authentication successful, close this tab" right before that would be
  * confusing — then navigates.
  */
-const NEXT_POLL_SCRIPT = `<script>
+function buildNextPollScript(settleMsg: string): string {
+  return `<script>
 (function () {
   var tries = 0;
+  var misses = 0;
   var setCopy = function (heading, msg) {
     var h = document.getElementById('heading');
     var m = document.getElementById('close-msg');
     if (h && heading) h.textContent = heading;
     if (m && msg) m.textContent = msg;
   };
+  var settle = function () { setCopy(null, ${JSON.stringify(settleMsg)}); };
   var timer = setInterval(function () {
     tries += 1;
-    if (tries > 720) { clearInterval(timer); setCopy(null, ${JSON.stringify(SUCCESS_COPY.auth.close)}); return; }
+    if (tries > 720) { clearInterval(timer); settle(); return; }
     fetch('/next').then(function (res) {
+      misses = 0;
       if (res.status === 200) {
         clearInterval(timer);
         res.json().then(function (body) {
@@ -193,12 +199,16 @@ const NEXT_POLL_SCRIPT = `<script>
         });
       } else if (res.status === 410) {
         clearInterval(timer);
-        setCopy(null, ${JSON.stringify(SUCCESS_COPY.auth.close)});
+        settle();
       }
-    }).catch(function () {});
+    }).catch(function () {
+      misses += 1;
+      if (misses >= 8) { clearInterval(timer); settle(); }
+    });
   }, 250);
 })();
 </script>`;
+}
 
 function buildSuccessHtml(
   email?: string,
@@ -330,7 +340,7 @@ h1 {
     <span class="tip-label">Did you know?</span>
     You can use Dosu to make your coding agents faster and cheaper. Just ask your agent to use Dosu to update your AGENTS.md.
 </div>
-${withNextPoll ? NEXT_POLL_SCRIPT : ""}
+${withNextPoll ? buildNextPollScript(copy.close) : ""}
 </body>
 </html>`;
 }

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -111,17 +111,13 @@ vi.mock("../commands/skill", () => ({
   skillCommand: vi.fn(),
 }));
 
-const { mockStepConnectGitHubRepo, mockStepImportGitHubDocs } = vi.hoisted(() => ({
+const { mockStepConnectGitHubRepo } = vi.hoisted(() => ({
   mockStepConnectGitHubRepo: vi.fn(),
-  mockStepImportGitHubDocs: vi.fn(),
 }));
 vi.mock("./github-step", () => ({
   stepConnectGitHubRepo: (...args: unknown[]) => mockStepConnectGitHubRepo(...args),
   // Audit handoff never fires in these tests: not a git repo.
   detectGitRepo: vi.fn(() => null),
-}));
-vi.mock("./github-doc-import-step", () => ({
-  stepImportGitHubDocs: (...args: unknown[]) => mockStepImportGitHubDocs(...args),
 }));
 
 import * as p from "@clack/prompts";
@@ -176,7 +172,6 @@ function mockToolSelection(selection: string[]) {
 
 function installSetupStepDefaults() {
   mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
-  mockStepImportGitHubDocs.mockResolvedValue({ advance: false });
 }
 
 function installRemoteSetupDefaults() {
@@ -1443,7 +1438,7 @@ describe("runSetup integration", () => {
     expect(mockInstallSkill).toHaveBeenCalled();
   });
 
-  it("shows the GitHub docs import label in the one-shot confirm", async () => {
+  it("offers only MCP + skill in the one-shot confirm (docs import lives in the web wizard)", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);
 
@@ -1452,6 +1447,10 @@ describe("runSetup integration", () => {
       user_id: "test-user-id",
       finished_onboarding: false,
       cli_onboarding_enabled: true,
+    });
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
     });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
@@ -1463,12 +1462,10 @@ describe("runSetup integration", () => {
         String((args as { message?: string }).message ?? "").includes("Dosu will set"),
       );
     const options = (oneShotCall?.[0] as { options: Array<{ label: string }> }).options;
-    expect(options.map((option) => String(option.label))).toEqual(
-      expect.arrayContaining([expect.stringContaining("Import docs from GitHub")]),
-    );
-    expect(options.map((option) => String(option.label))).toEqual(
-      expect.arrayContaining([expect.stringContaining("Keep them up to date")]),
-    );
+    expect(options.map((option) => String(option.label))).toEqual([
+      "Install Dosu MCP",
+      "Install Dosu skill",
+    ]);
   });
 });
 
@@ -1649,7 +1646,7 @@ describe("runSetup checkpoint behavior", () => {
     expect(saved.api_key).toBe("fresh-key");
   });
 
-  it("marks remote onboarding complete at the end of first-run cloud onboarding", async () => {
+  it("does not mark onboarding complete server-side — the web wizard owns that", async () => {
     saveConfig(makeCfg());
     setupAuthed();
     mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
@@ -1657,17 +1654,15 @@ describe("runSetup checkpoint behavior", () => {
       finished_onboarding: false,
       cli_onboarding_enabled: true,
     });
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+    });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
 
     await runSetup();
 
-    expect(mockTrpc.user.updateProfile.mutate).toHaveBeenCalledTimes(1);
-    expect(mockTrpc.user.updateProfile.mutate).toHaveBeenCalledWith({
-      user_id: "test-user-id",
-      finished_onboarding: true,
-    });
+    expect(mockTrpc.user.updateProfile.mutate).not.toHaveBeenCalled();
   });
 
   it("tracks completion when at least one valuable onboarding action succeeds", async () => {
@@ -1685,90 +1680,6 @@ describe("runSetup checkpoint behavior", () => {
           properties: expect.objectContaining({
             completed_mcp: false,
             completed_skill: true,
-            imported_docs: false,
-          }),
-        }),
-      ]),
-    );
-  });
-
-  it("tracks docs import as activation during first-run onboarding", async () => {
-    saveConfig(makeCfg());
-    setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({
-      advance: true,
-      has_connected_repo: true,
-      created_data_source_ids: ["ds-1"],
-    });
-    mockStepImportGitHubDocs.mockResolvedValue({
-      advance: true,
-      imported: true,
-      imported_count: 3,
-      failed_count: 0,
-      task_id: "task-1",
-    });
-
-    await runSetup();
-
-    expect(trackedCliOnboardingEvents()).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ event: "cli_onboarding_github_connected" }),
-        expect.objectContaining({
-          event: "cli_onboarding_docs_imported",
-          properties: expect.objectContaining({ imported_count: 3, task_id: "task-1" }),
-        }),
-        expect.objectContaining({
-          event: "cli_onboarding_activated",
-          properties: expect.objectContaining({ imported_count: 3 }),
-        }),
-        expect.objectContaining({
-          event: "cli_onboarding_completed",
-          properties: expect.objectContaining({ imported_docs: true }),
-        }),
-      ]),
-    );
-  });
-
-  it("does not track activation when docs import is only queued", async () => {
-    saveConfig(makeCfg());
-    setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({
-      advance: true,
-      has_connected_repo: true,
-      created_data_source_ids: ["ds-1"],
-    });
-    mockStepImportGitHubDocs.mockResolvedValue({
-      advance: true,
-      imported: false,
-      imported_count: 0,
-      queued: true,
-      task_id: "task-1",
-    });
-
-    await runSetup();
-
-    const events = trackedCliOnboardingEvents().map((input) => input.event);
-    expect(events).not.toContain("cli_onboarding_docs_imported");
-    expect(events).not.toContain("cli_onboarding_activated");
-    expect(trackedCliOnboardingEvents()).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          event: "cli_onboarding_completed",
-          properties: expect.objectContaining({
-            completed_skill: true,
-            imported_docs: false,
           }),
         }),
       ]),
@@ -1785,26 +1696,6 @@ describe("runSetup checkpoint behavior", () => {
     expect(mockTrpc.user.updateProfile.mutate).not.toHaveBeenCalled();
   });
 
-  it("warns but does not throw when remote onboarding completion fails", async () => {
-    saveConfig(makeCfg());
-    setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    mockTrpc.user.updateProfile.mutate.mockRejectedValueOnce(new Error("503 Service Unavailable"));
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
-
-    await runSetup();
-
-    expect(p.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("Could not mark onboarding complete"),
-    );
-  });
-
   it("keeps ordinary setup free of GitHub when the remote profile is already onboarded", async () => {
     saveConfig(makeCfg());
     setupAuthed();
@@ -1813,10 +1704,9 @@ describe("runSetup checkpoint behavior", () => {
     await runSetup();
 
     expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
-    expect(mockStepImportGitHubDocs).not.toHaveBeenCalled();
   });
 
-  it("keeps setup free of GitHub when onboarding is incomplete but the CLI flag is disabled", async () => {
+  it("hands first-run users to the web onboarding wizard even when the legacy CLI flag is disabled", async () => {
     saveConfig(makeCfg());
     setupAuthed();
     mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
@@ -1824,13 +1714,72 @@ describe("runSetup checkpoint behavior", () => {
       finished_onboarding: false,
       cli_onboarding_enabled: false,
     });
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+    });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
 
+    expect(mockStartOAuthFlow).toHaveBeenCalledWith(
+      undefined,
+      "/onboarding/connections",
+      expect.objectContaining({ source: "cli" }),
+      undefined,
+      expect.objectContaining({ waitWithoutBrowser: true }),
+    );
     expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
-    expect(mockStepImportGitHubDocs).not.toHaveBeenCalled();
-    expect(mockTrpc.user.updateProfile.mutate).not.toHaveBeenCalled();
+  });
+
+  it("saves the freshly minted session from the web onboarding handback", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-minted", refresh_token: "ref-minted", expires_in: 3600 },
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.access_token).toBe("tok-minted");
+    expect(saved.refresh_token).toBe("ref-minted");
+  });
+
+  it("aborts and tracks failure when the web onboarding handoff does not complete", async () => {
+    saveConfig(makeCfg());
+    const methods = setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    mockStartOAuthFlow.mockRejectedValue(new Error("timed out"));
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Finish onboarding there, then re-run `dosu setup`."),
+    );
+    expect(trackedCliOnboardingEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "cli_onboarding_failed",
+          properties: expect.objectContaining({ reason: "web_onboarding_incomplete" }),
+        }),
+      ]),
+    );
+    // Never reached deployment binding or the one-shot confirm.
+    expect(methods.getDeployments).not.toHaveBeenCalled();
+    expect(p.multiselect).not.toHaveBeenCalled();
   });
 
   it("binds first-run onboarding to the owner org instead of stale local config", async () => {
@@ -1866,9 +1815,11 @@ describe("runSetup checkpoint behavior", () => {
     mockTrpc.organization.getOrganizations.query.mockResolvedValue([
       { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
     ]);
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+    });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
 
     await runSetup();
 
@@ -1878,7 +1829,7 @@ describe("runSetup checkpoint behavior", () => {
     expect(saved.deployment_id).toBe("dep-owner");
   });
 
-  it("always starts the GitHub step from repo selection during first-run onboarding", async () => {
+  it("never runs the terminal GitHub step during first-run onboarding", async () => {
     saveConfig(makeCfg());
     setupAuthed();
     mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
@@ -1886,45 +1837,101 @@ describe("runSetup checkpoint behavior", () => {
       finished_onboarding: false,
       cli_onboarding_enabled: true,
     });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({
-      advance: true,
-      has_connected_repo: true,
-      deployment_id: "dep-github",
-      space_id: "space-1",
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
     });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
 
-    expect(mockStepConnectGitHubRepo).toHaveBeenCalledTimes(1);
-    expect(mockStepImportGitHubDocs).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({ waitForFreshDocs: true }),
-    );
+    expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
   });
 
-  it("does not wait for fresh docs when no repo was connected in this run", async () => {
-    saveConfig(makeCfg());
+  it("steers the auth tab into the web wizard instead of opening a second one", async () => {
+    // Fresh config → browser auth happens this run, so an auth tab exists.
+    saveConfig(makeCfg({ access_token: "", refresh_token: "", expires_at: 0 }));
     setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: false,
+    });
+    const authTab = { port: 1, close: vi.fn(), setNext: vi.fn() };
+    mockStartOAuthFlow
+      .mockResolvedValueOnce({
+        browserOpened: true,
+        token: { access_token: "tok-auth", refresh_token: "ref-auth", expires_in: 3600 },
+        server: authTab,
+      })
+      .mockImplementationOnce(async (_signal, _path, _params, _onAuthURL, options) => {
+        options?.onAuthURL?.("https://app.test/onboarding/connections?source=cli&callback=x");
+        return {
+          browserOpened: true,
+          token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+        };
+      });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // The existing tab was steered to the wizard URL…
+    expect(authTab.setNext).toHaveBeenCalledWith(
+      "https://app.test/onboarding/connections?source=cli&callback=x",
+    );
+    // …and the wizard call suppressed its own browser open.
+    const handoffOptions = mockStartOAuthFlow.mock.calls[1]?.[4];
+    expect(handoffOptions).toMatchObject({
+      suppressBrowserOpen: true,
+      successVariant: "onboarding",
+    });
+    expect(authTab.close).toHaveBeenCalled();
+  });
+
+  it("releases the auth tab when the profile is already onboarded", async () => {
+    saveConfig(makeCfg({ access_token: "", refresh_token: "", expires_at: 0 }));
+    setupAuthed();
+    // installRemoteSetupDefaults: finished_onboarding=true → ordinary setup.
+    const authTab = { port: 1, close: vi.fn(), setNext: vi.fn() };
+    mockStartOAuthFlow.mockResolvedValueOnce({
+      browserOpened: true,
+      token: { access_token: "tok-auth", refresh_token: "ref-auth", expires_in: 3600 },
+      server: authTab,
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // Tab dismissed (stops polling) and the server closed; no second flow.
+    expect(authTab.setNext).toHaveBeenCalledWith(null);
+    expect(authTab.close).toHaveBeenCalled();
+    expect(mockStartOAuthFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors --deployment over the web onboarding handoff for unfinished profiles", async () => {
+    // `--deployment` is an explicit escape hatch: even a first-run profile
+    // must be wired straight to the requested deployment, never silently
+    // rerouted through the wizard and auto-bound elsewhere.
+    saveConfig(makeCfg({ deployment_id: undefined, deployment_name: undefined }));
+    setupAuthed({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "dep-explicit" })]),
+    });
     mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
       user_id: "test-user-id",
       finished_onboarding: false,
       cli_onboarding_enabled: true,
     });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({
-      advance: true,
-      has_connected_repo: false,
-    });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
 
-    await runSetup();
+    await runSetup({ deploymentID: "dep-explicit" });
 
-    expect(mockStepImportGitHubDocs).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({ waitForFreshDocs: false }),
-    );
+    // No web-onboarding handoff was started (no browser flow at all — the
+    // session was already valid), and the explicit deployment was bound.
+    expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+    const saved = loadConfig();
+    expect(saved.deployment_id).toBe("dep-explicit");
   });
 });
 
@@ -2040,9 +2047,11 @@ describe("runSetup additional branches", () => {
     mockTrpc.organization.getOrganizations.query.mockResolvedValue([
       { org_id: "member-org", name: "Member Org", user_role: "MEMBER" },
     ]);
+    vi.mocked(startOAuthFlow).mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+    });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
 
     await runSetup();
 
@@ -2067,6 +2076,10 @@ describe("runSetup additional branches", () => {
     mockTrpc.organization.getOrganizations.query.mockResolvedValue([
       { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
     ]);
+    vi.mocked(startOAuthFlow).mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+    });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
@@ -2103,9 +2116,11 @@ describe("runSetup additional branches", () => {
     mockTrpc.organization.getOrganizations.query.mockResolvedValue([
       { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
     ]);
+    vi.mocked(startOAuthFlow).mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+    });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
 
     await runSetup();
 
@@ -2177,86 +2192,6 @@ describe("runSetup additional branches", () => {
     ).toBe(true);
   });
 
-  it("aborts when the GitHub docs import step does not advance", async () => {
-    saveConfig(makeCfg());
-    setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
-    // Docs import refuses to advance → tracks github_docs_import_failed and returns.
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: false });
-
-    await runSetup();
-
-    expect(p.outro).not.toHaveBeenCalled();
-    expect(
-      trackedCliOnboardingEvents().some(
-        (e) =>
-          e.event === "cli_onboarding_failed" &&
-          e.properties?.reason === "github_docs_import_failed",
-      ),
-    ).toBe(true);
-  });
-
-  it("returns early and tracks cancellation when the GitHub connect step does not advance", async () => {
-    saveConfig(makeCfg());
-    setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
-
-    await runSetup();
-
-    expect(mockStepImportGitHubDocs).not.toHaveBeenCalled();
-    expect(p.outro).not.toHaveBeenCalled();
-    expect(
-      trackedCliOnboardingEvents().some(
-        (e) =>
-          e.event === "cli_onboarding_cancelled" &&
-          e.properties?.reason === "github_connect_not_advanced",
-      ),
-    ).toBe(true);
-  });
-
-  it("persists a fresh space_id surfaced by the GitHub connect step", async () => {
-    // After binding the onboarding deployment cfg has no space_id, and the
-    // connect step returns one → the `connectResult.space_id && !cfg.space_id`
-    // branch saves it.
-    saveConfig(makeCfg({ space_id: undefined }));
-    // Bound deployment carries no space_id so cfg.space_id stays empty until
-    // the connect step supplies one.
-    setupAuthed({
-      getDeployments: vi
-        .fn()
-        .mockResolvedValue([makeDeployment({ org_id: "o1", space_id: undefined })]),
-    });
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({
-      advance: true,
-      has_connected_repo: false,
-      space_id: "space-from-connect",
-    });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true });
-
-    await runSetup();
-
-    const saved = loadConfig();
-    expect(saved.space_id).toBe("space-from-connect");
-  });
-
   it("switches mode from OSS to Cloud when --mode cloud is passed over an OSS config", async () => {
     saveConfig(makeCfg({ mode: "oss" }));
     setupAuthed();
@@ -2266,62 +2201,6 @@ describe("runSetup additional branches", () => {
 
     const saved = loadConfig();
     expect(saved.mode).toBeUndefined();
-  });
-
-  it("treats docs import with no imported count as not activated", async () => {
-    // imported is true but imported_count is absent → the `(imported_count ?? 0)
-    // > 0` guard is false, so docsImported stays false (no activation event).
-    saveConfig(makeCfg());
-    setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
-    mockStepImportGitHubDocs.mockResolvedValue({ advance: true, imported: true });
-
-    await runSetup();
-
-    const events = trackedCliOnboardingEvents().map((input) => input.event);
-    expect(events).not.toContain("cli_onboarding_docs_imported");
-    expect(events).not.toContain("cli_onboarding_activated");
-  });
-
-  it("defaults the failed count to zero in the docs-imported tracking events", async () => {
-    // docsImported is true (imported_count > 0) but failed_count is absent, so
-    // the `failed_count ?? 0` fallbacks are exercised.
-    saveConfig(makeCfg());
-    setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: false });
-    mockStepImportGitHubDocs.mockResolvedValue({
-      advance: true,
-      imported: true,
-      imported_count: 2,
-      task_id: "task-x",
-    });
-
-    await runSetup();
-
-    expect(trackedCliOnboardingEvents()).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          event: "cli_onboarding_docs_imported",
-          properties: expect.objectContaining({ imported_count: 2, failed_count: 0 }),
-        }),
-        expect.objectContaining({
-          event: "cli_onboarding_activated",
-          properties: expect.objectContaining({ imported_count: 2, failed_count: 0 }),
-        }),
-      ]),
-    );
   });
 
   it("continues to the outro when the skill install reports failure", async () => {
@@ -2399,9 +2278,9 @@ describe("runSetup additional branches", () => {
     expect(p.outro).not.toHaveBeenCalled();
   });
 
-  it("tracks MCP configuration and docs import when MCP and GitHub onboarding both ran", async () => {
-    // Configure an MCP tool (so mcpConfiguredThisRun is true) AND complete the
-    // GitHub onboarding step — both completion events should be tracked.
+  it("tracks MCP configuration after the web onboarding handback", async () => {
+    // First-run: the web wizard hands back, then the MCP tool configuration
+    // still runs (and is tracked) in the terminal.
     saveConfig(makeCfg());
     setupAuthed();
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
@@ -2410,20 +2289,17 @@ describe("runSetup additional branches", () => {
       finished_onboarding: false,
       cli_onboarding_enabled: true,
     });
+    vi.mocked(startOAuthFlow).mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+    });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection(["cursor"]);
-    mockStepConnectGitHubRepo.mockResolvedValue({ advance: true, has_connected_repo: true });
-    mockStepImportGitHubDocs.mockResolvedValue({
-      advance: true,
-      imported: true,
-      imported_count: 1,
-      failed_count: 0,
-    });
 
     await runSetup();
 
     const events = trackedCliOnboardingEvents().map((input) => input.event);
     expect(events).toContain("cli_onboarding_mcp_configured");
-    expect(events).toContain("cli_onboarding_docs_imported");
+    expect(events).toContain("cli_onboarding_completed");
   });
 });

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -4,6 +4,7 @@
 
 import { randomUUID } from "node:crypto";
 import * as p from "@clack/prompts";
+import type { CallbackServer } from "../auth/server";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
 import type { TypedClient } from "../client/trpc";
 import { installSkill } from "../commands/skill";
@@ -38,7 +39,6 @@ export interface ToolSelection {
 interface OneShotChoices {
   configureMcp: boolean;
   installSkill: boolean;
-  connectGitHub: boolean;
 }
 
 type SetupFlowKind = "onboarding" | "setup";
@@ -58,7 +58,8 @@ interface OwnedOrg {
 interface CliOnboardingProfile {
   user_id?: string | null;
   finished_onboarding?: boolean | null;
-  cli_onboarding_enabled?: boolean | null;
+  // The server also returns `cli_onboarding_enabled` (a dead feature flag);
+  // the CLI deliberately no longer reads it.
 }
 
 export async function runSetup(opts: SetupOptions = {}): Promise<void> {
@@ -85,10 +86,17 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     saveConfig(cfg);
   }
 
-  // Authenticate — always runs so we can verify/refresh tokens.
-  const authedCfg = await stepAuthenticate(cfg, onboardingRunID);
-  if (!authedCfg) return;
-  cfg = authedCfg;
+  // Authenticate — always runs so we can verify/refresh tokens. When the
+  // browser was involved, `authTab` steers that same tab onward (into the
+  // web onboarding wizard) instead of opening a second one.
+  const authed = await stepAuthenticate(cfg, onboardingRunID);
+  if (!authed) return;
+  cfg = authed.cfg;
+  const authTab = authed.authTab;
+  const releaseAuthTab = () => {
+    authTab?.setNext(null);
+    authTab?.close();
+  };
   await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_auth_completed");
 
   const apiClient = new Client(cfg);
@@ -103,6 +111,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
         reason: "cloud_setup_context_failed",
       });
       s.stop("Workspace load failed");
+      releaseAuthTab();
       return;
     }
     s.stop("Workspace loaded");
@@ -111,11 +120,34 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     flow_kind: cloudSetupContext?.kind ?? "oss",
   });
 
+  // First-run web onboarding applies to cloud-mode users who haven't
+  // finished onboarding — unless they passed `--deployment`, which is an
+  // explicit "just wire me to this deployment" escape hatch that must never
+  // be silently overridden by the onboarding auto-bind.
+  const firstRunOnboarding =
+    cfg.mode !== MODE_OSS && cloudSetupContext?.kind === "onboarding" && !opts.deploymentID;
+
+  // Only the first-run web-onboarding handoff can steer the auth tab; every
+  // other path lets the success page settle where it is.
+  if (!firstRunOnboarding) {
+    releaseAuthTab();
+  }
+
   // Deployment: first-run onboarding binds the user's default deployment.
   // Otherwise we only run the interactive picker when we don't already have
   // a deployment id locked in, OR when the caller passed `--deployment` to
   // explicitly switch. Everyday re-runs reuse the stored deployment silently.
-  if (cfg.mode !== MODE_OSS && cloudSetupContext?.kind === "onboarding") {
+  if (firstRunOnboarding && cloudSetupContext) {
+    // First-run: repo connection + docs import live in the web onboarding
+    // wizard (the one code path we trust). Hand the browser over, wait for
+    // the wizard to finish, then bind the deployment context it left behind.
+    const onboarded = await stepWebOnboarding(cfg, onboardingRunID, authTab);
+    if (!onboarded) {
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+        reason: "web_onboarding_incomplete",
+      });
+      return;
+    }
     const ok = await bindOnboardingDeployment(apiClient, cfg, cloudSetupContext.targetOrg ?? null);
     if (!ok) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
@@ -146,10 +178,9 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   saveConfig(cfg);
 
   // One-shot confirm: MCP + skill are always listed (user picks what to
-  // (re)run); GitHub docs import only shows during first-run onboarding.
-  const choices = await stepOneShotConfirm({
-    includeGitHub: cloudSetupContext?.kind === "onboarding",
-  });
+  // (re)run). Repo connection + docs import happen in the web onboarding
+  // wizard, so the CLI no longer offers them here.
+  const choices = await stepOneShotConfirm();
   if (!choices) {
     await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
       reason: "options_cancelled",
@@ -159,7 +190,6 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_options_selected", {
     configure_mcp: choices.configureMcp,
     install_skill: choices.installSkill,
-    connect_github: choices.connectGitHub,
   });
 
   // MCP tools. Track whether at least one agent ended up with Dosu MCP
@@ -168,7 +198,6 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   let mcpConfiguredThisRun = false;
   let mcpCompleted = false;
   let skillCompleted = false;
-  let docsImported = false;
   if (choices.configureMcp) {
     const configured = await stepConfigureMcpTools(cfg);
     if (configured === null) {
@@ -198,81 +227,6 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     }
   }
 
-  let githubOnboardingDone = !choices.connectGitHub;
-  if (choices.connectGitHub && cloudSetupContext?.kind === "onboarding") {
-    const { stepConnectGitHubRepo } = await import("./github-step");
-    const connectResult = await stepConnectGitHubRepo(cfg);
-    if (!connectResult.advance) {
-      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
-        reason: "github_connect_not_advanced",
-        has_connected_repo: connectResult.has_connected_repo,
-      });
-      return;
-    }
-    if (
-      connectResult.has_connected_repo ||
-      (connectResult.created_data_source_ids?.length ?? 0) > 0
-    ) {
-      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_github_connected", {
-        created_data_source_count: connectResult.created_data_source_ids?.length ?? 0,
-        created_repository_slugs: connectResult.created_repository_slugs,
-      });
-    }
-    if (connectResult.space_id && !cfg.space_id) {
-      cfg.space_id = connectResult.space_id;
-      saveConfig(cfg);
-    }
-
-    const { stepImportGitHubDocs } = await import("./github-doc-import-step");
-    const importResult = await stepImportGitHubDocs(cfg, {
-      waitForFreshDocs: Boolean(connectResult.deployment_id),
-      expectedDataSourceIds: connectResult.created_data_source_ids,
-    });
-    if (!importResult.advance) {
-      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
-        reason: "github_docs_import_failed",
-      });
-      return;
-    }
-    docsImported = importResult.imported === true && (importResult.imported_count ?? 0) > 0;
-    if (docsImported) {
-      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_docs_imported", {
-        imported_count: importResult.imported_count ?? 0,
-        failed_count: importResult.failed_count ?? 0,
-        task_id: importResult.task_id,
-      });
-      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_activated", {
-        imported_count: importResult.imported_count ?? 0,
-        failed_count: importResult.failed_count ?? 0,
-      });
-    }
-    githubOnboardingDone = true;
-  }
-
-  const shouldCompleteRemoteOnboarding =
-    cloudSetupContext?.kind === "onboarding" && githubOnboardingDone;
-
-  if (shouldCompleteRemoteOnboarding && cloudSetupContext) {
-    const profileUserID = cloudSetupContext.profileUserID;
-    try {
-      const { createTypedClient } = await import("../client/trpc");
-      const trpc = createTypedClient(cfg);
-      await trpc.user.updateProfile.mutate({
-        user_id: profileUserID,
-        finished_onboarding: true,
-      });
-      logger.info("setup", "Server onboarding marked complete");
-    } catch (err) {
-      logger.warn(
-        "setup",
-        `completeOnboarding failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      p.log.warn(
-        "Could not mark onboarding complete on the server — you can retry later by running `dosu setup` again.",
-      );
-    }
-  }
-
   // Codebase audit handoff (cloud mode only — it acts on the user's own
   // repo): offer to launch Claude Code with the audit prompt so there's no
   // gap between finishing setup and seeing what Dosu can generate.
@@ -281,11 +235,10 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     handoffToAudit = await offerAuditHandoff();
   }
 
-  if (mcpCompleted || skillCompleted || docsImported) {
+  if (mcpCompleted || skillCompleted) {
     await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_completed", {
       completed_mcp: mcpCompleted,
       completed_skill: skillCompleted,
-      imported_docs: docsImported,
     });
   }
 
@@ -334,23 +287,15 @@ function applyModeOverride(cfg: Config, opts: SetupOptions): void {
  * unticks specific items.
  *
  * MCP + skill are always listed so users can re-run either step at any
- * time (add a new agent, reinstall the skill). GitHub docs import only
- * shows during first-run cloud onboarding.
+ * time (add a new agent, reinstall the skill). Repo connection + docs
+ * import happen in the web onboarding wizard, not here.
  */
-async function stepOneShotConfirm(opts: {
-  includeGitHub: boolean;
-}): Promise<OneShotChoices | null> {
+async function stepOneShotConfirm(): Promise<OneShotChoices | null> {
   type Item = { value: keyof OneShotChoices; label: string };
   const items: Item[] = [
     { value: "configureMcp", label: "Install Dosu MCP" },
     { value: "installSkill", label: "Install Dosu skill" },
   ];
-  if (opts.includeGitHub) {
-    items.push({
-      value: "connectGitHub",
-      label: `Import docs from GitHub ${dim("(Keep them up to date)")}`,
-    });
-  }
 
   const selected = await p.multiselect({
     message: "Dosu will set these up — press Enter to accept, space to toggle",
@@ -368,7 +313,6 @@ async function stepOneShotConfirm(opts: {
   return {
     configureMcp: chosen.has("configureMcp"),
     installSkill: chosen.has("installSkill"),
-    connectGitHub: chosen.has("connectGitHub"),
   };
 }
 
@@ -416,10 +360,20 @@ export async function runInstallSkill(): Promise<boolean> {
   }
 }
 
+interface AuthenticatedSetup {
+  cfg: Config;
+  /**
+   * Present when this run authenticated via the browser: the still-open
+   * callback server whose success page polls /next, letting the setup flow
+   * steer that same tab onward (web onboarding) instead of opening another.
+   */
+  authTab?: CallbackServer;
+}
+
 async function stepAuthenticate(
   existingCfg?: Config,
   onboardingRunID?: string,
-): Promise<Config | null> {
+): Promise<AuthenticatedSetup | null> {
   logger.info("setup", "Step: authenticate");
   const cfg = existingCfg ?? loadConfig();
 
@@ -432,7 +386,7 @@ async function stepAuthenticate(
       if (resp.status === 200) {
         logger.info("setup", `Session verified, status=${resp.status}`);
         s.stop("Authenticated");
-        return cfg;
+        return { cfg };
       }
       try {
         logger.debug("setup", "Attempting token refresh");
@@ -440,7 +394,7 @@ async function stepAuthenticate(
         const resp2 = await apiClient.doRequestRaw("GET", "/v1/mcp/deployments");
         if (resp2.status === 200) {
           s.stop("Authenticated");
-          return cfg;
+          return { cfg };
         }
       } catch {
         // refresh failed, fall through to login
@@ -459,7 +413,10 @@ async function stepAuthenticate(
   return await openBrowserForSetup(cfg, onboardingRunID);
 }
 
-async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promise<Config | null> {
+async function openBrowserForSetup(
+  cfg: Config,
+  onboardingRunID?: string,
+): Promise<AuthenticatedSetup | null> {
   try {
     const { startOAuthFlow } = await import("../auth/flow");
     const s = p.spinner();
@@ -470,6 +427,9 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
       undefined,
       {
         waitWithoutBrowser: true,
+        // Keep the callback server alive so the success page's tab can be
+        // steered into the web onboarding wizard for first-run users.
+        holdNext: true,
         onAuthURL: (url) => {
           p.log.message(browserFallbackHint(url));
           s.start("Waiting for authentication...");
@@ -489,7 +449,7 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
     cfg.refresh_token = token.refresh_token;
     cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
     saveConfig(cfg);
-    return cfg;
+    return { cfg, authTab: result.server };
   } catch (err: unknown) {
     /* v8 ignore next 2 -- err is always Error in practice */
     const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
@@ -514,6 +474,77 @@ async function openBrowserForSetup(cfg: Config, onboardingRunID?: string): Promi
   }
 }
 
+/**
+ * First-run onboarding handoff: repo connection + docs import happen in the
+ * web onboarding wizard, not the terminal. Opens the browser at
+ * `/onboarding/connections?source=cli&callback=…` — the wizard detects the
+ * CLI flow, skips its "set up the CLI" step, marks onboarding finished on
+ * the server, and redirects back to the local callback with a freshly
+ * minted CLI session (same payload shape as the auth callback, so
+ * `startOAuthFlow` provides the listener, browser open, and timeout).
+ *
+ * Returns `true` once the wizard handed back, `false` on timeout/failure
+ * (with a hint to finish in the browser and re-run `dosu setup`).
+ *
+ * When `authTab` is present (this run authenticated via the browser), the
+ * auth success page is steered straight into the wizard via `setNext` — one
+ * tab for the whole journey. Without it, a fresh tab is opened.
+ */
+async function stepWebOnboarding(
+  cfg: Config,
+  onboardingRunID: string,
+  authTab?: CallbackServer,
+): Promise<boolean> {
+  logger.info("setup", "Step: web onboarding handoff");
+  p.log.info("Almost there — connect your repos in the browser and we'll pick up from here.");
+  const s = p.spinner();
+  try {
+    const { startOAuthFlow } = await import("../auth/flow");
+    const result = await startOAuthFlow(
+      undefined,
+      "/onboarding/connections",
+      { source: "cli", onboarding_run_id: onboardingRunID },
+      undefined,
+      {
+        waitWithoutBrowser: true,
+        suppressBrowserOpen: Boolean(authTab),
+        successVariant: "onboarding",
+        onAuthURL: (url) => {
+          authTab?.setNext(url);
+          p.log.message(browserFallbackHint(url));
+          s.start("Waiting for onboarding to finish in the browser...");
+        },
+      },
+    );
+    /* v8 ignore next 4 -- unreachable with waitWithoutBrowser */
+    if (!result.browserOpened) {
+      s.stop("Could not open a browser");
+      return false;
+    }
+    // The wizard hands back a freshly minted CLI session — keep the newest.
+    cfg.access_token = result.token.access_token;
+    cfg.refresh_token = result.token.refresh_token;
+    cfg.expires_at = Math.floor(Date.now() / 1000) + result.token.expires_in;
+    saveConfig(cfg);
+    s.stop("Onboarding finished in the browser");
+    logger.info("setup", "Web onboarding handoff completed");
+    return true;
+  } catch (err: unknown) {
+    /* v8 ignore next -- err is always Error in practice */
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("setup", `Web onboarding handoff did not complete: ${msg}`);
+    s.stop("Onboarding not completed");
+    p.log.warn(
+      "Didn't hear back from the browser. Finish onboarding there, then re-run `dosu setup`.",
+    );
+    return false;
+  } finally {
+    // The auth tab either navigated into the wizard already or was closed by
+    // the user; either way its server has served its purpose.
+    authTab?.close();
+  }
+}
+
 async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext | null> {
   try {
     const { createTypedClient } = await import("../client/trpc");
@@ -525,7 +556,11 @@ async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext 
       return null;
     }
 
-    if (profile.finished_onboarding === true || profile.cli_onboarding_enabled !== true) {
+    // First-run detection is driven purely by `finished_onboarding`. The old
+    // `cli_onboarding_enabled` flag gated a terminal-local onboarding path
+    // that no longer exists — first-run users now finish onboarding in the
+    // web wizard via `stepWebOnboarding`.
+    if (profile.finished_onboarding === true) {
       return {
         kind: "setup",
         profileUserID: profile.user_id,


### PR DESCRIPTION
## What

First-run `dosu setup` now hands repo connection + docs import to the web onboarding wizard instead of the terminal-local GitHub flow, then picks up where the wizard leaves off.

**Before:** new users were never asked to connect GitHub or import docs — the terminal onboarding path was gated behind `cli_onboarding_enabled`, hardcoded off since May (dosu#10418), and its connect pipeline had drifted from the library-membership data model. Setup ended with an empty, unusable workspace and no pointer to the web wizard.

**After:**
1. Browser auth (unchanged)
2. `finished_onboarding !== true` → the auth tab is steered in place to `/onboarding/connections?source=cli&callback=<localhost>` (single tab, no second window)
3. User connects repos / imports docs in the wizard — the one maintained code path; the wizard already detects `source=cli`, skips its CLI-instructions step, marks onboarding finished, and redirects back
4. CLI auto-binds the org's `dosu_mcp` deployment (no interactive picker), then continues: API key → MCP → skill → audit handoff

## How the tab steering works

The auth success page polls `GET /next` on the local callback server (250ms, ~3min budget, tolerant of transient errors). The CLI answers with the wizard URL (page swaps copy to *"You're ready to connect your data sources — Redirecting..."* and navigates), or dismisses it (page settles to the usual *"you can close this tab"*). The wizard's handback is served an onboarding-specific success page. New `startOAuthFlow` options (`holdNext`, `suppressBrowserOpen`, `successVariant`) are opt-in; `dosu login` and the agent/ticket flows are untouched.

## Notes

- `--deployment` remains an explicit escape hatch — never overridden by the handoff
- Returning users (`finished_onboarding=true`) keep the exact current setup behavior
- Web app requires **zero changes**; `cli_onboarding_enabled` is no longer read
- Callback server now `unref()`s and severs keep-alive sockets on close, so it can never hang CLI exit
- `github-doc-import-step` / `github-step` modules are kept (still used by `dosu audit`) but no longer called from setup

## Follow-ups (separate PRs)

- CLI no longer emits `cli_onboarding_docs_imported` / `cli_onboarding_activated` / `cli_onboarding_github_connected` — dashboards keyed on them need equivalent web-side events
- Fix `dosu audit`'s connect fallback ordering (attach before sync + `auto_import`)
- Web dead-code cleanup: `checkWebOnboardingCliInstall` + `OnboardingInstallCli`

## Testing

- 1508 unit tests green; coverage 97.9% stmts / 93.5% branches (thresholds 95/90)
- Verified end-to-end against a local full stack: fresh user → setup → wizard steered in same tab → repos connected + docs imported → handback → auto-bound deployment → MCP configured