### PR TITLE
fix: prevent account state mixing during login

### DIFF
--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -35,7 +35,8 @@ vi.mock("../auth/ticket", () => ({
   exchangeTicket: mockExchangeTicket,
 }));
 
-vi.mock("../config/config", () => ({
+vi.mock("../config/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config")>()),
   loadConfig: mockLoadConfig,
   saveConfig: mockSaveConfig,
 }));

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -15,7 +15,7 @@
 
 import { exchangeTicket, mintTicket } from "../auth/ticket";
 import { Client, type Deployment } from "../client/client";
-import { type Config, loadConfig, saveConfig } from "../config/config";
+import { type Config, loadConfig, replaceLoginSession, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
@@ -147,9 +147,11 @@ async function redeemTicket(
       });
       return { code: 0, cfg, exit: true };
     }
-    cfg.access_token = result.access_token ?? "";
-    cfg.refresh_token = result.refresh_token ?? "";
-    cfg.expires_at = Math.floor(Date.now() / 1000) + (result.expires_in ?? 3600);
+    replaceLoginSession(cfg, {
+      access_token: result.access_token ?? "",
+      refresh_token: result.refresh_token ?? "",
+      expires_at: Math.floor(Date.now() / 1000) + (result.expires_in ?? 3600),
+    });
     saveConfig(cfg);
     logger.info("agent.flow", "Ticket redeemed; session saved");
     emitStep({ step: "auth", email: result.email });

--- a/src/agent/login-commands.test.ts
+++ b/src/agent/login-commands.test.ts
@@ -12,7 +12,8 @@ vi.mock("../auth/ticket", () => ({
   exchangeTicket: mockExchangeTicket,
 }));
 
-vi.mock("../config/config", () => ({
+vi.mock("../config/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config")>()),
   loadConfig: mockLoadConfig,
   saveConfig: mockSaveConfig,
 }));

--- a/src/agent/login-commands.ts
+++ b/src/agent/login-commands.ts
@@ -8,7 +8,7 @@
  */
 
 import { exchangeTicket, mintTicket } from "../auth/ticket";
-import { loadConfig, saveConfig } from "../config/config";
+import { loadConfig, replaceLoginSession, saveConfig } from "../config/config";
 import { logger } from "../debug/logger";
 import { emitError, emitJSONLine, emitStep } from "./output";
 
@@ -73,9 +73,11 @@ export async function runLoginCheck(opts: { ticket: string; json: boolean }): Pr
 
   if (result.status === "authenticated") {
     const cfg = loadConfig();
-    cfg.access_token = result.access_token ?? "";
-    cfg.refresh_token = result.refresh_token ?? "";
-    cfg.expires_at = Math.floor(Date.now() / 1000) + (result.expires_in ?? 3600);
+    replaceLoginSession(cfg, {
+      access_token: result.access_token ?? "",
+      refresh_token: result.refresh_token ?? "",
+      expires_at: Math.floor(Date.now() / 1000) + (result.expires_in ?? 3600),
+    });
     saveConfig(cfg);
     logger.info("auth.ticket", "Ticket redeemed via dosu login --check");
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -29,6 +29,7 @@ import {
   isTokenExpired,
   loadConfig,
   MODE_OSS,
+  replaceLoginSession,
   saveConfig,
 } from "../config/config";
 import { logger } from "../debug/logger";
@@ -214,9 +215,11 @@ export function createProgram(): Command {
           }
         }
 
-        cfg.access_token = token.access_token;
-        cfg.refresh_token = token.refresh_token;
-        cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
+        replaceLoginSession(cfg, {
+          access_token: token.access_token,
+          refresh_token: token.refresh_token,
+          expires_at: Math.floor(Date.now() / 1000) + token.expires_in,
+        });
         saveConfig(cfg);
 
         console.log("Successfully authenticated!");

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -10,6 +10,7 @@ import {
   isAuthenticated,
   isTokenExpired,
   loadConfig,
+  replaceLoginSession,
   saveConfig,
 } from "./config";
 
@@ -121,6 +122,36 @@ describe("config", () => {
   it("isAuthenticated returns true when access_token is set", () => {
     expect(isAuthenticated({ access_token: "tok", refresh_token: "", expires_at: 0 })).toBe(true);
     expect(isAuthenticated({ access_token: "", refresh_token: "", expires_at: 0 })).toBe(false);
+  });
+
+  it("replaceLoginSession clears deployment state that may belong to another account", () => {
+    const cfg: Config = {
+      access_token: "old-token",
+      refresh_token: "old-refresh",
+      expires_at: 1,
+      deployment_id: "old-deployment",
+      deployment_name: "Old deployment",
+      api_key: "old-key",
+      org_id: "old-org",
+      space_id: "old-space",
+    };
+
+    replaceLoginSession(cfg, {
+      access_token: "new-token",
+      refresh_token: "new-refresh",
+      expires_at: 2,
+    });
+
+    expect(cfg).toEqual({
+      access_token: "new-token",
+      refresh_token: "new-refresh",
+      expires_at: 2,
+      deployment_id: undefined,
+      deployment_name: undefined,
+      api_key: undefined,
+      org_id: undefined,
+      space_id: undefined,
+    });
   });
 
   it("isTokenExpired returns false when expires_at is 0", () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -21,6 +21,31 @@ export interface Config {
   space_id?: string;
 }
 
+export interface SessionCredentials {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+}
+
+/**
+ * Replace credentials obtained from an explicit login flow.
+ *
+ * A login may authenticate a different account, so deployment-scoped state
+ * from the previous session must never survive the transition. Token refresh
+ * deliberately does not use this helper because it preserves the same
+ * authenticated identity.
+ */
+export function replaceLoginSession(cfg: Config, session: SessionCredentials): void {
+  cfg.access_token = session.access_token;
+  cfg.refresh_token = session.refresh_token;
+  cfg.expires_at = session.expires_at;
+  cfg.deployment_id = undefined;
+  cfg.deployment_name = undefined;
+  cfg.api_key = undefined;
+  cfg.org_id = undefined;
+  cfg.space_id = undefined;
+}
+
 /**
  * The CLI uses separate config directories for dev and production so that
  * testing against a local dev stack never clobbers a user's real credentials.

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1917,6 +1917,68 @@ describe("runSetup checkpoint behavior", () => {
     expect(saved.deployment_id).toBe("dep-owner");
   });
 
+  it("re-resolves onboarding state when the browser hands back a different account", async () => {
+    saveConfig(
+      makeCfg({
+        access_token: "account-a-token",
+        refresh_token: "account-a-refresh",
+        deployment_id: "account-a-deployment",
+        deployment_name: "Account A MCP",
+        api_key: "account-a-key",
+        org_id: "account-a-org",
+        space_id: "account-a-space",
+      }),
+    );
+    const methods = setupAuthed({
+      getDeployments: vi.fn().mockResolvedValue([
+        makeDeployment({
+          deployment_id: "account-a-deployment",
+          org_id: "account-a-org",
+          org_name: "Account A Org",
+          space_id: "account-a-space",
+        }),
+        makeDeployment({
+          deployment_id: "account-b-deployment",
+          org_id: "account-b-org",
+          org_name: "Account B Org",
+          space_id: "account-b-space",
+        }),
+      ]),
+    });
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "account-a-user",
+      finished_onboarding: false,
+      cli_onboarding_enabled: true,
+    });
+    mockTrpc.organization.getOrganizations.query
+      .mockResolvedValueOnce([
+        { org_id: "account-a-org", name: "Account A Org", user_role: "OWNER" },
+      ])
+      .mockResolvedValueOnce([
+        { org_id: "account-b-org", name: "Account B Org", user_role: "OWNER" },
+      ]);
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: {
+        access_token: "account-b-token",
+        refresh_token: "account-b-refresh",
+        expires_in: 3600,
+      },
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.access_token).toBe("account-b-token");
+    expect(saved.refresh_token).toBe("account-b-refresh");
+    expect(saved.org_id).toBe("account-b-org");
+    expect(saved.space_id).toBe("account-b-space");
+    expect(saved.deployment_id).toBe("account-b-deployment");
+    expect(saved.api_key).toBe("new-key");
+    expect(methods.validateAPIKey).not.toHaveBeenCalled();
+  });
+
   it("never runs the terminal GitHub step during first-run onboarding", async () => {
     saveConfig(makeCfg());
     setupAuthed();

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -8,7 +8,14 @@ import type { CallbackServer } from "../auth/server";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
 import type { TypedClient } from "../client/trpc";
 import { installSkill } from "../commands/skill";
-import { type Config, loadConfig, MODE_OSS, type SetupMode, saveConfig } from "../config/config";
+import {
+  type Config,
+  loadConfig,
+  MODE_OSS,
+  replaceLoginSession,
+  type SetupMode,
+  saveConfig,
+} from "../config/config";
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
@@ -101,7 +108,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   };
   await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_auth_completed");
 
-  const apiClient = new Client(cfg);
+  let apiClient = new Client(cfg);
   let cloudSetupContext: CloudSetupContext | null = null;
 
   if (cfg.mode !== MODE_OSS) {
@@ -150,7 +157,12 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       });
       return;
     }
-    const ok = await bindOnboardingDeployment(apiClient, cfg, cloudSetupContext.targetOrg ?? null);
+    // The browser may have completed onboarding under a different account.
+    // Resolve the target again with the returned session; never reuse the
+    // pre-handoff organization or client across an authentication boundary.
+    apiClient = new Client(cfg);
+    const targetOrg = await resolveCurrentOnboardingTargetOrg(cfg);
+    const ok = await bindOnboardingDeployment(apiClient, cfg, targetOrg);
     if (!ok) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
         reason: "onboarding_deployment_failed",
@@ -462,9 +474,11 @@ async function openBrowserForSetup(
     s.stop("Authenticated");
     logger.info("setup", "Browser auth completed");
 
-    cfg.access_token = token.access_token;
-    cfg.refresh_token = token.refresh_token;
-    cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
+    replaceLoginSession(cfg, {
+      access_token: token.access_token,
+      refresh_token: token.refresh_token,
+      expires_at: Math.floor(Date.now() / 1000) + token.expires_in,
+    });
     saveConfig(cfg);
     return { cfg, authTab: result.server };
   } catch (err: unknown) {
@@ -538,10 +552,14 @@ async function stepWebOnboarding(
       s.stop("Could not open a browser");
       return false;
     }
-    // The wizard hands back a freshly minted CLI session — keep the newest.
-    cfg.access_token = result.token.access_token;
-    cfg.refresh_token = result.token.refresh_token;
-    cfg.expires_at = Math.floor(Date.now() / 1000) + result.token.expires_in;
+    // The wizard may hand back a session for a different browser account.
+    // Replace the session and discard every deployment-scoped value before
+    // resolving the newly authenticated account's onboarding target.
+    replaceLoginSession(cfg, {
+      access_token: result.token.access_token,
+      refresh_token: result.token.refresh_token,
+      expires_at: Math.floor(Date.now() / 1000) + result.token.expires_in,
+    });
     saveConfig(cfg);
     s.stop("Onboarding finished in the browser");
     logger.info("setup", "Web onboarding handoff completed");
@@ -611,6 +629,18 @@ async function resolveOnboardingTargetOrg(trpc: TypedClient): Promise<OwnedOrg |
     return ownerOrg;
   }
   return accessibleOrgs[0] ?? null;
+}
+
+async function resolveCurrentOnboardingTargetOrg(cfg: Config): Promise<OwnedOrg | null> {
+  try {
+    const { createTypedClient } = await import("../client/trpc");
+    return await resolveOnboardingTargetOrg(createTypedClient(cfg));
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("setup", `Failed to resolve post-onboarding organization: ${msg}`);
+    p.log.error(`Could not determine your onboarding organization: ${msg}`);
+    return null;
+  }
 }
 
 async function bindOnboardingDeployment(

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -8,7 +8,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { Client } from "../client/client";
 import { executeInsights } from "../commands/insights";
-import { isAuthenticated, loadConfig, saveConfig } from "../config/config";
+import { isAuthenticated, loadConfig, replaceLoginSession, saveConfig } from "../config/config";
 import { runSetup } from "../setup/flow";
 import { browserFallbackHint } from "../setup/styles";
 
@@ -127,9 +127,11 @@ async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<v
     const token = result.token;
     s.stop("Authenticated");
 
-    cfg.access_token = token.access_token;
-    cfg.refresh_token = token.refresh_token;
-    cfg.expires_at = Math.floor(Date.now() / 1000) + token.expires_in;
+    replaceLoginSession(cfg, {
+      access_token: token.access_token,
+      refresh_token: token.refresh_token,
+      expires_at: Math.floor(Date.now() / 1000) + token.expires_in,
+    });
     saveConfig(cfg);
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */


### PR DESCRIPTION
## Why

The CLI assumed a newly authenticated session still belonged to the org, deployment, and API key already stored locally. If browser onboarding returned a different account, the config could mix the new session with the previous account's state.

## What changed

- Clear account-scoped state whenever an explicit login replaces the session.
- Re-resolve the org and deployment after the onboarding handoff.
- Cover the account A to account B flow with a regression test.

## Validation

- `bun run test`
- `bun run typecheck`
- `bun run check`
