### PR TITLE
refactor(config): introduce account-owned schema

### DIFF
--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  type FlatTestConfig,
+  makeTestConfig,
+  testAccessTokenFor,
+  testSession,
+  testTarget,
+} from "../config/config.test-utils";
 import type { SetupProvider } from "../mcp/providers";
 
 const {
@@ -85,11 +92,14 @@ function makeProvider(id: string, opts: Partial<SetupProvider> = {}): SetupProvi
   };
 }
 
-const baseCfg = {
+const baseCfg: FlatTestConfig = {
   access_token: "",
   refresh_token: "",
   expires_at: 0,
 };
+const makeBaseConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...baseCfg, ...overrides });
+const ticketAccessToken = testAccessTokenFor("ticket-user");
 
 describe("buildResumeCommand", () => {
   it("includes --tool and --login-ticket and uses the npx invocation", () => {
@@ -143,7 +153,7 @@ describe("runAgentSetup", () => {
 
     mockAllSetupProviders.mockReturnValue([claudeProvider, stdioProvider]);
     mockIsStdioOnly.mockImplementation((p: SetupProvider) => p.id() === "claude-desktop");
-    mockLoadConfig.mockReturnValue({ ...baseCfg });
+    mockLoadConfig.mockReturnValue(makeBaseConfig());
   });
 
   afterEach(() => {
@@ -201,7 +211,7 @@ describe("runAgentSetup", () => {
   it("redeems the ticket, picks the lone deployment, mints an API key, installs MCP", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
-      access_token: "tok",
+      access_token: ticketAccessToken,
       refresh_token: "ref",
       expires_in: 3600,
       email: "user@example.com",
@@ -239,14 +249,10 @@ describe("runAgentSetup", () => {
     ]);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
     expect(mockSaveConfig).toHaveBeenCalled();
-    const lastSave = mockSaveConfig.mock.calls.at(-1)?.[0] as {
-      access_token: string;
-      api_key?: string;
-      deployment_id?: string;
-    };
-    expect(lastSave.access_token).toBe("tok");
-    expect(lastSave.api_key).toBe("sk_user_x");
-    expect(lastSave.deployment_id).toBe("dep-1");
+    const lastSave = mockSaveConfig.mock.calls.at(-1)?.[0];
+    expect(testSession(lastSave).access_token).toBe(ticketAccessToken);
+    expect(testTarget(lastSave).api_key).toBe("sk_user_x");
+    expect(testTarget(lastSave).deployment_id).toBe("dep-1");
     expect(events.at(-1)).toMatchObject({
       step: "done",
       status: "ok",
@@ -257,7 +263,7 @@ describe("runAgentSetup", () => {
   it("errors with multiple_deployments when the user has more than one dosu_mcp", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
-      access_token: "tok",
+      access_token: ticketAccessToken,
       refresh_token: "ref",
       expires_in: 3600,
     });
@@ -303,7 +309,7 @@ describe("runAgentSetup", () => {
   it("auto-picks the lone dosu_mcp when other non-MCP deployments coexist", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
-      access_token: "tok",
+      access_token: ticketAccessToken,
       refresh_token: "ref",
       expires_in: 3600,
       email: "user@example.com",
@@ -365,7 +371,7 @@ describe("runAgentSetup", () => {
   it("errors with no_mcp_deployment when account has deployments but none are MCP", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
-      access_token: "tok",
+      access_token: ticketAccessToken,
       refresh_token: "ref",
       expires_in: 3600,
     });
@@ -434,12 +440,13 @@ describe("runAgentSetup", () => {
   });
 
   it("uses --deployment when supplied", async () => {
-    mockLoadConfig.mockReturnValue({
-      ...baseCfg,
-      access_token: "tok",
-      refresh_token: "ref",
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-    });
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.getDeployments.mockResolvedValue([
       {
@@ -487,7 +494,7 @@ describe("runAgentSetup", () => {
   it("errors when --deployment refers to an inaccessible deployment", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
-      access_token: "tok",
+      access_token: ticketAccessToken,
       refresh_token: "ref",
       expires_in: 3600,
     });
@@ -511,7 +518,7 @@ describe("runAgentSetup", () => {
   it("emits fetch_failed when loading deployments throws while resolving --deployment", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
-      access_token: "tok",
+      access_token: ticketAccessToken,
       refresh_token: "ref",
       expires_in: 3600,
     });
@@ -537,7 +544,7 @@ describe("runAgentSetup", () => {
   it("emits fetch_failed when auto-resolving deployments throws", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
-      access_token: "tok",
+      access_token: ticketAccessToken,
       refresh_token: "ref",
       expires_in: 3600,
     });
@@ -559,7 +566,7 @@ describe("runAgentSetup", () => {
   it("emits no_deployments when the account has no deployments at all", async () => {
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
-      access_token: "tok",
+      access_token: ticketAccessToken,
       refresh_token: "ref",
       expires_in: 3600,
     });
@@ -578,14 +585,15 @@ describe("runAgentSetup", () => {
   });
 
   it("reuses a deployment already locked in from a previous run", async () => {
-    mockLoadConfig.mockReturnValue({
-      ...baseCfg,
-      access_token: "tok",
-      refresh_token: "ref",
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-      deployment_id: "dep-locked",
-      deployment_name: "acme/locked",
-    });
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+      }),
+    );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.validateAPIKey.mockResolvedValue(false);
     mockClient.createAPIKey.mockResolvedValue({
@@ -612,15 +620,16 @@ describe("runAgentSetup", () => {
   });
 
   it("reuses a still-valid API key without minting a new one", async () => {
-    mockLoadConfig.mockReturnValue({
-      ...baseCfg,
-      access_token: "tok",
-      refresh_token: "ref",
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-      deployment_id: "dep-locked",
-      deployment_name: "acme/locked",
-      api_key: "sk_existing",
-    });
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.validateAPIKey.mockResolvedValue(true);
 
@@ -635,14 +644,15 @@ describe("runAgentSetup", () => {
   });
 
   it("emits create_failed when minting the API key throws", async () => {
-    mockLoadConfig.mockReturnValue({
-      ...baseCfg,
-      access_token: "tok",
-      refresh_token: "ref",
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-      deployment_id: "dep-locked",
-      deployment_name: "acme/locked",
-    });
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+      }),
+    );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.validateAPIKey.mockResolvedValue(false);
     mockClient.createAPIKey.mockRejectedValue(new Error("key service down"));
@@ -661,15 +671,16 @@ describe("runAgentSetup", () => {
   });
 
   it("emits install_failed when the provider install throws", async () => {
-    mockLoadConfig.mockReturnValue({
-      ...baseCfg,
-      access_token: "tok",
-      refresh_token: "ref",
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-      deployment_id: "dep-locked",
-      deployment_name: "acme/locked",
-      api_key: "sk_existing",
-    });
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.validateAPIKey.mockResolvedValue(true);
     (claudeProvider.install as ReturnType<typeof vi.fn>).mockImplementation(() => {
@@ -688,8 +699,11 @@ describe("runAgentSetup", () => {
     });
   });
 
-  it("redeems a ticket whose response omits tokens, falling back to defaults", async () => {
-    mockExchangeTicket.mockResolvedValue({ status: "authenticated" });
+  it("redeems a ticket whose response omits optional session fields", async () => {
+    mockExchangeTicket.mockResolvedValue({
+      status: "authenticated",
+      access_token: ticketAccessToken,
+    });
     mockClient.getDeployments.mockResolvedValue([
       {
         deployment_id: "dep-1",
@@ -713,14 +727,10 @@ describe("runAgentSetup", () => {
     const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt-good" });
 
     expect(code).toBe(0);
-    const authSave = mockSaveConfig.mock.calls[0]?.[0] as {
-      access_token: string;
-      refresh_token: string;
-      expires_at: number;
-    };
-    expect(authSave.access_token).toBe("");
-    expect(authSave.refresh_token).toBe("");
-    expect(authSave.expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000) + 3000);
+    const authSave = mockSaveConfig.mock.calls[0]?.[0];
+    expect(testSession(authSave).access_token).toBe(ticketAccessToken);
+    expect(testSession(authSave).refresh_token).toBe("");
+    expect(testSession(authSave).expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000) + 3000);
   });
 
   it("emits ticket_exchange_failed when redeeming a ticket throws", async () => {
@@ -742,21 +752,23 @@ describe("runAgentSetup", () => {
 
   it("refreshes an expired token and continues when the raw probe is unauthorized", async () => {
     mockLoadConfig
-      .mockReturnValueOnce({
-        ...baseCfg,
-        access_token: "stale",
-        refresh_token: "ref",
-        expires_at: Math.floor(Date.now() / 1000) + 3600,
-      })
-      .mockReturnValue({
-        ...baseCfg,
-        access_token: "fresh",
-        refresh_token: "ref2",
-        expires_at: Math.floor(Date.now() / 1000) + 3600,
-        deployment_id: "dep-locked",
-        deployment_name: "acme/locked",
-        api_key: "sk_existing",
-      });
+      .mockReturnValueOnce(
+        makeBaseConfig({
+          access_token: "stale",
+          refresh_token: "ref",
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        }),
+      )
+      .mockReturnValue(
+        makeBaseConfig({
+          access_token: "fresh",
+          refresh_token: "ref2",
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          deployment_id: "dep-locked",
+          deployment_name: "acme/locked",
+          api_key: "sk_existing",
+        }),
+      );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 401 }));
     mockClient.refreshToken.mockResolvedValue(undefined);
     mockClient.validateAPIKey.mockResolvedValue(true);
@@ -771,12 +783,13 @@ describe("runAgentSetup", () => {
   });
 
   it("mints a ticket when the existing session is unauthorized and refresh fails", async () => {
-    mockLoadConfig.mockReturnValue({
-      ...baseCfg,
-      access_token: "stale",
-      refresh_token: "ref",
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-    });
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: "stale",
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 401 }));
     mockClient.refreshToken.mockRejectedValue(new Error("refresh failed"));
     mockMintTicket.mockResolvedValue({

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -15,7 +15,13 @@
 
 import { exchangeTicket, mintTicket } from "../auth/ticket";
 import { Client, type Deployment } from "../client/client";
-import { type Config, loadConfig, replaceLoginSession, saveConfig } from "../config/config";
+import {
+  type Config,
+  loadConfig,
+  replaceLoginSession,
+  saveConfig,
+  updateTarget,
+} from "../config/config";
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
@@ -179,7 +185,7 @@ async function verifyOrMint(
   cfg: Config,
   opts: AgentSetupOptions,
 ): Promise<{ code: number; cfg: Config; exit?: boolean }> {
-  if (cfg.access_token) {
+  if (cfg.active_account?.session.access_token) {
     try {
       const client = new Client(cfg);
       const resp = await client.doRequestRaw("GET", "/v1/mcp/deployments");
@@ -242,10 +248,12 @@ async function resolveDeployment(
         });
         return { code: 1, cfg };
       }
-      cfg.deployment_id = d.deployment_id;
-      cfg.deployment_name = d.name;
-      cfg.org_id = d.org_id;
-      cfg.space_id = d.space_id;
+      updateTarget(cfg, {
+        deployment_id: d.deployment_id,
+        deployment_name: d.name,
+        org_id: d.org_id,
+        space_id: d.space_id,
+      });
       cfg.mode = undefined;
       saveConfig(cfg);
       emitStep({
@@ -267,11 +275,11 @@ async function resolveDeployment(
   }
 
   // Already locked in from a previous run — reuse it.
-  if (cfg.deployment_id) {
+  if (cfg.active_account?.target?.deployment_id) {
     emitStep({
       step: "deployment",
-      deployment_id: cfg.deployment_id,
-      name: cfg.deployment_name,
+      deployment_id: cfg.active_account?.target?.deployment_id,
+      name: cfg.active_account?.target?.deployment_name,
     });
     return { code: 0, cfg };
   }
@@ -307,10 +315,12 @@ async function resolveDeployment(
 
     if (mcpDeployments.length === 1) {
       const d = mcpDeployments[0];
-      cfg.deployment_id = d.deployment_id;
-      cfg.deployment_name = d.name;
-      cfg.org_id = d.org_id;
-      cfg.space_id = d.space_id;
+      updateTarget(cfg, {
+        deployment_id: d.deployment_id,
+        deployment_name: d.name,
+        org_id: d.org_id,
+        space_id: d.space_id,
+      });
       cfg.mode = undefined;
       saveConfig(cfg);
       emitStep({
@@ -354,7 +364,9 @@ function formatCandidates(deployments: Deployment[]): string {
 }
 
 async function ensureAPIKey(client: Client, cfg: Config): Promise<{ code: number; cfg: Config }> {
-  if (!cfg.deployment_id) {
+  const target = cfg.active_account?.target;
+  const deploymentID = target?.deployment_id;
+  if (!deploymentID) {
     emitError({
       step: "api_key",
       reason: "no_deployment",
@@ -365,15 +377,15 @@ async function ensureAPIKey(client: Client, cfg: Config): Promise<{ code: number
   }
 
   try {
-    if (cfg.api_key) {
-      const valid = await client.validateAPIKey(cfg.api_key, cfg.deployment_id);
+    if (target.api_key) {
+      const valid = await client.validateAPIKey(target.api_key, deploymentID);
       if (valid) {
         emitStep({ step: "api_key", reused: true });
         return { code: 0, cfg };
       }
     }
-    const resp = await client.createAPIKey(cfg.deployment_id, "dosu-cli");
-    cfg.api_key = resp.api_key;
+    const resp = await client.createAPIKey(deploymentID, "dosu-cli");
+    updateTarget(cfg, { api_key: resp.api_key });
     saveConfig(cfg);
     emitStep({ step: "api_key", reused: false });
     return { code: 0, cfg };

--- a/src/agent/login-commands.test.ts
+++ b/src/agent/login-commands.test.ts
@@ -29,6 +29,8 @@ vi.mock("../debug/logger", () => ({
   },
 }));
 
+import { emptyConfig } from "../config/config";
+import { testSession } from "../config/config.test-utils";
 import { runLoginCheck, runLoginRequest } from "./login-commands";
 
 describe("runLoginRequest", () => {
@@ -129,11 +131,7 @@ describe("runLoginCheck", () => {
     mockExchangeTicket.mockReset();
     mockLoadConfig.mockReset();
     mockSaveConfig.mockReset();
-    mockLoadConfig.mockReturnValue({
-      access_token: "",
-      refresh_token: "",
-      expires_at: 0,
-    });
+    mockLoadConfig.mockReturnValue(emptyConfig());
   });
 
   afterEach(() => {
@@ -154,14 +152,10 @@ describe("runLoginCheck", () => {
 
     expect(code).toBe(0);
     expect(mockSaveConfig).toHaveBeenCalledTimes(1);
-    const saved = mockSaveConfig.mock.calls[0]?.[0] as {
-      access_token: string;
-      refresh_token: string;
-      expires_at: number;
-    };
-    expect(saved.access_token).toBe("tok");
-    expect(saved.refresh_token).toBe("ref");
-    expect(saved.expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    const saved = mockSaveConfig.mock.calls[0]?.[0];
+    expect(testSession(saved).access_token).toBe("tok");
+    expect(testSession(saved).refresh_token).toBe("ref");
+    expect(testSession(saved).expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000));
 
     const payload = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
     expect(payload).toMatchObject({
@@ -260,15 +254,11 @@ describe("runLoginCheck", () => {
 
     expect(code).toBe(0);
     expect(mockSaveConfig).toHaveBeenCalledTimes(1);
-    const saved = mockSaveConfig.mock.calls[0]?.[0] as {
-      access_token: string;
-      refresh_token: string;
-      expires_at: number;
-    };
-    expect(saved.access_token).toBe("");
-    expect(saved.refresh_token).toBe("");
+    const saved = mockSaveConfig.mock.calls[0]?.[0];
+    expect(testSession(saved).access_token).toBe("");
+    expect(testSession(saved).refresh_token).toBe("");
     // 3600s fallback applied.
-    expect(saved.expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000) + 3000);
+    expect(testSession(saved).expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000) + 3000);
   });
 
   it("omits the email line in non-JSON mode when no email is returned", async () => {

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OAuthCallbackError } from "../auth/errors";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
+import { makeTestConfig, testSession, testTarget } from "../config/config.test-utils";
 import { allProviders } from "../mcp/providers";
 import { createProgram } from "./cli";
 
@@ -39,14 +40,14 @@ const { mockRefreshToken } = vi.hoisted(() => ({
 }));
 vi.mock("../client/client", () => ({
   Client: class MockClient {
-    private cfg: { refresh_token?: string };
+    private cfg: Config;
 
-    constructor(cfg: { refresh_token?: string }) {
+    constructor(cfg: Config) {
       this.cfg = cfg;
     }
 
     refreshToken() {
-      if (!this.cfg.refresh_token) {
+      if (!this.cfg.active_account?.session.refresh_token) {
         throw new Error("no refresh token available");
       }
       return mockRefreshToken(this.cfg);
@@ -111,14 +112,14 @@ afterEach(() => {
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function authenticatedConfig(): Config {
-  return {
+  return makeTestConfig({
     access_token: "tok_abc",
     refresh_token: "ref_abc",
     expires_at: Math.floor(Date.now() / 1000) + 3600,
     deployment_id: "dep_123",
     deployment_name: "My App",
     api_key: "key_abc",
-  };
+  });
 }
 
 async function run(...args: string[]) {
@@ -133,9 +134,9 @@ function allLogOutput(): string {
 
 function mockSuccessfulRefresh(accessToken: string, refreshToken: string): void {
   mockRefreshToken.mockImplementationOnce(async (cfg: Config) => {
-    cfg.access_token = accessToken;
-    cfg.refresh_token = refreshToken;
-    cfg.expires_at = Math.floor(Date.now() / 1000) + 3600;
+    testSession(cfg).access_token = accessToken;
+    testSession(cfg).refresh_token = refreshToken;
+    testSession(cfg).expires_at = Math.floor(Date.now() / 1000) + 3600;
     saveConfig(cfg);
   });
 }
@@ -231,14 +232,14 @@ describe("CLI actions", () => {
 
       // Verify the real config file was written
       const cfg = loadConfig();
-      expect(cfg.access_token).toBe("new_tok");
-      expect(cfg.refresh_token).toBe("new_ref");
-      expect(cfg.expires_at).toBeGreaterThan(0);
+      expect(cfg.active_account?.session.access_token).toBe("new_tok");
+      expect(cfg.active_account?.session.refresh_token).toBe("new_ref");
+      expect(cfg.active_account?.session.expires_at).toBeGreaterThan(0);
     });
 
     it("refreshes the session when token is expired", async () => {
       const cfg = authenticatedConfig();
-      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000; // expired
+      testSession(cfg).expires_at = Math.floor(Date.now() / 1000) - 1000; // expired
       saveConfig(cfg);
 
       mockSuccessfulRefresh("refreshed_tok", "refreshed_ref");
@@ -249,13 +250,13 @@ describe("CLI actions", () => {
       expect(logSpy).toHaveBeenCalledWith("Session refreshed.");
 
       const updated = loadConfig();
-      expect(updated.access_token).toBe("refreshed_tok");
-      expect(updated.refresh_token).toBe("refreshed_ref");
+      expect(updated.active_account?.session.access_token).toBe("refreshed_tok");
+      expect(updated.active_account?.session.refresh_token).toBe("refreshed_ref");
     });
 
     it("runs OAuth flow when expired token cannot be refreshed", async () => {
       const cfg = authenticatedConfig();
-      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000; // expired
+      testSession(cfg).expires_at = Math.floor(Date.now() / 1000) - 1000; // expired
       saveConfig(cfg);
 
       mockRefreshToken.mockRejectedValueOnce(new Error("refresh failed"));
@@ -269,8 +270,8 @@ describe("CLI actions", () => {
       expect(mockStartOAuthFlow).toHaveBeenCalledOnce();
 
       const updated = loadConfig();
-      expect(updated.access_token).toBe("oauth_tok");
-      expect(updated.refresh_token).toBe("oauth_ref");
+      expect(updated.active_account?.session.access_token).toBe("oauth_tok");
+      expect(updated.active_account?.session.refresh_token).toBe("oauth_ref");
     });
 
     it("prints curated OAuth callback errors without saving credentials", async () => {
@@ -289,7 +290,7 @@ describe("CLI actions", () => {
         "Authentication failed: OAuth state expired. Run `dosu login` again.",
       );
       expect(process.exitCode).toBe(1);
-      expect(loadConfig().access_token).toBe("");
+      expect(loadConfig().active_account).toBeUndefined();
 
       process.exitCode = originalExitCode;
       errorSpy.mockRestore();
@@ -304,7 +305,7 @@ describe("CLI actions", () => {
 
       expect(errorSpy).toHaveBeenCalledWith("Authentication timed out after 8 minutes");
       expect(process.exitCode).toBe(1);
-      expect(loadConfig().access_token).toBe("");
+      expect(loadConfig().active_account).toBeUndefined();
 
       process.exitCode = originalExitCode;
       errorSpy.mockRestore();
@@ -323,8 +324,8 @@ describe("CLI actions", () => {
       expect(mockStartDeviceFlow).toHaveBeenCalledOnce();
       expect(logSpy).toHaveBeenCalledWith("Successfully authenticated!");
       const cfg = loadConfig();
-      expect(cfg.access_token).toBe("dev_tok");
-      expect(cfg.refresh_token).toBe("dev_ref");
+      expect(cfg.active_account?.session.access_token).toBe("dev_tok");
+      expect(cfg.active_account?.session.refresh_token).toBe("dev_ref");
     });
 
     it("uses device flow when headless environment is detected", async () => {
@@ -340,7 +341,7 @@ describe("CLI actions", () => {
       expect(mockStartOAuthFlow).not.toHaveBeenCalled();
       expect(mockStartDeviceFlow).toHaveBeenCalledOnce();
       const cfg = loadConfig();
-      expect(cfg.access_token).toBe("ssh_tok");
+      expect(cfg.active_account?.session.access_token).toBe("ssh_tok");
     });
 
     it("falls through to device flow when browser cannot be opened", async () => {
@@ -356,7 +357,7 @@ describe("CLI actions", () => {
       expect(mockStartOAuthFlow).toHaveBeenCalledOnce();
       expect(mockStartDeviceFlow).toHaveBeenCalledOnce();
       const cfg = loadConfig();
-      expect(cfg.access_token).toBe("fb_tok");
+      expect(cfg.active_account?.session.access_token).toBe("fb_tok");
     });
 
     it("prints error and sets exitCode when device flow fails", async () => {
@@ -369,7 +370,7 @@ describe("CLI actions", () => {
 
       expect(errorSpy).toHaveBeenCalledWith("Login session expired");
       expect(process.exitCode).toBe(1);
-      expect(loadConfig().access_token).toBe("");
+      expect(loadConfig().active_account).toBeUndefined();
 
       process.exitCode = originalExitCode;
       errorSpy.mockRestore();
@@ -470,12 +471,7 @@ describe("CLI actions", () => {
 
       // Read back the real config file and verify credentials are cleared
       const cfg = loadConfig();
-      expect(cfg.access_token).toBe("");
-      expect(cfg.refresh_token).toBe("");
-      expect(cfg.expires_at).toBe(0);
-      expect(cfg.deployment_id).toBeUndefined();
-      expect(cfg.deployment_name).toBeUndefined();
-      expect(cfg.api_key).toBeUndefined();
+      expect(cfg.active_account).toBeUndefined();
     });
 
     it("prints not-logged-in when config has no credentials", async () => {
@@ -508,8 +504,8 @@ describe("CLI actions", () => {
 
     it("shows token-expired status", async () => {
       const cfg = authenticatedConfig();
-      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
-      cfg.refresh_token = "";
+      testSession(cfg).expires_at = Math.floor(Date.now() / 1000) - 1000;
+      testSession(cfg).refresh_token = "";
       saveConfig(cfg);
 
       await run("status");
@@ -520,7 +516,7 @@ describe("CLI actions", () => {
 
     it("refreshes expired token before showing logged-in status", async () => {
       const cfg = authenticatedConfig();
-      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
+      testSession(cfg).expires_at = Math.floor(Date.now() / 1000) - 1000;
       saveConfig(cfg);
       mockSuccessfulRefresh("status_tok", "status_ref");
 
@@ -528,13 +524,13 @@ describe("CLI actions", () => {
 
       expect(logSpy).toHaveBeenCalledWith("Status: Logged in");
       expect(allLogOutput()).not.toContain("Status: Token expired");
-      expect(loadConfig().access_token).toBe("status_tok");
+      expect(loadConfig().active_account?.session.access_token).toBe("status_tok");
     });
 
     it("shows no deployment when none selected", async () => {
       const cfg = authenticatedConfig();
-      cfg.deployment_id = undefined;
-      cfg.deployment_name = undefined;
+      testTarget(cfg).deployment_id = undefined;
+      testTarget(cfg).deployment_name = undefined;
       saveConfig(cfg);
 
       await run("status");
@@ -548,8 +544,8 @@ describe("CLI actions", () => {
     it("shows OSS mode without requiring a deployment", async () => {
       const cfg = authenticatedConfig();
       cfg.mode = "oss";
-      cfg.deployment_id = undefined;
-      cfg.deployment_name = undefined;
+      testTarget(cfg).deployment_id = undefined;
+      testTarget(cfg).deployment_name = undefined;
       saveConfig(cfg);
 
       await run("status");
@@ -632,8 +628,8 @@ describe("CLI actions", () => {
 
     it("throws error when token is expired", async () => {
       const cfg = authenticatedConfig();
-      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
-      cfg.refresh_token = "";
+      testSession(cfg).expires_at = Math.floor(Date.now() / 1000) - 1000;
+      testSession(cfg).refresh_token = "";
       saveConfig(cfg);
 
       await expect(run("mcp", "add", "cursor")).rejects.toThrow("session expired");
@@ -641,7 +637,7 @@ describe("CLI actions", () => {
 
     it("refreshes expired token before adding MCP config", async () => {
       const cfg = authenticatedConfig();
-      cfg.expires_at = Math.floor(Date.now() / 1000) - 1000;
+      testSession(cfg).expires_at = Math.floor(Date.now() / 1000) - 1000;
       saveConfig(cfg);
       mockSuccessfulRefresh("mcp_tok", "mcp_ref");
 
@@ -650,12 +646,12 @@ describe("CLI actions", () => {
       const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
       const cursorConfig = JSON.parse(readFileSync(cursorConfigPath, "utf-8"));
       expect(cursorConfig.mcpServers.dosu).toBeDefined();
-      expect(loadConfig().access_token).toBe("mcp_tok");
+      expect(loadConfig().active_account?.session.access_token).toBe("mcp_tok");
     });
 
     it("throws error when no deployment selected", async () => {
       const cfg = authenticatedConfig();
-      cfg.deployment_id = undefined;
+      testTarget(cfg).deployment_id = undefined;
       saveConfig(cfg);
 
       await expect(run("mcp", "add", "cursor")).rejects.toThrow("no MCP selected");
@@ -663,7 +659,7 @@ describe("CLI actions", () => {
 
     it("throws error when API key is missing before writing tool config", async () => {
       const cfg = authenticatedConfig();
-      cfg.api_key = undefined;
+      testTarget(cfg).api_key = undefined;
       saveConfig(cfg);
 
       await expect(run("mcp", "add", "cursor", "--global")).rejects.toThrow("no API key available");
@@ -672,8 +668,8 @@ describe("CLI actions", () => {
     it("supports OSS mode without a selected deployment", async () => {
       const cfg = authenticatedConfig();
       cfg.mode = "oss";
-      cfg.deployment_id = undefined;
-      cfg.deployment_name = undefined;
+      testTarget(cfg).deployment_id = undefined;
+      testTarget(cfg).deployment_name = undefined;
       saveConfig(cfg);
 
       await run("mcp", "add", "cursor", "--global");

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -24,6 +24,7 @@ import { threadsCommand } from "../commands/threads";
 import { topicsCommand } from "../commands/topics";
 import {
   type Config,
+  clearConfigInPlace,
   getConfigPath,
   isAuthenticated,
   isTokenExpired,
@@ -237,14 +238,7 @@ export function createProgram(): Command {
         console.log("You are not logged in.");
         return;
       }
-      cfg.access_token = "";
-      cfg.refresh_token = "";
-      cfg.expires_at = 0;
-      cfg.deployment_id = undefined;
-      cfg.deployment_name = undefined;
-      cfg.api_key = undefined;
-      cfg.org_id = undefined;
-      cfg.space_id = undefined;
+      clearConfigInPlace(cfg);
       saveConfig(cfg);
       console.log("Successfully logged out.");
     });
@@ -269,9 +263,9 @@ export function createProgram(): Command {
       if (cfg.mode === MODE_OSS) {
         console.log("Mode: OSS");
         console.log("MCP: Public libraries only");
-      } else if (cfg.deployment_id) {
-        console.log(`MCP: ${cfg.deployment_name}`);
-        console.log(`MCP ID: ${cfg.deployment_id}`);
+      } else if (cfg.active_account?.target?.deployment_id) {
+        console.log(`MCP: ${cfg.active_account?.target?.deployment_name}`);
+        console.log(`MCP ID: ${cfg.active_account?.target?.deployment_id}`);
       } else {
         console.log("MCP: None selected");
         console.log(
@@ -303,10 +297,10 @@ export function createProgram(): Command {
       if (isTokenExpired(cfg) && !(await ensureFreshSession(cfg))) {
         throw new Error("session expired. Run 'dosu login' to re-authenticate");
       }
-      if (cfg.mode !== MODE_OSS && !cfg.deployment_id) {
+      if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id) {
         throw new Error("no MCP selected. Run 'dosu' to open the TUI and select an MCP");
       }
-      if (!cfg.api_key) {
+      if (!cfg.active_account?.target?.api_key) {
         throw new Error("no API key available. Run 'dosu setup' to create one");
       }
 

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { Client, SessionExpiredError } from "./client";
 
 // Mock saveConfig to avoid filesystem writes (hoisted; applies to the whole file)
@@ -15,13 +16,13 @@ vi.mock("../config/config", async () => {
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-function makeConfig(overrides: Partial<Config> = {}): Config {
-  return {
+function makeConfig(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "test-token",
     refresh_token: "test-refresh",
     expires_at: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
     ...overrides,
-  };
+  });
 }
 
 function jsonResponse(data: unknown, status = 200): Response {
@@ -126,8 +127,8 @@ describe("Client", () => {
       // First call should be to the refresh endpoint
       expect(mockFetch.mock.calls[0][0]).toContain("/auth/v1/token");
       // Config should be updated with new tokens
-      expect(cfg.access_token).toBe("refreshed-token");
-      expect(cfg.refresh_token).toBe("refreshed-refresh");
+      expect(cfg.active_account?.session.access_token).toBe("refreshed-token");
+      expect(cfg.active_account?.session.refresh_token).toBe("refreshed-refresh");
     });
 
     it("throws when refresh_token is missing and token is expired", async () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -3,7 +3,13 @@
  */
 
 import type { Config } from "../config/config";
-import { isAuthenticated, isTokenExpired, loadConfig, saveConfig } from "../config/config";
+import {
+  getConfigUserID,
+  isAuthenticated,
+  isTokenExpired,
+  loadConfig,
+  saveConfig,
+} from "../config/config";
 import { getBackendURL, getSupabaseAnonKey, getSupabaseURL } from "../config/constants";
 
 export class SessionExpiredError extends Error {
@@ -196,6 +202,7 @@ export class Client {
    */
   private adoptNewerDiskTokens(): boolean {
     const disk = loadConfig();
+    this.assertSameActiveAccount(disk);
     const diskSession = disk.active_account?.session;
     const memorySession = this.config.active_account?.session;
     if (
@@ -237,11 +244,24 @@ export class Client {
       expires_in: number;
     };
 
+    // A browser login in another process may have switched accounts while the
+    // refresh request was in flight. Never let this stale client overwrite the
+    // new account aggregate with tokens from the previous account.
+    this.assertSameActiveAccount(loadConfig());
+
     session.access_token = data.access_token;
     session.refresh_token = data.refresh_token;
     session.expires_at = Math.floor(Date.now() / 1000) + data.expires_in;
 
     saveConfig(this.config);
+  }
+
+  private assertSameActiveAccount(disk: Config): void {
+    const memoryUserID = getConfigUserID(this.config);
+    const diskUserID = getConfigUserID(disk);
+    if (memoryUserID && diskUserID && memoryUserID !== diskUserID) {
+      throw new Error("authenticated account changed while this command was running; retry it");
+    }
   }
 
   async getDeployments(): Promise<Deployment[]> {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -84,7 +84,7 @@ export class Client {
     const url = this.baseURL + path;
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "Supabase-Access-Token": this.config.access_token,
+      "Supabase-Access-Token": this.config.active_account?.session.access_token ?? "",
     };
 
     const options: RequestInit = { method, headers };
@@ -135,13 +135,13 @@ export class Client {
   }
 
   private async apiKeyRequest(method: string, path: string, body?: unknown): Promise<Response> {
-    if (!this.config.api_key) {
+    if (!this.config.active_account?.target?.api_key) {
       throw new Error("no API key available");
     }
     const url = this.baseURL + path;
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "X-Dosu-API-Key": this.config.api_key,
+      "X-Dosu-API-Key": this.config.active_account?.target?.api_key,
     };
 
     const options: RequestInit = { method, headers };
@@ -173,7 +173,7 @@ export class Client {
    */
   async refreshToken(): Promise<void> {
     this.adoptNewerDiskTokens();
-    if (!this.config.refresh_token) {
+    if (!this.config.active_account?.session.refresh_token) {
       throw new Error("no refresh token available");
     }
 
@@ -196,16 +196,25 @@ export class Client {
    */
   private adoptNewerDiskTokens(): boolean {
     const disk = loadConfig();
-    if (!disk.refresh_token || disk.refresh_token === this.config.refresh_token) {
+    const diskSession = disk.active_account?.session;
+    const memorySession = this.config.active_account?.session;
+    if (
+      !diskSession?.refresh_token ||
+      !memorySession ||
+      diskSession.refresh_token === memorySession.refresh_token
+    ) {
       return false;
     }
-    this.config.access_token = disk.access_token;
-    this.config.refresh_token = disk.refresh_token;
-    this.config.expires_at = disk.expires_at;
+    memorySession.access_token = diskSession.access_token;
+    memorySession.refresh_token = diskSession.refresh_token;
+    memorySession.expires_at = diskSession.expires_at;
     return true;
   }
 
   private async refreshTokenOnce(): Promise<void> {
+    const session = this.config.active_account?.session;
+    if (!session?.refresh_token) throw new Error("no refresh token available");
+
     const supabaseURL = getSupabaseURL();
     const endpoint = `${supabaseURL}/auth/v1/token?grant_type=refresh_token`;
 
@@ -215,7 +224,7 @@ export class Client {
         "Content-Type": "application/json",
         apikey: getSupabaseAnonKey(),
       },
-      body: JSON.stringify({ refresh_token: this.config.refresh_token }),
+      body: JSON.stringify({ refresh_token: session.refresh_token }),
     });
 
     if (resp.status !== 200) {
@@ -228,9 +237,9 @@ export class Client {
       expires_in: number;
     };
 
-    this.config.access_token = data.access_token;
-    this.config.refresh_token = data.refresh_token;
-    this.config.expires_at = Math.floor(Date.now() / 1000) + data.expires_in;
+    session.access_token = data.access_token;
+    session.refresh_token = data.refresh_token;
+    session.expires_at = Math.floor(Date.now() / 1000) + data.expires_in;
 
     saveConfig(this.config);
   }

--- a/src/client/refresh.test.ts
+++ b/src/client/refresh.test.ts
@@ -27,6 +27,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { type Config, loadConfig, saveConfig } from "../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { Client } from "./client";
 
 const mockFetch = vi.fn();
@@ -68,13 +69,13 @@ class FakeGoTrue {
   };
 }
 
-function makeConfig(overrides: Partial<Config> = {}): Config {
-  return {
+function makeConfig(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "at-stale",
     refresh_token: "rt-stale",
     expires_at: Math.floor(Date.now() / 1000) + 3600,
     ...overrides,
-  };
+  });
 }
 
 describe("refresh self-healing", () => {
@@ -122,8 +123,8 @@ describe("refresh self-healing", () => {
 
     expect(gotrue.presented).toEqual(["rt-disk"]); // never "rt-stale"
     expect(gotrue.rejections).toBe(0);
-    expect(cfg.refresh_token).toBe("rt-1");
-    expect(loadConfig().refresh_token).toBe("rt-1"); // rotation persisted
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-1");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-1"); // rotation persisted
   });
 
   it("retries once with the on-disk token when a sibling rotates mid-flight", async () => {
@@ -147,8 +148,8 @@ describe("refresh self-healing", () => {
     await new Client(cfg).refreshToken();
 
     expect(gotrue.presented).toEqual(["rt-a", "rt-b"]); // failed once, healed
-    expect(cfg.refresh_token).toBe("rt-1");
-    expect(loadConfig().refresh_token).toBe("rt-1");
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-1");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-1");
   });
 
   it("two clients sharing one config file relay the rotation instead of killing it", async () => {
@@ -167,7 +168,7 @@ describe("refresh self-healing", () => {
 
     expect(gotrue.presented).toEqual(["rt-0", "rt-1"]);
     expect(gotrue.rejections).toBe(0); // a replayed token would kill the session
-    expect(loadConfig().refresh_token).toBe("rt-2");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-2");
 
     // The config dir contains exactly the config file — no stray tmp files.
     expect(readdirSync(join(tempDir, "dosu-cli"))).toEqual(["config.json"]);

--- a/src/client/refresh.test.ts
+++ b/src/client/refresh.test.ts
@@ -78,6 +78,10 @@ function makeConfig(overrides: Partial<FlatTestConfig> = {}): Config {
   });
 }
 
+function makeAccountConfig(userID: string, overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeConfig({ ...overrides, user_id: userID });
+}
+
 describe("refresh self-healing", () => {
   const savedEnv: Record<string, string | undefined> = {};
   let tempDir: string;
@@ -183,5 +187,40 @@ describe("refresh self-healing", () => {
     await expect(new Client(cfg).refreshToken()).rejects.toThrow("refresh failed with status 400");
     // One attempt only — disk has nothing newer to retry with.
     expect(gotrue.presented).toEqual(["rt-dead"]);
+  });
+
+  it("does not adopt tokens from a different account on disk", async () => {
+    saveConfig(makeAccountConfig("account-b", { refresh_token: "rt-b" }));
+    const cfg = makeAccountConfig("account-a", { refresh_token: "rt-a" });
+
+    await expect(new Client(cfg).refreshToken()).rejects.toThrow(
+      "authenticated account changed while this command was running",
+    );
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(loadConfig().active_account?.user_id).toBe("account-b");
+  });
+
+  it("does not overwrite a different account that logs in during refresh", async () => {
+    saveConfig(makeAccountConfig("account-a", { refresh_token: "rt-a" }));
+    const cfg = loadConfig();
+    mockFetch.mockImplementation(async () => {
+      saveConfig(makeAccountConfig("account-b", { refresh_token: "rt-b" }));
+      return new Response(
+        JSON.stringify({
+          access_token: "at-a-refreshed",
+          refresh_token: "rt-a-refreshed",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      );
+    });
+
+    await expect(new Client(cfg).refreshToken()).rejects.toThrow(
+      "authenticated account changed while this command was running",
+    );
+
+    expect(loadConfig().active_account?.user_id).toBe("account-b");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-b");
   });
 });

--- a/src/client/trpc.test.ts
+++ b/src/client/trpc.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../config/config";
+import { type FlatTestConfig, makeTestConfig, testSession } from "../config/config.test-utils";
 import { CLI_CONTRACT_HASH } from "./contract";
 import { createTypedClient } from "./trpc";
 
@@ -19,9 +20,13 @@ vi.mock("../config/constants", () => ({
 const { mockIsTokenExpired } = vi.hoisted(() => ({
   mockIsTokenExpired: vi.fn<(cfg: Config) => boolean>().mockReturnValue(false),
 }));
-vi.mock("../config/config", () => ({
-  isTokenExpired: (cfg: Config) => mockIsTokenExpired(cfg),
-}));
+vi.mock("../config/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config")>();
+  return {
+    ...actual,
+    isTokenExpired: (cfg: Config) => mockIsTokenExpired(cfg),
+  };
+});
 
 const { mockRefreshToken } = vi.hoisted(() => ({
   mockRefreshToken: vi.fn(),
@@ -32,14 +37,14 @@ vi.mock("./client", () => ({
   }),
 }));
 
-function makeConfig(overrides: Partial<Config> = {}): Config {
-  return {
+function makeConfig(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "t",
     refresh_token: "r",
     expires_at: 0,
     api_key: "sk_user_test_key_123",
     ...overrides,
-  };
+  });
 }
 
 /** Build a minimal tRPC-compatible single response (httpLink, not batch). */
@@ -85,7 +90,7 @@ describe("createTypedClient", () => {
       const cfg = makeConfig();
       mockIsTokenExpired.mockReturnValue(true);
       mockRefreshToken.mockImplementation(async () => {
-        cfg.access_token = "refreshed";
+        testSession(cfg).access_token = "refreshed";
       });
       mockFetch.mockResolvedValue(trpcOk({ ok: true }));
 
@@ -119,7 +124,7 @@ describe("createTypedClient", () => {
     it("retries on 401 with refreshed token", async () => {
       const cfg = makeConfig({ access_token: "old" });
       mockRefreshToken.mockImplementation(async () => {
-        cfg.access_token = "new_token";
+        testSession(cfg).access_token = "new_token";
       });
       // First call: 401, retry: success
       mockFetch.mockResolvedValueOnce(trpcError(401));

--- a/src/client/trpc.ts
+++ b/src/client/trpc.ts
@@ -38,7 +38,7 @@ export function createTypedClient<TClient extends object = TypedClient>(config: 
   if (!webAppURL) {
     throw new Error("Web app URL not configured");
   }
-  if (!config.access_token) {
+  if (!config.active_account?.session.access_token) {
     throw new Error("Not authenticated. Run 'dosu login' first.");
   }
 
@@ -59,7 +59,7 @@ export function createTypedClient<TClient extends object = TypedClient>(config: 
             }
           }
           return {
-            "Supabase-Access-Token": config.access_token,
+            "Supabase-Access-Token": config.active_account?.session.access_token ?? "",
             "x-dosu-cli-contract": CLI_CONTRACT_HASH,
           };
         },
@@ -77,7 +77,7 @@ export function createTypedClient<TClient extends object = TypedClient>(config: 
               ...options,
               headers: {
                 ...(options?.headers as Record<string, string>),
-                "Supabase-Access-Token": config.access_token,
+                "Supabase-Access-Token": config.active_account?.session.access_token ?? "",
                 "x-dosu-cli-contract": CLI_CONTRACT_HASH,
               },
             });

--- a/src/commands/analytics.test.ts
+++ b/src/commands/analytics.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { analyticsCommand } from "./analytics";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,13 +30,16 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
   api_key: "sk_user_test",
   space_id: "sp1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -147,12 +151,12 @@ describe("analytics", () => {
 
 describe("requireConfig", () => {
   it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ space_id: undefined }));
     await expect(run()).rejects.toThrow("exit");
   });
 
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run()).rejects.toThrow("exit");
   });
 });

--- a/src/commands/analytics.ts
+++ b/src/commands/analytics.ts
@@ -10,7 +10,7 @@ import { printInfo, printResult } from "./output";
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.space_id) {
+  if (!cfg.active_account?.target?.space_id) {
     console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -28,7 +28,7 @@ export function analyticsCommand(): Command {
 
       const stats = await client.analytics.getUsageStats.query({
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        spaceId: cfg.space_id!,
+        spaceId: cfg.active_account!.target!.space_id!,
         days: Number.parseInt(opts.days ?? "30", 10),
       });
 

--- a/src/commands/ask.test.ts
+++ b/src/commands/ask.test.ts
@@ -12,12 +12,13 @@ vi.mock("../debug/logger", () => ({
   logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { askCommand } from "./ask";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -25,6 +26,9 @@ const validConfig = {
   deployment_id: "dep1",
   space_id: "sp1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -200,12 +204,12 @@ describe("error handling", () => {
 
 describe("requireConfig", () => {
   it("exits when api_key is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, api_key: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ api_key: undefined }));
     await expect(run("question")).rejects.toThrow("exit");
   });
 
   it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ space_id: undefined }));
     await expect(run("question")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -14,11 +14,11 @@ import { printResult } from "./output";
 
 function requireConfig() {
   const cfg = loadConfig();
-  if (!cfg.api_key) {
+  if (!cfg.active_account?.target?.api_key) {
     console.error(pc.red("Not configured. Run 'dosu setup' first."));
     process.exit(1);
   }
-  if (!cfg.deployment_id || !cfg.space_id) {
+  if (!cfg.active_account?.target?.deployment_id || !cfg.active_account?.target?.space_id) {
     console.error(pc.red("Missing deployment config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -51,11 +51,11 @@ export function askCommand(): Command {
           headers: {
             "Content-Type": "application/json",
             // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-            "X-Dosu-API-Key": cfg.api_key!,
+            "X-Dosu-API-Key": cfg.active_account!.target!.api_key!,
           },
           body: JSON.stringify({
             // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-            deployment_id: cfg.deployment_id!,
+            deployment_id: cfg.active_account!.target!.deployment_id!,
             question,
             session_id: opts.session ?? undefined,
           }),

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -69,6 +69,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 import { join } from "node:path";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { auditCommand, cleanupFindings } from "./audit";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -76,7 +77,7 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -84,6 +85,9 @@ const validConfig = {
   org_id: "org1",
   space_id: "sp1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 const detected = { owner: "o", name: "r", slug: "o/r" };
 
@@ -190,17 +194,17 @@ afterEach(() => {
 
 describe("config guard", () => {
   it("exits when api_key missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, api_key: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ api_key: undefined }));
     await expect(run()).rejects.toThrow("exit");
   });
 
   it("exits when org_id missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, org_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ org_id: undefined }));
     await expect(run()).rejects.toThrow("exit");
   });
 
   it("exits when not logged in", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run()).rejects.toThrow("exit");
   });
 });

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -63,17 +63,17 @@ interface AuditFindings {
   items: AuditItem[];
 }
 
-function requireConfig(): Config & { api_key: string; org_id: string } {
+function requireConfig(): Config {
   const cfg = requireLoginConfig();
-  if (!cfg.api_key) {
+  if (!cfg.active_account?.target?.api_key) {
     console.error(pc.red("API key not configured. Run 'dosu setup' first."));
     process.exit(1);
   }
-  if (!cfg.org_id) {
+  if (!cfg.active_account?.target?.org_id) {
     console.error(pc.red("Missing org config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
-  return cfg as Config & { api_key: string; org_id: string };
+  return cfg;
 }
 
 function requireBackendURL(): string {
@@ -178,7 +178,7 @@ async function waitForIndexed(
  * data_source_id on success.
  */
 async function ensureSyncedRepo(
-  cfg: Config & { org_id: string },
+  cfg: Config,
   client: TypedClient,
   detected: DetectedRepo,
   explicitDataSourceId: string | undefined,
@@ -188,7 +188,9 @@ async function ensureSyncedRepo(
     return explicitDataSourceId;
   }
 
-  let sources = await listDataSources(client, cfg.org_id);
+  const orgID = cfg.active_account?.target?.org_id;
+  if (!orgID) throw new Error("missing org config");
+  let sources = await listDataSources(client, orgID);
   let match = findMatch(sources, detected);
 
   if (!match) {
@@ -214,7 +216,7 @@ async function ensureSyncedRepo(
       console.error(pc.red(`Could not connect ${detected.slug}. Run 'dosu setup' and retry.`));
       process.exit(1);
     }
-    sources = await listDataSources(client, cfg.org_id);
+    sources = await listDataSources(client, orgID);
     match = findMatch(sources, detected);
     if (!match) {
       console.error(pc.red(`Could not find ${detected.slug} after connecting. Retry shortly.`));
@@ -223,7 +225,7 @@ async function ensureSyncedRepo(
   }
 
   if (match.is_indexed !== true) {
-    const indexed = await waitForIndexed(client, cfg.org_id, detected, nonInteractive);
+    const indexed = await waitForIndexed(client, orgID, detected, nonInteractive);
     if (!indexed) {
       if (nonInteractive) {
         console.error(pc.red(`${detected.slug} is still indexing. Re-run once indexing finishes.`));

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -4,7 +4,7 @@ import { loadConfig } from "../config/config";
 
 export function requireLoginConfig(): Config {
   const cfg = loadConfig();
-  if (!cfg.access_token) {
+  if (!cfg.active_account?.session.access_token) {
     console.error(pc.red("Not logged in. Run 'dosu login' first."));
     process.exit(1);
   }
@@ -12,9 +12,9 @@ export function requireLoginConfig(): Config {
 }
 
 export function requireAPIKey(cfg: Config): string {
-  if (!cfg.api_key) {
+  if (!cfg.active_account?.target?.api_key) {
     console.error(pc.red("API key not configured. Run 'dosu setup' first."));
     process.exit(1);
   }
-  return cfg.api_key;
+  return cfg.active_account?.target?.api_key;
 }

--- a/src/commands/deployments.test.ts
+++ b/src/commands/deployments.test.ts
@@ -19,11 +19,13 @@ vi.mock("../client/trpc", () => ({
 
 const mockLoadConfig = vi.fn();
 const mockSaveConfig = vi.fn();
-vi.mock("../config/config", () => ({
+vi.mock("../config/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config")>()),
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
   saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig, testTarget } from "../config/config.test-utils";
 import { deploymentsCommand } from "./deployments";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -31,7 +33,7 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -40,6 +42,9 @@ const validConfig = {
   deployment_id: "dep1",
   deployment_name: "My Deploy",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -77,7 +82,7 @@ describe("deployments list", () => {
   });
 
   it("calls workspaces.listAll when org_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, org_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ org_id: undefined }));
     mockQuery.mockResolvedValueOnce([]);
     await run("list");
     expect(mockQuery).toHaveBeenCalledWith("workspaces.listAll", {});
@@ -145,11 +150,12 @@ describe("deployments list", () => {
   });
 
   it("shows deployment_id when deployment_name is missing", async () => {
-    mockLoadConfig.mockReturnValue({
-      ...validConfig,
-      deployment_name: undefined,
-      deployment_id: "dep1",
-    });
+    mockLoadConfig.mockReturnValue(
+      makeValidConfig({
+        deployment_name: undefined,
+        deployment_id: "dep1",
+      }),
+    );
     mockQuery.mockResolvedValueOnce([
       { deployment_id: "d1", name: "Test", enabled: true, org_id: "org1" },
     ]);
@@ -173,7 +179,7 @@ describe("deployments info", () => {
   });
 
   it("exits when no deployment_id in config", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, deployment_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ deployment_id: undefined }));
     await expect(run("info")).rejects.toThrow("exit");
   });
 
@@ -269,11 +275,11 @@ describe("deployments switch", () => {
     mockQuery.mockResolvedValueOnce(deployment);
     await run("switch", "new-dep");
 
-    const saved = mockSaveConfig.mock.calls[0][0];
-    expect(saved.deployment_id).toBe("new-dep");
-    expect(saved.deployment_name).toBe("New Deploy");
-    expect(saved.org_id).toBe("org2");
-    expect(saved.space_id).toBe("sp2");
+    const savedTarget = testTarget(mockSaveConfig.mock.calls[0][0]);
+    expect(savedTarget.deployment_id).toBe("new-dep");
+    expect(savedTarget.deployment_name).toBe("New Deploy");
+    expect(savedTarget.org_id).toBe("org2");
+    expect(savedTarget.space_id).toBe("sp2");
   });
 
   it("outputs JSON with --json", async () => {
@@ -303,7 +309,7 @@ describe("deployments switch", () => {
 
 describe("requireConfig", () => {
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -5,7 +5,7 @@
 import { Command } from "commander";
 import pc from "picocolors";
 import { createTypedClient } from "../client/trpc";
-import { saveConfig } from "../config/config";
+import { saveConfig, updateTarget } from "../config/config";
 import { requireLoginConfig } from "./auth";
 import { formatDate, printInfo, printResult, printTable } from "./output";
 
@@ -24,8 +24,8 @@ export function deploymentsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      const deployments = cfg.org_id
-        ? await client.workspaces.listForOrg.query(cfg.org_id)
+      const deployments = cfg.active_account?.target?.org_id
+        ? await client.workspaces.listForOrg.query(cfg.active_account?.target?.org_id)
         : await client.workspaces.listAll.query({});
 
       if (opts.json) {
@@ -51,8 +51,10 @@ export function deploymentsCommand(): Command {
         { rawData: deployments },
       );
 
-      if (cfg.deployment_id) {
-        console.log(`\n${pc.dim(`Current: ${cfg.deployment_name ?? cfg.deployment_id}`)}`);
+      if (cfg.active_account?.target?.deployment_id) {
+        console.log(
+          `\n${pc.dim(`Current: ${cfg.active_account?.target?.deployment_name ?? cfg.active_account?.target?.deployment_id}`)}`,
+        );
       }
     });
 
@@ -63,7 +65,7 @@ export function deploymentsCommand(): Command {
     .action(async (opts: { json?: boolean }) => {
       const cfg = requireConfig();
 
-      if (!cfg.deployment_id) {
+      if (!cfg.active_account?.target?.deployment_id) {
         console.error(
           pc.red("No deployment selected. Run 'dosu setup' or 'dosu deployments switch'."),
         );
@@ -71,10 +73,12 @@ export function deploymentsCommand(): Command {
       }
 
       const client = createTypedClient(cfg);
-      const deployment = await client.workspaces.get.query(cfg.deployment_id);
+      const deployment = await client.workspaces.get.query(
+        cfg.active_account?.target?.deployment_id,
+      );
 
       if (!deployment) {
-        console.error(pc.red(`Deployment not found: ${cfg.deployment_id}`));
+        console.error(pc.red(`Deployment not found: ${cfg.active_account?.target?.deployment_id}`));
         process.exit(1);
       }
 
@@ -116,10 +120,12 @@ export function deploymentsCommand(): Command {
         process.exit(1);
       }
 
-      cfg.deployment_id = deployment.deployment_id;
-      cfg.deployment_name = deployment.name;
-      cfg.org_id = deployment.org_id;
-      cfg.space_id = deployment.space_id;
+      updateTarget(cfg, {
+        deployment_id: deployment.deployment_id,
+        deployment_name: deployment.name,
+        org_id: deployment.org_id,
+        space_id: deployment.space_id,
+      });
       saveConfig(cfg);
 
       if (opts.json) {

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -45,6 +45,7 @@ vi.mock("../debug/logger", () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { logger } from "../debug/logger";
 import { docsCommand } from "./docs";
 
@@ -53,7 +54,7 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -61,6 +62,9 @@ const validConfig = {
   space_id: "sp1",
   org_id: "org1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -1279,12 +1283,12 @@ describe("backendPost", () => {
 
 describe("requireConfig", () => {
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 
   it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ space_id: undefined }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -15,7 +15,7 @@ import { formatDate, printInfo, printResult, printTable, truncate } from "./outp
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.space_id) {
+  if (!cfg.active_account?.target?.space_id) {
     console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -155,7 +155,7 @@ export function docsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
       const result = await client.page.listWithTags.query({
         knowledge_store_id: ksId,
@@ -234,7 +234,7 @@ export function docsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
       const body = readBody(opts);
       const result = await client.page.create.mutate({
@@ -267,7 +267,7 @@ export function docsCommand(): Command {
         const cfg = requireConfig();
         const client = createTypedClient(cfg);
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+        const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
         const body = readBody(opts);
         const result = await client.page.update.mutate({
@@ -387,7 +387,7 @@ export function docsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
       const result = await backendPost("/doc/generate", requireAPIKey(cfg), {
         knowledge_store_id: ksId,
@@ -430,7 +430,7 @@ export function docsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
       const fileIds = opts.files.split(",").map((id) => id.trim());
 
       // biome-ignore lint/suspicious/noExplicitAny: dynamic platform dispatch
@@ -458,7 +458,7 @@ export function docsCommand(): Command {
         const result = await fn({
           knowledge_store_id: ksId,
           // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-          space_id: cfg.space_id!,
+          space_id: cfg.active_account!.target!.space_id!,
           [idField]: fileIds,
         });
 

--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -39,6 +39,7 @@ vi.mock("../hooks/runtime", () => ({
 
 import { Client } from "../client/client";
 import { loadConfig, MODE_OSS } from "../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { loadState, saveState, type TicketState } from "../hooks/state";
 import { requestCreateTicket, requestGetTicket, TicketHttpError } from "../hooks/ticket-client";
 import {
@@ -54,7 +55,7 @@ import {
   runUserPromptSubmit,
 } from "./hooks";
 
-const AUTHED = {
+const AUTHED_FLAT: FlatTestConfig = {
   access_token: "at",
   refresh_token: "rt",
   expires_at: Date.now() + 3_600_000,
@@ -62,6 +63,9 @@ const AUTHED = {
   deployment_name: "My Deploy",
   api_key: "key-abc",
 };
+const authed = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...AUTHED_FLAT, ...overrides });
+const AUTHED = authed();
 
 function pending(overrides: Partial<TicketState> = {}): TicketState {
   return {
@@ -146,9 +150,9 @@ describe("runUserPromptSubmit", () => {
     await runUserPromptSubmit({ prompt: "x" });
     await runUserPromptSubmit({ session_id: "s", prompt: "   " });
     vi.mocked(loadState).mockReturnValue(null);
-    vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, deployment_id: undefined });
+    vi.mocked(loadConfig).mockReturnValue(authed({ deployment_id: undefined }));
     await runUserPromptSubmit({ session_id: "s", prompt: "real" });
-    vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, api_key: undefined });
+    vi.mocked(loadConfig).mockReturnValue(authed({ api_key: undefined }));
     await runUserPromptSubmit({ session_id: "s", prompt: "real" });
     expect(requestCreateTicket).not.toHaveBeenCalled();
     expect(stdout()).toBe("");
@@ -313,7 +317,7 @@ describe("runPostToolUse", () => {
 
   it("records the check but never polls when auth/deployment is missing", async () => {
     vi.mocked(loadState).mockReturnValue(pending());
-    vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, deployment_id: undefined });
+    vi.mocked(loadConfig).mockReturnValue(authed({ deployment_id: undefined }));
     await runPostToolUse({ session_id: "sess" }, 50_000);
     expect(requestGetTicket).not.toHaveBeenCalled();
     expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ lastCheckedAt: 50_000 }));
@@ -460,7 +464,7 @@ describe("runStop", () => {
 
   it("continues without polling when auth/deployment is missing", async () => {
     vi.mocked(loadState).mockReturnValue(pending());
-    vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, api_key: undefined });
+    vi.mocked(loadConfig).mockReturnValue(authed({ api_key: undefined }));
     await runStop({ session_id: "sess" }, 70_000);
     expect(requestGetTicket).not.toHaveBeenCalled();
     expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
@@ -729,7 +733,9 @@ describe("lifecycle commands", () => {
   });
 
   it("doctor flags missing config / auth / deployment and exits non-zero", async () => {
-    vi.mocked(loadConfig).mockReturnValue({ access_token: "", refresh_token: "", expires_at: 0 });
+    vi.mocked(loadConfig).mockReturnValue(
+      makeTestConfig({ access_token: "", refresh_token: "", expires_at: 0 }),
+    );
     const checks = await collectDoctorChecks({ dir });
     const byName = Object.fromEntries(checks.map((c) => [c.name, c.status]));
     expect(byName).toMatchObject({
@@ -945,7 +951,7 @@ describe("collectDoctorChecks deployment detail", () => {
   });
 
   it("falls back to deployment_id when no deployment_name is set", async () => {
-    vi.mocked(loadConfig).mockReturnValue({ ...AUTHED, deployment_name: undefined });
+    vi.mocked(loadConfig).mockReturnValue(authed({ deployment_name: undefined }));
     const checks = await collectDoctorChecks({});
     const deployment = checks.find((c) => c.name === "deployment");
     expect(deployment?.status).toBe("ok");
@@ -953,12 +959,14 @@ describe("collectDoctorChecks deployment detail", () => {
   });
 
   it("reports 'oss' for an OSS-mode config with no deployment id or name", async () => {
-    vi.mocked(loadConfig).mockReturnValue({
-      access_token: "at",
-      refresh_token: "rt",
-      expires_at: Date.now() + 3_600_000,
-      mode: MODE_OSS,
-    });
+    vi.mocked(loadConfig).mockReturnValue(
+      makeTestConfig({
+        access_token: "at",
+        refresh_token: "rt",
+        expires_at: Date.now() + 3_600_000,
+        mode: MODE_OSS,
+      }),
+    );
     const checks = await collectDoctorChecks({});
     const deployment = checks.find((c) => c.name === "deployment");
     expect(deployment?.status).toBe("ok");

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -133,7 +133,7 @@ export async function runUserPromptSubmit(
   }
 
   const cfg = loadConfig();
-  if (!cfg.api_key || !cfg.deployment_id) {
+  if (!cfg.active_account?.target?.api_key || !cfg.active_account?.target?.deployment_id) {
     logger.debug("hooks", "submit skipped reason=not-configured");
     return; // a hook never prompts the user; `doctor` surfaces this
   }
@@ -143,7 +143,7 @@ export async function runUserPromptSubmit(
   let resp: import("../hooks/ticket-client").CreateTicketResponse;
   try {
     resp = await tc.requestCreateTicket(cfg, {
-      deployment_id: cfg.deployment_id,
+      deployment_id: cfg.active_account?.target?.deployment_id,
       agent,
       session_id: sessionId,
       turn_id: input.turn_id ?? String(now),
@@ -198,7 +198,7 @@ export async function runPostToolUse(input: HookInput, now: number = Date.now())
   }
 
   const cfg = loadConfig();
-  if (!cfg.api_key || !cfg.deployment_id) {
+  if (!cfg.active_account?.target?.api_key || !cfg.active_account?.target?.deployment_id) {
     saveState({ ...state, lastCheckedAt: now });
     return;
   }
@@ -269,7 +269,8 @@ export async function runStop(input: HookInput, now: number = Date.now()): Promi
   if (state.status !== "pending" || now > state.expiresAt) return printContinue();
 
   const cfg = loadConfig();
-  if (!cfg.api_key || !cfg.deployment_id) return printContinue();
+  if (!cfg.active_account?.target?.api_key || !cfg.active_account?.target?.deployment_id)
+    return printContinue();
 
   const tc = await import("../hooks/ticket-client");
   const pollMs = stopPollMs();
@@ -641,11 +642,14 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
   } else {
     checks.push({ name: "auth", status: "fail", detail: "not logged in (run 'dosu login')" });
   }
-  if (cfg.deployment_id || cfg.mode === MODE_OSS) {
+  if (cfg.active_account?.target?.deployment_id || cfg.mode === MODE_OSS) {
     checks.push({
       name: "deployment",
       status: "ok",
-      detail: cfg.deployment_name ?? cfg.deployment_id ?? "oss",
+      detail:
+        cfg.active_account?.target?.deployment_name ??
+        cfg.active_account?.target?.deployment_id ??
+        "oss",
     });
   } else {
     checks.push({
@@ -658,9 +662,12 @@ export async function collectDoctorChecks(opts: { dir?: string }): Promise<Docto
   // 5. Backend reachable + API key valid (best-effort; optimistic on network error).
   // This validates the SAME credential the hooks use (`X-Dosu-API-Key`), so it
   // reflects real hook auth — independent of the OAuth login state above.
-  if (cfg.api_key && cfg.deployment_id) {
+  if (cfg.active_account?.target?.api_key && cfg.active_account?.target?.deployment_id) {
     const { Client } = await import("../client/client");
-    const ok = await new Client(cfg).validateAPIKey(cfg.api_key, cfg.deployment_id);
+    const ok = await new Client(cfg).validateAPIKey(
+      cfg.active_account?.target?.api_key,
+      cfg.active_account?.target?.deployment_id,
+    );
     checks.push({
       name: "backend",
       status: ok ? "ok" : "fail",

--- a/src/commands/insights.test.ts
+++ b/src/commands/insights.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as joinPath } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 
 const spinnerStart = vi.fn();
 const spinnerStop = vi.fn();
@@ -81,7 +82,7 @@ let tempConfigDir: string;
 let origXDG: string | undefined;
 let origHome: string | undefined;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -90,6 +91,9 @@ const validConfig = {
   deployment_id: "d1",
   deployment_name: "Test Deploy",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 const fakeReport: InsightsReport = {
   generatedAt: "2026-04-16T00:00:00Z",
@@ -382,7 +386,7 @@ describe("insightsCommand", () => {
 
   it("prompts to run setup when not logged in, then runs insights after a successful setup", async () => {
     mockLoadConfig
-      .mockReturnValueOnce({ ...validConfig, access_token: "" })
+      .mockReturnValueOnce(makeValidConfig({ access_token: "" }))
       .mockReturnValue(validConfig);
     mockConfirm.mockResolvedValue(true);
     mockRunSetup.mockResolvedValue(undefined);
@@ -410,7 +414,7 @@ describe("insightsCommand", () => {
   });
 
   it("warns about missing deployment when api_key is missing", async () => {
-    mockLoadConfig.mockReturnValueOnce({ ...validConfig, api_key: undefined });
+    mockLoadConfig.mockReturnValueOnce(makeValidConfig({ api_key: undefined }));
     mockConfirm.mockResolvedValue(false);
 
     await expect(runCmd()).resolves.toBeUndefined();
@@ -419,7 +423,7 @@ describe("insightsCommand", () => {
   });
 
   it("returns without running insights when the user declines setup", async () => {
-    mockLoadConfig.mockReturnValueOnce({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValueOnce(makeValidConfig({ space_id: undefined }));
     mockConfirm.mockResolvedValue(false);
 
     await expect(runCmd()).resolves.toBeUndefined();
@@ -428,7 +432,7 @@ describe("insightsCommand", () => {
   });
 
   it("returns without running insights when the user cancels the prompt", async () => {
-    mockLoadConfig.mockReturnValueOnce({ ...validConfig, deployment_id: undefined });
+    mockLoadConfig.mockReturnValueOnce(makeValidConfig({ deployment_id: undefined }));
     const cancelSentinel = Symbol("cancel");
     mockConfirm.mockResolvedValue(cancelSentinel);
     mockIsCancel.mockImplementation((v: unknown) => v === cancelSentinel);
@@ -440,8 +444,8 @@ describe("insightsCommand", () => {
 
   it("returns gracefully when setup completes but config is still incomplete", async () => {
     mockLoadConfig
-      .mockReturnValueOnce({ ...validConfig, access_token: "" })
-      .mockReturnValue({ ...validConfig, access_token: "" });
+      .mockReturnValueOnce(makeValidConfig({ access_token: "" }))
+      .mockReturnValue(makeValidConfig({ access_token: "" }));
     mockConfirm.mockResolvedValue(true);
     mockRunSetup.mockResolvedValue(undefined);
 

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -97,14 +97,19 @@ export function createDotsSpinner(): Spinner {
 }
 
 function isFullConfig(cfg: Config): boolean {
-  return Boolean(cfg.access_token && cfg.api_key && cfg.space_id && cfg.deployment_id);
+  return Boolean(
+    cfg.active_account?.session.access_token &&
+      cfg.active_account?.target?.api_key &&
+      cfg.active_account?.target?.space_id &&
+      cfg.active_account?.target?.deployment_id,
+  );
 }
 
 export async function ensureFullConfig(): Promise<Config | null> {
   let cfg = loadConfig();
   if (isFullConfig(cfg)) return cfg;
 
-  const reason = !cfg.access_token
+  const reason = !cfg.active_account?.session.access_token
     ? "Insights needs you to log in first."
     : "Insights needs a configured Dosu deployment.";
   p.log.warn(reason);
@@ -136,11 +141,11 @@ export function makeAskFn(cfg: Config): AskFn {
         headers: {
           "Content-Type": "application/json",
           // biome-ignore lint/style/noNonNullAssertion: checked in requireFullConfig
-          "X-Dosu-API-Key": cfg.api_key!,
+          "X-Dosu-API-Key": cfg.active_account!.target!.api_key!,
         },
         body: JSON.stringify({
           // biome-ignore lint/style/noNonNullAssertion: checked in requireFullConfig
-          deployment_id: cfg.deployment_id!,
+          deployment_id: cfg.active_account!.target!.deployment_id!,
           question,
         }),
         signal: controller.signal,

--- a/src/commands/integrations.test.ts
+++ b/src/commands/integrations.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { integrationsCommand } from "./integrations";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,13 +30,16 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
   api_key: "sk_user_test",
   org_id: "org1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -262,12 +266,12 @@ describe("integrations github-collaborators (JSON branch)", () => {
 
 describe("requireConfig", () => {
   it("exits when org_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, org_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ org_id: undefined }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -10,7 +10,7 @@ import { printResult, printTable } from "./output";
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.org_id) {
+  if (!cfg.active_account?.target?.org_id) {
     console.error(pc.red("Missing org config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -59,7 +59,7 @@ export function integrationsCommand(): Command {
               provider: nangoProvider,
               providerConfigKey: nangoProvider,
               // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-              orgId: cfg.org_id!,
+              orgId: cfg.active_account!.target!.org_id!,
             });
             results.push({ platform, connected: conn !== null });
           } catch {
@@ -110,7 +110,7 @@ export function integrationsCommand(): Command {
           provider: nangoProvider,
           providerConfigKey: nangoProvider,
           // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-          orgId: cfg.org_id!,
+          orgId: cfg.active_account!.target!.org_id!,
         });
 
         const connected = conn !== null;
@@ -137,7 +137,7 @@ export function integrationsCommand(): Command {
       const client = createTypedClient(cfg);
 
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const channels = await client.slackChannel.getAll.query(cfg.org_id!);
+      const channels = await client.slackChannel.getAll.query(cfg.active_account!.target!.org_id!);
 
       if (opts.json) {
         printResult(channels, opts);

--- a/src/commands/knowledge.test.ts
+++ b/src/commands/knowledge.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { knowledgeCommand } from "./knowledge";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,7 +30,7 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -37,6 +38,9 @@ const validConfig = {
   org_id: "org1",
   space_id: "sp1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -164,18 +168,18 @@ describe("knowledge list", () => {
 
 describe("requireConfig", () => {
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("search", "q")).rejects.toThrow("exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it("exits when org_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, org_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ org_id: undefined }));
     await expect(run("search", "q")).rejects.toThrow("exit");
   });
 
   it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ space_id: undefined }));
     await expect(run("search", "q")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/knowledge.ts
+++ b/src/commands/knowledge.ts
@@ -10,7 +10,7 @@ import { printResult, printTable, truncate } from "./output";
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.org_id || !cfg.space_id) {
+  if (!cfg.active_account?.target?.org_id || !cfg.active_account?.target?.space_id) {
     console.error(pc.red("Missing org/space config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -33,7 +33,7 @@ export function knowledgeCommand(): Command {
       // Get data source IDs for the org
       const dataSources = await client.dataSource.list.query({
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        org_id: cfg.org_id!,
+        org_id: cfg.active_account!.target!.org_id!,
         excluded_provider_slugs: [],
       });
 
@@ -90,7 +90,7 @@ export function knowledgeCommand(): Command {
 
       const store = await client.knowledgeStore.getBySpaceId.query(
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        { space_id: cfg.space_id! },
+        { space_id: cfg.active_account!.target!.space_id! },
       );
 
       if (opts.json) {

--- a/src/commands/members.test.ts
+++ b/src/commands/members.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { membersCommand } from "./members";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,13 +30,16 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
   api_key: "sk_user_test",
   org_id: "org1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -262,12 +266,12 @@ describe("members requests", () => {
 
 describe("requireConfig", () => {
   it("exits when org_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, org_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ org_id: undefined }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/members.ts
+++ b/src/commands/members.ts
@@ -10,7 +10,7 @@ import { printResult, printTable } from "./output";
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.org_id) {
+  if (!cfg.active_account?.target?.org_id) {
     console.error(pc.red("Missing org config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -64,7 +64,7 @@ export function membersCommand(): Command {
       const role = opts.role.toUpperCase() === "ADMIN" ? "ADMIN" : "MEMBER";
       await client.invitations.invite.mutate({
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        orgId: cfg.org_id!,
+        orgId: cfg.active_account!.target!.org_id!,
         email,
         // biome-ignore lint/suspicious/noExplicitAny: Role enum requires cast from string
         role: role as any,
@@ -118,7 +118,7 @@ export function membersCommand(): Command {
 
       await client.invitations.acceptInvitation.mutate({
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        orgId: cfg.org_id!,
+        orgId: cfg.active_account!.target!.org_id!,
         email,
       });
 
@@ -140,7 +140,7 @@ export function membersCommand(): Command {
 
       await client.invitations.rejectInvitation.mutate({
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        orgId: cfg.org_id!,
+        orgId: cfg.active_account!.target!.org_id!,
         email,
       });
 

--- a/src/commands/org.test.ts
+++ b/src/commands/org.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { orgCommand } from "./org";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,13 +30,16 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
   api_key: "sk_user_test",
   org_id: "org1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -121,7 +125,7 @@ describe("org info", () => {
 
 describe("requireConfig", () => {
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("info")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/org.ts
+++ b/src/commands/org.ts
@@ -53,8 +53,8 @@ export function orgCommand(): Command {
         { rawData: orgs },
       );
 
-      if (cfg.org_id) {
-        console.log(`\n${pc.dim(`Current: ${cfg.org_id}`)}`);
+      if (cfg.active_account?.target?.org_id) {
+        console.log(`\n${pc.dim(`Current: ${cfg.active_account?.target?.org_id}`)}`);
       }
     });
 

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -32,6 +32,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { reviewCommand } from "./review";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -39,7 +40,7 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -47,6 +48,9 @@ const validConfig = {
   space_id: "sp1",
   deployment_id: "dep1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 // A tRPC NOT_FOUND error, as the client surfaces it. Verbs route by the opaque
 // id's prefix (draft_message:<uuid> → draft, bare uuid → doc_change), so a
@@ -242,7 +246,7 @@ describe("review list", () => {
   });
 
   it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ space_id: undefined }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 
@@ -845,7 +849,7 @@ describe("review error propagation", () => {
 
 describe("requireConfig", () => {
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("context", "t1")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -223,19 +223,19 @@ export function reviewCommand(): Command {
     .option("--json", "Output as JSON")
     .action(async (opts: { json?: boolean }) => {
       const cfg = requireConfig();
-      if (!cfg.space_id) {
+      if (!cfg.active_account?.target?.space_id) {
         console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
         process.exit(1);
       }
       const client = createTypedClient(cfg);
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account?.target?.space_id);
 
       // Docs are knowledge-store-scoped; drafts are deployment-scoped. Passing
       // deploymentId merges draft replies into the list (ENG-524) — omit it and
       // the server returns doc changes only.
       const result: ReviewListResult = await client.review.listPending.query({
         knowledgeStoreId: ksId,
-        deploymentId: cfg.deployment_id,
+        deploymentId: cfg.active_account?.target?.deployment_id,
       });
       const { items, truncated, total } = result;
 

--- a/src/commands/sources.test.ts
+++ b/src/commands/sources.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { sourcesCommand } from "./sources";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,13 +30,16 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
   api_key: "sk_user_test",
   org_id: "org1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -231,12 +235,12 @@ describe("sources delete", () => {
 
 describe("requireConfig", () => {
   it("exits when org_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, org_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ org_id: undefined }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -10,7 +10,7 @@ import { formatDate, printInfo, printResult, printTable } from "./output";
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.org_id) {
+  if (!cfg.active_account?.target?.org_id) {
     console.error(pc.red("Missing org config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -30,7 +30,7 @@ export function sourcesCommand(): Command {
 
       const dataSources = await client.dataSource.list.query({
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        org_id: cfg.org_id!,
+        org_id: cfg.active_account!.target!.org_id!,
         excluded_provider_slugs: [],
       });
 

--- a/src/commands/suggest.test.ts
+++ b/src/commands/suggest.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { suggestCommand } from "./suggest";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,7 +30,7 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -37,6 +38,9 @@ const validConfig = {
   space_id: "sp1",
   org_id: "org1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -172,12 +176,12 @@ describe("getKnowledgeStoreId", () => {
 
 describe("requireConfig", () => {
   it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ space_id: undefined }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -10,7 +10,7 @@ import { printResult, printTable } from "./output";
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.space_id) {
+  if (!cfg.active_account?.target?.space_id) {
     console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -39,7 +39,7 @@ export function suggestCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
       const suggestions = await client.suggestedDoc.listForKnowledgeStore.query({
         knowledgeStoreId: ksId,
@@ -73,16 +73,16 @@ export function suggestCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
-      if (!cfg.org_id) {
+      if (!cfg.active_account?.target?.org_id) {
         console.error(pc.red("Missing org config. Run 'dosu setup' to reconfigure."));
         process.exit(1);
       }
 
       // Get data source IDs
       const dataSources = await client.dataSource.list.query({
-        org_id: cfg.org_id,
+        org_id: cfg.active_account?.target?.org_id,
         excluded_provider_slugs: [],
       });
       const dataSourceIds = dataSources

--- a/src/commands/threads.test.ts
+++ b/src/commands/threads.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { threadsCommand } from "./threads";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,13 +30,16 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
   api_key: "sk_user_test",
   space_id: "sp1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -329,13 +333,13 @@ describe("threads get (human-readable)", () => {
 
 describe("requireConfig", () => {
   it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ space_id: undefined }));
     await expect(run("list")).rejects.toThrow("exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -28,7 +28,7 @@ type ThreadMessageGroup = {
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.space_id) {
+  if (!cfg.active_account?.target?.space_id) {
     console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -63,7 +63,7 @@ export function threadsCommand(): Command {
         resolved: undefined,
         search: undefined,
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        space_id: cfg.space_id!,
+        space_id: cfg.active_account!.target!.space_id!,
         workspaces: undefined,
         limit: Math.min(Number.parseInt(opts.limit ?? "20", 10), 100),
       };

--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -22,6 +22,7 @@ vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { topicsCommand } from "./topics";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -29,13 +30,16 @@ let errorSpy: ReturnType<typeof vi.spyOn>;
 // biome-ignore lint/suspicious/noExplicitAny: process.exit mock type mismatch
 let exitSpy: any;
 
-const validConfig = {
+const validFlatConfig: FlatTestConfig = {
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
   api_key: "sk_user_test",
   space_id: "sp1",
 };
+const makeValidConfig = (overrides: Partial<FlatTestConfig> = {}) =>
+  makeTestConfig({ ...validFlatConfig, ...overrides });
+const validConfig = makeValidConfig();
 
 function allOutput(): string {
   return logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
@@ -144,12 +148,12 @@ describe("getKnowledgeStoreId", () => {
 
 describe("requireConfig", () => {
   it("exits when access_token is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, access_token: "" });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 
   it("exits when space_id is missing", async () => {
-    mockLoadConfig.mockReturnValue({ ...validConfig, space_id: undefined });
+    mockLoadConfig.mockReturnValue(makeValidConfig({ space_id: undefined }));
     await expect(run("list")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -13,7 +13,7 @@ import { printResult, printTable } from "./output";
 
 function requireConfig() {
   const cfg = requireLoginConfig();
-  if (!cfg.space_id) {
+  if (!cfg.active_account?.target?.space_id) {
     console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
     process.exit(1);
   }
@@ -45,7 +45,7 @@ export function topicsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
       const topics = await client.topic.listTopicsByKnowledgeStore.query({
         knowledge_store_id: ksId,
@@ -83,7 +83,7 @@ export function topicsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-      const ksId = await getKnowledgeStoreId(client, cfg.space_id!);
+      const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
       const result = await client.topic.getPagesByTopicId.query({
         knowledge_store_id: ksId,

--- a/src/config/config-v1-migration.ts
+++ b/src/config/config-v1-migration.ts
@@ -1,0 +1,53 @@
+import { getAccessTokenUserID } from "./identity";
+import { type AccountTarget, CONFIG_SCHEMA_VERSION, type Config, MODE_OSS } from "./schema";
+
+/** Convert the pre-v2 flat config at the storage boundary. */
+export function migrateLegacyConfig(value: unknown): Config {
+  if (!isRecord(value)) return { schema_version: CONFIG_SCHEMA_VERSION };
+
+  const accessToken = stringValue(value.access_token) ?? "";
+  const refreshToken = stringValue(value.refresh_token) ?? "";
+  const expiresAt = numberValue(value.expires_at) ?? 0;
+  const hasSession = Boolean(accessToken || refreshToken || expiresAt);
+  const userID = stringValue(value.user_id) ?? getAccessTokenUserID(accessToken);
+
+  return {
+    schema_version: CONFIG_SCHEMA_VERSION,
+    mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
+    active_account: hasSession
+      ? {
+          user_id: userID,
+          session: {
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            expires_at: expiresAt,
+          },
+          // An unowned legacy target is unsafe to carry into a future login.
+          target: userID ? legacyTarget(value) : undefined,
+        }
+      : undefined,
+  };
+}
+
+function legacyTarget(value: Record<string, unknown>): AccountTarget | undefined {
+  const target: AccountTarget = {
+    deployment_id: stringValue(value.deployment_id),
+    deployment_name: stringValue(value.deployment_name),
+    api_key: stringValue(value.api_key),
+    org_id: stringValue(value.org_id),
+    space_id: stringValue(value.space_id),
+  };
+  return Object.values(target).some((field) => field !== undefined) ? target : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/src/config/config.atomic.test.ts
+++ b/src/config/config.atomic.test.ts
@@ -25,6 +25,7 @@ vi.mock("node:fs", async (importOriginal) => {
 
 import { renameSync, writeFileSync } from "node:fs";
 import { type Config, getConfigPath, loadConfig, saveConfig } from "./config";
+import { makeTestConfig } from "./config.test-utils";
 
 describe("saveConfig atomicity", () => {
   let origXDG: string | undefined;
@@ -48,7 +49,11 @@ describe("saveConfig atomicity", () => {
   });
 
   it("writes a temp file and atomically renames it over the final path", () => {
-    const cfg: Config = { access_token: "tok", refresh_token: "ref", expires_at: 1 };
+    const cfg: Config = makeTestConfig({
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: 1,
+    });
     saveConfig(cfg);
 
     const finalPath = getConfigPath();
@@ -67,12 +72,14 @@ describe("saveConfig atomicity", () => {
     expect(dirname(String(from))).toBe(dirname(finalPath));
 
     // Result round-trips and leaves no stray temp files behind.
-    expect(loadConfig()).toEqual(cfg);
+    const loaded = loadConfig();
+    expect(loaded.active_account?.session).toEqual(cfg.active_account?.session);
+    expect(loaded.schema_version).toBe(2);
     expect(readdirSync(dirname(finalPath))).toEqual(["config.json"]);
   });
 
   it("keeps the 0600 mode on the written file", () => {
-    saveConfig({ access_token: "tok", refresh_token: "ref", expires_at: 1 });
+    saveConfig(makeTestConfig({ access_token: "tok", refresh_token: "ref", expires_at: 1 }));
     const dataWrite = vi
       .mocked(writeFileSync)
       .mock.calls.find((c) => String(c[0]).includes("dosu-cli"));

--- a/src/config/config.test-utils.ts
+++ b/src/config/config.test-utils.ts
@@ -1,0 +1,56 @@
+import { type AccountTarget, CONFIG_SCHEMA_VERSION, type Config, type SetupMode } from "./schema";
+
+export interface FlatTestConfig {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  user_id?: string;
+  deployment_id?: string;
+  deployment_name?: string;
+  api_key?: string;
+  org_id?: string;
+  space_id?: string;
+  mode?: SetupMode;
+}
+
+/** Keep test fixtures terse without exposing the retired flat schema to production code. */
+export function makeTestConfig(flat: FlatTestConfig): Config {
+  const target: AccountTarget = {
+    deployment_id: flat.deployment_id,
+    deployment_name: flat.deployment_name,
+    api_key: flat.api_key,
+    org_id: flat.org_id,
+    space_id: flat.space_id,
+  };
+
+  return {
+    schema_version: CONFIG_SCHEMA_VERSION,
+    mode: flat.mode,
+    active_account: {
+      user_id: flat.user_id ?? "test-user-id",
+      session: {
+        access_token: flat.access_token,
+        refresh_token: flat.refresh_token,
+        expires_at: flat.expires_at,
+      },
+      target: Object.values(target).some((value) => value !== undefined) ? target : undefined,
+    },
+  };
+}
+
+export function testSession(cfg: Config) {
+  const session = cfg.active_account?.session;
+  if (!session) throw new Error("test config has no session");
+  return session;
+}
+
+export function testTarget(cfg: Config) {
+  const target = cfg.active_account?.target;
+  if (!target) throw new Error("test config has no target");
+  return target;
+}
+
+export function testAccessTokenFor(userID: string): string {
+  const payload = Buffer.from(JSON.stringify({ sub: userID })).toString("base64url");
+  return `test.${payload}.signature`;
+}

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  CONFIG_SCHEMA_VERSION,
   type Config,
   clearConfig,
   emptyConfig,
@@ -11,8 +12,16 @@ import {
   isTokenExpired,
   loadConfig,
   replaceLoginSession,
+  type SessionCredentials,
   saveConfig,
 } from "./config";
+import { makeTestConfig } from "./config.test-utils";
+
+function accessTokenFor(userID: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ sub: userID })).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
 
 describe("config", () => {
   let origXDG: string | undefined;
@@ -48,22 +57,22 @@ describe("config", () => {
       expect(existsSync(join(tempDir, "dosu-cli-dev"))).toBe(true);
 
       // Writing under dev must not touch the prod dir.
-      const devCfg: Config = {
+      const devCfg: Config = makeTestConfig({
         access_token: "dev-tok",
         refresh_token: "dev-ref",
         expires_at: 1,
-      };
+      });
       saveConfig(devCfg);
 
       // Switch back to prod — we should see empty config, not the dev one.
       delete process.env.DOSU_DEV;
       const prodCfg = loadConfig();
-      expect(prodCfg.access_token).toBe("");
+      expect(prodCfg.active_account).toBeUndefined();
 
       // Switch back to dev — dev config must still be there.
       process.env.DOSU_DEV = "true";
       const devCfgReloaded = loadConfig();
-      expect(devCfgReloaded.access_token).toBe("dev-tok");
+      expect(devCfgReloaded.active_account?.session.access_token).toBe("dev-tok");
     } finally {
       if (origDev !== undefined) {
         process.env.DOSU_DEV = origDev;
@@ -95,143 +104,199 @@ describe("config", () => {
 
   it("loadConfig returns empty config when file does not exist", () => {
     const cfg = loadConfig();
-    expect(cfg.access_token).toBe("");
-    expect(cfg.refresh_token).toBe("");
-    expect(cfg.expires_at).toBe(0);
+    expect(cfg).toEqual({ schema_version: CONFIG_SCHEMA_VERSION });
   });
 
   it("saveConfig and loadConfig round-trip", () => {
-    const cfg: Config = {
+    const cfg: Config = makeTestConfig({
       access_token: "tok_abc",
       refresh_token: "ref_xyz",
       expires_at: 1700000000,
       deployment_id: "dep-123",
       deployment_name: "My Deployment",
       api_key: "key-456",
-    };
+    });
     saveConfig(cfg);
     const loaded = loadConfig();
-    expect(loaded.access_token).toBe("tok_abc");
-    expect(loaded.refresh_token).toBe("ref_xyz");
-    expect(loaded.expires_at).toBe(1700000000);
-    expect(loaded.deployment_id).toBe("dep-123");
-    expect(loaded.deployment_name).toBe("My Deployment");
-    expect(loaded.api_key).toBe("key-456");
+    expect(loaded.active_account?.session).toEqual({
+      access_token: "tok_abc",
+      refresh_token: "ref_xyz",
+      expires_at: 1700000000,
+    });
+    expect(loaded.active_account?.target).toEqual({
+      deployment_id: "dep-123",
+      deployment_name: "My Deployment",
+      api_key: "key-456",
+    });
+
+    const persisted = JSON.parse(readFileSync(getConfigPath(), "utf8"));
+    expect(persisted).toEqual({
+      schema_version: 2,
+      active_account: {
+        user_id: "test-user-id",
+        session: {
+          access_token: "tok_abc",
+          refresh_token: "ref_xyz",
+          expires_at: 1700000000,
+        },
+        target: {
+          deployment_id: "dep-123",
+          deployment_name: "My Deployment",
+          api_key: "key-456",
+        },
+      },
+    });
+    expect(persisted.access_token).toBeUndefined();
+  });
+
+  it("migrates a legacy flat config into the account-owned V2 schema", () => {
+    const path = getConfigPath();
+    writeFileSync(
+      path,
+      JSON.stringify({
+        access_token: accessTokenFor("account-a"),
+        refresh_token: "legacy-refresh",
+        expires_at: 1700000000,
+        deployment_id: "legacy-deployment",
+        deployment_name: "Legacy deployment",
+        api_key: "legacy-key",
+        org_id: "legacy-org",
+        space_id: "legacy-space",
+      }),
+    );
+
+    const loaded = loadConfig();
+
+    expect(loaded.active_account?.user_id).toBe("account-a");
+    expect(loaded.active_account?.target?.deployment_id).toBe("legacy-deployment");
+    expect(loaded.active_account?.target?.api_key).toBe("legacy-key");
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+      schema_version: CONFIG_SCHEMA_VERSION,
+      active_account: {
+        user_id: "account-a",
+        session: {
+          access_token: accessTokenFor("account-a"),
+          refresh_token: "legacy-refresh",
+          expires_at: 1700000000,
+        },
+        target: {
+          deployment_id: "legacy-deployment",
+          deployment_name: "Legacy deployment",
+          api_key: "legacy-key",
+          org_id: "legacy-org",
+          space_id: "legacy-space",
+        },
+      },
+    });
+  });
+
+  it("drops an unowned legacy target when the token identity cannot be verified", () => {
+    writeFileSync(
+      getConfigPath(),
+      JSON.stringify({
+        access_token: "opaque-old-token",
+        refresh_token: "old-refresh",
+        expires_at: 1,
+        deployment_id: "old-deployment",
+        api_key: "old-key",
+      }),
+    );
+    const cfg = loadConfig();
+
+    expect(cfg.active_account?.target).toBeUndefined();
   });
 
   it("isAuthenticated returns true when access_token is set", () => {
-    expect(isAuthenticated({ access_token: "tok", refresh_token: "", expires_at: 0 })).toBe(true);
-    expect(isAuthenticated({ access_token: "", refresh_token: "", expires_at: 0 })).toBe(false);
+    expect(
+      isAuthenticated(makeTestConfig({ access_token: "tok", refresh_token: "", expires_at: 0 })),
+    ).toBe(true);
+    expect(
+      isAuthenticated(makeTestConfig({ access_token: "", refresh_token: "", expires_at: 0 })),
+    ).toBe(false);
   });
 
-  it("replaceLoginSession clears deployment state that may belong to another account", () => {
-    const cfg: Config = {
+  it("replaceLoginSession clears target state before resolving the authenticated account", () => {
+    const cfg = makeTestConfig({
       access_token: "old-token",
       refresh_token: "old-refresh",
       expires_at: 1,
-      deployment_id: "old-deployment",
-      deployment_name: "Old deployment",
-      api_key: "old-key",
-      org_id: "old-org",
-      space_id: "old-space",
+      deployment_id: "account-a-deployment",
+      deployment_name: "Account A deployment",
+      api_key: "account-a-key",
+      org_id: "account-a-org",
+      space_id: "account-a-space",
+      user_id: "account-a",
+    });
+    const session: SessionCredentials = {
+      access_token: "new-token",
+      refresh_token: "new-refresh",
+      expires_at: 2,
+      user_id: "account-a",
     };
 
-    replaceLoginSession(cfg, {
-      access_token: "new-token",
-      refresh_token: "new-refresh",
-      expires_at: 2,
-    });
+    replaceLoginSession(cfg, session);
 
-    expect(cfg).toEqual({
-      access_token: "new-token",
-      refresh_token: "new-refresh",
-      expires_at: 2,
-      deployment_id: undefined,
-      deployment_name: undefined,
-      api_key: undefined,
-      org_id: undefined,
-      space_id: undefined,
-    });
+    expect(cfg.active_account?.target).toBeUndefined();
+    expect(cfg.active_account?.user_id).toBe("account-a");
   });
 
   it("isTokenExpired returns false when expires_at is 0", () => {
-    expect(isTokenExpired({ access_token: "", refresh_token: "", expires_at: 0 })).toBe(false);
+    expect(
+      isTokenExpired(makeTestConfig({ access_token: "", refresh_token: "", expires_at: 0 })),
+    ).toBe(false);
   });
 
   it("isTokenExpired returns true when within 5 minutes of expiry", () => {
     const nowSec = Math.floor(Date.now() / 1000);
     // Expires in 4 minutes (< 5 minute buffer)
-    expect(isTokenExpired({ access_token: "", refresh_token: "", expires_at: nowSec + 240 })).toBe(
-      true,
-    );
+    expect(
+      isTokenExpired(
+        makeTestConfig({ access_token: "", refresh_token: "", expires_at: nowSec + 240 }),
+      ),
+    ).toBe(true);
     // Expires in 10 minutes (> 5 minute buffer)
-    expect(isTokenExpired({ access_token: "", refresh_token: "", expires_at: nowSec + 600 })).toBe(
-      false,
-    );
+    expect(
+      isTokenExpired(
+        makeTestConfig({ access_token: "", refresh_token: "", expires_at: nowSec + 600 }),
+      ),
+    ).toBe(false);
   });
 
   it("clearConfig returns empty config", () => {
-    const cfg: Config = {
+    const cfg: Config = makeTestConfig({
       access_token: "tok",
       refresh_token: "ref",
       expires_at: 123,
       deployment_id: "dep",
       deployment_name: "name",
       api_key: "key",
-    };
+    });
     const cleared = clearConfig(cfg);
-    expect(cleared.access_token).toBe("");
-    expect(cleared.refresh_token).toBe("");
-    expect(cleared.expires_at).toBe(0);
-    expect(cleared.deployment_id).toBeUndefined();
-    expect(cleared.api_key).toBeUndefined();
+    expect(cleared).toEqual({ schema_version: CONFIG_SCHEMA_VERSION });
   });
 
   it("emptyConfig returns exact default shape", () => {
     const cfg = emptyConfig();
-    expect(cfg).toEqual({
-      access_token: "",
-      refresh_token: "",
-      expires_at: 0,
-    });
-    // Ensure optional fields are not present
-    expect(cfg.deployment_id).toBeUndefined();
-    expect(cfg.deployment_name).toBeUndefined();
-    expect(cfg.api_key).toBeUndefined();
+    expect(cfg).toEqual({ schema_version: CONFIG_SCHEMA_VERSION });
   });
 
   it("loadConfig returns emptyConfig on corrupt JSON file", () => {
-    const { writeFileSync } = require("node:fs");
     const path = getConfigPath();
     writeFileSync(path, "NOT VALID JSON {{{{");
     const cfg = loadConfig();
-    expect(cfg).toEqual({
-      access_token: "",
-      refresh_token: "",
-      expires_at: 0,
-    });
+    expect(cfg).toEqual({ schema_version: CONFIG_SCHEMA_VERSION });
   });
 
   it("clearConfig returns exact empty shape with undefined optional fields", () => {
-    const cfg: Config = {
+    const cfg: Config = makeTestConfig({
       access_token: "tok",
       refresh_token: "ref",
       expires_at: 999,
       deployment_id: "dep",
       deployment_name: "name",
       api_key: "key",
-    };
-    const cleared = clearConfig(cfg);
-    expect(cleared).toEqual({
-      access_token: "",
-      refresh_token: "",
-      expires_at: 0,
-      deployment_id: undefined,
-      deployment_name: undefined,
-      api_key: undefined,
-      mode: undefined,
-      org_id: undefined,
-      space_id: undefined,
     });
+    const cleared = clearConfig(cfg);
+    expect(cleared).toEqual({ schema_version: CONFIG_SCHEMA_VERSION });
   });
 });

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  bindAccountIdentity,
   CONFIG_SCHEMA_VERSION,
   type Config,
   clearConfig,
@@ -190,6 +191,37 @@ describe("config", () => {
     });
   });
 
+  it("uses a migrated legacy config when the migration cannot be persisted", () => {
+    const path = getConfigPath();
+    const legacy = {
+      access_token: accessTokenFor("account-a"),
+      refresh_token: "legacy-refresh",
+      expires_at: 1700000000,
+      deployment_id: "legacy-deployment",
+      api_key: "legacy-key",
+    };
+    writeFileSync(path, JSON.stringify(legacy));
+    mkdirSync(`${path}.${process.pid}.tmp`);
+
+    const loaded = loadConfig();
+
+    expect(loaded.active_account?.user_id).toBe("account-a");
+    expect(loaded.active_account?.target?.api_key).toBe("legacy-key");
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(legacy);
+  });
+
+  it("does not overwrite a config with an unknown schema version", () => {
+    const path = getConfigPath();
+    const futureConfig = {
+      schema_version: CONFIG_SCHEMA_VERSION + 1,
+      active_account: { future_session: "preserve-me" },
+    };
+    writeFileSync(path, JSON.stringify(futureConfig));
+
+    expect(loadConfig()).toEqual(emptyConfig());
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(futureConfig);
+  });
+
   it("drops an unowned legacy target when the token identity cannot be verified", () => {
     writeFileSync(
       getConfigPath(),
@@ -215,7 +247,7 @@ describe("config", () => {
     ).toBe(false);
   });
 
-  it("replaceLoginSession clears target state before resolving the authenticated account", () => {
+  it("replaceLoginSession preserves target state when the authenticated account is unchanged", () => {
     const cfg = makeTestConfig({
       access_token: "old-token",
       refresh_token: "old-refresh",
@@ -236,8 +268,56 @@ describe("config", () => {
 
     replaceLoginSession(cfg, session);
 
-    expect(cfg.active_account?.target).toBeUndefined();
+    expect(cfg.active_account?.target).toEqual({
+      deployment_id: "account-a-deployment",
+      deployment_name: "Account A deployment",
+      api_key: "account-a-key",
+      org_id: "account-a-org",
+      space_id: "account-a-space",
+    });
     expect(cfg.active_account?.user_id).toBe("account-a");
+  });
+
+  it("replaceLoginSession clears target state when the authenticated account changes", () => {
+    const cfg = makeTestConfig({
+      access_token: "old-token",
+      refresh_token: "old-refresh",
+      expires_at: 1,
+      deployment_id: "account-a-deployment",
+      deployment_name: "Account A deployment",
+      api_key: "account-a-key",
+      org_id: "account-a-org",
+      space_id: "account-a-space",
+      user_id: "account-a",
+    });
+    const session: SessionCredentials = {
+      access_token: "new-token",
+      refresh_token: "new-refresh",
+      expires_at: 2,
+      user_id: "account-b",
+    };
+
+    replaceLoginSession(cfg, session);
+
+    expect(cfg.active_account?.target).toBeUndefined();
+    expect(cfg.active_account?.user_id).toBe("account-b");
+  });
+
+  it("bindAccountIdentity clears target state when the verified identity changes", () => {
+    const cfg = makeTestConfig({
+      access_token: "account-a-token",
+      refresh_token: "account-a-refresh",
+      expires_at: 1,
+      user_id: "account-a",
+      deployment_id: "account-a-deployment",
+      api_key: "account-a-key",
+    });
+
+    bindAccountIdentity(cfg, "account-b");
+
+    expect(cfg.active_account?.user_id).toBe("account-b");
+    expect(cfg.active_account?.session.access_token).toBe("account-a-token");
+    expect(cfg.active_account?.target).toBeUndefined();
   });
 
   it("isTokenExpired returns false when expires_at is 0", () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -26,18 +26,30 @@ export {
   type SetupMode,
 } from "./schema";
 
+export function getConfigUserID(cfg: Config): string | undefined {
+  return (
+    cfg.active_account?.user_id ??
+    getAccessTokenUserID(cfg.active_account?.session.access_token ?? "")
+  );
+}
+
 /**
  * Replace credentials obtained from an explicit login flow.
  *
- * Explicit login clears the target so deployment-scoped state cannot survive
- * a possible account transition. Token refresh deliberately does not use this
- * helper because it preserves the identity.
+ * Re-authenticating the same verified account preserves its target. Changing
+ * accounts replaces the entire aggregate, so the previous account's org,
+ * deployment, space, and API key cannot survive the transition. Token refresh
+ * deliberately does not use this helper because it preserves the identity.
  */
 export function replaceLoginSession(cfg: Config, session: SessionCredentials): void {
+  const previousUserID = getConfigUserID(cfg);
   const nextUserID = session.user_id ?? getAccessTokenUserID(session.access_token);
+  const preserveTarget = Boolean(previousUserID && nextUserID && previousUserID === nextUserID);
+
   cfg.active_account = {
     user_id: nextUserID,
     session: sessionWithoutIdentity(session),
+    target: preserveTarget ? cloneTarget(cfg.active_account?.target) : undefined,
   };
 }
 
@@ -88,16 +100,26 @@ export function loadConfig(): Config {
   const path = getConfigPath();
   if (!existsSync(path)) return emptyConfig();
 
+  let raw: unknown;
   try {
-    const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
-    if (isConfigV2(raw)) return normalizeV2(raw);
-
-    const migrated = migrateLegacyConfig(raw);
-    writeConfig(path, migrated);
-    return migrated;
+    raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
   } catch {
     return emptyConfig();
   }
+
+  if (isConfigV2(raw)) return normalizeV2(raw);
+  // Legacy configs were unversioned. Never rewrite a schema this version does
+  // not understand, or downgrading could destroy newer config data.
+  if (isRecord(raw) && "schema_version" in raw) return emptyConfig();
+
+  const migrated = migrateLegacyConfig(raw);
+  try {
+    writeConfig(path, migrated);
+  } catch {
+    // The parsed config is still usable even when its migration cannot be
+    // persisted (for example, on a temporarily read-only filesystem).
+  }
+  return migrated;
 }
 
 export function saveConfig(cfg: Config): void {
@@ -136,6 +158,10 @@ function sessionWithoutIdentity(session: SessionCredentials): Omit<SessionCreden
     refresh_token: session.refresh_token,
     expires_at: session.expires_at,
   };
+}
+
+function cloneTarget(target: AccountTarget | undefined): AccountTarget | undefined {
+  return target ? { ...target } : undefined;
 }
 
 function isConfigV2(value: unknown): value is Config {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,46 +4,56 @@
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { migrateLegacyConfig } from "./config-v1-migration";
+import { getAccessTokenUserID } from "./identity";
+import {
+  type AccountTarget,
+  type AuthenticatedConfig,
+  CONFIG_SCHEMA_VERSION,
+  type Config,
+  MODE_OSS,
+  type SessionCredentials,
+} from "./schema";
 
-/** Setup mode: OSS = public libraries only, undefined = standard (cloud) flow. */
-export const MODE_OSS = "oss" as const;
-export type SetupMode = typeof MODE_OSS;
-
-export interface Config {
-  access_token: string;
-  refresh_token: string;
-  expires_at: number;
-  deployment_id?: string;
-  deployment_name?: string;
-  api_key?: string;
-  mode?: SetupMode;
-  org_id?: string;
-  space_id?: string;
-}
-
-export interface SessionCredentials {
-  access_token: string;
-  refresh_token: string;
-  expires_at: number;
-}
+export {
+  type AccountTarget,
+  type ActiveAccount,
+  type AuthenticatedConfig,
+  CONFIG_SCHEMA_VERSION,
+  type Config,
+  MODE_OSS,
+  type SessionCredentials,
+  type SetupMode,
+} from "./schema";
 
 /**
  * Replace credentials obtained from an explicit login flow.
  *
- * A login may authenticate a different account, so deployment-scoped state
- * from the previous session must never survive the transition. Token refresh
- * deliberately does not use this helper because it preserves the same
- * authenticated identity.
+ * Explicit login clears the target so deployment-scoped state cannot survive
+ * a possible account transition. Token refresh deliberately does not use this
+ * helper because it preserves the identity.
  */
 export function replaceLoginSession(cfg: Config, session: SessionCredentials): void {
-  cfg.access_token = session.access_token;
-  cfg.refresh_token = session.refresh_token;
-  cfg.expires_at = session.expires_at;
-  cfg.deployment_id = undefined;
-  cfg.deployment_name = undefined;
-  cfg.api_key = undefined;
-  cfg.org_id = undefined;
-  cfg.space_id = undefined;
+  const nextUserID = session.user_id ?? getAccessTokenUserID(session.access_token);
+  cfg.active_account = {
+    user_id: nextUserID,
+    session: sessionWithoutIdentity(session),
+  };
+}
+
+/** Attach a backend-verified identity to the current session. */
+export function bindAccountIdentity(cfg: Config, userID: string): void {
+  const account = cfg.active_account;
+  if (!account) throw new Error("cannot bind an identity without an authenticated session");
+  if (account.user_id && account.user_id !== userID) account.target = undefined;
+  account.user_id = userID;
+}
+
+export function updateTarget(cfg: Config, target: AccountTarget): void {
+  if (!cfg.active_account?.user_id) {
+    throw new Error("cannot bind a target without a verified account identity");
+  }
+  cfg.active_account.target = { ...cfg.active_account.target, ...target };
 }
 
 /**
@@ -76,23 +86,105 @@ export function getConfigPath(): string {
 
 export function loadConfig(): Config {
   const path = getConfigPath();
-  if (!existsSync(path)) {
-    return emptyConfig();
-  }
+  if (!existsSync(path)) return emptyConfig();
+
   try {
-    const data = readFileSync(path, "utf-8");
-    return JSON.parse(data) as Config;
+    const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    if (isConfigV2(raw)) return normalizeV2(raw);
+
+    const migrated = migrateLegacyConfig(raw);
+    writeConfig(path, migrated);
+    return migrated;
   } catch {
     return emptyConfig();
   }
 }
 
 export function saveConfig(cfg: Config): void {
-  const path = getConfigPath();
-  const dir = getConfigDir();
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeConfig(getConfigPath(), cfg);
+}
+
+export function isAuthenticated(cfg: Config): cfg is AuthenticatedConfig {
+  return Boolean(cfg.active_account?.session.access_token);
+}
+
+/**
+ * Check if the token is expired or about to expire (within 5 minutes).
+ */
+export function isTokenExpired(cfg: Config): boolean {
+  const expiresAt = cfg.active_account?.session.expires_at ?? 0;
+  if (expiresAt === 0) return false;
+  return Math.floor(Date.now() / 1000) > expiresAt - 300;
+}
+
+export function clearConfig(_cfg: Config): Config {
+  return emptyConfig();
+}
+
+export function clearConfigInPlace(cfg: Config): void {
+  cfg.mode = undefined;
+  cfg.active_account = undefined;
+}
+
+export function emptyConfig(): Config {
+  return { schema_version: CONFIG_SCHEMA_VERSION };
+}
+
+function sessionWithoutIdentity(session: SessionCredentials): Omit<SessionCredentials, "user_id"> {
+  return {
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+    expires_at: session.expires_at,
+  };
+}
+
+function isConfigV2(value: unknown): value is Config {
+  return isRecord(value) && value.schema_version === CONFIG_SCHEMA_VERSION;
+}
+
+function normalizeV2(value: Config): Config {
+  const active = isRecord(value.active_account) ? value.active_account : undefined;
+  const session = active && isRecord(active.session) ? active.session : undefined;
+  if (!active || !session) {
+    return {
+      schema_version: CONFIG_SCHEMA_VERSION,
+      mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
+    };
   }
+
+  const accessToken = stringValue(session.access_token) ?? "";
+  const userID = stringValue(active.user_id) ?? getAccessTokenUserID(accessToken);
+  return {
+    schema_version: CONFIG_SCHEMA_VERSION,
+    mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
+    active_account: {
+      user_id: userID,
+      session: {
+        access_token: accessToken,
+        refresh_token: stringValue(session.refresh_token) ?? "",
+        expires_at: numberValue(session.expires_at) ?? 0,
+      },
+      target: userID ? normalizeTarget(active.target) : undefined,
+    },
+  };
+}
+
+function normalizeTarget(value: unknown): AccountTarget | undefined {
+  if (!isRecord(value)) return undefined;
+  const target: AccountTarget = {
+    deployment_id: stringValue(value.deployment_id),
+    deployment_name: stringValue(value.deployment_name),
+    api_key: stringValue(value.api_key),
+    org_id: stringValue(value.org_id),
+    space_id: stringValue(value.space_id),
+  };
+  return Object.values(target).some((field) => field !== undefined) ? target : undefined;
+}
+
+function writeConfig(path: string, config: Config): void {
+  const dir = getConfigDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+
   // Write-then-rename so concurrent CLI processes never observe a partially
   // written config and never interleave writes. A clobbered refresh token
   // would be replayed on the next refresh, and GoTrue's reuse detection can
@@ -100,40 +192,18 @@ export function saveConfig(cfg: Config): void {
   // the same directory (rename is only atomic within one filesystem) and is
   // pid-suffixed so sibling processes never share it.
   const tmp = `${path}.${process.pid}.tmp`;
-  writeFileSync(tmp, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+  writeFileSync(tmp, JSON.stringify(config, null, 2), { mode: 0o600 });
   renameSync(tmp, path);
 }
 
-export function isAuthenticated(cfg: Config): boolean {
-  return cfg.access_token !== "";
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/**
- * Check if the token is expired or about to expire (within 5 minutes).
- */
-export function isTokenExpired(cfg: Config): boolean {
-  if (cfg.expires_at === 0) return false;
-  return Math.floor(Date.now() / 1000) > cfg.expires_at - 300;
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
-export function clearConfig(_cfg: Config): Config {
-  return {
-    access_token: "",
-    refresh_token: "",
-    expires_at: 0,
-    deployment_id: undefined,
-    deployment_name: undefined,
-    api_key: undefined,
-    mode: undefined,
-    org_id: undefined,
-    space_id: undefined,
-  };
-}
-
-export function emptyConfig(): Config {
-  return {
-    access_token: "",
-    refresh_token: "",
-    expires_at: 0,
-  };
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }

--- a/src/config/identity.ts
+++ b/src/config/identity.ts
@@ -1,0 +1,18 @@
+/**
+ * Read the stable identity carried by a Supabase JWT.
+ *
+ * This only correlates local state with an account. It is never an
+ * authorization decision; the backend still validates every token.
+ */
+export function getAccessTokenUserID(accessToken: string): string | undefined {
+  try {
+    const payload = accessToken.split(".")[1];
+    if (!payload) return undefined;
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      sub?: unknown;
+    };
+    return typeof decoded.sub === "string" && decoded.sub.length > 0 ? decoded.sub : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,37 @@
+/** Setup mode: OSS = public libraries only, undefined = standard (cloud) flow. */
+export const MODE_OSS = "oss" as const;
+export type SetupMode = typeof MODE_OSS;
+
+export const CONFIG_SCHEMA_VERSION = 2 as const;
+
+export interface SessionCredentials {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  /** Stable account identity. Falls back to the access token's `sub` claim. */
+  user_id?: string;
+}
+
+export interface AccountTarget {
+  deployment_id?: string;
+  deployment_name?: string;
+  api_key?: string;
+  org_id?: string;
+  space_id?: string;
+}
+
+export interface ActiveAccount {
+  /** Missing only when a token does not expose a readable identity. */
+  user_id?: string;
+  session: Omit<SessionCredentials, "user_id">;
+  target?: AccountTarget;
+}
+
+/** Runtime and on-disk schema. Account-owned target state cannot exist outside its account. */
+export interface Config {
+  schema_version: typeof CONFIG_SCHEMA_VERSION;
+  mode?: SetupMode;
+  active_account?: ActiveAccount;
+}
+
+export type AuthenticatedConfig = Config & { active_account: ActiveAccount };

--- a/src/hooks/ticket-client.test.ts
+++ b/src/hooks/ticket-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../config/config";
+import { makeTestConfig } from "../config/config.test-utils";
 
 const postWithApiKey = vi.fn();
 const getWithApiKey = vi.fn();
@@ -17,7 +18,7 @@ import {
   TicketHttpError,
 } from "./ticket-client";
 
-const cfg = { access_token: "at", refresh_token: "rt", expires_at: 0 } as Config;
+const cfg: Config = makeTestConfig({ access_token: "at", refresh_token: "rt", expires_at: 0 });
 
 function jsonResponse(status: number, body: unknown) {
   return { status, json: async () => body };

--- a/src/insights/insights.test.ts
+++ b/src/insights/insights.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../config/config";
+import { makeTestConfig, testSession } from "../config/config.test-utils";
 import {
   type AskFn,
   buildAtAGlancePrompt,
@@ -22,7 +23,7 @@ function createMockClient(): unknown {
   return proxy();
 }
 
-const cfg: Config = {
+const cfg: Config = makeTestConfig({
   access_token: "t",
   refresh_token: "r",
   expires_at: 0,
@@ -30,7 +31,7 @@ const cfg: Config = {
   deployment_id: "d1",
   deployment_name: "Acme Docs",
   api_key: "sk_user_test",
-};
+});
 
 const NOW = () => new Date("2026-04-16T12:00:00Z");
 
@@ -141,7 +142,14 @@ describe("buildInsights", () => {
     await expect(
       buildInsights({
         client: createMockClient() as never,
-        cfg: { ...cfg, space_id: undefined },
+        cfg: {
+          ...cfg,
+          active_account: {
+            ...cfg.active_account,
+            session: testSession(cfg),
+            target: { ...cfg.active_account?.target, space_id: undefined },
+          },
+        },
         ask: okAsk,
       }),
     ).rejects.toThrow(/space_id/);
@@ -152,7 +160,14 @@ describe("buildInsights", () => {
     mockQuery.mockResolvedValueOnce(stats());
     const r = await buildInsights({
       client: createMockClient() as never,
-      cfg: { ...cfg, deployment_name: undefined },
+      cfg: {
+        ...cfg,
+        active_account: {
+          ...cfg.active_account,
+          session: testSession(cfg),
+          target: { ...cfg.active_account?.target, deployment_name: undefined },
+        },
+      },
       ask: okAsk,
       windowDays: 30,
       now: NOW,

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -85,10 +85,10 @@ export async function buildInsights({
   now = () => new Date(),
   onProgress,
 }: BuildInsightsArgs): Promise<InsightsReport> {
-  if (!cfg.space_id) {
+  if (!cfg.active_account?.target?.space_id) {
     throw new Error("space_id missing. Run 'dosu setup' first");
   }
-  const spaceId = cfg.space_id;
+  const spaceId = cfg.active_account?.target?.space_id;
 
   onProgress?.("stats");
   const [currentRaw, combinedRaw] = await Promise.all([
@@ -112,7 +112,7 @@ export async function buildInsights({
   return {
     generatedAt: now().toISOString(),
     windowDays,
-    spaceName: cfg.deployment_name ?? "your space",
+    spaceName: cfg.active_account?.target?.deployment_name ?? "your space",
     current,
     previous,
     derived,

--- a/src/mcp/providers/antigravity.ts
+++ b/src/mcp/providers/antigravity.ts
@@ -12,8 +12,8 @@ export const AntigravityProvider = () =>
     topKey: "mcpServers",
     buildServer: (cfg) => ({
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      serverUrl: mcpURL(cfg.deployment_id!),
+      serverUrl: mcpURL(cfg.active_account!.target!.deployment_id!),
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.api_key!),
+      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
   });

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -35,15 +35,15 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
   const defaultBuildServer = (cfg: Config): Record<string, any> => ({
     type: "http",
     // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-    url: mcpURL(cfg.deployment_id!),
-    headers: mcpHeaders(cfg.api_key),
+    url: mcpURL(cfg.active_account!.target!.deployment_id!),
+    headers: mcpHeaders(cfg.active_account?.target?.api_key),
   });
 
   // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
   const defaultBuildOSSServer = (cfg: Config): Record<string, any> => ({
     type: "http",
     url: mcpBaseURL(),
-    headers: mcpHeaders(cfg.api_key),
+    headers: mcpHeaders(cfg.active_account?.target?.api_key),
   });
 
   const buildServer = opts.buildServer ?? defaultBuildServer;
@@ -59,7 +59,8 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     isConfigured: () => isJSONKeyConfigured(expandHome(opts.globalPath), opts.topKey),
 
     install(cfg: Config, global: boolean): void {
-      if (cfg.mode !== MODE_OSS && !cfg.deployment_id) throw new Error("deployment ID is required");
+      if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
+        throw new Error("deployment ID is required");
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);

--- a/src/mcp/providers/cline-cli.ts
+++ b/src/mcp/providers/cline-cli.ts
@@ -18,10 +18,10 @@ export const ClineCliProvider = () =>
     topKey: "mcpServers",
     buildServer: (cfg) => ({
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.deployment_id!),
+      url: mcpURL(cfg.active_account!.target!.deployment_id!),
       type: "streamableHttp",
       disabled: false,
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.api_key!),
+      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
   });

--- a/src/mcp/providers/cline.ts
+++ b/src/mcp/providers/cline.ts
@@ -17,10 +17,10 @@ export const ClineProvider = () =>
     topKey: "mcpServers",
     buildServer: (cfg) => ({
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.deployment_id!),
+      url: mcpURL(cfg.active_account!.target!.deployment_id!),
       type: "streamableHttp",
       disabled: false,
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.api_key!),
+      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
   });

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -35,8 +35,8 @@ function writeTOML(path: string, content: string): void {
 
 function mcpEndpoint(cfg: Config): string {
   if (cfg.mode === MODE_OSS) return mcpBaseURL();
-  if (!cfg.deployment_id) throw new Error("deployment ID is required");
-  return mcpURL(cfg.deployment_id);
+  if (!cfg.active_account?.target?.deployment_id) throw new Error("deployment ID is required");
+  return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
 function installDosuToTOML(path: string, cfg: Config): void {
@@ -45,7 +45,7 @@ function installDosuToTOML(path: string, cfg: Config): void {
   content = removeDosuFromTOML(content);
   // Append new section
   const url = mcpEndpoint(cfg);
-  const headers = mcpHeaders(cfg.api_key);
+  const headers = mcpHeaders(cfg.active_account?.target?.api_key);
   const headerEntries = Object.entries(headers)
     .map(([k, v]) => `${k} = "${v}"`)
     .join("\n");
@@ -90,7 +90,8 @@ export const CodexProvider = (): SetupProvider => ({
     return content.includes("[mcp_servers.dosu]");
   },
   install(cfg: Config, global: boolean): void {
-    if (cfg.mode !== MODE_OSS && !cfg.deployment_id) throw new Error("deployment ID is required");
+    if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
+      throw new Error("deployment ID is required");
     installDosuToTOML(getConfigPath(global), cfg);
   },
   remove(global: boolean): void {

--- a/src/mcp/providers/copilot.ts
+++ b/src/mcp/providers/copilot.ts
@@ -20,8 +20,8 @@ function globalPath(): string {
 
 function mcpEndpoint(cfg: Config): string {
   if (cfg.mode === MODE_OSS) return mcpBaseURL();
-  if (!cfg.deployment_id) throw new Error("deployment ID is required");
-  return mcpURL(cfg.deployment_id);
+  if (!cfg.active_account?.target?.deployment_id) throw new Error("deployment ID is required");
+  return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
 export const CopilotProvider = (): SetupProvider => ({
@@ -43,7 +43,7 @@ export const CopilotProvider = (): SetupProvider => ({
         url,
         tools: ["*"],
         // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-        headers: mcpHeaders(cfg.api_key!),
+        headers: mcpHeaders(cfg.active_account!.target!.api_key!),
       };
       installJSONServer(globalPath(), "mcpServers", server);
     } else {
@@ -52,7 +52,7 @@ export const CopilotProvider = (): SetupProvider => ({
         type: "http",
         url,
         // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-        headers: mcpHeaders(cfg.api_key!),
+        headers: mcpHeaders(cfg.active_account!.target!.api_key!),
       };
       installJSONServer(configPath, "servers", server);
     }

--- a/src/mcp/providers/cursor.ts
+++ b/src/mcp/providers/cursor.ts
@@ -13,9 +13,9 @@ export const CursorProvider = () =>
     topKey: "mcpServers",
     buildServer: (cfg) => ({
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.deployment_id!),
+      url: mcpURL(cfg.active_account!.target!.deployment_id!),
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.api_key!),
+      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
     localConfigPath: (cwd) => join(cwd, ".cursor", "mcp.json"),
   });

--- a/src/mcp/providers/manual.ts
+++ b/src/mcp/providers/manual.ts
@@ -4,8 +4,8 @@ import type { Provider, ProviderInstallOptions } from "../providers";
 
 function mcpEndpoint(cfg: Config): string {
   if (cfg.mode === MODE_OSS) return mcpBaseURL();
-  if (!cfg.deployment_id) throw new Error("deployment ID is required");
-  return mcpURL(cfg.deployment_id);
+  if (!cfg.active_account?.target?.deployment_id) throw new Error("deployment ID is required");
+  return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
 function maskSecret(secret: string): string {
@@ -21,7 +21,7 @@ export const ManualProvider = (): Provider => ({
 
   install(cfg: Config, _global: boolean, opts: ProviderInstallOptions = {}): void {
     const url = mcpEndpoint(cfg);
-    const apiKey = mcpHeaders(cfg.api_key)["X-Dosu-API-Key"];
+    const apiKey = mcpHeaders(cfg.active_account?.target?.api_key)["X-Dosu-API-Key"];
     const headerValue = opts.showSecret ? apiKey : maskSecret(apiKey);
     console.log("Use these details to configure the Dosu MCP server in your client:");
     console.log();

--- a/src/mcp/providers/mcporter.ts
+++ b/src/mcp/providers/mcporter.ts
@@ -22,8 +22,8 @@ function resolveGlobalConfigPath(): string {
 
 function mcpEndpoint(cfg: Config): string {
   if (cfg.mode === MODE_OSS) return mcpBaseURL();
-  if (!cfg.deployment_id) throw new Error("deployment ID is required");
-  return mcpURL(cfg.deployment_id);
+  if (!cfg.active_account?.target?.deployment_id) throw new Error("deployment ID is required");
+  return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
 export const MCPorterProvider = (): SetupProvider => ({
@@ -44,7 +44,7 @@ export const MCPorterProvider = (): SetupProvider => ({
       type: "http",
       url: mcpEndpoint(cfg),
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.api_key!),
+      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     };
     installJSONServer(configPath, "mcpServers", server);
   },

--- a/src/mcp/providers/opencode.ts
+++ b/src/mcp/providers/opencode.ts
@@ -14,10 +14,10 @@ export const OpenCodeProvider = () =>
     buildServer: (cfg) => ({
       type: "remote",
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.deployment_id!),
+      url: mcpURL(cfg.active_account!.target!.deployment_id!),
       enabled: true,
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.api_key!),
+      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
     localConfigPath: (cwd) => join(cwd, "opencode.json"),
   });

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -11,14 +11,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../../config/config.test-utils";
 import { loadJSONConfig } from "../config-helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeCfg(overrides: Partial<Config> = {}): Config {
-  return {
+function makeCfg(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "at",
     refresh_token: "rt",
     expires_at: Date.now() + 3600_000,
@@ -26,7 +27,7 @@ function makeCfg(overrides: Partial<Config> = {}): Config {
     deployment_name: "my-deploy",
     api_key: "key-abc",
     ...overrides,
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -225,7 +226,7 @@ describe("createJSONProvider (base)", () => {
       globalPath,
       topKey: "servers",
       buildServer: (cfg) => ({
-        myUrl: `custom-${cfg.deployment_id}`,
+        myUrl: `custom-${cfg.active_account?.target?.deployment_id}`,
       }),
     });
 

--- a/src/mcp/providers/zed.ts
+++ b/src/mcp/providers/zed.ts
@@ -25,9 +25,9 @@ export const ZedProvider = () =>
       source: "custom",
       type: "http",
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.deployment_id!),
+      url: mcpURL(cfg.active_account!.target!.deployment_id!),
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.api_key!),
+      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
     localConfigPath: (cwd) => join(cwd, ".zed", "settings.json"),
   });

--- a/src/setup/analytics.test.ts
+++ b/src/setup/analytics.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CLI_CONTRACT_HASH } from "../client/contract";
 import type { Config } from "../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 
 const { mockCreateTypedClient, mockCreateTRPCClient, mockDebug, mockGetWebAppURL, mockHttpLink } =
   vi.hoisted(() => ({
@@ -32,8 +33,8 @@ import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analy
 
 const mutate = vi.fn();
 
-function makeConfig(overrides: Partial<Config> = {}): Config {
-  return {
+function makeConfig(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "token",
     refresh_token: "refresh",
     expires_at: 0,
@@ -41,7 +42,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     deployment_id: "dep-1",
     space_id: "space-1",
     ...overrides,
-  };
+  });
 }
 
 function mockTrackingClient() {
@@ -90,7 +91,11 @@ describe("setup analytics", () => {
     );
 
     expect(mockCreateTypedClient).toHaveBeenCalledWith(
-      expect.objectContaining({ access_token: "token" }),
+      expect.objectContaining({
+        active_account: expect.objectContaining({
+          session: expect.objectContaining({ access_token: "token" }),
+        }),
+      }),
     );
     expect(mutate).toHaveBeenCalledWith({
       event: "cli_onboarding_completed",

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -2,7 +2,7 @@ import { createTRPCClient, httpLink } from "@trpc/client";
 import superjson from "superjson";
 import { CLI_CONTRACT_HASH } from "../client/contract";
 import { createTypedClient } from "../client/trpc";
-import type { Config } from "../config/config";
+import { type Config, emptyConfig } from "../config/config";
 import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
 import type { CliApiClient } from "../generated/dosu-api-types";
@@ -44,7 +44,7 @@ export async function trackCliOnboardingEvent(
   event: CliOnboardingEvent,
   properties: CliOnboardingProperties = {},
 ): Promise<void> {
-  if (!cfg.access_token) return;
+  if (!cfg.active_account?.session.access_token) return;
 
   try {
     const trpc: CliOnboardingAnalyticsClient = createTypedClient(cfg);
@@ -77,7 +77,7 @@ export async function trackCliOnboardingPreAuthEvent(
         event,
         onboarding_run_id: onboardingRunID,
         properties: {
-          ...baseProperties({ access_token: "", refresh_token: "", expires_at: 0 }),
+          ...baseProperties(emptyConfig()),
           ...properties,
         },
       }),
@@ -95,9 +95,9 @@ function baseProperties(cfg: Config): CliOnboardingProperties {
     platform: process.platform,
     arch: process.arch,
     mode: cfg.mode ?? "cloud",
-    org_id: cfg.org_id,
-    deployment_id: cfg.deployment_id,
-    space_id: cfg.space_id,
+    org_id: cfg.active_account?.target?.org_id,
+    deployment_id: cfg.active_account?.target?.deployment_id,
+    space_id: cfg.active_account?.target?.space_id,
   };
 }
 

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -138,6 +138,7 @@ import { startOAuthFlow } from "../auth/flow";
 import { Client } from "../client/client";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { loadJSONConfig, saveJSONConfig } from "../mcp/config-helpers";
 import * as providersModule from "../mcp/providers";
 import { ClaudeDesktopProvider } from "../mcp/providers/claude-desktop";
@@ -228,8 +229,8 @@ function teardownTempEnv() {
   rmSync(tempDir, { recursive: true, force: true });
 }
 
-function makeCfg(overrides: Partial<Config> = {}): Config {
-  return {
+function makeCfg(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "tok",
     refresh_token: "ref",
     expires_at: Math.floor(Date.now() / 1000) + 3600,
@@ -237,7 +238,7 @@ function makeCfg(overrides: Partial<Config> = {}): Config {
     deployment_name: "TestDeploy",
     api_key: "key-abc",
     ...overrides,
-  };
+  });
 }
 
 function makeDeployment(overrides: Record<string, unknown> = {}) {
@@ -720,8 +721,8 @@ describe("runSetup integration", () => {
 
     // Config should have been saved with deployment info
     const savedCfg = loadConfig();
-    expect(savedCfg.deployment_id).toBe("d1");
-    expect(savedCfg.deployment_name).toBe("Deploy1");
+    expect(savedCfg.active_account?.target?.deployment_id).toBe("d1");
+    expect(savedCfg.active_account?.target?.deployment_name).toBe("Deploy1");
   });
 
   it("completes full flow with tool install via real filesystem", async () => {
@@ -772,8 +773,8 @@ describe("runSetup integration", () => {
 
     // Real config on disk should have OAuth tokens
     const savedCfg = loadConfig();
-    expect(savedCfg.access_token).toBe("oauth-tok");
-    expect(savedCfg.refresh_token).toBe("oauth-ref");
+    expect(savedCfg.active_account?.session.access_token).toBe("oauth-tok");
+    expect(savedCfg.active_account?.session.refresh_token).toBe("oauth-ref");
     expect(p.log.message).toHaveBeenCalledWith(
       expect.stringContaining(
         "If your browser doesn't open automatically, visit:\nhttps://app.test/cli/auth?callback=cb",
@@ -787,7 +788,7 @@ describe("runSetup integration", () => {
     const result = await runSetup();
 
     expect(result).toBeUndefined();
-    expect(loadConfig().access_token).toBe("");
+    expect(loadConfig().active_account).toBeUndefined();
   });
 
   it("uses deploymentID option to resolve deployment directly", async () => {
@@ -809,8 +810,8 @@ describe("runSetup integration", () => {
 
     // Config on disk should have d2
     const savedCfg = loadConfig();
-    expect(savedCfg.deployment_id).toBe("d2");
-    expect(savedCfg.deployment_name).toBe("Deploy2");
+    expect(savedCfg.active_account?.target?.deployment_id).toBe("d2");
+    expect(savedCfg.active_account?.target?.deployment_name).toBe("Deploy2");
   });
 
   it("clears OSS mode when re-running setup with a specific deployment", async () => {
@@ -847,8 +848,8 @@ describe("runSetup integration", () => {
 
     const savedCfg = loadConfig();
     expect(savedCfg.mode).toBeUndefined();
-    expect(savedCfg.deployment_id).toBe("d2");
-    expect(savedCfg.api_key).toBe("key-abc");
+    expect(savedCfg.active_account?.target?.deployment_id).toBe("d2");
+    expect(savedCfg.active_account?.target?.api_key).toBe("key-abc");
 
     const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
     expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp/deployments/d2");
@@ -872,7 +873,7 @@ describe("runSetup integration", () => {
 
     // Config on disk should have fresh key
     const savedCfg = loadConfig();
-    expect(savedCfg.api_key).toBe("fresh-key");
+    expect(savedCfg.active_account?.target?.api_key).toBe("fresh-key");
   });
 
   it("reinstalls configured tools when only the API key changes", async () => {
@@ -1030,7 +1031,7 @@ describe("runSetup integration", () => {
 
     expect(p.select).toHaveBeenCalledWith(expect.objectContaining({ message: "Select an MCP" }));
     const saved = loadConfig();
-    expect(saved.deployment_id).toBe("d2");
+    expect(saved.active_account?.target?.deployment_id).toBe("d2");
   });
 
   it("returns early when no deployments for org", async () => {
@@ -1163,7 +1164,7 @@ describe("runSetup integration", () => {
 
     // Should return early without saving deployment
     const saved = loadConfig();
-    expect(saved.deployment_id).toBeUndefined();
+    expect(saved.active_account?.target?.deployment_id).toBeUndefined();
   });
 
   it("handles user cancelling deployment selection", async () => {
@@ -1185,7 +1186,7 @@ describe("runSetup integration", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.deployment_id).toBeUndefined();
+    expect(saved.active_account?.target?.deployment_id).toBeUndefined();
   });
 
   it("shows deployment not found error", async () => {
@@ -1285,7 +1286,7 @@ describe("runSetup integration", () => {
 
     // Should have saved deployment from fetchDeployments
     const saved = loadConfig();
-    expect(saved.deployment_id).toBe("d1");
+    expect(saved.active_account?.target?.deployment_id).toBe("d1");
     expect(saved.mode).toBe("oss");
   });
 
@@ -1302,7 +1303,7 @@ describe("runSetup integration", () => {
 
     expect(p.log.error).toHaveBeenCalledWith("No MCP available for API key creation");
     const saved = loadConfig();
-    expect(saved.deployment_id).toBeUndefined();
+    expect(saved.active_account?.target?.deployment_id).toBeUndefined();
     expect(p.outro).not.toHaveBeenCalled();
   });
 
@@ -1319,7 +1320,7 @@ describe("runSetup integration", () => {
 
     expect(p.log.error).toHaveBeenCalledWith("No MCP available for API key creation");
     const saved = loadConfig();
-    expect(saved.deployment_id).toBeUndefined();
+    expect(saved.active_account?.target?.deployment_id).toBeUndefined();
     expect(p.outro).not.toHaveBeenCalled();
   });
 
@@ -1718,8 +1719,8 @@ describe("runSetup checkpoint behavior", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.access_token).toBe("tok-fresh");
-    expect(saved.refresh_token).toBe("ref-fresh");
+    expect(saved.active_account?.session.access_token).toBe("tok-fresh");
+    expect(saved.active_account?.session.refresh_token).toBe("ref-fresh");
   });
 
   it("mints a new API key when the existing one is invalid", async () => {
@@ -1731,7 +1732,7 @@ describe("runSetup checkpoint behavior", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.api_key).toBe("fresh-key");
+    expect(saved.active_account?.target?.api_key).toBe("fresh-key");
   });
 
   it("does not mark onboarding complete server-side — the web wizard owns that", async () => {
@@ -1837,8 +1838,8 @@ describe("runSetup checkpoint behavior", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.access_token).toBe("tok-minted");
-    expect(saved.refresh_token).toBe("ref-minted");
+    expect(saved.active_account?.session.access_token).toBe("tok-minted");
+    expect(saved.active_account?.session.refresh_token).toBe("ref-minted");
   });
 
   it("aborts and tracks failure when the web onboarding handoff does not complete", async () => {
@@ -1912,9 +1913,9 @@ describe("runSetup checkpoint behavior", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.org_id).toBe("owner-org");
-    expect(saved.space_id).toBe("space-owner");
-    expect(saved.deployment_id).toBe("dep-owner");
+    expect(saved.active_account?.target?.org_id).toBe("owner-org");
+    expect(saved.active_account?.target?.space_id).toBe("space-owner");
+    expect(saved.active_account?.target?.deployment_id).toBe("dep-owner");
   });
 
   it("re-resolves onboarding state when the browser hands back a different account", async () => {
@@ -1970,12 +1971,12 @@ describe("runSetup checkpoint behavior", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.access_token).toBe("account-b-token");
-    expect(saved.refresh_token).toBe("account-b-refresh");
-    expect(saved.org_id).toBe("account-b-org");
-    expect(saved.space_id).toBe("account-b-space");
-    expect(saved.deployment_id).toBe("account-b-deployment");
-    expect(saved.api_key).toBe("new-key");
+    expect(saved.active_account?.session.access_token).toBe("account-b-token");
+    expect(saved.active_account?.session.refresh_token).toBe("account-b-refresh");
+    expect(saved.active_account?.target?.org_id).toBe("account-b-org");
+    expect(saved.active_account?.target?.space_id).toBe("account-b-space");
+    expect(saved.active_account?.target?.deployment_id).toBe("account-b-deployment");
+    expect(saved.active_account?.target?.api_key).toBe("new-key");
     expect(methods.validateAPIKey).not.toHaveBeenCalled();
   });
 
@@ -2081,7 +2082,7 @@ describe("runSetup checkpoint behavior", () => {
     // session was already valid), and the explicit deployment was bound.
     expect(mockStartOAuthFlow).not.toHaveBeenCalled();
     const saved = loadConfig();
-    expect(saved.deployment_id).toBe("dep-explicit");
+    expect(saved.active_account?.target?.deployment_id).toBe("dep-explicit");
   });
 });
 
@@ -2206,8 +2207,8 @@ describe("runSetup additional branches", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.org_id).toBe("member-org");
-    expect(saved.deployment_id).toBe("dep-member");
+    expect(saved.active_account?.target?.org_id).toBe("member-org");
+    expect(saved.active_account?.target?.deployment_id).toBe("dep-member");
   });
 
   it("aborts onboarding when no deployment exists for the target org", async () => {
@@ -2275,7 +2276,7 @@ describe("runSetup additional branches", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.deployment_id).toBe("dep-fallback");
+    expect(saved.active_account?.target?.deployment_id).toBe("dep-fallback");
   });
 
   it("returns early when the one-shot confirm is cancelled", async () => {
@@ -2404,7 +2405,7 @@ describe("runSetup additional branches", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.deployment_id).toBeUndefined();
+    expect(saved.active_account?.target?.deployment_id).toBeUndefined();
     expect(p.outro).not.toHaveBeenCalled();
   });
 
@@ -2424,7 +2425,7 @@ describe("runSetup additional branches", () => {
     await runSetup();
 
     const saved = loadConfig();
-    expect(saved.deployment_id).toBeUndefined();
+    expect(saved.active_account?.target?.deployment_id).toBeUndefined();
     expect(p.outro).not.toHaveBeenCalled();
   });
 

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -9,12 +9,14 @@ import { Client, type Deployment, type Org, SessionExpiredError } from "../clien
 import type { TypedClient } from "../client/trpc";
 import { installSkill } from "../commands/skill";
 import {
+  bindAccountIdentity,
   type Config,
   loadConfig,
   MODE_OSS,
   replaceLoginSession,
   type SetupMode,
   saveConfig,
+  updateTarget,
 } from "../config/config";
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
@@ -169,7 +171,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       });
       return;
     }
-  } else if (!cfg.deployment_id || opts.deploymentID) {
+  } else if (!cfg.active_account?.target?.deployment_id || opts.deploymentID) {
     const ok = await resolveDeployment(apiClient, cfg, opts);
     if (!ok) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
@@ -188,7 +190,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     });
     return;
   }
-  cfg.api_key = apiKey;
+  updateTarget(cfg, { api_key: apiKey });
   saveConfig(cfg);
 
   // One-shot confirm: MCP + skill are always listed (user picks what to
@@ -286,10 +288,12 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
  * clear `cfg.mode` (Cloud paths do; the OSS auto-pick path doesn't).
  */
 function applyDeployment(cfg: Config, d: Deployment): void {
-  cfg.deployment_id = d.deployment_id;
-  cfg.deployment_name = d.name;
-  cfg.org_id = d.org_id;
-  cfg.space_id = d.space_id;
+  updateTarget(cfg, {
+    deployment_id: d.deployment_id,
+    deployment_name: d.name,
+    org_id: d.org_id,
+    space_id: d.space_id,
+  });
 }
 
 /**
@@ -406,7 +410,7 @@ async function stepAuthenticate(
   logger.info("setup", "Step: authenticate");
   const cfg = existingCfg ?? loadConfig();
 
-  if (cfg.access_token) {
+  if (cfg.active_account?.session.access_token) {
     const s = p.spinner();
     s.start("Verifying session...");
     try {
@@ -590,6 +594,8 @@ async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext 
       p.log.error("Could not load your profile.");
       return null;
     }
+    bindAccountIdentity(cfg, profile.user_id);
+    saveConfig(cfg);
 
     // First-run detection is driven purely by `finished_onboarding`. The old
     // `cli_onboarding_enabled` flag gated a terminal-local onboarding path
@@ -634,7 +640,12 @@ async function resolveOnboardingTargetOrg(trpc: TypedClient): Promise<OwnedOrg |
 async function resolveCurrentOnboardingTargetOrg(cfg: Config): Promise<OwnedOrg | null> {
   try {
     const { createTypedClient } = await import("../client/trpc");
-    return await resolveOnboardingTargetOrg(createTypedClient(cfg));
+    const trpc = createTypedClient(cfg);
+    const profile: CliOnboardingProfile | null = await trpc.user.getCliOnboardingContext.query();
+    if (!profile?.user_id) return null;
+    bindAccountIdentity(cfg, profile.user_id);
+    saveConfig(cfg);
+    return await resolveOnboardingTargetOrg(trpc);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.error("setup", `Failed to resolve post-onboarding organization: ${msg}`);
@@ -806,25 +817,25 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
 }
 
 async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | null> {
-  if (!cfg.deployment_id) {
+  const target = cfg.active_account?.target;
+  const deploymentID = target?.deployment_id;
+  if (!deploymentID) {
     p.log.error("No MCP available for API key creation");
     return null;
   }
 
-  if (cfg.api_key) {
-    // biome-ignore lint/style/noNonNullAssertion: checked above
-    const valid = await apiClient.validateAPIKey(cfg.api_key, cfg.deployment_id!);
+  if (target.api_key) {
+    const valid = await apiClient.validateAPIKey(target.api_key, deploymentID);
     logger.debug("setup", `Existing API key valid=${valid}`);
     if (valid) {
       p.log.success(`API key\n${dim("using existing")}`);
-      return cfg.api_key;
+      return target.api_key;
     }
     p.log.warn("Existing API key is invalid, creating a new one...");
   }
 
   try {
-    // biome-ignore lint/style/noNonNullAssertion: checked above
-    const resp = await apiClient.createAPIKey(cfg.deployment_id!, "dosu-cli");
+    const resp = await apiClient.createAPIKey(deploymentID, "dosu-cli");
     logger.info("setup", "API key created");
     p.log.success(`API key\n${dim("created")}`);
     return resp.api_key;

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -557,8 +557,8 @@ async function stepWebOnboarding(
       return false;
     }
     // The wizard may hand back a session for a different browser account.
-    // Replace the session and discard every deployment-scoped value before
-    // resolving the newly authenticated account's onboarding target.
+    // Replace the account aggregate: same-account auth keeps its target, while
+    // an account change drops the old target before resolving the new one.
     replaceLoginSession(cfg, {
       access_token: result.token.access_token,
       refresh_token: result.token.refresh_token,

--- a/src/setup/github-doc-import-step.test.ts
+++ b/src/setup/github-doc-import-step.test.ts
@@ -48,10 +48,11 @@ vi.mock("./github-doc-import-prompt", () => ({
 
 import * as p from "@clack/prompts";
 import type { Config } from "../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { stepImportGitHubDocs } from "./github-doc-import-step";
 
-function makeCfg(overrides: Partial<Config> = {}): Config {
-  return {
+function makeCfg(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "tok",
     refresh_token: "ref",
     expires_at: Math.floor(Date.now() / 1000) + 3600,
@@ -61,7 +62,7 @@ function makeCfg(overrides: Partial<Config> = {}): Config {
     org_id: "org-1",
     space_id: "space-1",
     ...overrides,
-  };
+  });
 }
 
 describe("stepImportGitHubDocs", () => {

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -82,7 +82,7 @@ export async function stepImportGitHubDocs(
 ): Promise<GitHubDocsImportStepResult> {
   logger.info("setup", "Step: import GitHub docs");
 
-  if (!cfg.org_id || !cfg.space_id) {
+  if (!cfg.active_account?.target?.org_id || !cfg.active_account?.target?.space_id) {
     p.log.warn(
       "Cannot import GitHub docs: your Dosu workspace is missing org/space context. " +
         "Re-run `dosu setup` from a fresh state.",
@@ -92,8 +92,13 @@ export async function stepImportGitHubDocs(
 
   const trpc = createTypedClient(cfg);
   const files = opts.waitForFreshDocs
-    ? await waitForImportableGithubFiles(trpc, cfg.org_id, cfg.space_id, opts.expectedDataSourceIds)
-    : await fetchImportableGithubFiles(trpc, cfg.space_id);
+    ? await waitForImportableGithubFiles(
+        trpc,
+        cfg.active_account?.target?.org_id,
+        cfg.active_account?.target?.space_id,
+        opts.expectedDataSourceIds,
+      )
+    : await fetchImportableGithubFiles(trpc, cfg.active_account?.target?.space_id);
   if (files === null) {
     return { advance: false };
   }
@@ -116,7 +121,7 @@ export async function stepImportGitHubDocs(
     return { advance: true, imported: false, imported_count: 0 };
   }
 
-  const knowledgeStoreID = await getKnowledgeStoreID(trpc, cfg.space_id);
+  const knowledgeStoreID = await getKnowledgeStoreID(trpc, cfg.active_account?.target?.space_id);
   if (!knowledgeStoreID) {
     return { advance: false };
   }
@@ -126,7 +131,7 @@ export async function stepImportGitHubDocs(
   try {
     const result = (await trpc.docImports.importGithubFiles.mutate({
       knowledge_store_id: knowledgeStoreID,
-      space_id: cfg.space_id,
+      space_id: cfg.active_account?.target?.space_id,
       file_ids: fileIDs,
     })) as { task_id?: string } | null;
 

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -94,6 +94,7 @@ vi.mock("../client/trpc", () => ({
 
 import * as p from "@clack/prompts";
 import type { Config } from "../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { detectGitRepo, stepConnectGitHubRepo, verifyDataSourcesPersist } from "./github-step";
 
 // Skip the post-connect verify-poll budget so each test resolves in real
@@ -109,8 +110,8 @@ const NO_WAIT_REFRESH = {
   refresh: { timeoutMs: 0, intervalMs: 0 },
 } as const;
 
-function makeCfg(overrides: Partial<Config> = {}): Config {
-  return {
+function makeCfg(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "tok",
     refresh_token: "ref",
     expires_at: Math.floor(Date.now() / 1000) + 3600,
@@ -120,7 +121,7 @@ function makeCfg(overrides: Partial<Config> = {}): Config {
     org_id: "org-1",
     space_id: "space-1",
     ...overrides,
-  };
+  });
 }
 
 describe("detectGitRepo", () => {

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -474,15 +474,15 @@ export async function stepConnectGitHubRepo(
 ): Promise<GithubStepResult> {
   logger.info("setup", "Step: connect GitHub repo(s)");
 
-  if (!cfg.org_id || !cfg.space_id) {
+  if (!cfg.active_account?.target?.org_id || !cfg.active_account?.target?.space_id) {
     p.log.warn(
       "Cannot connect GitHub: your Dosu workspace is missing org/space context. " +
         "Re-run `dosu setup` from a fresh state.",
     );
     return { advance: false, has_connected_repo: false };
   }
-  const orgID = cfg.org_id;
-  const spaceID = cfg.space_id;
+  const orgID = cfg.active_account?.target?.org_id;
+  const spaceID = cfg.active_account?.target?.space_id;
 
   if (detected) {
     p.log.info(`Connecting GitHub repos (detected local repo: ${detected.slug})`);
@@ -622,7 +622,7 @@ export async function stepConnectGitHubRepo(
       advance: true,
       has_connected_repo: true,
       deployment_id: primary.deployment_id,
-      space_id: cfg.space_id,
+      space_id: cfg.active_account?.target?.space_id,
       created_data_source_ids: survived.map((c) => c.data_source_id),
       created_repository_slugs: survived.map((c) => c.slug),
     };

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -56,7 +56,7 @@ import { startOAuthFlow } from "../auth/flow";
 import { Client } from "../client/client";
 import { executeInsights } from "../commands/insights";
 import type { Config } from "../config/config";
-import { loadConfig, saveConfig, updateTarget } from "../config/config";
+import { emptyConfig, loadConfig, saveConfig, updateTarget } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { runSetup } from "../setup/flow";
 import { handleLogout, runTUI } from "./tui";
@@ -468,5 +468,21 @@ describe("runTUI", () => {
 
     expect(mockRunSetup).toHaveBeenCalled();
     expect(mockOutro).toHaveBeenCalledWith("Goodbye!");
+  });
+
+  it("setup reload removes account state that was cleared on disk", async () => {
+    writeRealConfig(
+      makeCfg({ access_token: "tok", space_id: "sp", deployment_id: "d", api_key: "k" }),
+    );
+    mockIsCancel.mockReturnValue(false);
+    mockRunSetup.mockImplementation(async () => {
+      writeRealConfig(emptyConfig());
+    });
+    mockSelect.mockResolvedValueOnce("setup").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    const nextOptions = mockSelect.mock.calls[1]?.[0]?.options as Array<{ value: string }>;
+    expect(nextOptions.map((option) => option.value)).not.toContain("insights");
   });
 });

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -56,7 +56,8 @@ import { startOAuthFlow } from "../auth/flow";
 import { Client } from "../client/client";
 import { executeInsights } from "../commands/insights";
 import type { Config } from "../config/config";
-import { loadConfig, saveConfig } from "../config/config";
+import { loadConfig, saveConfig, updateTarget } from "../config/config";
+import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { runSetup } from "../setup/flow";
 import { handleLogout, runTUI } from "./tui";
 
@@ -111,8 +112,8 @@ afterEach(() => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeCfg(overrides: Partial<Config> = {}): Config {
-  return {
+function makeCfg(overrides: Partial<FlatTestConfig> = {}): Config {
+  return makeTestConfig({
     access_token: "tok",
     refresh_token: "ref",
     expires_at: 9999999999,
@@ -120,7 +121,7 @@ function makeCfg(overrides: Partial<Config> = {}): Config {
     deployment_name: undefined,
     api_key: undefined,
     ...overrides,
-  };
+  });
 }
 
 function writeRealConfig(cfg: Config): void {
@@ -151,21 +152,11 @@ describe("handleLogout (direct)", () => {
     handleLogout(cfg);
 
     // Verify the object was cleared
-    expect(cfg.access_token).toBe("");
-    expect(cfg.refresh_token).toBe("");
-    expect(cfg.expires_at).toBe(0);
-    expect(cfg.deployment_id).toBeUndefined();
-    expect(cfg.deployment_name).toBeUndefined();
-    expect(cfg.api_key).toBeUndefined();
+    expect(cfg.active_account).toBeUndefined();
 
     // Verify the file on disk was actually written with cleared values
     const ondisk = readRealConfig();
-    expect(ondisk.access_token).toBe("");
-    expect(ondisk.refresh_token).toBe("");
-    expect(ondisk.expires_at).toBe(0);
-    expect(ondisk.deployment_id).toBeUndefined();
-    expect(ondisk.deployment_name).toBeUndefined();
-    expect(ondisk.api_key).toBeUndefined();
+    expect(ondisk.active_account).toBeUndefined();
 
     expect(p.log.success).toHaveBeenCalledWith("Credentials cleared.");
   });
@@ -333,8 +324,8 @@ describe("runTUI", () => {
       ),
     );
     const ondisk = readRealConfig();
-    expect(ondisk.access_token).toBe("new-tok");
-    expect(ondisk.refresh_token).toBe("new-ref");
+    expect(ondisk.active_account?.session.access_token).toBe("new-tok");
+    expect(ondisk.active_account?.session.refresh_token).toBe("new-ref");
   });
 
   it("shows error when OAuth flow fails", async () => {
@@ -380,7 +371,7 @@ describe("runTUI", () => {
     expect(p.log.error).toHaveBeenCalledWith(
       "Run 'dosu login --no-browser' from the terminal to authenticate over SSH.",
     );
-    expect(readRealConfig().access_token).toBe("");
+    expect(readRealConfig().active_account?.session.access_token).toBe("");
   });
 
   it("does nothing when user cancels confirm prompt", async () => {
@@ -413,9 +404,7 @@ describe("runTUI", () => {
 
     // Verify real file on disk was cleared
     const ondisk = readRealConfig();
-    expect(ondisk.access_token).toBe("");
-    expect(ondisk.refresh_token).toBe("");
-    expect(ondisk.expires_at).toBe(0);
+    expect(ondisk.active_account).toBeUndefined();
     expect(ondisk.mode).toBeUndefined();
     expect(p.log.success).toHaveBeenCalledWith("Credentials cleared.");
   });
@@ -465,9 +454,11 @@ describe("runTUI", () => {
     // Simulate setup writing new deployment to config
     mockRunSetup.mockImplementation(async () => {
       const cfg = readRealConfig();
-      cfg.deployment_id = "dep-from-setup";
-      cfg.deployment_name = "Setup Deploy";
-      cfg.api_key = "key-from-setup";
+      updateTarget(cfg, {
+        deployment_id: "dep-from-setup",
+        deployment_name: "Setup Deploy",
+        api_key: "key-from-setup",
+      });
       writeRealConfig(cfg);
     });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -8,7 +8,13 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { Client } from "../client/client";
 import { executeInsights } from "../commands/insights";
-import { isAuthenticated, loadConfig, replaceLoginSession, saveConfig } from "../config/config";
+import {
+  clearConfigInPlace,
+  isAuthenticated,
+  loadConfig,
+  replaceLoginSession,
+  saveConfig,
+} from "../config/config";
 import { runSetup } from "../setup/flow";
 import { browserFallbackHint } from "../setup/styles";
 
@@ -30,7 +36,11 @@ export async function runTUI(): Promise<void> {
 
   // Main menu
   while (true) {
-    const insightsReady = Boolean(cfg.space_id && cfg.deployment_id && cfg.api_key);
+    const insightsReady = Boolean(
+      cfg.active_account?.target?.space_id &&
+        cfg.active_account?.target?.deployment_id &&
+        cfg.active_account?.target?.api_key,
+    );
     const options: Array<{ label: string; value: string; hint?: string }> = [
       {
         label: "Setup",
@@ -86,7 +96,7 @@ export async function runTUI(): Promise<void> {
 }
 
 async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<void> {
-  if (cfg.access_token) {
+  if (cfg.active_account?.session.access_token) {
     const s = p.spinner();
     s.start("Verifying session...");
     try {
@@ -149,13 +159,7 @@ export function handleLogout(cfg: ReturnType<typeof loadConfig>): void {
     p.log.warn("You are not logged in.");
     return;
   }
-  cfg.access_token = "";
-  cfg.refresh_token = "";
-  cfg.expires_at = 0;
-  cfg.mode = undefined;
-  cfg.deployment_id = undefined;
-  cfg.deployment_name = undefined;
-  cfg.api_key = undefined;
+  clearConfigInPlace(cfg);
   saveConfig(cfg);
   p.log.success("Credentials cleared.");
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -81,7 +81,11 @@ export async function runTUI(): Promise<void> {
       case "setup":
         await runSetup();
         // Reload config after setup (it may have changed deployment, api_key, etc.)
-        Object.assign(cfg, loadConfig());
+        {
+          const fresh = loadConfig();
+          cfg.mode = fresh.mode;
+          cfg.active_account = fresh.active_account;
+        }
         break;
       case "insights":
         await executeInsights(cfg);

--- a/src/version/pending-tasks-check.test.ts
+++ b/src/version/pending-tasks-check.test.ts
@@ -12,6 +12,8 @@ vi.mock("../config/config", async (importOriginal) => {
   };
 });
 
+import { emptyConfig } from "../config/config";
+import { makeTestConfig } from "../config/config.test-utils";
 import {
   addPendingTask,
   checkForReadyTasks,
@@ -44,7 +46,14 @@ beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "dosu-pending-test-"));
   process.env.XDG_CONFIG_HOME = tempDir;
   process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api.example.test";
-  mockLoadConfig.mockReturnValue({ api_key: "sk_user_test" });
+  mockLoadConfig.mockReturnValue(
+    makeTestConfig({
+      access_token: "test-token",
+      refresh_token: "test-refresh",
+      expires_at: 0,
+      api_key: "sk_user_test",
+    }),
+  );
 });
 
 afterEach(() => {
@@ -303,7 +312,7 @@ describe("checkForReadyTasks — polling", () => {
   });
 
   it("does not poll when api key is missing", () => {
-    mockLoadConfig.mockReturnValue({});
+    mockLoadConfig.mockReturnValue(emptyConfig());
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/version/pending-tasks-check.ts
+++ b/src/version/pending-tasks-check.ts
@@ -148,7 +148,7 @@ export function checkForReadyTasks(): void {
     // 2. Fire background polls for stale, in-flight tasks.
     const cfg = loadConfig();
     const backendURL = getBackendURL();
-    const apiKey = cfg.api_key;
+    const apiKey = cfg.active_account?.target?.api_key;
     if (backendURL && apiKey) {
       const now = Date.now();
       // Only in-flight tasks remain here — finished ones were displayed and


### PR DESCRIPTION
## Summary

- introduce config schema v2 with identity, session, and target grouped under active_account
- migrate unversioned flat config files on first load
- update CLI consumers and test fixtures to the nested schema
- bind the backend-verified account identity during setup

## Behavior boundary

This layer preserves the existing login behavior: every explicit login clears target state. Account-aware target preservation and refresh race protection are isolated in the next PR.

## Validation

- 1,536 tests pass
- typecheck passes
- Biome check passes

## Stack

Layer 1 of 3. Next: PR #133, then PR #130.