### PR TITLE
fix(types): consume contract types directly instead of any-era local mirrors

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -14,6 +14,7 @@ import { createTypedClient, type TypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
 import { getBackendURL } from "../config/constants";
 import { logger } from "../debug/logger";
+import type { CliDataSource } from "../generated/dosu-api-types";
 import { type DetectedRepo, detectGitRepo, stepConnectGitHubRepo } from "../setup/github-step";
 import { addPendingTask } from "../version/pending-tasks-check";
 import { requireAPIKey, requireLoginConfig } from "./auth";
@@ -22,14 +23,8 @@ import { printResult } from "./output";
 const INDEX_POLL_INTERVAL_MS = 2_000;
 const INDEX_POLL_TIMEOUT_MS = 120_000;
 
-/** A data source as returned by `dataSource.list` (subset we rely on). */
-interface DataSourceLike {
-  data_source_id?: string;
-  provider_slug?: string;
-  name?: string;
-  is_indexed?: boolean;
-  status?: string;
-}
+/** A data source as returned by `dataSource.list` — contract-typed (dosu#11679). */
+type DataSourceLike = CliDataSource;
 
 /** A capability as returned by `GET /v1/cli/tasks`. */
 interface Capability {
@@ -118,10 +113,10 @@ async function backendPost(
 }
 
 async function listDataSources(client: TypedClient, orgId: string): Promise<DataSourceLike[]> {
-  const result = (await client.dataSource.list.query({
+  const result = await client.dataSource.list.query({
     org_id: orgId,
     excluded_provider_slugs: [],
-  })) as DataSourceLike[] | null;
+  });
   return result ?? [];
 }
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -8,62 +8,21 @@ import { isTRPCClientError } from "@trpc/client";
 import { Command } from "commander";
 import pc from "picocolors";
 import { createTypedClient, type TypedClient } from "../client/trpc";
+import type {
+  CliPendingReviewItem,
+  MessagesGetMessageOutput,
+  ReviewGetChangeOutput,
+} from "../generated/dosu-api-types";
 import { requireLoginConfig } from "./auth";
 import { formatDate, printInfo, printResult, printTable, truncate } from "./output";
 
-// The server-rendered change view consumed by the approve/reject confirm-gate.
-type ChangeView = {
-  title: string;
-  source: string;
-  version: number;
-  publishedVersion?: number | null;
-  isNewDoc: boolean;
-  hasChanges: boolean;
-  diff: string;
-};
-
-// The raw message row behind a draft id (used to preview a draft in the gate).
-type DraftMessageRow = {
-  id: string;
-  title?: string | null;
-  body?: string | null;
-};
-
-type ReviewOrigin =
-  | "manual_update"
-  | "llm_generated"
-  | "sync_upstream"
-  | "api_update"
-  | (string & {});
-
-type DocReviewItem = {
-  id: string;
-  kind: "doc_change";
-  title?: string | null;
-  origin: ReviewOrigin;
-  version: number;
-  pendingStatus: string;
-  createdAt: string;
-};
-
-type DraftReviewItem = {
-  id: string;
-  kind: "draft_message";
-  title?: string | null;
-  createdAt: string;
-};
-
-type ReviewListItem = DocReviewItem | DraftReviewItem;
-
-// Shape of `review.listPending` (ENG-605, dosu-ai/dosu#11478): `truncated` is
-// true when `items` may be a slice rather than the full backlog; `total` is the
-// pre-cap count (itself a lower bound). The contract types this output as `any`
-// until the procedure gets a real `.output()` DTO, so model the result locally.
-type ReviewListResult = {
-  items: ReviewListItem[];
-  truncated: boolean;
-  total: number;
-};
+// Contract-typed since dosu#11679: ChangeView, review-list items, and the raw
+// message row all come from the vendored contract — no local mirror types, so a
+// contract-side shape change fails typecheck here instead of silently breaking
+// at runtime.
+type ChangeView = ReviewGetChangeOutput;
+type DraftMessageRow = NonNullable<MessagesGetMessageOutput>;
+type ReviewOrigin = CliPendingReviewItem["origin"];
 
 function requireConfig() {
   return requireLoginConfig();
@@ -233,7 +192,7 @@ export function reviewCommand(): Command {
       // Docs are knowledge-store-scoped; drafts are deployment-scoped. Passing
       // deploymentId merges draft replies into the list (ENG-524) — omit it and
       // the server returns doc changes only.
-      const result: ReviewListResult = await client.review.listPending.query({
+      const result = await client.review.listPending.query({
         knowledgeStoreId: ksId,
         deploymentId: cfg.active_account?.target?.deployment_id,
       });

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -9,23 +9,6 @@ import type { ThreadListInput } from "../generated/dosu-api-types";
 import { requireLoginConfig } from "./auth";
 import { formatDate, printInfo, printResult, printTable, truncate } from "./output";
 
-type ThreadListItem = {
-  id: string;
-  generated_title?: string | null;
-  initial_message_title?: string | null;
-  resolved?: boolean | null;
-  inbox_archived_at?: string | null;
-  created_at?: string | null;
-};
-
-type ThreadMessageGroup = {
-  messages: Array<{
-    author_role?: string | null;
-    created_at?: string | null;
-    body?: string | null;
-  }>;
-};
-
 function requireConfig() {
   const cfg = requireLoginConfig();
   if (!cfg.active_account?.target?.space_id) {
@@ -81,7 +64,10 @@ export function threadsCommand(): Command {
       }
 
       const data = await client.thread.list.query(input);
-      const threads = data.list as ThreadListItem[];
+      // Contract-typed since dosu#11679 — no local mirror type or cast, so a
+      // contract-side field change fails this file's typecheck instead of
+      // silently returning undefined at runtime.
+      const threads = data.list;
 
       if (opts.json) {
         printResult(data, opts);
@@ -141,7 +127,7 @@ export function threadsCommand(): Command {
         ["Channel", thread.channel],
       ]);
 
-      const messages = messagesData.list as ThreadMessageGroup[] | undefined;
+      const messages = messagesData.list;
       if (messages && messages.length > 0) {
         // Flatten message groups into individual messages
         const allMessages = messages.flatMap((group) => group.messages);

--- a/src/setup/github-doc-import-step.ts
+++ b/src/setup/github-doc-import-step.ts
@@ -2,6 +2,7 @@ import * as p from "@clack/prompts";
 import { createTypedClient, type TypedClient } from "../client/trpc";
 import type { Config } from "../config/config";
 import { logger } from "../debug/logger";
+import type { CliDataSource } from "../generated/dosu-api-types";
 import {
   type GitHubImportFileOption,
   type GitHubImportRepositoryOption,
@@ -13,11 +14,8 @@ const DOC_SCAN_POLL_TIMEOUT_MS = 60_000;
 const IMPORT_STATUS_POLL_INTERVAL_MS = 2_000;
 const IMPORT_STATUS_MAX_ERRORS = 3;
 
-interface GitHubDataSource {
-  data_source_id?: string;
-  provider_slug?: string;
-  is_indexed?: boolean;
-}
+// Contract-typed (dosu#11679): rows from `dataSource.list`.
+type GitHubDataSource = CliDataSource;
 
 interface ImportableGithubFile {
   id: string;
@@ -375,10 +373,10 @@ async function fetchGitHubDataSources(
   orgID: string,
 ): Promise<GitHubDataSource[]> {
   try {
-    const dataSources = (await trpc.dataSource.list.query({
+    const dataSources = await trpc.dataSource.list.query({
       org_id: orgID,
       excluded_provider_slugs: [],
-    })) as GitHubDataSource[];
+    });
     return dataSources.filter((dataSource) => dataSource.provider_slug === "github");
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -427,9 +425,10 @@ function buildRepositories(files: ImportableGithubFile[]): GitHubImportRepositor
 
 async function getKnowledgeStoreID(trpc: TypedClient, spaceID: string): Promise<string | null> {
   try {
-    const store = (await trpc.knowledgeStore.getBySpaceId.query({
+    // Contract-typed (dosu#11679) — no cast needed.
+    const store = await trpc.knowledgeStore.getBySpaceId.query({
       space_id: spaceID,
-    })) as { id: string } | null;
+    });
     if (!store?.id) {
       p.log.error("No knowledge store found for this deployment.");
       return null;


### PR DESCRIPTION
## Summary

Removes the hand-written mirror types + `as` casts that survived from when these tRPC outputs were `any` in the vendored contract. Since [dosu#11679](https://github.com/dosu-ai/dosu/pull/11679) the contract carries real output types for the CLI hot path — but the casts silently bypassed them.

**Drill-verified gap:** renaming `generated_title` in the contract passed `tsc` cleanly before this change (the cast swallowed it → runtime `undefined` reads). After this change the same rename fails with TS2339 at the exact call sites (`threads.ts:86/:122`).

## Changes

- `threads.ts`: drop `ThreadListItem`/`ThreadMessageGroup` + 2 casts → contract types
- `review.ts`: drop 7 mirror types (`ChangeView`, `ReviewListResult`, …) → `ReviewGetChangeOutput` / `ReviewListPendingOutput` / `CliPendingReviewItem` / `MessagesGetMessageOutput`
- `audit.ts` + `github-doc-import-step.ts`: drop `dataSource.list` / `knowledgeStore.getBySpaceId` casts → `CliDataSource` + contract types

Kept: local types shadowing still-untyped outputs (`docImports.*`, `githubRepository.listForOrg`) — they go when those procedures get contract DTOs (batch 2 in dosu).

## Verification

- `tsc --noEmit` ✅ · `biome check` ✅ · **1558/1558 tests** ✅
- Red/green drill: contract field rename → tsc red (was green) → restore → green