### PR TITLE
fix(setup): clarify inaccessible MCP account mismatch

### DIFF
--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -512,6 +512,10 @@ describe("runAgentSetup", () => {
       step: "deployment",
       status: "error",
       reason: "not_found",
+      agent_next_steps:
+        "The requested MCP is not accessible to the current Dosu account. " +
+        "Make sure the user is logged in to the correct account. " +
+        "Run 'dosu logout', then retry setup.",
     });
   });
 

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -244,7 +244,10 @@ async function resolveDeployment(
         emitError({
           step: "deployment",
           reason: "not_found",
-          agent_next_steps: `Deployment '${opts.deploymentID}' is not accessible. Run 'dosu deployments list --json' to see options and try again with a valid id.`,
+          agent_next_steps:
+            "The requested MCP is not accessible to the current Dosu account. " +
+            "Make sure the user is logged in to the correct account. " +
+            "Run 'dosu logout', then retry setup.",
         });
         return { code: 1, cfg };
       }

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1189,7 +1189,7 @@ describe("runSetup integration", () => {
     expect(saved.active_account?.target?.deployment_id).toBeUndefined();
   });
 
-  it("shows deployment not found error", async () => {
+  it("shows an account hint when the requested MCP is inaccessible", async () => {
     const cfg = makeCfg({ deployment_id: undefined, deployment_name: undefined });
     saveConfig(cfg);
 
@@ -1201,7 +1201,10 @@ describe("runSetup integration", () => {
 
     await runSetup({ deploymentID: "nonexistent" });
 
-    expect(p.log.error).toHaveBeenCalledWith("MCP nonexistent not found");
+    expect(p.log.error).toHaveBeenCalledWith(
+      "This MCP is not accessible to the current Dosu account.\n" +
+        "Make sure you are logged in to the correct account. Run `dosu logout`, then try again.",
+    );
   });
 
   it("handles resolve deployment fetch error", async () => {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -773,8 +773,11 @@ async function stepResolveDeployment(apiClient: Client, id: string): Promise<Dep
     const deployments = await apiClient.getDeployments();
     const d = deployments.find((d) => d.deployment_id === id);
     if (!d) {
-      logger.warn("setup", `Deployment ${id} not found`);
-      p.log.error(`MCP ${id} not found`);
+      logger.warn("setup", `Deployment ${id} is not accessible to the current account`);
+      p.log.error(
+        "This MCP is not accessible to the current Dosu account.\n" +
+          "Make sure you are logged in to the correct account. Run `dosu logout`, then try again.",
+      );
       return null;
     }
     logger.info("setup", `Resolved deployment: ${d.name}`);


### PR DESCRIPTION
## Summary

- Explain when the requested MCP is inaccessible to the current Dosu account.
- Tell users to run `dosu logout` and retry with the correct account.
- Align interactive and agent setup guidance while preserving the existing reason code.

## Test plan

- [x] `bun run test` (1,558 tests)
- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `bun run build`
