### PR TITLE
chore: sync vendored CLI contract (a27c8fdd5baf)

### DIFF
--- a/src/client/contract.ts
+++ b/src/client/contract.ts
@@ -1,2 +1,2 @@
 export const CLI_CONTRACT_HASH: typeof import("../generated/dosu-api-types").CLI_CONTRACT_HASH =
-  "f5c0727a7884";
+  "a27c8fdd5baf";

--- a/src/generated/dosu-api-types.d.ts
+++ b/src/generated/dosu-api-types.d.ts
@@ -8,6 +8,7 @@
 // - dataSource.update
 // - deploymentDataSource.create
 // - docImports.getImportStatus
+// - docImports.importAzureDevopsFiles
 // - docImports.importCodaPages
 // - docImports.importConfluencePages
 // - docImports.importGithubFiles
@@ -289,7 +290,7 @@ export type CliProviderSlug =
 	| 'teams'
 	| 'azure_devops'
 
-export declare const CLI_CONTRACT_HASH: 'f5c0727a7884'
+export declare const CLI_CONTRACT_HASH: 'a27c8fdd5baf'
 
 export type AnalyticsGetUsageStatsInput = {
 	days?: number
@@ -445,6 +446,14 @@ export type DeploymentDataSourceCreateOutput = any
 export type DocImportsGetImportStatusInput = string
 
 export type DocImportsGetImportStatusOutput = any
+
+export type DocImportsImportAzureDevopsFilesInput = {
+	file_ids: Array<string>
+	knowledge_store_id: string
+	space_id: string
+}
+
+export type DocImportsImportAzureDevopsFilesOutput = any
 
 export type DocImportsImportCodaPagesInput = {
 	knowledge_store_id: string
@@ -1142,6 +1151,10 @@ export interface CliApiClient {
 	}
 	docImports: {
 		getImportStatus: QueryProcedure<DocImportsGetImportStatusInput, DocImportsGetImportStatusOutput>
+		importAzureDevopsFiles: MutationProcedure<
+			DocImportsImportAzureDevopsFilesInput,
+			DocImportsImportAzureDevopsFilesOutput
+		>
 		importCodaPages: MutationProcedure<
 			DocImportsImportCodaPagesInput,
 			DocImportsImportCodaPagesOutput


### PR DESCRIPTION
Automated sync of the vendored CLI contract from dosu-ai/dosu@6c10ccfa1bfdd668abb3bcfcc905992f53dbeeab (contract hash `a27c8fdd5baf`).

- `src/generated/dosu-api-types.d.ts` — full copy of `frontend/packages/api/generated/cli-contract.d.ts`
- `src/client/contract.ts` — pinned `CLI_CONTRACT_HASH` updated to match

**Green CI** on this PR means the contract change is compatible with current CLI code — safe to merge.
**Red typecheck** means the CLI needs adapting before this can land.