### PR TITLE
feat(status): add machine-readable --json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Or right-click the binary, select "Open", and click "Open" in the dialog.
 | `dosu setup` | Run the setup wizard (auth → deployment → detect tools → configure) |
 | `dosu login` | Authenticate with Dosu via browser OAuth |
 | `dosu logout` | Clear saved credentials |
-| `dosu status` | Show current authentication and MCP status |
+| `dosu status [--json]` | Show current authentication and MCP status |
 | `dosu mcp list` | List supported AI tools |
 | `dosu mcp add <tool>` | Add the Dosu MCP server to a specific tool |
 | `dosu logs` | View or manage debug logs (`--tail`, `--clear`) |

--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -256,7 +256,7 @@ describe("runAgentSetup", () => {
     expect(events.at(-1)).toMatchObject({
       step: "done",
       status: "ok",
-      agent_next_steps: expect.stringContaining("Claude Code"),
+      agent_next_steps: expect.stringMatching(/Claude Code.*dosu status --json/),
     });
   });
 

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -121,7 +121,7 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
 
   emitStep({
     step: "done",
-    agent_next_steps: `Dosu MCP is configured for ${provider.name()}. Tell the user setup is complete and they can ask their agent a Dosu question. Run 'dosu status' to verify.`,
+    agent_next_steps: `Dosu MCP is configured for ${provider.name()}. Tell the user setup is complete and they can ask their agent a Dosu question. Run 'dosu status --json' to verify.`,
   });
   return 0;
 }

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -553,6 +553,106 @@ describe("CLI actions", () => {
       expect(logSpy).toHaveBeenCalledWith("Mode: OSS");
       expect(logSpy).toHaveBeenCalledWith("MCP: Public libraries only");
     });
+
+    it("outputs configured cloud status as JSON without secrets", async () => {
+      saveConfig(authenticatedConfig());
+
+      await run("status", "--json");
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const output = allLogOutput();
+      expect(JSON.parse(output)).toEqual({
+        authenticated: true,
+        session_status: "valid",
+        mode: "cloud",
+        mcp: {
+          status: "configured",
+          deployment_id: "dep_123",
+          deployment_name: "My App",
+        },
+      });
+      expect(output).not.toContain("tok_abc");
+      expect(output).not.toContain("ref_abc");
+      expect(output).not.toContain("key_abc");
+    });
+
+    it("outputs missing authentication as JSON", async () => {
+      await run("status", "--json");
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(allLogOutput())).toEqual({
+        authenticated: false,
+        session_status: "missing",
+        mode: "cloud",
+        mcp: {
+          status: "not_configured",
+          deployment_id: null,
+          deployment_name: null,
+        },
+      });
+    });
+
+    it("outputs an expired session as JSON", async () => {
+      const cfg = authenticatedConfig();
+      testSession(cfg).expires_at = Math.floor(Date.now() / 1000) - 1000;
+      testSession(cfg).refresh_token = "";
+      saveConfig(cfg);
+
+      await run("status", "--json");
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(allLogOutput())).toEqual({
+        authenticated: false,
+        session_status: "expired",
+        mode: "cloud",
+        mcp: {
+          status: "configured",
+          deployment_id: "dep_123",
+          deployment_name: "My App",
+        },
+      });
+    });
+
+    it("outputs an unconfigured cloud MCP as JSON", async () => {
+      const cfg = authenticatedConfig();
+      testTarget(cfg).deployment_id = undefined;
+      testTarget(cfg).deployment_name = undefined;
+      saveConfig(cfg);
+
+      await run("status", "--json");
+
+      expect(JSON.parse(allLogOutput())).toEqual({
+        authenticated: true,
+        session_status: "valid",
+        mode: "cloud",
+        mcp: {
+          status: "not_configured",
+          deployment_id: null,
+          deployment_name: null,
+        },
+      });
+    });
+
+    it("outputs OSS status as JSON", async () => {
+      const cfg = authenticatedConfig();
+      cfg.mode = "oss";
+      testTarget(cfg).deployment_id = undefined;
+      testTarget(cfg).deployment_name = undefined;
+      saveConfig(cfg);
+
+      await run("status", "--json");
+
+      expect(JSON.parse(allLogOutput())).toEqual({
+        authenticated: true,
+        session_status: "valid",
+        mode: "oss",
+        mcp: {
+          status: "public_libraries",
+          deployment_id: null,
+          deployment_name: null,
+        },
+      });
+    });
   });
 
   // ── mcp list ────────────────────────────────────────────────────────────

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -53,6 +53,7 @@ describe("CLI", () => {
     const cmd = program.commands.find((c) => c.name() === "status");
     expect(cmd).toBeDefined();
     expect(cmd?.description()).toContain("status");
+    expect(cmd?.options.find((o) => o.long === "--json")).toBeDefined();
   });
 
   it("has mcp command with add and list subcommands", () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -247,14 +247,66 @@ export function createProgram(): Command {
   program
     .command("status")
     .description("Show current authentication and MCP status")
-    .action(async () => {
+    .option("--json", "Output as JSON")
+    .action(async (opts: { json?: boolean }) => {
       const cfg = loadConfig();
+      const mode = cfg.mode === MODE_OSS ? "oss" : "cloud";
       if (!isAuthenticated(cfg)) {
+        if (opts.json) {
+          console.log(
+            JSON.stringify(
+              {
+                authenticated: false,
+                session_status: "missing",
+                mode,
+                mcp: {
+                  status: "not_configured",
+                  deployment_id: null,
+                  deployment_name: null,
+                },
+              },
+              null,
+              2,
+            ),
+          );
+          return;
+        }
         console.log("Status: Not logged in");
         console.log("Run 'dosu login' to authenticate.");
         return;
       }
-      if (isTokenExpired(cfg) && !(await ensureFreshSession(cfg))) {
+
+      const sessionStatus =
+        isTokenExpired(cfg) && !(await ensureFreshSession(cfg)) ? "expired" : "valid";
+      if (opts.json) {
+        const deploymentId = cfg.active_account.target?.deployment_id ?? null;
+        const deploymentName = cfg.active_account.target?.deployment_name ?? null;
+        const mcpStatus =
+          cfg.mode === MODE_OSS
+            ? "public_libraries"
+            : deploymentId
+              ? "configured"
+              : "not_configured";
+        console.log(
+          JSON.stringify(
+            {
+              authenticated: sessionStatus === "valid",
+              session_status: sessionStatus,
+              mode,
+              mcp: {
+                status: mcpStatus,
+                deployment_id: deploymentId,
+                deployment_name: deploymentName,
+              },
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      if (sessionStatus === "expired") {
         console.log("Status: Token expired");
         console.log("Run 'dosu login' to re-authenticate.");
       } else {


### PR DESCRIPTION
## Summary

- add machine-readable output to `dosu status`
- preserve the existing human output and keep credentials out of JSON
- use structured status verification in agent setup guidance

## Testing

- `bun run check`
- `bunx tsc --noEmit`
- full Vitest suite with coverage (1,567 tests; 97.99% statements)
- standalone, cross-platform, and npm builds plus a binary smoke test
