### PR TITLE
feat(setup): install complete agent bundle

### DIFF
--- a/rules/dosu.md
+++ b/rules/dosu.md
@@ -1,0 +1,7 @@
+The team you are assisting maintains shared knowledge in Dosu: consult it to build on prior work, and contribute durable knowledge so future teammates and agents do not have to rediscover it. Always use only tools currently listed by the server.
+
+When `read_knowledge` is listed, call it before non-trivial code or documentation work involving architecture, conventions, prior decisions, gotchas, incidents, ownership, or branch history. **If unsure whether relevant context exists, read first.** Pass `repo` and `branch` when available. Skip generic questions, trivial or self-contained edits, and context already injected by Dosu. Treat results as leads and verify them against current code and state.
+
+When `write_knowledge` is listed, use it after the task for durable, non-obvious knowledge that future work would otherwise have to rediscover. Do not save task or PR summaries, progress, test results, obvious facts, speculation, duplicates, or sensitive data. **If nothing durable was learned, do not write.**
+
+Use `review_knowledge` only when the user asks to inspect or manage pending knowledge. Preview one item at a time and require explicit confirmation before making changes.

--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -18,6 +18,13 @@ const {
   mockIsStdioOnly,
   mockClient,
   mockClientConstructor,
+  mockFetchDosuRule,
+  mockInstallRuleForAgent,
+  mockIsRuleAgent,
+  mockInstallSkill,
+  mockSkillAgentIDsForProviders,
+  mockInGitWorkTree,
+  mockUpsertDosuAgentsSection,
 } = vi.hoisted(() => {
   return {
     mockMintTicket: vi.fn(),
@@ -34,6 +41,13 @@ const {
       createAPIKey: vi.fn(),
     },
     mockClientConstructor: vi.fn(),
+    mockFetchDosuRule: vi.fn(),
+    mockInstallRuleForAgent: vi.fn(),
+    mockIsRuleAgent: vi.fn(),
+    mockInstallSkill: vi.fn(),
+    mockSkillAgentIDsForProviders: vi.fn(),
+    mockInGitWorkTree: vi.fn(),
+    mockUpsertDosuAgentsSection: vi.fn(),
   };
 });
 
@@ -54,6 +68,22 @@ vi.mock("../mcp/providers", () => ({
 
 vi.mock("../setup/flow", () => ({
   isStdioOnly: mockIsStdioOnly,
+}));
+
+vi.mock("../rules/installer", () => ({
+  fetchDosuRule: mockFetchDosuRule,
+  installRuleForAgent: mockInstallRuleForAgent,
+  isRuleAgent: mockIsRuleAgent,
+}));
+
+vi.mock("../commands/skill", () => ({
+  installSkill: mockInstallSkill,
+  skillAgentIDsForProviders: mockSkillAgentIDsForProviders,
+}));
+
+vi.mock("../setup/agents-md-step", () => ({
+  inGitWorkTree: mockInGitWorkTree,
+  upsertDosuAgentsSection: mockUpsertDosuAgentsSection,
 }));
 
 vi.mock("../client/client", () => ({
@@ -146,6 +176,13 @@ describe("runAgentSetup", () => {
     mockAllSetupProviders.mockReset();
     mockIsStdioOnly.mockReset();
     mockClientConstructor.mockReset();
+    mockFetchDosuRule.mockReset();
+    mockInstallRuleForAgent.mockReset();
+    mockIsRuleAgent.mockReset();
+    mockInstallSkill.mockReset();
+    mockSkillAgentIDsForProviders.mockReset();
+    mockInGitWorkTree.mockReset();
+    mockUpsertDosuAgentsSection.mockReset();
     for (const fn of Object.values(mockClient)) fn.mockReset();
 
     claudeProvider = makeProvider("claude", { name: () => "Claude Code" });
@@ -154,6 +191,22 @@ describe("runAgentSetup", () => {
     mockAllSetupProviders.mockReturnValue([claudeProvider, stdioProvider]);
     mockIsStdioOnly.mockImplementation((p: SetupProvider) => p.id() === "claude-desktop");
     mockLoadConfig.mockReturnValue(makeBaseConfig());
+    mockFetchDosuRule.mockResolvedValue("canonical rule\n");
+    mockIsRuleAgent.mockImplementation((agent: string) => agent === "claude");
+    mockInstallRuleForAgent.mockImplementation((agent: string) => ({
+      agent,
+      action: "created",
+      path: `/tmp/${agent}/rules/dosu.md`,
+    }));
+    mockSkillAgentIDsForProviders.mockImplementation((agents: string[]) =>
+      agents.includes("claude") ? ["claude-code"] : [],
+    );
+    mockInstallSkill.mockResolvedValue({ success: true, sha: "skill-sha" });
+    mockInGitWorkTree.mockReturnValue(false);
+    mockUpsertDosuAgentsSection.mockReturnValue({
+      action: "created",
+      path: "/tmp/repo/AGENTS.md",
+    });
   });
 
   afterEach(() => {
@@ -209,6 +262,7 @@ describe("runAgentSetup", () => {
   });
 
   it("redeems the ticket, picks the lone deployment, mints an API key, installs MCP", async () => {
+    mockInGitWorkTree.mockReturnValue(true);
     mockExchangeTicket.mockResolvedValue({
       status: "authenticated",
       access_token: ticketAccessToken,
@@ -245,6 +299,9 @@ describe("runAgentSetup", () => {
       "deployment",
       "api_key",
       "mcp_install",
+      "rule_install",
+      "skill_install",
+      "agents_md_install",
       "done",
     ]);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
@@ -258,6 +315,9 @@ describe("runAgentSetup", () => {
       status: "ok",
       agent_next_steps: expect.stringContaining("Claude Code"),
     });
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n");
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
+    expect(mockUpsertDosuAgentsSection).toHaveBeenCalledWith(process.cwd(), "canonical rule\n");
   });
 
   it("errors with multiple_deployments when the user has more than one dosu_mcp", async () => {
@@ -700,6 +760,98 @@ describe("runAgentSetup", () => {
       status: "error",
       reason: "install_failed",
       agent_next_steps: expect.stringContaining("disk full"),
+    });
+    expect(mockInstallRuleForAgent).not.toHaveBeenCalled();
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+  });
+
+  it("reports a rule failure after preserving the installed MCP configuration", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockInstallRuleForAgent.mockImplementation(() => {
+      throw new Error("rule directory is read-only");
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "rule_install",
+      status: "error",
+      reason: "install_failed",
+      agent_next_steps: expect.stringContaining("idempotent"),
+    });
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+  });
+
+  it("reports a skill failure after preserving the MCP and rule installation", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockInstallSkill.mockResolvedValue({ success: false });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+    expect(mockInstallRuleForAgent).toHaveBeenCalledTimes(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "skill_install",
+      status: "error",
+      reason: "install_failed",
+      agent_next_steps: expect.stringContaining("idempotent"),
+    });
+  });
+
+  it("reports an AGENTS.md failure after preserving the other bundled installs", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockInGitWorkTree.mockReturnValue(true);
+    mockUpsertDosuAgentsSection.mockImplementation(() => {
+      throw new Error("AGENTS.md is read-only");
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+    expect(mockInstallRuleForAgent).toHaveBeenCalledTimes(1);
+    expect(mockInstallSkill).toHaveBeenCalledTimes(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "agents_md_install",
+      status: "error",
+      reason: "install_failed",
+      agent_next_steps: expect.stringContaining("idempotent"),
     });
   });
 

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -15,6 +15,7 @@
 
 import { exchangeTicket, mintTicket } from "../auth/ticket";
 import { Client, type Deployment } from "../client/client";
+import { installSkill, skillAgentIDsForProviders } from "../commands/skill";
 import {
   type Config,
   loadConfig,
@@ -25,6 +26,8 @@ import {
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
+import { fetchDosuRule, installRuleForAgent, isRuleAgent } from "../rules/installer";
+import { inGitWorkTree, upsertDosuAgentsSection } from "../setup/agents-md-step";
 import { isStdioOnly } from "../setup/flow";
 import { emitError, emitNeedUserAction, emitStep } from "./output";
 
@@ -119,9 +122,88 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     return 1;
   }
 
+  // 5. Install the matching always-on rule when this agent is part of the
+  // mainstream rule matrix. Unsupported MCP clients simply skip this step.
+  let instruction: string | undefined;
+  try {
+    if (isRuleAgent(provider.id())) {
+      instruction = await fetchDosuRule();
+      const rule = installRuleForAgent(provider.id(), instruction);
+      if (rule) {
+        emitStep({
+          step: "rule_install",
+          tool: provider.id(),
+          tool_name: provider.name(),
+          rule_path: rule.path,
+          action: rule.action,
+        });
+      }
+    }
+  } catch (err: unknown) {
+    emitError({
+      step: "rule_install",
+      reason: "install_failed",
+      agent_next_steps: `Dosu MCP was installed, but its rule could not be installed for ${provider.name()}: ${
+        err instanceof Error ? err.message : String(err)
+      }. Re-run this setup command; installation is idempotent.`,
+    });
+    return 1;
+  }
+
+  // 6. Install the remote Dosu skill only for the requested agent. Keep the
+  // child process quiet so agent mode preserves its one-JSON-line-per-step
+  // stdout contract.
+  if (skillAgentIDsForProviders([provider.id()]).length > 0) {
+    try {
+      const skill = await installSkill([provider.id()], { quiet: true });
+      if (!skill.success) {
+        throw new Error("the skills installer failed");
+      }
+      emitStep({
+        step: "skill_install",
+        tool: provider.id(),
+        tool_name: provider.name(),
+        source: "dosu-ai/dosu-skill",
+      });
+    } catch (err: unknown) {
+      emitError({
+        step: "skill_install",
+        reason: "install_failed",
+        agent_next_steps: `Dosu MCP and its rule were installed, but the skill could not be installed for ${provider.name()}: ${
+          err instanceof Error ? err.message : String(err)
+        }. Re-run this setup command; installation is idempotent.`,
+      });
+      return 1;
+    }
+  }
+
+  // 7. Add the project-level pointer when setup runs from a git work tree.
+  // Use the low-level writer instead of the clack wrapper so stdout stays
+  // valid NDJSON.
+  if (inGitWorkTree()) {
+    try {
+      instruction ??= await fetchDosuRule();
+      const agentsMd = upsertDosuAgentsSection(process.cwd(), instruction);
+      emitStep({
+        step: "agents_md_install",
+        path: agentsMd.path,
+        action: agentsMd.action,
+      });
+    } catch (err: unknown) {
+      emitError({
+        step: "agents_md_install",
+        reason: "install_failed",
+        agent_next_steps: `Dosu's agent integrations were installed, but AGENTS.md could not be updated: ${
+          err instanceof Error ? err.message : String(err)
+        }. Re-run this setup command; installation is idempotent.`,
+      });
+      return 1;
+    }
+  }
+
   emitStep({
     step: "done",
-    agent_next_steps: `Dosu MCP is configured for ${provider.name()}. Tell the user setup is complete and they can ask their agent a Dosu question. Run 'dosu status' to verify.`,
+    agent_next_steps: `Dosu is configured for ${provider.name()}. Tell the user setup is complete and they can ask their agent a Dosu question. Run 'dosu status' to verify.`,
   });
   return 0;
 }

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,7 +8,12 @@ vi.mock("node:child_process", () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
 }));
 
-import { installSkill, skillAgentIDsForProviders, skillCommand } from "./skill";
+import {
+  installSkill,
+  skillAgentIDsForProviders,
+  skillCommand,
+  skillInstallTargetForProvider,
+} from "./skill";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -66,6 +71,7 @@ afterEach(() => {
     delete process.env.XDG_CONFIG_HOME;
   }
   rmSync(tempDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -186,6 +192,33 @@ describe("installSkill helper", () => {
     expect(
       skillAgentIDsForProviders(["vscode", "copilot", "cline", "cline-cli", "manual"]),
     ).toEqual(["github-copilot", "cline"]);
+  });
+
+  it("reports the Claude symlink target and respects CLAUDE_CONFIG_DIR", () => {
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "/tmp/custom-claude");
+
+    expect(skillInstallTargetForProvider("claude")).toEqual({
+      path: "/tmp/custom-claude/skills/dosu",
+      symlink: true,
+    });
+  });
+
+  it("reports the universal skill target for Codex", () => {
+    expect(skillInstallTargetForProvider("codex")).toEqual({
+      path: join(homedir(), ".agents", "skills", "dosu"),
+      symlink: false,
+    });
+  });
+
+  it("reports the Windsurf symlink target", () => {
+    expect(skillInstallTargetForProvider("windsurf")).toEqual({
+      path: join(homedir(), ".codeium", "windsurf", "skills", "dosu"),
+      symlink: true,
+    });
+  });
+
+  it("returns null for a provider without skill support", () => {
+    expect(skillInstallTargetForProvider("manual")).toBeNull();
   });
 
   it("keeps the installer quiet for agent-mediated setup", async () => {

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -8,7 +8,7 @@ vi.mock("node:child_process", () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
 }));
 
-import { installSkill, skillCommand } from "./skill";
+import { installSkill, skillAgentIDsForProviders, skillCommand } from "./skill";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -172,6 +172,35 @@ describe("skill update", () => {
 });
 
 describe("installSkill helper", () => {
+  it("installs only for the selected MCP providers", async () => {
+    const result = await installSkill(["claude", "codex"]);
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      "npx skills add dosu-ai/dosu-skill -g -a claude-code -a codex -s dosu -y",
+      { stdio: "inherit" },
+    );
+  });
+
+  it("maps provider aliases and de-duplicates shared skill agents", () => {
+    expect(
+      skillAgentIDsForProviders(["vscode", "copilot", "cline", "cline-cli", "manual"]),
+    ).toEqual(["github-copilot", "cline"]);
+  });
+
+  it("keeps the installer quiet for agent-mediated setup", async () => {
+    await installSkill(["claude"], { quiet: true });
+
+    expect(mockExecSync).toHaveBeenCalledWith(expect.any(String), { stdio: "pipe" });
+  });
+
+  it("does not broaden an unsupported provider into an all-agent install", async () => {
+    const result = await installSkill(["manual"]);
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
   it("writes cache with SHA on success", async () => {
     const result = await installSkill();
     expect(result.success).toBe(true);

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -4,7 +4,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecSync = vi.fn();
+const mockExec = vi.fn();
 vi.mock("node:child_process", () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
   execSync: (...args: unknown[]) => mockExecSync(...args),
 }));
 
@@ -38,6 +40,11 @@ async function run(...args: string[]) {
 }
 
 beforeEach(() => {
+  mockExec.mockReset();
+  mockExec.mockImplementation((...args: unknown[]) => {
+    const callback = args.at(-1) as (error: Error | null) => void;
+    callback(null);
+  });
   mockExecSync.mockReset();
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -224,7 +231,23 @@ describe("installSkill helper", () => {
   it("keeps the installer quiet for agent-mediated setup", async () => {
     await installSkill(["claude"], { quiet: true });
 
-    expect(mockExecSync).toHaveBeenCalledWith(expect.any(String), { stdio: "pipe" });
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.any(String),
+      { windowsHide: true },
+      expect.any(Function),
+    );
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("returns failure when the async quiet installer fails", async () => {
+    mockExec.mockImplementation((...args: unknown[]) => {
+      const callback = args.at(-1) as (error: Error | null) => void;
+      callback(new Error("command failed"));
+    });
+
+    const result = await installSkill(["claude"], { quiet: true });
+
+    expect(result.success).toBe(false);
   });
 
   it("does not broaden an unsupported provider into an all-agent install", async () => {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -3,6 +3,8 @@
  */
 
 import { execSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { Command } from "commander";
 import pc from "picocolors";
 import { logger } from "../debug/logger";
@@ -46,6 +48,33 @@ export function skillAgentIDsForProviders(providerIDs: readonly string[]): strin
         .filter((agent): agent is string => Boolean(agent)),
     ),
   ];
+}
+
+export interface SkillInstallTarget {
+  path: string;
+  symlink: boolean;
+}
+
+export function skillInstallTargetForProvider(providerID: string): SkillInstallTarget | null {
+  const agentID = SKILL_AGENT_BY_PROVIDER[providerID];
+  if (!agentID) return null;
+
+  if (agentID === "claude-code") {
+    const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude");
+    return { path: join(claudeConfigDir, "skills", SKILL_NAME), symlink: true };
+  }
+
+  if (agentID === "windsurf") {
+    return {
+      path: join(homedir(), ".codeium", "windsurf", "skills", SKILL_NAME),
+      symlink: true,
+    };
+  }
+
+  return {
+    path: join(homedir(), ".agents", "skills", SKILL_NAME),
+    symlink: false,
+  };
 }
 
 function skillAgentArgs(providerIDs?: readonly string[]): string {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -23,8 +23,35 @@ const SUPPORTED_SKILL_AGENTS = [
   "antigravity",
 ];
 
-function supportedSkillAgentArgs(): string {
-  return SUPPORTED_SKILL_AGENTS.map((agent) => `-a ${agent}`).join(" ");
+const SKILL_AGENT_BY_PROVIDER: Readonly<Record<string, string>> = {
+  claude: "claude-code",
+  cursor: "cursor",
+  vscode: "github-copilot",
+  gemini: "gemini-cli",
+  codex: "codex",
+  windsurf: "windsurf",
+  zed: "zed",
+  cline: "cline",
+  "cline-cli": "cline",
+  copilot: "github-copilot",
+  opencode: "opencode",
+  antigravity: "antigravity",
+};
+
+export function skillAgentIDsForProviders(providerIDs: readonly string[]): string[] {
+  return [
+    ...new Set(
+      providerIDs
+        .map((providerID) => SKILL_AGENT_BY_PROVIDER[providerID])
+        .filter((agent): agent is string => Boolean(agent)),
+    ),
+  ];
+}
+
+function skillAgentArgs(providerIDs?: readonly string[]): string {
+  const agents =
+    providerIDs === undefined ? SUPPORTED_SKILL_AGENTS : skillAgentIDsForProviders(providerIDs);
+  return agents.map((agent) => `-a ${agent}`).join(" ");
 }
 
 /**
@@ -34,10 +61,19 @@ function supportedSkillAgentArgs(): string {
  * installed, the SHA is just not cached (the update checker will fill it
  * in on the next stale check).
  */
-export async function installSkill(): Promise<{ success: boolean; sha?: string }> {
+export async function installSkill(
+  providerIDs?: readonly string[],
+  options: { quiet?: boolean } = {},
+): Promise<{ success: boolean; sha?: string }> {
+  const agentArgs = skillAgentArgs(providerIDs);
+  if (!agentArgs) {
+    logger.debug("skill", "No selected providers support the Dosu skill");
+    return { success: true };
+  }
+
   try {
-    execSync(`npx skills add ${SKILL_REPO} -g ${supportedSkillAgentArgs()} -s ${SKILL_NAME} -y`, {
-      stdio: "inherit",
+    execSync(`npx skills add ${SKILL_REPO} -g ${agentArgs} -s ${SKILL_NAME} -y`, {
+      stdio: options.quiet ? "pipe" : "inherit",
     });
   } catch (err) {
     logger.error("skill", `Failed to install skill: ${err}`);

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -2,7 +2,7 @@
  * `dosu skill` — manage the Dosu agent skill.
  */
 
-import { execSync } from "node:child_process";
+import { exec, execSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
@@ -83,6 +83,15 @@ function skillAgentArgs(providerIDs?: readonly string[]): string {
   return agents.map((agent) => `-a ${agent}`).join(" ");
 }
 
+function execQuiet(command: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    exec(command, { windowsHide: true }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
 /**
  * Install the Dosu skill via `npx skills`. After a successful install we try
  * to fetch the latest commit SHA and cache it so the update checker knows
@@ -101,9 +110,9 @@ export async function installSkill(
   }
 
   try {
-    execSync(`npx skills add ${SKILL_REPO} -g ${agentArgs} -s ${SKILL_NAME} -y`, {
-      stdio: options.quiet ? "pipe" : "inherit",
-    });
+    const command = `npx skills add ${SKILL_REPO} -g ${agentArgs} -s ${SKILL_NAME} -y`;
+    if (options.quiet) await execQuiet(command);
+    else execSync(command, { stdio: "inherit" });
   } catch (err) {
     logger.error("skill", `Failed to install skill: ${err}`);
     return { success: false };

--- a/src/rules/installer.test.ts
+++ b/src/rules/installer.test.ts
@@ -1,0 +1,224 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DOSU_RULE_SECTION_END,
+  DOSU_RULE_SECTION_START,
+  DOSU_RULE_URLS,
+  FALLBACK_DOSU_RULE,
+  fetchDosuRule,
+  installRuleForAgent,
+  isRuleAgent,
+  removeRuleForAgent,
+  rulePathForAgent,
+  SUPPORTED_RULE_AGENT_IDS,
+} from "./installer";
+
+let tempDir: string;
+let originalHome: string | undefined;
+let originalClaudeConfigDir: string | undefined;
+let originalCodexHome: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-rules-"));
+  originalHome = process.env.HOME;
+  originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  originalCodexHome = process.env.CODEX_HOME;
+  process.env.HOME = tempDir;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CODEX_HOME;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = originalCodexHome;
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("rule template", () => {
+  it("keeps the bundled fallback aligned with the canonical repository file", () => {
+    const canonical = readFileSync(join(process.cwd(), "rules", "dosu.md"), "utf-8");
+    expect(FALLBACK_DOSU_RULE.trim()).toBe(canonical.trim());
+  });
+
+  it("uses the first available remote source", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("remote rule", { status: 200 }));
+
+    await expect(fetchDosuRule(fetchImpl)).resolves.toBe("remote rule\n");
+    expect(fetchImpl).toHaveBeenCalledWith(DOSU_RULE_URLS[0]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("tries the backup source before using the bundled fallback", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("", { status: 404 }))
+      .mockResolvedValueOnce(new Response("backup rule", { status: 200 }));
+
+    await expect(fetchDosuRule(fetchImpl)).resolves.toBe("backup rule\n");
+    expect(fetchImpl).toHaveBeenNthCalledWith(2, DOSU_RULE_URLS[1]);
+  });
+
+  it("falls back when every remote request fails", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error("offline"));
+
+    await expect(fetchDosuRule(fetchImpl)).resolves.toBe(`${FALLBACK_DOSU_RULE.trim()}\n`);
+    expect(fetchImpl).toHaveBeenCalledTimes(DOSU_RULE_URLS.length);
+  });
+});
+
+describe("agent registry", () => {
+  it("supports the same six mainstream agents as Context7 setup", () => {
+    expect(SUPPORTED_RULE_AGENT_IDS).toEqual([
+      "claude",
+      "cursor",
+      "codex",
+      "opencode",
+      "gemini",
+      "antigravity",
+    ]);
+    expect(isRuleAgent("toString")).toBe(false);
+  });
+
+  it("resolves agent-specific global paths and environment overrides", () => {
+    process.env.CLAUDE_CONFIG_DIR = join(tempDir, "custom-claude");
+    process.env.CODEX_HOME = join(tempDir, "custom-codex");
+
+    expect(rulePathForAgent("claude")).toBe(join(tempDir, "custom-claude", "rules", "dosu.md"));
+    expect(rulePathForAgent("cursor")).toBe(join(tempDir, ".cursor", "rules", "dosu.mdc"));
+    expect(rulePathForAgent("codex")).toBe(join(tempDir, "custom-codex", "AGENTS.md"));
+    expect(rulePathForAgent("opencode")).toBe(join(tempDir, ".config", "opencode", "AGENTS.md"));
+    expect(rulePathForAgent("gemini")).toBe(join(tempDir, ".gemini", "GEMINI.md"));
+    expect(rulePathForAgent("antigravity")).toBe(join(tempDir, ".gemini", "GEMINI.md"));
+    expect(rulePathForAgent("windsurf")).toBeNull();
+  });
+});
+
+describe("standalone rule files", () => {
+  it("creates, updates, and then leaves Claude's rule unchanged", () => {
+    const first = installRuleForAgent("claude", "first rule");
+    expect(first?.action).toBe("created");
+    expect(readFileSync(first?.path ?? "", "utf-8")).toBe("first rule\n");
+
+    const second = installRuleForAgent("claude", "second rule");
+    expect(second?.action).toBe("updated");
+    expect(readFileSync(second?.path ?? "", "utf-8")).toBe("second rule\n");
+
+    const third = installRuleForAgent("claude", "second rule");
+    expect(third?.action).toBe("unchanged");
+  });
+
+  it("adds alwaysApply frontmatter only to Cursor", () => {
+    const cursor = installRuleForAgent("cursor", "shared rule");
+    const claude = installRuleForAgent("claude", "shared rule");
+
+    expect(readFileSync(cursor?.path ?? "", "utf-8")).toBe(
+      "---\nalwaysApply: true\n---\n\nshared rule\n",
+    );
+    expect(readFileSync(claude?.path ?? "", "utf-8")).toBe("shared rule\n");
+  });
+
+  it("removes a standalone rule idempotently", () => {
+    const installed = installRuleForAgent("claude", "rule");
+    expect(removeRuleForAgent("claude")?.action).toBe("removed");
+    expect(existsSync(installed?.path ?? "")).toBe(false);
+    expect(removeRuleForAgent("claude")?.action).toBe("not_found");
+  });
+});
+
+describe("marker-delimited instruction sections", () => {
+  it("preserves surrounding Codex instructions and replaces only the Dosu section", () => {
+    const path = rulePathForAgent("codex");
+    expect(path).not.toBeNull();
+    mkdirSync(dirname(path ?? ""), { recursive: true });
+    writeFileSync(path ?? "", "# Before\n\n# After\n", { encoding: "utf-8", flag: "w" });
+
+    const first = installRuleForAgent("codex", "first rule");
+    expect(first?.action).toBe("updated");
+    const installed = readFileSync(path ?? "", "utf-8");
+    expect(installed).toContain("# Before");
+    expect(installed).toContain("# After");
+    expect(installed).toContain("first rule");
+
+    const second = installRuleForAgent("codex", "second rule");
+    expect(second?.action).toBe("updated");
+    const updated = readFileSync(path ?? "", "utf-8");
+    expect(updated).not.toContain("first rule");
+    expect(updated).toContain("second rule");
+    expect(updated.match(/<!-- dosu:rules:start v1 -->/g)).toHaveLength(1);
+    expect(updated.match(/<!-- dosu:rules:end -->/g)).toHaveLength(1);
+
+    expect(installRuleForAgent("codex", "second rule")?.action).toBe("unchanged");
+  });
+
+  it("shares one idempotent GEMINI.md section between Gemini and Antigravity", () => {
+    const gemini = installRuleForAgent("gemini", "shared rule");
+    const antigravity = installRuleForAgent("antigravity", "shared rule");
+
+    expect(gemini?.path).toBe(antigravity?.path);
+    expect(antigravity?.action).toBe("unchanged");
+    const content = readFileSync(gemini?.path ?? "", "utf-8");
+    expect(content.match(/<!-- dosu:rules:start v1 -->/g)).toHaveLength(1);
+  });
+
+  it("removes only the marked section and preserves surrounding content", () => {
+    const installed = installRuleForAgent("opencode", "rule");
+    const path = installed?.path ?? "";
+    writeFileSync(path, `# Before\n\n${readFileSync(path, "utf-8")}\n# After\n`, "utf-8");
+
+    expect(removeRuleForAgent("opencode")?.action).toBe("removed");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toBe("# Before\n\n# After\n");
+    expect(content).not.toContain(DOSU_RULE_SECTION_START);
+    expect(content).not.toContain(DOSU_RULE_SECTION_END);
+    expect(removeRuleForAgent("opencode")?.action).toBe("not_found");
+  });
+
+  it("preserves CRLF line endings while installing, updating, and removing a section", () => {
+    const path = rulePathForAgent("codex") ?? "";
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "# Before\r\n\r\n# After\r\n", "utf-8");
+
+    expect(installRuleForAgent("codex", "first rule")?.action).toBe("updated");
+    expect(readFileSync(path, "utf-8")).toBe(
+      `# Before\r\n\r\n# After\r\n\r\n${DOSU_RULE_SECTION_START}\r\nfirst rule\r\n${DOSU_RULE_SECTION_END}\r\n`,
+    );
+
+    expect(installRuleForAgent("codex", "second rule")?.action).toBe("updated");
+    expect(readFileSync(path, "utf-8")).toContain(
+      `${DOSU_RULE_SECTION_START}\r\nsecond rule\r\n${DOSU_RULE_SECTION_END}`,
+    );
+
+    expect(removeRuleForAgent("codex")?.action).toBe("removed");
+    expect(readFileSync(path, "utf-8")).toBe("# Before\r\n\r\n# After\r\n");
+  });
+
+  it("deletes a generated instruction file when no user content remains", () => {
+    const installed = installRuleForAgent("codex", "rule");
+    expect(removeRuleForAgent("codex")?.action).toBe("removed");
+    expect(existsSync(installed?.path ?? "")).toBe(false);
+  });
+
+  it("refuses to overwrite a file with incomplete markers", () => {
+    const path = rulePathForAgent("codex");
+    mkdirSync(dirname(path ?? ""), { recursive: true });
+    writeFileSync(path ?? "", `${DOSU_RULE_SECTION_START}\nbroken\n`, "utf-8");
+
+    expect(() => installRuleForAgent("codex", "new rule")).toThrow(
+      "Dosu rule markers are incomplete",
+    );
+  });
+
+  it("ignores unsupported agents", () => {
+    expect(installRuleForAgent("windsurf", "rule")).toBeNull();
+    expect(removeRuleForAgent("windsurf")).toBeNull();
+  });
+});

--- a/src/rules/installer.ts
+++ b/src/rules/installer.ts
@@ -1,0 +1,243 @@
+/**
+ * Agent rule installation.
+ *
+ * This follows Context7 CLI's file-vs-marker strategy:
+ * - Claude Code and Cursor get standalone rule files.
+ * - Codex, OpenCode, Gemini CLI, and Antigravity get a marker-delimited
+ *   section in the instruction file their agent already reads.
+ *
+ * The canonical rule is fetched from GitHub during setup, with a bundled
+ * fallback so a transient network failure never prevents installation.
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type RuleAgentID = "claude" | "cursor" | "codex" | "opencode" | "gemini" | "antigravity";
+
+type RuleTarget =
+  | {
+      kind: "file";
+      path: () => string;
+      cursorFrontmatter?: boolean;
+    }
+  | {
+      kind: "section";
+      path: () => string;
+    };
+
+export type RuleAction = "created" | "updated" | "unchanged" | "removed" | "not_found";
+
+export interface RuleResult {
+  agent: RuleAgentID;
+  path: string;
+  action: RuleAction;
+}
+
+export const DOSU_RULE_SECTION_VERSION = 1;
+export const DOSU_RULE_SECTION_START = `<!-- dosu:rules:start v${DOSU_RULE_SECTION_VERSION} -->`;
+export const DOSU_RULE_SECTION_END = "<!-- dosu:rules:end -->";
+
+const DOSU_RULE_SECTION_START_RE = /<!-- dosu:rules:start(?: v\d+)? -->/;
+const CURSOR_FRONTMATTER = "---\nalwaysApply: true\n---\n\n";
+
+export const DOSU_RULE_URLS = [
+  "https://raw.githubusercontent.com/dosu-ai/dosu-cli/main/rules/dosu.md",
+  "https://raw.githubusercontent.com/dosu-ai/dosu-cli/master/rules/dosu.md",
+] as const;
+
+export const FALLBACK_DOSU_RULE = `The team you are assisting maintains shared knowledge in Dosu: consult it to build on prior work, and contribute durable knowledge so future teammates and agents do not have to rediscover it. Always use only tools currently listed by the server.
+
+When \`read_knowledge\` is listed, call it before non-trivial code or documentation work involving architecture, conventions, prior decisions, gotchas, incidents, ownership, or branch history. **If unsure whether relevant context exists, read first.** Pass \`repo\` and \`branch\` when available. Skip generic questions, trivial or self-contained edits, and context already injected by Dosu. Treat results as leads and verify them against current code and state.
+
+When \`write_knowledge\` is listed, use it after the task for durable, non-obvious knowledge that future work would otherwise have to rediscover. Do not save task or PR summaries, progress, test results, obvious facts, speculation, duplicates, or sensitive data. **If nothing durable was learned, do not write.**
+
+Use \`review_knowledge\` only when the user asks to inspect or manage pending knowledge. Preview one item at a time and require explicit confirmation before making changes.
+`;
+
+function claudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+
+function codexHome(): string {
+  return process.env.CODEX_HOME || join(homedir(), ".codex");
+}
+
+const RULE_TARGETS: Record<RuleAgentID, RuleTarget> = {
+  claude: {
+    kind: "file",
+    path: () => join(claudeConfigDir(), "rules", "dosu.md"),
+  },
+  cursor: {
+    kind: "file",
+    path: () => join(homedir(), ".cursor", "rules", "dosu.mdc"),
+    cursorFrontmatter: true,
+  },
+  codex: {
+    kind: "section",
+    path: () => join(codexHome(), "AGENTS.md"),
+  },
+  opencode: {
+    kind: "section",
+    path: () => join(homedir(), ".config", "opencode", "AGENTS.md"),
+  },
+  gemini: {
+    kind: "section",
+    path: () => join(homedir(), ".gemini", "GEMINI.md"),
+  },
+  antigravity: {
+    kind: "section",
+    path: () => join(homedir(), ".gemini", "GEMINI.md"),
+  },
+};
+
+export const SUPPORTED_RULE_AGENT_IDS = Object.keys(RULE_TARGETS) as RuleAgentID[];
+
+export function isRuleAgent(agent: string): agent is RuleAgentID {
+  return Object.hasOwn(RULE_TARGETS, agent);
+}
+
+export function rulePathForAgent(agent: string): string | null {
+  return isRuleAgent(agent) ? RULE_TARGETS[agent].path() : null;
+}
+
+function normalizeRule(content: string): string {
+  return `${content.trim()}\n`;
+}
+
+export async function fetchDosuRule(
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+): Promise<string> {
+  for (const url of DOSU_RULE_URLS) {
+    try {
+      const response = await fetchImpl(url);
+      if (!response.ok) continue;
+      const content = await response.text();
+      if (content.trim()) return normalizeRule(content);
+    } catch {
+      // Try the next source, then fall back to the bundled rule.
+    }
+  }
+  return normalizeRule(FALLBACK_DOSU_RULE);
+}
+
+function ensureParent(path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+}
+
+function writeIfChanged(path: string, content: string): RuleAction {
+  if (!existsSync(path)) {
+    ensureParent(path);
+    writeFileSync(path, content, "utf-8");
+    return "created";
+  }
+
+  if (readFileSync(path, "utf-8") === content) return "unchanged";
+  writeFileSync(path, content, "utf-8");
+  return "updated";
+}
+
+function findSection(content: string): { start: number; end: number } | null {
+  const startMatch = content.match(DOSU_RULE_SECTION_START_RE);
+  const start = startMatch?.index ?? -1;
+  const end = content.indexOf(DOSU_RULE_SECTION_END, Math.max(start, 0));
+
+  if (start === -1 && end === -1) return null;
+  if (start === -1 || end < start) {
+    throw new Error("Dosu rule markers are incomplete; refusing to overwrite the instruction file");
+  }
+  return { start, end };
+}
+
+function lineEndingFor(content: string): "\r\n" | "\n" {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function buildSection(content: string, lineEnding: "\r\n" | "\n" = "\n"): string {
+  const body = content.trimEnd().replace(/\r?\n/g, lineEnding);
+  return `${DOSU_RULE_SECTION_START}${lineEnding}${body}${lineEnding}${DOSU_RULE_SECTION_END}`;
+}
+
+function upsertSection(path: string, content: string): RuleAction {
+  if (!existsSync(path)) {
+    const section = buildSection(content);
+    ensureParent(path);
+    writeFileSync(path, `${section}\n`, "utf-8");
+    return "created";
+  }
+
+  const existing = readFileSync(path, "utf-8");
+  const lineEnding = lineEndingFor(existing);
+  const section = buildSection(content, lineEnding);
+  const location = findSection(existing);
+  let next: string;
+
+  if (location) {
+    next =
+      existing.slice(0, location.start) +
+      section +
+      existing.slice(location.end + DOSU_RULE_SECTION_END.length);
+  } else {
+    const separator =
+      existing.length > 0 && !existing.endsWith(lineEnding)
+        ? `${lineEnding}${lineEnding}`
+        : existing.length > 0
+          ? lineEnding
+          : "";
+    next = `${existing}${separator}${section}${lineEnding}`;
+  }
+
+  if (next === existing) return "unchanged";
+  writeFileSync(path, next, "utf-8");
+  return "updated";
+}
+
+export function installRuleForAgent(agent: string, content: string): RuleResult | null {
+  if (!isRuleAgent(agent)) return null;
+
+  const target = RULE_TARGETS[agent];
+  const path = target.path();
+  const normalized = normalizeRule(content);
+  const action =
+    target.kind === "file"
+      ? writeIfChanged(
+          path,
+          target.cursorFrontmatter ? `${CURSOR_FRONTMATTER}${normalized}` : normalized,
+        )
+      : upsertSection(path, normalized);
+
+  return { agent, path, action };
+}
+
+export function removeRuleForAgent(agent: string): RuleResult | null {
+  if (!isRuleAgent(agent)) return null;
+
+  const target = RULE_TARGETS[agent];
+  const path = target.path();
+  if (!existsSync(path)) return { agent, path, action: "not_found" };
+
+  if (target.kind === "file") {
+    unlinkSync(path);
+    return { agent, path, action: "removed" };
+  }
+
+  const existing = readFileSync(path, "utf-8");
+  const lineEnding = lineEndingFor(existing);
+  const location = findSection(existing);
+  if (!location) return { agent, path, action: "not_found" };
+
+  const next = (
+    existing.slice(0, location.start) + existing.slice(location.end + DOSU_RULE_SECTION_END.length)
+  )
+    .replace(/(?:\r?\n){3,}/g, `${lineEnding}${lineEnding}`)
+    .replace(/^(?:\r?\n)+/, "")
+    .trimEnd();
+
+  if (!next) {
+    unlinkSync(path);
+  } else {
+    writeFileSync(path, `${next}${lineEnding}`, "utf-8");
+  }
+  return { agent, path, action: "removed" };
+}

--- a/src/setup/agents-md-step.test.ts
+++ b/src/setup/agents-md-step.test.ts
@@ -174,13 +174,15 @@ describe("installedDosuSectionVersion", () => {
 describe("stepUpdateAgentsMd", () => {
   it("returns true and logs success on create", async () => {
     await expect(stepUpdateAgentsMd(dir, "canonical instruction")).resolves.toBe(true);
-    expect(p.log.success).toHaveBeenCalled();
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining(join(dir, "AGENTS.md")));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("(created)"));
   });
 
   it("returns true when already up to date", async () => {
     upsertDosuAgentsSection(dir, "canonical instruction");
     await expect(stepUpdateAgentsMd(dir, "canonical instruction")).resolves.toBe(true);
-    expect(vi.mocked(p.log.success).mock.calls[0][0]).toContain("already up to date");
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining(join(dir, "AGENTS.md")));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("(already up to date)"));
   });
 
   it("returns false and logs error when the write fails", async () => {

--- a/src/setup/agents-md-step.test.ts
+++ b/src/setup/agents-md-step.test.ts
@@ -34,16 +34,19 @@ afterEach(() => {
 });
 
 describe("buildDosuAgentsSection", () => {
-  it("wraps the section in the dosu markers", () => {
-    const section = buildDosuAgentsSection("dosu");
+  it("wraps the canonical instruction in the dosu markers without extra headings", () => {
+    const section = buildDosuAgentsSection("Canonical paragraph one.\n\nCanonical paragraph two.");
     expect(section.startsWith(DOSU_SECTION_START)).toBe(true);
     expect(section.endsWith(DOSU_SECTION_END)).toBe(true);
-    expect(section).toContain("read_knowledge");
-    expect(section).toContain("write_knowledge");
+    expect(section).toContain("Canonical paragraph one.\n\nCanonical paragraph two.");
+    expect(section).not.toContain("## Dosu");
   });
 
-  it("embeds the given dosu invocation", () => {
-    expect(buildDosuAgentsSection("npx -y @dosu/cli")).toContain("`npx -y @dosu/cli setup --help`");
+  it("uses the repository's canonical instruction by default", () => {
+    const canonical = readFileSync(join(process.cwd(), "rules", "dosu.md"), "utf-8").trim();
+    expect(buildDosuAgentsSection()).toBe(
+      `${DOSU_SECTION_START}\n${canonical}\n${DOSU_SECTION_END}`,
+    );
   });
 });
 
@@ -70,7 +73,7 @@ describe("inGitWorkTree", () => {
 
 describe("upsertDosuAgentsSection", () => {
   it("creates AGENTS.md when missing", () => {
-    const result = upsertDosuAgentsSection(dir, "dosu");
+    const result = upsertDosuAgentsSection(dir, "canonical instruction");
     expect(result.action).toBe("created");
     const content = readFileSync(result.path, "utf-8");
     expect(content).toContain(DOSU_SECTION_START);
@@ -80,12 +83,23 @@ describe("upsertDosuAgentsSection", () => {
   it("appends the section to an existing file without markers", () => {
     const path = join(dir, "AGENTS.md");
     writeFileSync(path, "# My project\n\nSome instructions.\n");
-    const result = upsertDosuAgentsSection(dir, "dosu");
+    const result = upsertDosuAgentsSection(dir, "canonical instruction");
     expect(result.action).toBe("updated");
     const content = readFileSync(path, "utf-8");
     expect(content.startsWith("# My project")).toBe(true);
     expect(content).toContain(DOSU_SECTION_START);
     expect(content.indexOf("Some instructions.")).toBeLessThan(content.indexOf(DOSU_SECTION_START));
+  });
+
+  it("preserves CRLF line endings when appending the section", () => {
+    const path = join(dir, "AGENTS.md");
+    writeFileSync(path, "# My project\r\n\r\nSome instructions.\r\n");
+
+    expect(upsertDosuAgentsSection(dir, "canonical instruction").action).toBe("updated");
+    expect(readFileSync(path, "utf-8")).toBe(
+      `# My project\r\n\r\nSome instructions.\r\n\r\n${DOSU_SECTION_START}\r\ncanonical instruction\r\n${DOSU_SECTION_END}\r\n`,
+    );
+    expect(upsertDosuAgentsSection(dir, "canonical instruction").action).toBe("unchanged");
   });
 
   it("replaces an existing marked section in place", () => {
@@ -94,33 +108,48 @@ describe("upsertDosuAgentsSection", () => {
       path,
       `# Top\n\n${DOSU_SECTION_START}\nold stale content\n${DOSU_SECTION_END}\n\n# Bottom\n`,
     );
-    const result = upsertDosuAgentsSection(dir, "dosu");
+    const result = upsertDosuAgentsSection(dir, "canonical instruction");
     expect(result.action).toBe("updated");
     const content = readFileSync(path, "utf-8");
     expect(content).not.toContain("old stale content");
-    expect(content).toContain("read_knowledge");
+    expect(content).toContain("canonical instruction");
     expect(content.indexOf("# Top")).toBeLessThan(content.indexOf(DOSU_SECTION_START));
     expect(content.indexOf(DOSU_SECTION_END)).toBeLessThan(content.indexOf("# Bottom"));
     expect(content.match(new RegExp(DOSU_SECTION_START, "g"))).toHaveLength(1);
   });
 
-  it("replaces a section left by the original unversioned marker", () => {
+  it.each([
+    ["the original unversioned marker", "<!-- dosu:mcp:start -->"],
+    ["the v1 marker", "<!-- dosu:mcp:start v1 -->"],
+  ])("replaces a section left by %s", (_label, startMarker) => {
     const path = join(dir, "AGENTS.md");
-    writeFileSync(
-      path,
-      `# Top\n\n<!-- dosu:mcp:start -->\nold unversioned content\n${DOSU_SECTION_END}\n`,
-    );
-    const result = upsertDosuAgentsSection(dir, "dosu");
+    writeFileSync(path, `# Top\n\n${startMarker}\nold content\n${DOSU_SECTION_END}\n`);
+    const result = upsertDosuAgentsSection(dir, "canonical instruction");
     expect(result.action).toBe("updated");
     const content = readFileSync(path, "utf-8");
-    expect(content).not.toContain("old unversioned content");
+    expect(content).not.toContain("old content");
     expect(content).toContain(DOSU_SECTION_START);
+    expect(content.match(/<!-- dosu:mcp:start(?: v\d+)? -->/g)).toHaveLength(1);
+    expect(content.match(/<!-- dosu:mcp:end -->/g)).toHaveLength(1);
   });
 
   it("is idempotent — a second run reports unchanged", () => {
-    upsertDosuAgentsSection(dir, "dosu");
-    const result = upsertDosuAgentsSection(dir, "dosu");
+    upsertDosuAgentsSection(dir, "canonical instruction");
+    const result = upsertDosuAgentsSection(dir, "canonical instruction");
     expect(result.action).toBe("unchanged");
+  });
+
+  it.each([
+    `${DOSU_SECTION_START}\nbroken\n`,
+    `orphan end\n${DOSU_SECTION_END}\n`,
+  ])("refuses to overwrite incomplete markers", (existing) => {
+    const path = join(dir, "AGENTS.md");
+    writeFileSync(path, existing);
+
+    expect(() => upsertDosuAgentsSection(dir, "canonical instruction")).toThrow(
+      "Dosu AGENTS.md markers are incomplete",
+    );
+    expect(readFileSync(path, "utf-8")).toBe(existing);
   });
 });
 
@@ -136,24 +165,28 @@ describe("installedDosuSectionVersion", () => {
   });
 
   it("returns the stamped version for a generated section", () => {
-    expect(installedDosuSectionVersion(buildDosuAgentsSection("dosu"))).toBe(DOSU_SECTION_VERSION);
+    expect(installedDosuSectionVersion(buildDosuAgentsSection("instruction"))).toBe(
+      DOSU_SECTION_VERSION,
+    );
   });
 });
 
 describe("stepUpdateAgentsMd", () => {
-  it("returns true and logs success on create", () => {
-    expect(stepUpdateAgentsMd(dir)).toBe(true);
+  it("returns true and logs success on create", async () => {
+    await expect(stepUpdateAgentsMd(dir, "canonical instruction")).resolves.toBe(true);
     expect(p.log.success).toHaveBeenCalled();
   });
 
-  it("returns true when already up to date", () => {
-    upsertDosuAgentsSection(dir);
-    expect(stepUpdateAgentsMd(dir)).toBe(true);
+  it("returns true when already up to date", async () => {
+    upsertDosuAgentsSection(dir, "canonical instruction");
+    await expect(stepUpdateAgentsMd(dir, "canonical instruction")).resolves.toBe(true);
     expect(vi.mocked(p.log.success).mock.calls[0][0]).toContain("already up to date");
   });
 
-  it("returns false and logs error when the write fails", () => {
-    expect(stepUpdateAgentsMd(join(dir, "does-not-exist"))).toBe(false);
+  it("returns false and logs error when the write fails", async () => {
+    await expect(
+      stepUpdateAgentsMd(join(dir, "does-not-exist"), "canonical instruction"),
+    ).resolves.toBe(false);
     expect(p.log.error).toHaveBeenCalled();
   });
 });

--- a/src/setup/agents-md-step.ts
+++ b/src/setup/agents-md-step.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { logger } from "../debug/logger";
 import { FALLBACK_DOSU_RULE, fetchDosuRule } from "../rules/installer";
-import { dim } from "./styles";
+import { formatSetupSummary } from "./styles";
 
 /**
  * Bump when the section content changes meaningfully. The version is stamped
@@ -144,11 +144,8 @@ export async function stepUpdateAgentsMd(
   try {
     const result = upsertDosuAgentsSection(cwd, content ?? (await fetchDosuRule()));
     logger.info("setup", `AGENTS.md ${result.action} at ${result.path}`);
-    if (result.action === "unchanged") {
-      p.log.success(`AGENTS.md\n${dim("Dosu section already up to date")}`);
-    } else {
-      p.log.success(`AGENTS.md\n${dim(`Dosu section ${result.action} — ${result.path}`)}`);
-    }
+    const status = result.action === "unchanged" ? "already up to date" : result.action;
+    p.log.success(formatSetupSummary("AGENTS.md", [{ path: result.path, status }]));
     return true;
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */

--- a/src/setup/agents-md-step.ts
+++ b/src/setup/agents-md-step.ts
@@ -1,7 +1,7 @@
 /**
  * AGENTS.md step — writes a marker-delimited Dosu section into the repo's
- * AGENTS.md during setup so coding agents are prompted to lean on the Dosu
- * MCP tools (pull knowledge before a task, write learnings back after).
+ * AGENTS.md during setup so coding agents receive the canonical Dosu
+ * knowledge instructions.
  *
  * The section lives between HTML-comment markers so re-running setup updates
  * it in place instead of appending duplicates, and users can freely edit the
@@ -13,15 +13,14 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { logger } from "../debug/logger";
-import { dosuInvocation } from "./audit-handoff";
+import { FALLBACK_DOSU_RULE, fetchDosuRule } from "../rules/installer";
 import { dim } from "./styles";
 
 /**
  * Bump when the section content changes meaningfully. The version is stamped
- * into the start marker so the CLI can tell whether a repo's section is
- * stale without diffing content (which varies with the embedded invocation).
+ * into the start marker so the CLI can tell whether a repo's section is stale.
  */
-export const DOSU_SECTION_VERSION = 1;
+export const DOSU_SECTION_VERSION = 2;
 
 export const DOSU_SECTION_START = `<!-- dosu:mcp:start v${DOSU_SECTION_VERSION} -->`;
 export const DOSU_SECTION_END = "<!-- dosu:mcp:end -->";
@@ -34,6 +33,11 @@ export type AgentsMdAction = "created" | "updated" | "unchanged";
 export interface AgentsMdResult {
   path: string;
   action: AgentsMdAction;
+}
+
+interface SectionLocation {
+  start: number;
+  end: number;
 }
 
 /**
@@ -55,19 +59,29 @@ export function inGitWorkTree(cwd: string = process.cwd()): boolean {
   }
 }
 
-export function buildDosuAgentsSection(dosuCmd: string = dosuInvocation()): string {
-  return [
-    DOSU_SECTION_START,
-    "## Dosu",
-    "",
-    "Shared team knowledge lives in [Dosu](https://dosu.dev), via the Dosu MCP server.",
-    "",
-    "- Before a task, and for any codebase or docs questions: pull context with `read_knowledge` before digging through source.",
-    "- After a task: save durable learnings with `write_knowledge`.",
-    "",
-    `Missing these tools? Run \`${dosuCmd} setup --help\` — it covers agent-assisted setup.`,
-    DOSU_SECTION_END,
-  ].join("\n");
+function lineEndingFor(content: string): "\r\n" | "\n" {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function renderDosuAgentsSection(content: string, lineEnding: "\r\n" | "\n"): string {
+  const body = content.trim().replace(/\r?\n/g, lineEnding);
+  return `${DOSU_SECTION_START}${lineEnding}${body}${lineEnding}${DOSU_SECTION_END}`;
+}
+
+export function buildDosuAgentsSection(content: string = FALLBACK_DOSU_RULE): string {
+  return renderDosuAgentsSection(content, "\n");
+}
+
+function findSection(content: string): SectionLocation | null {
+  const startMatch = content.match(SECTION_START_RE);
+  const start = startMatch?.index ?? -1;
+  const end = content.indexOf(DOSU_SECTION_END, Math.max(start, 0));
+
+  if (start === -1 && end === -1) return null;
+  if (start === -1 || end < start) {
+    throw new Error("Dosu AGENTS.md markers are incomplete; refusing to overwrite the file");
+  }
+  return { start, end };
 }
 
 /**
@@ -76,26 +90,29 @@ export function buildDosuAgentsSection(dosuCmd: string = dosuInvocation()): stri
  */
 export function upsertDosuAgentsSection(
   cwd: string = process.cwd(),
-  dosuCmd: string = dosuInvocation(),
+  content: string = FALLBACK_DOSU_RULE,
 ): AgentsMdResult {
   const path = join(cwd, "AGENTS.md");
-  const section = buildDosuAgentsSection(dosuCmd);
 
   if (!existsSync(path)) {
+    const section = buildDosuAgentsSection(content);
     writeFileSync(path, `${section}\n`);
     return { path, action: "created" };
   }
 
   const existing = readFileSync(path, "utf-8");
-  const startMatch = existing.match(SECTION_START_RE);
-  const start = startMatch?.index ?? -1;
-  const end = existing.indexOf(DOSU_SECTION_END);
+  const lineEnding = lineEndingFor(existing);
+  const section = renderDosuAgentsSection(content, lineEnding);
+  const location = findSection(existing);
 
   let next: string;
-  if (start !== -1 && end !== -1 && end >= start) {
-    next = existing.slice(0, start) + section + existing.slice(end + DOSU_SECTION_END.length);
+  if (location) {
+    next =
+      existing.slice(0, location.start) +
+      section +
+      existing.slice(location.end + DOSU_SECTION_END.length);
   } else {
-    next = `${existing.trimEnd()}\n\n${section}\n`;
+    next = `${existing.trimEnd()}${lineEnding}${lineEnding}${section}${lineEnding}`;
   }
 
   if (next === existing) return { path, action: "unchanged" };
@@ -119,10 +136,13 @@ export function installedDosuSectionVersion(content: string): number | null {
  * `true` when AGENTS.md ends up carrying the Dosu section (including the
  * already-up-to-date case).
  */
-export function stepUpdateAgentsMd(cwd: string = process.cwd()): boolean {
+export async function stepUpdateAgentsMd(
+  cwd: string = process.cwd(),
+  content?: string,
+): Promise<boolean> {
   logger.info("setup", "Step: update AGENTS.md");
   try {
-    const result = upsertDosuAgentsSection(cwd);
+    const result = upsertDosuAgentsSection(cwd, content ?? (await fetchDosuRule()));
     logger.info("setup", `AGENTS.md ${result.action} at ${result.path}`);
     if (result.action === "unchanged") {
       p.log.success(`AGENTS.md\n${dim("Dosu section already up to date")}`);

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -13,7 +13,6 @@ type CliOnboardingEvent =
   | "cli_onboarding_started"
   | "cli_onboarding_failed"
   | "cli_onboarding_cancelled"
-  | "cli_onboarding_options_selected"
   | "cli_onboarding_mcp_configured"
   | "cli_onboarding_skill_installed"
   | "cli_onboarding_github_connected"

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -26,6 +26,7 @@ vi.mock("@clack/prompts", () => ({
   spinner: vi.fn(() => ({
     start: vi.fn(),
     stop: vi.fn(),
+    clear: vi.fn(),
   })),
   log: {
     warn: vi.fn(),
@@ -1538,8 +1539,11 @@ describe("runInstallSkill", () => {
     mockInstallSkill.mockResolvedValue({ success: true, sha: "abc" });
 
     const result = await runInstallSkill([ClaudeProvider()]);
+    const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(true);
+    expect(spinner?.start).toHaveBeenCalledWith("Installing skill for 1 agent");
+    expect(spinner?.clear).toHaveBeenCalledOnce();
     expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Claude Code"));
@@ -1547,12 +1551,25 @@ describe("runInstallSkill", () => {
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("(symlink)"));
   });
 
+  it("uses plural loading copy for multiple selected agents", async () => {
+    mockInstallSkill.mockResolvedValue({ success: true });
+
+    await runInstallSkill([ClaudeProvider(), CursorProvider()]);
+    const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
+
+    expect(spinner?.start).toHaveBeenCalledWith("Installing skill for 2 agents");
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 2 agent"));
+  });
+
   it("returns false and logs error when installSkill reports failure", async () => {
     mockInstallSkill.mockResolvedValue({ success: false });
 
     const result = await runInstallSkill([ClaudeProvider()]);
+    const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(false);
+    expect(spinner?.start).toHaveBeenCalledWith("Installing skill for 1 agent");
+    expect(spinner?.clear).toHaveBeenCalledOnce();
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Failed to install skill"));
   });
 
@@ -1560,8 +1577,11 @@ describe("runInstallSkill", () => {
     mockInstallSkill.mockRejectedValue(new Error("boom"));
 
     const result = await runInstallSkill([ClaudeProvider()]);
+    const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(false);
+    expect(spinner?.start).toHaveBeenCalledWith("Installing skill for 1 agent");
+    expect(spinner?.clear).toHaveBeenCalledOnce();
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("boom"));
   });
 });

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1409,7 +1409,7 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"]);
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill installed"));
   });
 
@@ -1439,7 +1439,7 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"]);
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
   });
 
   it("goes directly to agent selection without a component-selection prompt", async () => {
@@ -1531,7 +1531,7 @@ describe("runInstallSkill", () => {
     const result = await runInstallSkill(["claude"]);
 
     expect(result).toBe(true);
-    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"]);
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill installed"));
   });
 

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -115,6 +115,13 @@ vi.mock("../commands/skill", () => ({
           ({ claude: "claude-code", cursor: "cursor" })[providerID as "claude" | "cursor"],
       )
       .filter(Boolean),
+  skillInstallTargetForProvider: (providerID: string) => {
+    const target = {
+      claude: { path: "/skills/claude/dosu", symlink: true },
+      cursor: { path: "/skills/cursor/dosu", symlink: false },
+    }[providerID as "claude" | "cursor"];
+    return target ?? null;
+  },
   skillCommand: vi.fn(),
 }));
 
@@ -155,6 +162,7 @@ import { loadConfig, saveConfig } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { loadJSONConfig, saveJSONConfig } from "../mcp/config-helpers";
 import * as providersModule from "../mcp/providers";
+import { ClaudeProvider } from "../mcp/providers/claude";
 import { ClaudeDesktopProvider } from "../mcp/providers/claude-desktop";
 import { CursorProvider } from "../mcp/providers/cursor";
 import { OpenCodeProvider } from "../mcp/providers/opencode";
@@ -1410,7 +1418,8 @@ describe("runSetup integration", () => {
     await runSetup();
 
     expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill installed"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/skills/cursor/dosu"));
   });
 
   it("does not install the skill when no agent is selected", async () => {
@@ -1528,17 +1537,20 @@ describe("runInstallSkill", () => {
   it("calls installSkill and returns true on success", async () => {
     mockInstallSkill.mockResolvedValue({ success: true, sha: "abc" });
 
-    const result = await runInstallSkill(["claude"]);
+    const result = await runInstallSkill([ClaudeProvider()]);
 
     expect(result).toBe(true);
     expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill installed"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Claude Code"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/skills/claude/dosu"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("(symlink)"));
   });
 
   it("returns false and logs error when installSkill reports failure", async () => {
     mockInstallSkill.mockResolvedValue({ success: false });
 
-    const result = await runInstallSkill(["claude"]);
+    const result = await runInstallSkill([ClaudeProvider()]);
 
     expect(result).toBe(false);
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Failed to install skill"));
@@ -1547,7 +1559,7 @@ describe("runInstallSkill", () => {
   it("returns false and logs error when installSkill throws", async () => {
     mockInstallSkill.mockRejectedValue(new Error("boom"));
 
-    const result = await runInstallSkill(["claude"]);
+    const result = await runInstallSkill([ClaudeProvider()]);
 
     expect(result).toBe(false);
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("boom"));

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -108,6 +108,13 @@ vi.mock("../client/client", () => {
 const mockInstallSkill = vi.fn();
 vi.mock("../commands/skill", () => ({
   installSkill: (...args: unknown[]) => mockInstallSkill(...args),
+  skillAgentIDsForProviders: (providerIDs: string[]) =>
+    providerIDs
+      .map(
+        (providerID) =>
+          ({ claude: "claude-code", cursor: "cursor" })[providerID as "claude" | "cursor"],
+      )
+      .filter(Boolean),
   skillCommand: vi.fn(),
 }));
 
@@ -125,6 +132,13 @@ const { mockInGitWorkTree, mockStepUpdateAgentsMd } = vi.hoisted(() => ({
 vi.mock("./agents-md-step", () => ({
   inGitWorkTree: (...args: unknown[]) => mockInGitWorkTree(...args),
   stepUpdateAgentsMd: (...args: unknown[]) => mockStepUpdateAgentsMd(...args),
+}));
+
+const { mockStepConfigureAgentRules } = vi.hoisted(() => ({
+  mockStepConfigureAgentRules: vi.fn(),
+}));
+vi.mock("./rules-step", () => ({
+  stepConfigureAgentRules: (...args: unknown[]) => mockStepConfigureAgentRules(...args),
 }));
 vi.mock("./github-step", () => ({
   stepConnectGitHubRepo: (...args: unknown[]) => mockStepConnectGitHubRepo(...args),
@@ -155,11 +169,7 @@ import {
   type ToolSelection,
 } from "./flow";
 
-/**
- * Default p.multiselect behaviour: auto-accept the initialValues for the
- * one-shot confirm step (`stepOneShotConfirm`) AND the tool-selection step.
- * Tests that want to override tool selection use `mockToolSelection()` below.
- */
+/** Default p.multiselect behaviour: accept the agent selection's initial values. */
 function installMultiselectDefault() {
   vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
     const o = opts as { message: string; initialValues?: unknown[] };
@@ -167,26 +177,16 @@ function installMultiselectDefault() {
   });
 }
 
-/**
- * Override tool selection with a specific set of provider IDs while still
- * auto-accepting the upfront one-shot confirm. Use instead of
- * `vi.mocked(p.multiselect).mockResolvedValue(...)`.
- */
+/** Override the selected agent provider IDs. */
 function mockToolSelection(selection: string[]) {
-  vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
-    const o = opts as { message: string; initialValues?: unknown[] };
-    const msg = String(o.message ?? "").toLowerCase();
-    if (msg.includes("dosu will set")) {
-      return (o.initialValues ?? []) as unknown as never;
-    }
-    return selection as unknown as never;
-  });
+  vi.mocked(p.multiselect).mockResolvedValue(selection as unknown as never);
 }
 
 function installSetupStepDefaults() {
   mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
   mockInGitWorkTree.mockReturnValue(false);
   mockStepUpdateAgentsMd.mockReturnValue(true);
+  mockStepConfigureAgentRules.mockResolvedValue([]);
 }
 
 function installRemoteSetupDefaults() {
@@ -751,6 +751,10 @@ describe("runSetup integration", () => {
 
     // Verify summary was shown
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
+    expect(mockStepConfigureAgentRules).toHaveBeenCalledWith(
+      expect.objectContaining({ toInstall: [expect.objectContaining({})] }),
+      [expect.objectContaining({ action: "install" })],
+    );
   });
 
   it("runs OAuth flow and saves tokens to real config", async () => {
@@ -1124,18 +1128,7 @@ describe("runSetup integration", () => {
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
 
     const cancelSymbol = Symbol("cancel");
-    // Cancel only the tool-selection multiselect; accept the one-shot confirm.
-    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
-      const o = opts as { message: string; initialValues?: unknown[] };
-      if (
-        String(o.message ?? "")
-          .toLowerCase()
-          .includes("dosu will set")
-      ) {
-        return (o.initialValues ?? []) as unknown as never;
-      }
-      return cancelSymbol as unknown as never;
-    });
+    vi.mocked(p.multiselect).mockResolvedValue(cancelSymbol as unknown as never);
     vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
 
     await runSetup();
@@ -1405,38 +1398,29 @@ describe("runSetup integration", () => {
     );
   });
 
-  it("installs skill automatically when the one-shot confirm leaves it ticked", async () => {
+  it("installs the skill automatically for the selected agent", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalled();
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"]);
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill installed"));
   });
 
-  it("does not install skill when the one-shot confirm unticks it", async () => {
+  it("does not install the skill when no agent is selected", async () => {
     const cfg = makeCfg({ mode: "oss" });
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    // Override the one-shot confirm to deselect the skill item.
-    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
-      const o = opts as { message: string; initialValues?: unknown[] };
-      if (
-        String(o.message ?? "")
-          .toLowerCase()
-          .includes("dosu will set")
-      ) {
-        return ["configureMcp"] as unknown as never;
-      }
-      return (o.initialValues ?? []) as unknown as never;
-    });
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection([]);
 
     await runSetup();
 
@@ -1444,68 +1428,51 @@ describe("runSetup integration", () => {
     expect(p.outro).toHaveBeenCalledWith(expect.stringContaining("open-source libraries only"));
   });
 
-  it("installs skill in OSS mode when the one-shot confirm leaves it ticked", async () => {
+  it("installs the selected agent skill in OSS mode", async () => {
     const cfg = makeCfg({ mode: "oss" });
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalled();
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"]);
   });
 
-  it("offers only MCP + skill in the one-shot confirm (docs import lives in the web wizard)", async () => {
+  it("goes directly to agent selection without a component-selection prompt", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    mockStartOAuthFlow.mockResolvedValue({
-      browserOpened: true,
-      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
-    const oneShotCall = vi
+    const messages = vi
       .mocked(p.multiselect)
-      .mock.calls.find(([args]) =>
-        String((args as { message?: string }).message ?? "").includes("Dosu will set"),
-      );
-    const options = (oneShotCall?.[0] as { options: Array<{ label: string }> }).options;
-    expect(options.map((option) => String(option.label))).toEqual([
-      "Install Dosu MCP",
-      "Install Dosu skill",
-    ]);
+      .mock.calls.map(([args]) => String((args as { message?: string }).message ?? ""));
+    expect(messages).toEqual(["Select agents — tick to configure, untick to remove"]);
+    expect(messages.some((message) => message.includes("Dosu will set"))).toBe(false);
   });
 
-  it("offers the AGENTS.md option and runs the step when the cwd is a git work tree", async () => {
+  it("automatically updates AGENTS.md after configuring an agent in a git work tree", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);
 
     setupAuthenticatedClient();
     mockInGitWorkTree.mockReturnValue(true);
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
-    const oneShotCall = vi
-      .mocked(p.multiselect)
-      .mock.calls.find(([args]) =>
-        String((args as { message?: string }).message ?? "").includes("Dosu will set"),
-      );
-    const options = (oneShotCall?.[0] as { options: Array<{ label: string }> }).options;
-    expect(options.map((option) => String(option.label))).toContain(
-      "Add Dosu instructions to AGENTS.md",
-    );
-    expect(mockStepUpdateAgentsMd).toHaveBeenCalled();
+    expect(mockStepUpdateAgentsMd).toHaveBeenCalledTimes(1);
 
     const completed = trackedCliOnboardingEvents().find(
       (e) => e.event === "cli_onboarding_completed",
@@ -1513,50 +1480,32 @@ describe("runSetup integration", () => {
     expect(completed?.properties.completed_agents_md).toBe(true);
   });
 
-  it("skips the AGENTS.md step when the one-shot confirm unticks it", async () => {
+  it("does not update AGENTS.md when no agent was configured", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);
 
     setupAuthenticatedClient();
     mockInGitWorkTree.mockReturnValue(true);
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    // Deselect only the AGENTS.md item in the one-shot confirm.
-    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
-      const o = opts as { message: string; initialValues?: unknown[] };
-      if (
-        String(o.message ?? "")
-          .toLowerCase()
-          .includes("dosu will set")
-      ) {
-        return ["configureMcp", "installSkill"] as unknown as never;
-      }
-      return (o.initialValues ?? []) as unknown as never;
-    });
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection([]);
 
     await runSetup();
 
     expect(mockStepUpdateAgentsMd).not.toHaveBeenCalled();
   });
 
-  it("never offers the AGENTS.md option outside a git work tree", async () => {
+  it("does not update AGENTS.md outside a git work tree", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
-    const oneShotCall = vi
-      .mocked(p.multiselect)
-      .mock.calls.find(([args]) =>
-        String((args as { message?: string }).message ?? "").includes("Dosu will set"),
-      );
-    const options = (oneShotCall?.[0] as { options: Array<{ label: string }> }).options;
-    expect(options.map((option) => String(option.label))).not.toContain(
-      "Add Dosu instructions to AGENTS.md",
-    );
     expect(mockStepUpdateAgentsMd).not.toHaveBeenCalled();
   });
 });
@@ -1579,17 +1528,17 @@ describe("runInstallSkill", () => {
   it("calls installSkill and returns true on success", async () => {
     mockInstallSkill.mockResolvedValue({ success: true, sha: "abc" });
 
-    const result = await runInstallSkill();
+    const result = await runInstallSkill(["claude"]);
 
     expect(result).toBe(true);
-    expect(mockInstallSkill).toHaveBeenCalled();
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"]);
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill installed"));
   });
 
   it("returns false and logs error when installSkill reports failure", async () => {
     mockInstallSkill.mockResolvedValue({ success: false });
 
-    const result = await runInstallSkill();
+    const result = await runInstallSkill(["claude"]);
 
     expect(result).toBe(false);
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Failed to install skill"));
@@ -1598,7 +1547,7 @@ describe("runInstallSkill", () => {
   it("returns false and logs error when installSkill throws", async () => {
     mockInstallSkill.mockRejectedValue(new Error("boom"));
 
-    const result = await runInstallSkill();
+    const result = await runInstallSkill(["claude"]);
 
     expect(result).toBe(false);
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("boom"));
@@ -1657,26 +1606,12 @@ describe("runSetup checkpoint behavior", () => {
     }
   });
 
-  it("does not offer the audit handoff when the user unticks MCP", async () => {
-    // If the user deselects both "Install Dosu MCP" and "Install Dosu skill"
-    // from the one-shot confirm, nothing was configured this run, so the
-    // audit handoff would be noise.
+  it("does not offer the audit handoff when the user selects no agents", async () => {
     saveConfig(makeCfg());
     setupAuthed();
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    // Override the one-shot confirm to return an empty selection.
-    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
-      const o = opts as { message: string };
-      if (
-        String(o.message ?? "")
-          .toLowerCase()
-          .includes("dosu will set")
-      ) {
-        return [] as unknown as never;
-      }
-      return [] as unknown as never;
-    });
+    mockToolSelection([]);
 
     await runSetup();
 
@@ -1760,7 +1695,9 @@ describe("runSetup checkpoint behavior", () => {
   it("tracks completion when at least one valuable onboarding action succeeds", async () => {
     saveConfig(makeCfg());
     setupAuthed();
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
 
     await runSetup();
 
@@ -1770,7 +1707,7 @@ describe("runSetup checkpoint behavior", () => {
         expect.objectContaining({
           event: "cli_onboarding_completed",
           properties: expect.objectContaining({
-            completed_mcp: false,
+            completed_mcp: true,
             completed_skill: true,
           }),
         }),
@@ -1869,7 +1806,7 @@ describe("runSetup checkpoint behavior", () => {
         }),
       ]),
     );
-    // Never reached deployment binding or the one-shot confirm.
+    // Never reached deployment binding or agent selection.
     expect(methods.getDeployments).not.toHaveBeenCalled();
     expect(p.multiselect).not.toHaveBeenCalled();
   });
@@ -2137,7 +2074,7 @@ describe("runSetup additional branches", () => {
     await runSetup();
 
     expect(p.log.error).toHaveBeenCalledWith("Could not load your profile.");
-    // Never advanced to the one-shot confirm / outro.
+    // Never advanced to agent selection / outro.
     expect(p.outro).not.toHaveBeenCalled();
     expect(
       trackedCliOnboardingEvents().some(
@@ -2282,36 +2219,18 @@ describe("runSetup additional branches", () => {
     expect(saved.active_account?.target?.deployment_id).toBe("dep-fallback");
   });
 
-  it("returns early when the one-shot confirm is cancelled", async () => {
+  it("does not emit the removed component-selection telemetry event", async () => {
     saveConfig(makeCfg());
     setupAuthed();
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
-    const cancelSymbol = Symbol("cancel");
-    // Cancel the one-shot confirm multiselect specifically.
-    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
-      const o = opts as { message: string; initialValues?: unknown[] };
-      if (
-        String(o.message ?? "")
-          .toLowerCase()
-          .includes("dosu will set")
-      ) {
-        return cancelSymbol as unknown as never;
-      }
-      return (o.initialValues ?? []) as unknown as never;
-    });
-    vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
-
     await runSetup();
 
     expect(mockInstallSkill).not.toHaveBeenCalled();
-    expect(p.outro).not.toHaveBeenCalled();
-    expect(
-      trackedCliOnboardingEvents().some(
-        (e) =>
-          e.event === "cli_onboarding_cancelled" && e.properties?.reason === "options_cancelled",
-      ),
-    ).toBe(true);
+    expect(p.outro).toHaveBeenCalled();
+    expect(trackedCliOnboardingEvents().map((event) => event.event)).not.toContain(
+      "cli_onboarding_options_selected",
+    );
   });
 
   it("returns early when the MCP tool selection is cancelled", async () => {
@@ -2321,17 +2240,7 @@ describe("runSetup additional branches", () => {
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
 
     const cancelSymbol = Symbol("cancel");
-    vi.mocked(p.multiselect).mockImplementation(async (opts: unknown) => {
-      const o = opts as { message: string; initialValues?: unknown[] };
-      if (
-        String(o.message ?? "")
-          .toLowerCase()
-          .includes("dosu will set")
-      ) {
-        return (o.initialValues ?? []) as unknown as never;
-      }
-      return cancelSymbol as unknown as never;
-    });
+    vi.mocked(p.multiselect).mockResolvedValue(cancelSymbol as unknown as never);
     vi.mocked(p.isCancel).mockImplementation((val) => val === cancelSymbol);
 
     await runSetup();
@@ -2382,8 +2291,7 @@ describe("runSetup additional branches", () => {
     setupAuthed();
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    // Accept the one-shot confirm and the (preselected = none, since
-    // unconfigured) tool selection as-is.
+    // Accept the agent selection's initial values (none, since unconfigured).
     installMultiselectDefault();
 
     await runSetup();

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -7,7 +7,7 @@ import * as p from "@clack/prompts";
 import type { CallbackServer } from "../auth/server";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
 import type { TypedClient } from "../client/trpc";
-import { installSkill } from "../commands/skill";
+import { installSkill, skillAgentIDsForProviders } from "../commands/skill";
 import {
   bindAccountIdentity,
   type Config,
@@ -24,6 +24,7 @@ import { allSetupProviders, type SetupProvider } from "../mcp/providers";
 import { inGitWorkTree, stepUpdateAgentsMd } from "./agents-md-step";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
 import { launchAuditAgent, offerAuditHandoff } from "./audit-handoff";
+import { stepConfigureAgentRules } from "./rules-step";
 import { browserFallbackHint, dim, info } from "./styles";
 
 export interface SetupOptions {
@@ -44,12 +45,6 @@ export interface ToolSelection {
   toInstall: SetupProvider[];
   toRemove: SetupProvider[];
   skipped: SetupProvider[];
-}
-
-interface OneShotChoices {
-  configureMcp: boolean;
-  installSkill: boolean;
-  updateAgentsMd: boolean;
 }
 
 type SetupFlowKind = "onboarding" | "setup";
@@ -193,64 +188,47 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   updateTarget(cfg, { api_key: apiKey });
   saveConfig(cfg);
 
-  // One-shot confirm: MCP + skill are always listed (user picks what to
-  // (re)run). Repo connection + docs import happen in the web onboarding
-  // wizard, so the CLI no longer offers them here.
-  const choices = await stepOneShotConfirm(inGitWorkTree());
-  if (!choices) {
+  // Agent selection is the only install choice. Every successfully configured
+  // agent receives the full supported bundle: MCP, rules, and skill.
+  const configured = await stepConfigureMcpTools(cfg);
+  if (configured === null) {
     await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
-      reason: "options_cancelled",
+      reason: "mcp_selection_cancelled",
     });
     return;
   }
-  await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_options_selected", {
-    configure_mcp: choices.configureMcp,
-    install_skill: choices.installSkill,
-    update_agents_md: choices.updateAgentsMd,
-  });
 
-  // MCP tools. Track whether at least one agent ended up with Dosu MCP
-  // configured (newly installed or previously installed) so we only offer
-  // the audit handoff when there's actually an agent that can use Dosu.
-  let mcpConfiguredThisRun = false;
-  let mcpCompleted = false;
-  let skillCompleted = false;
-  if (choices.configureMcp) {
-    const configured = await stepConfigureMcpTools(cfg);
-    if (configured === null) {
-      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
-        reason: "mcp_selection_cancelled",
-      });
-      return;
-    }
-    mcpConfiguredThisRun = configured.some((r) => r.action === "install" || r.action === "skip");
-    const configuredProviders = configured.filter(
-      (r) => (r.action === "install" || r.action === "skip") && !r.error,
-    );
-    mcpCompleted = configuredProviders.length > 0;
-    if (mcpCompleted) {
-      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_mcp_configured", {
-        provider_count: configuredProviders.length,
-        providers: configuredProviders.map((r) => r.provider.id()),
-      });
-    }
+  const mcpConfiguredThisRun = configured.some(
+    (result) => result.action === "install" || result.action === "skip",
+  );
+  const configuredProviders = configured.filter(
+    (result) => (result.action === "install" || result.action === "skip") && !result.error,
+  );
+  const mcpCompleted = configuredProviders.length > 0;
+  if (mcpCompleted) {
+    await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_mcp_configured", {
+      provider_count: configuredProviders.length,
+      providers: configuredProviders.map((result) => result.provider.id()),
+    });
   }
 
-  // Dosu skill
-  if (choices.installSkill) {
-    skillCompleted = await runInstallSkill();
+  // Skill installation follows the same agent selection as MCP and rules.
+  // Unsupported clients are left alone rather than broadening the install
+  // to every agent on the machine.
+  let skillCompleted = false;
+  const selectedProviderIDs = configuredProviders.map((result) => result.provider.id());
+  if (skillAgentIDsForProviders(selectedProviderIDs).length > 0) {
+    skillCompleted = await runInstallSkill(selectedProviderIDs);
     if (skillCompleted) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_skill_installed");
     }
   }
 
-  // AGENTS.md — prompt coding agents to use the Dosu MCP tools. Only offered
-  // (and run) when the cwd is a git work tree. Tracked via the
-  // `completed_agents_md` property on cli_onboarding_completed — the backend
-  // event enum has no dedicated event for this step.
+  // Project instructions are part of the bundle when setup runs inside a git
+  // work tree and at least one agent was configured.
   let agentsMdCompleted = false;
-  if (choices.updateAgentsMd) {
-    agentsMdCompleted = stepUpdateAgentsMd();
+  if (mcpCompleted && inGitWorkTree()) {
+    agentsMdCompleted = await stepUpdateAgentsMd();
   }
 
   // Codebase audit handoff (cloud mode only — it acts on the user's own
@@ -311,45 +289,6 @@ function applyModeOverride(cfg: Config, opts: SetupOptions): void {
 }
 
 /**
- * One-shot confirmation: a single multiselect listing everything Dosu will
- * set up. All items default checked; user hits Enter to do it all, or
- * unticks specific items.
- *
- * MCP + skill are always listed so users can re-run either step at any
- * time (add a new agent, reinstall the skill). Repo connection + docs
- * import happen in the web onboarding wizard, not here.
- */
-async function stepOneShotConfirm(offerAgentsMd: boolean): Promise<OneShotChoices | null> {
-  type Item = { value: keyof OneShotChoices; label: string };
-  const items: Item[] = [
-    { value: "configureMcp", label: "Install Dosu MCP" },
-    { value: "installSkill", label: "Install Dosu skill" },
-  ];
-  if (offerAgentsMd) {
-    items.push({ value: "updateAgentsMd", label: "Add Dosu instructions to AGENTS.md" });
-  }
-
-  const selected = await p.multiselect({
-    message: "Dosu will set these up — press Enter to accept, space to toggle",
-    options: items.map((it) => ({ value: it.value, label: it.label })),
-    initialValues: items.map((it) => it.value),
-    required: false,
-  });
-
-  if (p.isCancel(selected)) {
-    logger.info("setup", "One-shot confirm cancelled");
-    return null;
-  }
-
-  const chosen = new Set(selected as Array<keyof OneShotChoices>);
-  return {
-    configureMcp: chosen.has("configureMcp"),
-    installSkill: chosen.has("installSkill"),
-    updateAgentsMd: chosen.has("updateAgentsMd"),
-  };
-}
-
-/**
  * Runs MCP tool detection → selection → configuration as a single unit.
  * Returns the ConfigResult array on success, or null if the user cancelled.
  * An empty detection pool is treated as success (nothing to do).
@@ -366,17 +305,18 @@ async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null
   if (!selection) return null;
   const results = stepConfigureTools(cfg, selection);
   stepShowSummary(results);
+  await stepConfigureAgentRules(selection, results);
   return results;
 }
 
 /**
- * Run the skill install (no prompt). The upfront one-shot confirm already
- * decided whether to run this. Returns `true` on success.
+ * Install the skill for the same provider ids selected during MCP setup.
+ * Returns `true` on success.
  */
-export async function runInstallSkill(): Promise<boolean> {
+export async function runInstallSkill(providerIDs: readonly string[]): Promise<boolean> {
   logger.info("setup", "Step: install skill");
   try {
-    const result = await installSkill();
+    const result = await installSkill(providerIDs);
     if (result.success) {
       logger.info("setup", `Skill installed${result.sha ? ` sha=${result.sha}` : ""}`);
       p.log.success("Skill installed");

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -317,6 +317,9 @@ async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null
  */
 export async function runInstallSkill(providers: readonly SetupProvider[]): Promise<boolean> {
   logger.info("setup", "Step: install skill");
+  const spinner = p.spinner();
+  const agentLabel = providers.length === 1 ? "agent" : "agents";
+  spinner.start(`Installing skill for ${providers.length} ${agentLabel}`);
   try {
     // Interactive setup owns the summary UI. Keep the nested skills installer
     // quiet so its progress screens do not interrupt the standardized setup
@@ -339,15 +342,18 @@ export async function runInstallSkill(providers: readonly SetupProvider[]): Prom
           },
         ];
       });
+      spinner.clear();
       p.log.success(formatSetupSummary(`Skill ready for ${items.length} agent(s):`, items));
       return true;
     }
+    spinner.clear();
     p.log.error("Failed to install skill. Run `dosu skill install` to retry.");
     return false;
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
     const msg = err instanceof Error ? err.message : String(err);
     logger.error("setup", `Skill install failed: ${msg}`);
+    spinner.clear();
     p.log.error(`Skill install failed: ${msg}`);
     return false;
   }

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -7,7 +7,7 @@ import * as p from "@clack/prompts";
 import type { CallbackServer } from "../auth/server";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
 import type { TypedClient } from "../client/trpc";
-import { installSkill, skillAgentIDsForProviders } from "../commands/skill";
+import { installSkill, skillInstallTargetForProvider } from "../commands/skill";
 import {
   bindAccountIdentity,
   type Config,
@@ -25,7 +25,7 @@ import { inGitWorkTree, stepUpdateAgentsMd } from "./agents-md-step";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
 import { launchAuditAgent, offerAuditHandoff } from "./audit-handoff";
 import { stepConfigureAgentRules } from "./rules-step";
-import { browserFallbackHint, dim, info } from "./styles";
+import { browserFallbackHint, dim, formatSetupSummary, IconRemove, info } from "./styles";
 
 export interface SetupOptions {
   deploymentID?: string;
@@ -216,9 +216,11 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   // Unsupported clients are left alone rather than broadening the install
   // to every agent on the machine.
   let skillCompleted = false;
-  const selectedProviderIDs = configuredProviders.map((result) => result.provider.id());
-  if (skillAgentIDsForProviders(selectedProviderIDs).length > 0) {
-    skillCompleted = await runInstallSkill(selectedProviderIDs);
+  const skillProviders = configuredProviders
+    .map((result) => result.provider)
+    .filter((provider) => skillInstallTargetForProvider(provider.id()) !== null);
+  if (skillProviders.length > 0) {
+    skillCompleted = await runInstallSkill(skillProviders);
     if (skillCompleted) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_skill_installed");
     }
@@ -310,20 +312,34 @@ async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null
 }
 
 /**
- * Install the skill for the same provider ids selected during MCP setup.
+ * Install the skill for the same providers selected during MCP setup.
  * Returns `true` on success.
  */
-export async function runInstallSkill(providerIDs: readonly string[]): Promise<boolean> {
+export async function runInstallSkill(providers: readonly SetupProvider[]): Promise<boolean> {
   logger.info("setup", "Step: install skill");
   try {
     // Interactive setup owns the summary UI. Keep the nested skills installer
     // quiet so its progress screens do not interrupt the standardized setup
     // results below. The standalone `dosu skill install` command remains
     // verbose.
-    const result = await installSkill(providerIDs, { quiet: true });
+    const result = await installSkill(
+      providers.map((provider) => provider.id()),
+      { quiet: true },
+    );
     if (result.success) {
       logger.info("setup", `Skill installed${result.sha ? ` sha=${result.sha}` : ""}`);
-      p.log.success("Skill installed");
+      const items = providers.flatMap((provider) => {
+        const target = skillInstallTargetForProvider(provider.id());
+        if (!target) return [];
+        return [
+          {
+            label: provider.name(),
+            path: target.path,
+            status: target.symlink ? "symlink" : undefined,
+          },
+        ];
+      });
+      p.log.success(formatSetupSummary(`Skill ready for ${items.length} agent(s):`, items));
       return true;
     }
     p.log.error("Failed to install skill. Run `dosu skill install` to retry.");
@@ -890,17 +906,28 @@ export function stepShowSummary(results: ConfigResult[]): void {
   const skipped = results.filter((r) => r.action === "skip");
 
   if (installed.length > 0) {
-    const lines = installed
-      .map((r) => `+ ${r.provider.name()}\n  ${dim(r.provider.globalConfigPath())}`)
-      .join("\n");
-    p.log.success(`Configured ${installed.length} agent(s):\n${lines}`);
+    p.log.success(
+      formatSetupSummary(
+        `Configured ${installed.length} agent(s):`,
+        installed.map((result) => ({
+          label: result.provider.name(),
+          path: result.provider.globalConfigPath(),
+        })),
+      ),
+    );
   }
 
   if (removed.length > 0) {
-    const lines = removed
-      .map((r) => `- ${r.provider.name()}\n  ${dim(r.provider.globalConfigPath())}`)
-      .join("\n");
-    p.log.info(`Removed from ${removed.length} agent(s):\n${lines}`);
+    p.log.info(
+      formatSetupSummary(
+        `Removed from ${removed.length} agent(s):`,
+        removed.map((result) => ({
+          label: result.provider.name(),
+          path: result.provider.globalConfigPath(),
+        })),
+        IconRemove,
+      ),
+    );
   }
 
   if (installed.length === 0 && removed.length === 0 && skipped.length > 0) {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -316,7 +316,11 @@ async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null
 export async function runInstallSkill(providerIDs: readonly string[]): Promise<boolean> {
   logger.info("setup", "Step: install skill");
   try {
-    const result = await installSkill(providerIDs);
+    // Interactive setup owns the summary UI. Keep the nested skills installer
+    // quiet so its progress screens do not interrupt the standardized setup
+    // results below. The standalone `dosu skill install` command remains
+    // verbose.
+    const result = await installSkill(providerIDs, { quiet: true });
     if (result.success) {
       logger.info("setup", `Skill installed${result.sha ? ` sha=${result.sha}` : ""}`);
       p.log.success("Skill installed");

--- a/src/setup/rules-step.test.ts
+++ b/src/setup/rules-step.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SetupProvider } from "../mcp/providers";
+
+const {
+  mockFetchDosuRule,
+  mockInstallRuleForAgent,
+  mockRemoveRuleForAgent,
+  mockIsRuleAgent,
+  mockRulePathForAgent,
+} = vi.hoisted(() => ({
+  mockFetchDosuRule: vi.fn(),
+  mockInstallRuleForAgent: vi.fn(),
+  mockRemoveRuleForAgent: vi.fn(),
+  mockIsRuleAgent: vi.fn(),
+  mockRulePathForAgent: vi.fn(),
+}));
+
+vi.mock("../rules/installer", () => ({
+  fetchDosuRule: mockFetchDosuRule,
+  installRuleForAgent: mockInstallRuleForAgent,
+  removeRuleForAgent: mockRemoveRuleForAgent,
+  isRuleAgent: mockIsRuleAgent,
+  rulePathForAgent: mockRulePathForAgent,
+}));
+
+vi.mock("../debug/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@clack/prompts", () => ({
+  log: {
+    success: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import * as p from "@clack/prompts";
+import { stepConfigureAgentRules } from "./rules-step";
+
+function makeProvider(id: string): SetupProvider {
+  return {
+    id: () => id,
+    name: () => `Agent ${id}`,
+    supportsLocal: () => true,
+    install: vi.fn(),
+    remove: vi.fn(),
+    detectPaths: () => [],
+    isInstalled: () => true,
+    isConfigured: () => false,
+    globalConfigPath: () => `/config/${id}`,
+    priority: () => 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchDosuRule.mockResolvedValue("canonical rule\n");
+  mockIsRuleAgent.mockImplementation((agent: string) =>
+    ["claude", "cursor", "codex", "opencode", "gemini", "antigravity"].includes(agent),
+  );
+  mockRulePathForAgent.mockImplementation((agent: string) =>
+    agent === "gemini" || agent === "antigravity" ? "/rules/GEMINI.md" : `/rules/${agent}.md`,
+  );
+  mockInstallRuleForAgent.mockImplementation((agent: string) => ({
+    agent,
+    action: "created",
+    path: mockRulePathForAgent(agent),
+  }));
+  mockRemoveRuleForAgent.mockImplementation((agent: string) => ({
+    agent,
+    action: "removed",
+    path: mockRulePathForAgent(agent),
+  }));
+});
+
+describe("stepConfigureAgentRules", () => {
+  it("installs one fetched rule for every successfully configured supported agent", async () => {
+    const claude = makeProvider("claude");
+    const cursor = makeProvider("cursor");
+    const windsurf = makeProvider("windsurf");
+    const selection = {
+      toInstall: [claude, cursor, windsurf],
+      toRemove: [],
+    };
+    const mcpResults = [
+      { provider: claude, action: "install" as const },
+      { provider: cursor, action: "install" as const },
+      { provider: windsurf, action: "install" as const },
+    ];
+
+    const results = await stepConfigureAgentRules(selection, mcpResults);
+
+    expect(mockFetchDosuRule).toHaveBeenCalledTimes(1);
+    expect(mockInstallRuleForAgent).toHaveBeenCalledTimes(2);
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n");
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("cursor", "canonical rule\n");
+    expect(results).toHaveLength(2);
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Rules ready for 2 agent"));
+  });
+
+  it("does not install a rule when MCP configuration failed", async () => {
+    const claude = makeProvider("claude");
+
+    const results = await stepConfigureAgentRules({ toInstall: [claude], toRemove: [] }, [
+      { provider: claude, action: "install", error: new Error("disk full") },
+    ]);
+
+    expect(results).toEqual([]);
+    expect(mockFetchDosuRule).not.toHaveBeenCalled();
+    expect(mockInstallRuleForAgent).not.toHaveBeenCalled();
+  });
+
+  it("removes the rule after a successful MCP removal", async () => {
+    const codex = makeProvider("codex");
+
+    const results = await stepConfigureAgentRules({ toInstall: [], toRemove: [codex] }, [
+      { provider: codex, action: "remove" },
+    ]);
+
+    expect(mockRemoveRuleForAgent).toHaveBeenCalledWith("codex");
+    expect(results).toEqual([
+      expect.objectContaining({ provider: codex, action: "removed", path: "/rules/codex.md" }),
+    ]);
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Rules removed from 1 agent"));
+  });
+
+  it("keeps a shared GEMINI.md rule when the other Gemini-family agent remains selected", async () => {
+    const gemini = makeProvider("gemini");
+    const antigravity = makeProvider("antigravity");
+
+    await stepConfigureAgentRules({ toInstall: [gemini], toRemove: [antigravity] }, [
+      { provider: gemini, action: "install" },
+      { provider: antigravity, action: "remove" },
+    ]);
+
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("gemini", "canonical rule\n");
+    expect(mockRemoveRuleForAgent).not.toHaveBeenCalled();
+  });
+
+  it("reports one rule failure without preventing other agents from installing", async () => {
+    const claude = makeProvider("claude");
+    const cursor = makeProvider("cursor");
+    mockInstallRuleForAgent
+      .mockImplementationOnce(() => {
+        throw new Error("permission denied");
+      })
+      .mockImplementationOnce((agent: string) => ({
+        agent,
+        action: "created",
+        path: "/rules/cursor.md",
+      }));
+
+    const results = await stepConfigureAgentRules({ toInstall: [claude, cursor], toRemove: [] }, [
+      { provider: claude, action: "install" },
+      { provider: cursor, action: "install" },
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].error?.message).toBe("permission denied");
+    expect(results[1]).toMatchObject({ action: "created", path: "/rules/cursor.md" });
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("permission denied"));
+  });
+
+  it("reports a rule removal failure without throwing", async () => {
+    const codex = makeProvider("codex");
+    mockRemoveRuleForAgent.mockImplementationOnce(() => {
+      throw new Error("read only");
+    });
+
+    const results = await stepConfigureAgentRules({ toInstall: [], toRemove: [codex] }, [
+      { provider: codex, action: "remove" },
+    ]);
+
+    expect(results[0]).toMatchObject({ action: "not_found", path: "/rules/codex.md" });
+    expect(results[0].error?.message).toBe("read only");
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("read only"));
+  });
+});

--- a/src/setup/rules-step.test.ts
+++ b/src/setup/rules-step.test.ts
@@ -99,6 +99,8 @@ describe("stepConfigureAgentRules", () => {
     expect(mockInstallRuleForAgent).toHaveBeenCalledWith("cursor", "canonical rule\n");
     expect(results).toHaveLength(2);
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Rules ready for 2 agent"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Agent claude"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/rules/claude.md"));
   });
 
   it("does not install a rule when MCP configuration failed", async () => {

--- a/src/setup/rules-step.ts
+++ b/src/setup/rules-step.ts
@@ -1,0 +1,141 @@
+/**
+ * Setup integration for agent rules.
+ *
+ * MCP configuration remains the source of agent selection. Every successfully
+ * configured supported agent receives the same Dosu rule automatically; an
+ * agent removed from setup has its rule removed as well.
+ */
+
+import * as p from "@clack/prompts";
+import { logger } from "../debug/logger";
+import type { SetupProvider } from "../mcp/providers";
+import {
+  fetchDosuRule,
+  installRuleForAgent,
+  isRuleAgent,
+  type RuleAction,
+  removeRuleForAgent,
+  rulePathForAgent,
+} from "../rules/installer";
+import { dim } from "./styles";
+
+interface SetupSelection {
+  toInstall: SetupProvider[];
+  toRemove: SetupProvider[];
+}
+
+interface McpResult {
+  provider: SetupProvider;
+  action: "install" | "remove" | "skip";
+  error?: Error;
+}
+
+export interface AgentRuleSetupResult {
+  provider: SetupProvider;
+  action: RuleAction;
+  path: string;
+  error?: Error;
+}
+
+function successfulAgentIDs(results: McpResult[], action: "install" | "remove"): Set<string> {
+  return new Set(
+    results
+      .filter((result) => result.action === action && !result.error)
+      .map((result) => result.provider.id()),
+  );
+}
+
+function logRuleResults(results: AgentRuleSetupResult[]): void {
+  const ready = results.filter(
+    (result) =>
+      !result.error &&
+      (result.action === "created" || result.action === "updated" || result.action === "unchanged"),
+  );
+  const removed = results.filter((result) => !result.error && result.action === "removed");
+
+  if (ready.length > 0) {
+    const lines = ready
+      .map((result) => `+ ${result.provider.name()}\n  ${dim(result.path)}`)
+      .join("\n");
+    p.log.success(`Rules ready for ${ready.length} agent(s):\n${lines}`);
+  }
+
+  if (removed.length > 0) {
+    const lines = removed
+      .map((result) => `- ${result.provider.name()}\n  ${dim(result.path)}`)
+      .join("\n");
+    p.log.info(`Rules removed from ${removed.length} agent(s):\n${lines}`);
+  }
+}
+
+export async function stepConfigureAgentRules(
+  selection: SetupSelection,
+  mcpResults: McpResult[],
+): Promise<AgentRuleSetupResult[]> {
+  const successfulInstalls = successfulAgentIDs(mcpResults, "install");
+  const successfulRemovals = successfulAgentIDs(mcpResults, "remove");
+  const toInstall = selection.toInstall.filter(
+    (provider) => successfulInstalls.has(provider.id()) && isRuleAgent(provider.id()),
+  );
+  const toRemove = selection.toRemove.filter(
+    (provider) => successfulRemovals.has(provider.id()) && isRuleAgent(provider.id()),
+  );
+  const results: AgentRuleSetupResult[] = [];
+
+  if (toInstall.length > 0) {
+    const content = await fetchDosuRule();
+    for (const provider of toInstall) {
+      try {
+        const installed = installRuleForAgent(provider.id(), content);
+        if (installed) results.push({ provider, action: installed.action, path: installed.path });
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        logger.error(
+          "setup",
+          `Rule install failed for ${provider.name()}: ${error.stack ?? error.message}`,
+        );
+        p.log.error(`Failed to install ${provider.name()} rule: ${error.message}`);
+        results.push({
+          provider,
+          action: "not_found",
+          path: rulePathForAgent(provider.id()) ?? "",
+          error,
+        });
+      }
+    }
+  }
+
+  // Gemini CLI and Antigravity intentionally share ~/.gemini/GEMINI.md.
+  // Keep the shared section if either selected agent still needs it.
+  const retainedPaths = new Set(
+    toInstall
+      .map((provider) => rulePathForAgent(provider.id()))
+      .filter((path): path is string => path !== null),
+  );
+
+  for (const provider of toRemove) {
+    const path = rulePathForAgent(provider.id());
+    if (path && retainedPaths.has(path)) continue;
+
+    try {
+      const removed = removeRuleForAgent(provider.id());
+      if (removed) results.push({ provider, action: removed.action, path: removed.path });
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.error(
+        "setup",
+        `Rule removal failed for ${provider.name()}: ${error.stack ?? error.message}`,
+      );
+      p.log.error(`Failed to remove ${provider.name()} rule: ${error.message}`);
+      results.push({
+        provider,
+        action: "not_found",
+        path: path ?? "",
+        error,
+      });
+    }
+  }
+
+  logRuleResults(results);
+  return results;
+}

--- a/src/setup/rules-step.ts
+++ b/src/setup/rules-step.ts
@@ -17,7 +17,7 @@ import {
   removeRuleForAgent,
   rulePathForAgent,
 } from "../rules/installer";
-import { dim } from "./styles";
+import { formatSetupSummary, IconRemove } from "./styles";
 
 interface SetupSelection {
   toInstall: SetupProvider[];
@@ -54,17 +54,22 @@ function logRuleResults(results: AgentRuleSetupResult[]): void {
   const removed = results.filter((result) => !result.error && result.action === "removed");
 
   if (ready.length > 0) {
-    const lines = ready
-      .map((result) => `+ ${result.provider.name()}\n  ${dim(result.path)}`)
-      .join("\n");
-    p.log.success(`Rules ready for ${ready.length} agent(s):\n${lines}`);
+    p.log.success(
+      formatSetupSummary(
+        `Rules ready for ${ready.length} agent(s):`,
+        ready.map((result) => ({ label: result.provider.name(), path: result.path })),
+      ),
+    );
   }
 
   if (removed.length > 0) {
-    const lines = removed
-      .map((result) => `- ${result.provider.name()}\n  ${dim(result.path)}`)
-      .join("\n");
-    p.log.info(`Rules removed from ${removed.length} agent(s):\n${lines}`);
+    p.log.info(
+      formatSetupSummary(
+        `Rules removed from ${removed.length} agent(s):`,
+        removed.map((result) => ({ label: result.provider.name(), path: result.path })),
+        IconRemove,
+      ),
+    );
   }
 }
 

--- a/src/setup/styles.test.ts
+++ b/src/setup/styles.test.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import {
   bold,
@@ -72,10 +73,12 @@ describe("styles", () => {
     });
 
     it("formats labeled installation paths with optional status", () => {
-      const summary = formatSetupSummary("Skill ready for 2 agent(s):", [
-        { label: "Claude Code", path: "/tmp/claude/skills/dosu", status: "symlink" },
-        { label: "Codex CLI", path: "/tmp/agents/skills/dosu" },
-      ]);
+      const summary = stripVTControlCharacters(
+        formatSetupSummary("Skill ready for 2 agent(s):", [
+          { label: "Claude Code", path: "/tmp/claude/skills/dosu", status: "symlink" },
+          { label: "Codex CLI", path: "/tmp/agents/skills/dosu" },
+        ]),
+      );
 
       expect(summary).toContain("Skill ready for 2 agent(s):");
       expect(summary).toContain("+ Claude Code\n  /tmp/claude/skills/dosu (symlink)");
@@ -84,12 +87,16 @@ describe("styles", () => {
 
     it("formats an unlabeled path and supports a custom marker", () => {
       expect(
-        formatSetupSummary("AGENTS.md", [
-          { path: "/tmp/project/AGENTS.md", status: "already up to date" },
-        ]),
+        stripVTControlCharacters(
+          formatSetupSummary("AGENTS.md", [
+            { path: "/tmp/project/AGENTS.md", status: "already up to date" },
+          ]),
+        ),
       ).toContain("+ /tmp/project/AGENTS.md (already up to date)");
       expect(
-        formatSetupSummary("Removed", [{ label: "Codex CLI", path: "/tmp/config" }], IconRemove),
+        stripVTControlCharacters(
+          formatSetupSummary("Removed", [{ label: "Codex CLI", path: "/tmp/config" }], IconRemove),
+        ),
       ).toContain("- Codex CLI\n  /tmp/config");
     });
   });

--- a/src/setup/styles.test.ts
+++ b/src/setup/styles.test.ts
@@ -4,6 +4,7 @@ import {
   browserFallbackHint,
   dim,
   error,
+  formatSetupSummary,
   IconAdd,
   IconError,
   IconQuestion,
@@ -68,6 +69,28 @@ describe("styles", () => {
       const hint = browserFallbackHint("https://example.com/auth?x=1");
       expect(hint).toContain("If your browser doesn't open automatically, visit:\n");
       expect(hint).toContain("https://example.com/auth?x=1");
+    });
+
+    it("formats labeled installation paths with optional status", () => {
+      const summary = formatSetupSummary("Skill ready for 2 agent(s):", [
+        { label: "Claude Code", path: "/tmp/claude/skills/dosu", status: "symlink" },
+        { label: "Codex CLI", path: "/tmp/agents/skills/dosu" },
+      ]);
+
+      expect(summary).toContain("Skill ready for 2 agent(s):");
+      expect(summary).toContain("+ Claude Code\n  /tmp/claude/skills/dosu (symlink)");
+      expect(summary).toContain("+ Codex CLI\n  /tmp/agents/skills/dosu");
+    });
+
+    it("formats an unlabeled path and supports a custom marker", () => {
+      expect(
+        formatSetupSummary("AGENTS.md", [
+          { path: "/tmp/project/AGENTS.md", status: "already up to date" },
+        ]),
+      ).toContain("+ /tmp/project/AGENTS.md (already up to date)");
+      expect(
+        formatSetupSummary("Removed", [{ label: "Codex CLI", path: "/tmp/config" }], IconRemove),
+      ).toContain("- Codex CLI\n  /tmp/config");
     });
   });
 

--- a/src/setup/styles.ts
+++ b/src/setup/styles.ts
@@ -32,6 +32,24 @@ export function dim(msg: string): string {
   return pc.dim(msg);
 }
 
+export interface SetupSummaryItem {
+  label?: string;
+  path: string;
+  status?: string;
+}
+
+export function formatSetupSummary(
+  title: string,
+  items: readonly SetupSummaryItem[],
+  marker: string = IconAdd,
+): string {
+  const lines = items.map((item) => {
+    const path = `${item.path}${item.status ? ` (${item.status})` : ""}`;
+    return item.label ? `${marker} ${item.label}\n  ${dim(path)}` : `${marker} ${dim(path)}`;
+  });
+  return `${title}\n${lines.join("\n")}`;
+}
+
 export function bold(msg: string): string {
   return pc.bold(msg);
 }


### PR DESCRIPTION
## Summary

- Collapse setup to a single agent-selection step and automatically install the full Dosu bundle for each selected agent.
- Add idempotent rule installation for Claude Code, Cursor, Codex, OpenCode, Gemini CLI, and Antigravity, backed by the remotely fetched canonical rule with a bundled fallback.
- Align agent-assisted setup, provider-specific skill installation, and project `AGENTS.md` updates with the same bundle.
- Preserve existing LF or CRLF line endings when updating and removing marker-delimited instructions.

## Why

Users previously had to select individual components after selecting agents, which made onboarding fragmented and allowed MCP, skills, and instructions to drift apart. Selecting an agent now expresses the complete intent: configure everything Dosu needs for that agent.

## Testing

- `bun run check`
- `bun run typecheck`
- `bunx vitest run --coverage` (71 files, 1,595 tests; 97.97% statements, 93.13% branches, 98.10% functions, 98.49% lines)
- `bun run build`
- `bun run build:npm`
- `bun run build:all` (7 release targets)
- `npm pack --dry-run --json`
- Installed the generated tarball into a clean npm project and ran `dosu --version`, `dosu setup --help`, and `dosu status`
- Verified all supported rule targets and project `AGENTS.md` through create/update/no-op/remove cycles in an isolated home, including CRLF preservation
- Verified the real `skills` CLI accepts the complete supported agent matrix
