### PR TITLE
feat(docs): support azure_devops for import and publish

### DIFF
--- a/src/client/contract.ts
+++ b/src/client/contract.ts
@@ -1,2 +1,2 @@
 export const CLI_CONTRACT_HASH: typeof import("../generated/dosu-api-types").CLI_CONTRACT_HASH =
-  "f5c0727a7884";
+  "a27c8fdd5baf";

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -614,6 +614,19 @@ describe("docs import", () => {
     });
   });
 
+  it("calls docImports.importAzureDevopsFiles for azure_devops", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockResolvedValueOnce({ task_id: "task-1" });
+
+    await run("import", "azure_devops", "--files", "f1,f2");
+
+    expect(mockMutate).toHaveBeenCalledWith("docImports.importAzureDevopsFiles", {
+      knowledge_store_id: "ks1",
+      space_id: "sp1",
+      file_ids: ["f1", "f2"],
+    });
+  });
+
   it("calls docImports.importConfluencePages for confluence", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce({ task_id: "task-1" });
@@ -1143,6 +1156,29 @@ describe("docs publish", () => {
 
     const [, opts] = mockFetch.mock.calls[0];
     expect(JSON.parse(opts.body).target_directory).toBe("/");
+  });
+
+  it("publishes to azure_devops via Python backend", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockFetch.mockResolvedValueOnce(jsonResponse({ status: "ok" }));
+    mockQuery.mockReset();
+
+    await run(
+      "publish",
+      "p1",
+      "--to",
+      "azure_devops",
+      "--directory",
+      "docs/",
+      "--data-source-id",
+      "ds1",
+    );
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.test.dev/sync-back/azure_devops/p1/publish");
+    const body = JSON.parse(opts.body);
+    expect(body.target_directory).toBe("docs/");
+    expect(body.target_data_source_id).toBe("ds1");
   });
 
   it("publishes to notion via Python backend", async () => {

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -1181,6 +1181,29 @@ describe("docs publish", () => {
     expect(body.target_data_source_id).toBe("ds1");
   });
 
+  it("defaults azure_devops publish directory to / when omitted", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockFetch.mockResolvedValueOnce(jsonResponse({ status: "ok" }));
+    mockQuery.mockReset();
+
+    await run("publish", "p1", "--to", "azure_devops", "--data-source-id", "ds1");
+
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(JSON.parse(opts.body).target_directory).toBe("/");
+  });
+
+  it("exits when publishing to azure_devops without --data-source-id", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockReset();
+
+    await expect(
+      run("publish", "p1", "--to", "azure_devops", "--directory", "docs/"),
+    ).rejects.toThrow("exit");
+
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("--data-source-id");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("publishes to notion via Python backend", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockFetch.mockResolvedValueOnce(jsonResponse({ status: "ok" }));

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -572,11 +572,20 @@ export function docsCommand(): Command {
           },
           azure_devops: {
             path: `/sync-back/azure_devops/${id}/publish`,
-            // The repository is resolved from the data source server-side.
-            buildBody: () => ({
-              target_directory: opts.directory ?? "/",
-              target_data_source_id: opts.dataSourceId,
-            }),
+            // The repository is resolved server-side from the data source, so
+            // --data-source-id is the sole target identifier and is required.
+            buildBody: () => {
+              if (!opts.dataSourceId) {
+                console.error(
+                  pc.red("--data-source-id <id> is required when publishing to azure_devops"),
+                );
+                process.exit(1);
+              }
+              return {
+                target_directory: opts.directory ?? "/",
+                target_data_source_id: opts.dataSourceId,
+              };
+            },
           },
           confluence: {
             path: `/sync-back/confluence/${id}/publish`,

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -423,7 +423,7 @@ export function docsCommand(): Command {
   cmd
     .command("import")
     .description("Import documents from an external platform")
-    .argument("<platform>", "Platform: github, gitlab, confluence, notion, coda")
+    .argument("<platform>", "Platform: github, gitlab, azure_devops, confluence, notion, coda")
     .requiredOption("--files <ids>", "Comma-separated file/page IDs to import")
     .option("--json", "Output as JSON")
     .action(async (platform: string, opts: { files: string; json?: boolean }) => {
@@ -437,6 +437,7 @@ export function docsCommand(): Command {
       const importFn: Record<string, (input: any) => Promise<any>> = {
         github: (input) => client.docImports.importGithubFiles.mutate(input),
         gitlab: (input) => client.docImports.importGitlabFiles.mutate(input),
+        azure_devops: (input) => client.docImports.importAzureDevopsFiles.mutate(input),
         confluence: (input) => client.docImports.importConfluencePages.mutate(input),
         notion: (input) => client.docImports.importNotionPages.mutate(input),
         coda: (input) => client.docImports.importCodaPages.mutate(input),
@@ -445,7 +446,9 @@ export function docsCommand(): Command {
       const fn = importFn[platform.toLowerCase()];
       if (!fn) {
         console.error(
-          pc.red(`Unknown platform: ${platform}. Use: github, gitlab, confluence, notion, coda`),
+          pc.red(
+            `Unknown platform: ${platform}. Use: github, gitlab, azure_devops, confluence, notion, coda`,
+          ),
         );
         process.exit(1);
       }
@@ -519,7 +522,10 @@ export function docsCommand(): Command {
     .command("publish")
     .description("Publish a document to an external platform")
     .argument("<id>", "Page ID")
-    .requiredOption("--to <platform>", "Target: github, gitlab, confluence, notion, coda")
+    .requiredOption(
+      "--to <platform>",
+      "Target: github, gitlab, azure_devops, confluence, notion, coda",
+    )
     .option("--repo-id <id>", "GitHub repository ID")
     .option("--project-id <id>", "GitLab project ID")
     .option("--parent-page-id <id>", "Parent page ID (Confluence/Notion)")
@@ -560,6 +566,14 @@ export function docsCommand(): Command {
             path: `/sync-back/gitlab/${id}/publish`,
             buildBody: () => ({
               gitlab_project_id: opts.projectId,
+              target_directory: opts.directory ?? "/",
+              target_data_source_id: opts.dataSourceId,
+            }),
+          },
+          azure_devops: {
+            path: `/sync-back/azure_devops/${id}/publish`,
+            // The repository is resolved from the data source server-side.
+            buildBody: () => ({
               target_directory: opts.directory ?? "/",
               target_data_source_id: opts.dataSourceId,
             }),

--- a/src/generated/dosu-api-types.d.ts
+++ b/src/generated/dosu-api-types.d.ts
@@ -8,6 +8,7 @@
 // - dataSource.update
 // - deploymentDataSource.create
 // - docImports.getImportStatus
+// - docImports.importAzureDevopsFiles
 // - docImports.importCodaPages
 // - docImports.importConfluencePages
 // - docImports.importGithubFiles
@@ -289,7 +290,7 @@ export type CliProviderSlug =
 	| 'teams'
 	| 'azure_devops'
 
-export declare const CLI_CONTRACT_HASH: 'f5c0727a7884'
+export declare const CLI_CONTRACT_HASH: 'a27c8fdd5baf'
 
 export type AnalyticsGetUsageStatsInput = {
 	days?: number
@@ -445,6 +446,14 @@ export type DeploymentDataSourceCreateOutput = any
 export type DocImportsGetImportStatusInput = string
 
 export type DocImportsGetImportStatusOutput = any
+
+export type DocImportsImportAzureDevopsFilesInput = {
+	file_ids: Array<string>
+	knowledge_store_id: string
+	space_id: string
+}
+
+export type DocImportsImportAzureDevopsFilesOutput = any
 
 export type DocImportsImportCodaPagesInput = {
 	knowledge_store_id: string
@@ -1142,6 +1151,10 @@ export interface CliApiClient {
 	}
 	docImports: {
 		getImportStatus: QueryProcedure<DocImportsGetImportStatusInput, DocImportsGetImportStatusOutput>
+		importAzureDevopsFiles: MutationProcedure<
+			DocImportsImportAzureDevopsFilesInput,
+			DocImportsImportAzureDevopsFilesOutput
+		>
 		importCodaPages: MutationProcedure<
 			DocImportsImportCodaPagesInput,
 			DocImportsImportCodaPagesOutput


### PR DESCRIPTION
## Summary

Completes Azure DevOps parity for the `docs` commands:

- `dosu docs import azure_devops --files <ids>` — import Azure DevOps files into the knowledge base.
- `dosu docs publish <page-id> --to azure_devops --data-source-id <id> [--directory <path>]` — publish a page to an Azure DevOps repository as a pull request (the repository is resolved from the data source).

## Changes

- `src/commands/docs.ts` — add `azure_devops` to the import dispatch and the publish target map, plus help/usage text.
- `src/commands/docs.test.ts` — cover the new import and publish paths.
- Vendored CLI contract updated to include the `azure_devops` doc-import procedure.

## Testing

- `bun run test`, `bun run typecheck`, `bun run check` — all green.
- Verified live against a local stack: `import azure_devops` completed a real import task (file imported), and `publish --to azure_devops` opened a real pull request in an Azure DevOps repository.

## Note

Requires the corresponding backend support, which lands separately — this should not be released until that is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)