### PR TITLE
fix(auth): refresh OAuth-issued CLI sessions

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -11,6 +11,7 @@ import {
   saveConfig,
 } from "../config/config";
 import { getBackendURL, getSupabaseAnonKey, getSupabaseURL } from "../config/constants";
+import { getAccessTokenOAuthClientID } from "../config/identity";
 
 export class SessionExpiredError extends Error {
   constructor() {
@@ -223,15 +224,25 @@ export class Client {
     if (!session?.refresh_token) throw new Error("no refresh token available");
 
     const supabaseURL = getSupabaseURL();
-    const endpoint = `${supabaseURL}/auth/v1/token?grant_type=refresh_token`;
+    const oauthClientID = getAccessTokenOAuthClientID(session.access_token);
+    const endpoint = oauthClientID
+      ? `${supabaseURL}/auth/v1/oauth/token`
+      : `${supabaseURL}/auth/v1/token?grant_type=refresh_token`;
+    const headers: Record<string, string> = oauthClientID
+      ? { "Content-Type": "application/x-www-form-urlencoded" }
+      : { "Content-Type": "application/json", apikey: getSupabaseAnonKey() };
+    const body = oauthClientID
+      ? new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: session.refresh_token,
+          client_id: oauthClientID,
+        }).toString()
+      : JSON.stringify({ refresh_token: session.refresh_token });
 
     const resp = await fetch(endpoint, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        apikey: getSupabaseAnonKey(),
-      },
-      body: JSON.stringify({ refresh_token: session.refresh_token }),
+      headers,
+      body,
     });
 
     if (resp.status !== 200) {

--- a/src/client/refresh.test.ts
+++ b/src/client/refresh.test.ts
@@ -82,6 +82,13 @@ function makeAccountConfig(userID: string, overrides: Partial<FlatTestConfig> = 
   return makeConfig({ ...overrides, user_id: userID });
 }
 
+function oauthAccessToken(clientID: string): string {
+  const payload = Buffer.from(JSON.stringify({ sub: "oauth-user", client_id: clientID })).toString(
+    "base64url",
+  );
+  return `header.${payload}.signature`;
+}
+
 describe("refresh self-healing", () => {
   const savedEnv: Record<string, string | undefined> = {};
   let tempDir: string;
@@ -129,6 +136,32 @@ describe("refresh self-healing", () => {
     expect(gotrue.rejections).toBe(0);
     expect(cfg.active_account?.session.refresh_token).toBe("rt-1");
     expect(loadConfig().active_account?.session.refresh_token).toBe("rt-1"); // rotation persisted
+  });
+
+  it("refreshes OAuth 2.1 sessions through the OAuth token endpoint", async () => {
+    const accessToken = oauthAccessToken("cli-client-id");
+    saveConfig(makeConfig({ access_token: accessToken, refresh_token: "oauth-refresh" }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: oauthAccessToken("cli-client-id"),
+          refresh_token: "oauth-refresh-2",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await new Client(cfg).refreshToken();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://test.supabase.co/auth/v1/oauth/token");
+    expect(init.headers).toEqual({ "Content-Type": "application/x-www-form-urlencoded" });
+    expect(new URLSearchParams(init.body as string).get("grant_type")).toBe("refresh_token");
+    expect(new URLSearchParams(init.body as string).get("refresh_token")).toBe("oauth-refresh");
+    expect(new URLSearchParams(init.body as string).get("client_id")).toBe("cli-client-id");
   });
 
   it("retries once with the on-disk token when a sibling rotates mid-flight", async () => {

--- a/src/config/identity.ts
+++ b/src/config/identity.ts
@@ -4,15 +4,26 @@
  * This only correlates local state with an account. It is never an
  * authorization decision; the backend still validates every token.
  */
-export function getAccessTokenUserID(accessToken: string): string | undefined {
+function getAccessTokenClaim(accessToken: string, claim: string): string | undefined {
   try {
     const payload = accessToken.split(".")[1];
     if (!payload) return undefined;
-    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
-      sub?: unknown;
-    };
-    return typeof decoded.sub === "string" && decoded.sub.length > 0 ? decoded.sub : undefined;
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<
+      string,
+      unknown
+    >;
+    const value = decoded[claim];
+    return typeof value === "string" && value.length > 0 ? value : undefined;
   } catch {
     return undefined;
   }
+}
+
+export function getAccessTokenUserID(accessToken: string): string | undefined {
+  return getAccessTokenClaim(accessToken, "sub");
+}
+
+/** OAuth 2.1 access tokens carry the public client id needed for refresh. */
+export function getAccessTokenOAuthClientID(accessToken: string): string | undefined {
+  return getAccessTokenClaim(accessToken, "client_id");
 }


### PR DESCRIPTION
### Why

SAML SSO login returns Supabase OAuth 2.1 sessions. These sessions must be refreshed through the OAuth token endpoint; the CLI currently only supports the legacy GoTrue refresh endpoint, so login would stop working after the access token expires.

### Changes

Detect OAuth-issued sessions from the access token and refresh them through `/auth/v1/oauth/token`. Existing non-OAuth sessions keep using the current refresh path unchanged.

### Testing

- `bun run check`
- `bun run typecheck`
- `bun run test` — 1559 tests passed
