### PR TITLE
feat(ask): add --timeout option to configure request timeout

### DIFF
--- a/src/commands/ask.test.ts
+++ b/src/commands/ask.test.ts
@@ -99,6 +99,56 @@ describe("ask", () => {
   });
 });
 
+describe("--timeout", () => {
+  it("aborts the request after the given timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      mockLoadConfig.mockReturnValue(validConfig);
+      let captured: AbortSignal | undefined;
+      // Mimic fetch: reject with an AbortError once the signal aborts.
+      mockFetch.mockImplementationOnce(
+        (_url: string, opts: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            captured = opts.signal;
+            opts.signal.addEventListener("abort", () => {
+              const err = new Error("The operation was aborted");
+              err.name = "AbortError";
+              reject(err);
+            });
+          }),
+      );
+
+      const p = run("--timeout", "5", "question");
+      // Let the action run up to the awaited fetch so the signal is captured.
+      await Promise.resolve();
+      expect(captured?.aborted).toBe(false);
+
+      vi.advanceTimersByTime(5_000);
+      expect(captured?.aborted).toBe(true);
+
+      // The aborted fetch rejects → command prints a timeout and exits.
+      await expect(p).rejects.toThrow("exit");
+      expect(allErrors()).toContain("Request timed out");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a non-numeric timeout", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("--timeout", "abc", "question")).rejects.toThrow("exit");
+    expect(allErrors()).toContain("--timeout must be a positive number");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive timeout", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("--timeout", "0", "question")).rejects.toThrow("exit");
+    expect(allErrors()).toContain("--timeout must be a positive number");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
 describe("output formatting", () => {
   it("outputs raw JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -12,6 +12,8 @@ import { getBackendURL } from "../config/constants";
 import { logger } from "../debug/logger";
 import { printResult } from "./output";
 
+const DEFAULT_TIMEOUT_SECONDS = 600;
+
 function requireConfig() {
   const cfg = loadConfig();
   if (!cfg.active_account?.target?.api_key) {
@@ -30,85 +32,100 @@ export function askCommand(): Command {
     .description("Ask a question and get an AI-generated answer")
     .argument("<question>", "The question to ask")
     .option("--session <id>", "Continue a previous ask session")
+    .option(
+      "--timeout <seconds>",
+      `Request timeout in seconds (default: ${DEFAULT_TIMEOUT_SECONDS})`,
+    )
     .option("--json", "Output as JSON")
-    .action(async (question: string, opts: { session?: string; json?: boolean }) => {
-      const cfg = requireConfig();
-      const backendURL = getBackendURL();
+    .action(
+      async (question: string, opts: { session?: string; timeout?: string; json?: boolean }) => {
+        const cfg = requireConfig();
+        const backendURL = getBackendURL();
 
-      if (!backendURL) {
-        console.error(pc.red("Backend URL not configured."));
-        process.exit(1);
-      }
-
-      logger.debug("ask", `Asking: ${question}`);
-
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 600_000);
-
-      try {
-        const resp = await fetch(`${backendURL}/ask`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-            "X-Dosu-API-Key": cfg.active_account!.target!.api_key!,
-          },
-          body: JSON.stringify({
-            // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-            deployment_id: cfg.active_account!.target!.deployment_id!,
-            question,
-            session_id: opts.session ?? undefined,
-          }),
-          signal: controller.signal,
-        });
-
-        if (!resp.ok) {
-          let detail = `Request failed with status ${resp.status}`;
-          try {
-            const errBody = await resp.json();
-            const raw = errBody.detail ?? detail;
-            detail = typeof raw === "string" ? raw : JSON.stringify(raw, null, 2);
-          } catch {}
-          console.error(pc.red(`Error: ${detail}`));
+        if (!backendURL) {
+          console.error(pc.red("Backend URL not configured."));
           process.exit(1);
         }
 
-        const body = await resp.json();
-
-        if (opts.json) {
-          printResult(body, opts);
-          return;
-        }
-
-        // Display the answer
-        if (body.answer) {
-          console.log(body.answer);
-        } else {
-          console.log(JSON.stringify(body, null, 2));
-        }
-
-        // Show session ID for follow-up
-        if (body.session_id) {
-          console.log(`\n${pc.dim(`Session: ${body.session_id}`)}`);
-        }
-
-        // Show observations if available
-        if (body.observations && body.observations.length > 0) {
-          console.log(`\n${pc.bold("Key observations:")}`);
-          for (const obs of body.observations) {
-            console.log(`  ${pc.dim("•")} ${obs}`);
+        let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+        if (opts.timeout !== undefined) {
+          timeoutSeconds = Number(opts.timeout);
+          if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+            console.error(pc.red("--timeout must be a positive number of seconds."));
+            process.exit(1);
           }
         }
-      } catch (err: unknown) {
-        if (err instanceof Error && err.name === "AbortError") {
-          console.error(pc.red("Request timed out."));
-          process.exit(1);
+
+        logger.debug("ask", `Asking: ${question}`);
+
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), timeoutSeconds * 1_000);
+
+        try {
+          const resp = await fetch(`${backendURL}/ask`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
+              "X-Dosu-API-Key": cfg.active_account!.target!.api_key!,
+            },
+            body: JSON.stringify({
+              // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
+              deployment_id: cfg.active_account!.target!.deployment_id!,
+              question,
+              session_id: opts.session ?? undefined,
+            }),
+            signal: controller.signal,
+          });
+
+          if (!resp.ok) {
+            let detail = `Request failed with status ${resp.status}`;
+            try {
+              const errBody = await resp.json();
+              const raw = errBody.detail ?? detail;
+              detail = typeof raw === "string" ? raw : JSON.stringify(raw, null, 2);
+            } catch {}
+            console.error(pc.red(`Error: ${detail}`));
+            process.exit(1);
+          }
+
+          const body = await resp.json();
+
+          if (opts.json) {
+            printResult(body, opts);
+            return;
+          }
+
+          // Display the answer
+          if (body.answer) {
+            console.log(body.answer);
+          } else {
+            console.log(JSON.stringify(body, null, 2));
+          }
+
+          // Show session ID for follow-up
+          if (body.session_id) {
+            console.log(`\n${pc.dim(`Session: ${body.session_id}`)}`);
+          }
+
+          // Show observations if available
+          if (body.observations && body.observations.length > 0) {
+            console.log(`\n${pc.bold("Key observations:")}`);
+            for (const obs of body.observations) {
+              console.log(`  ${pc.dim("•")} ${obs}`);
+            }
+          }
+        } catch (err: unknown) {
+          if (err instanceof Error && err.name === "AbortError") {
+            console.error(pc.red("Request timed out."));
+            process.exit(1);
+          }
+          throw err;
+        } finally {
+          clearTimeout(timeout);
         }
-        throw err;
-      } finally {
-        clearTimeout(timeout);
-      }
-    });
+      },
+    );
 
   return cmd;
 }


### PR DESCRIPTION
## Summary

The `dosu ask` command's request timeout was a hardcoded constant (recently bumped to 600s in e6172bb). This adds a `--timeout <seconds>` option so it can be overridden per-invocation, defaulting to the existing 600s.

- New `--timeout <seconds>` option on `dosu ask`
- Falls back to the `DEFAULT_TIMEOUT_SECONDS` (600) default when omitted
- Rejects non-numeric / non-positive values with a clear error before hitting the network

## Testing

- `bunx vitest run src/commands/ask` — 16 passed (added 3 cases: abort fires after the timeout, non-numeric rejected, non-positive rejected)

Note: `bun run format` / `bun run typecheck` surface pre-existing issues on `main` (a Biome config key error and TS errors in `src/setup/github-repo-prompt.ts`) unrelated to this change; indentation here was fixed manually to match project style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)