### PR TITLE
fix(hooks): replace stale knowledge tickets on new turns

### DIFF
--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -158,10 +158,60 @@ describe("runUserPromptSubmit", () => {
     expect(stdout()).toBe("");
   });
 
-  it("reuses a live pending ticket instead of minting a second", async () => {
-    vi.mocked(loadState).mockReturnValue(pending({ expiresAt: 999_999 }));
-    await runUserPromptSubmit({ session_id: "sess", prompt: "another prompt" }, 1000);
+  it("reuses a live pending ticket from the same turn", async () => {
+    vi.mocked(loadState).mockReturnValue(pending({ turnId: "turn-1", expiresAt: 999_999 }));
+    await runUserPromptSubmit(
+      { session_id: "sess", turn_id: "turn-1", prompt: "same turn retry" },
+      1000,
+    );
     expect(requestCreateTicket).not.toHaveBeenCalled();
+  });
+
+  it("creates a fresh ticket when a pending ticket belongs to a previous turn", async () => {
+    vi.mocked(loadState).mockReturnValue(
+      pending({ ticketId: "kt_old", turnId: "turn-1", expiresAt: 999_999 }),
+    );
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_new",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+
+    await runUserPromptSubmit(
+      { session_id: "sess", turn_id: "turn-2", prompt: "new question" },
+      2000,
+    );
+
+    expect(requestCreateTicket).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ turn_id: "turn-2", prompt: "new question" }),
+    );
+    expect(saveState).toHaveBeenCalledWith(
+      expect.objectContaining({ ticketId: "kt_new", turnId: "turn-2" }),
+    );
+  });
+
+  it("treats a later submit without turn ids as a new turn", async () => {
+    vi.mocked(loadState).mockReturnValue(
+      pending({ ticketId: "kt_old", turnId: "2000", expiresAt: 999_999 }),
+    );
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_new",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+
+    await runUserPromptSubmit({ session_id: "sess", prompt: "new question" }, 2000);
+
+    expect(requestCreateTicket).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ turn_id: "2000", prompt: "new question" }),
+    );
+    expect(saveState).toHaveBeenCalledWith(
+      expect.objectContaining({ ticketId: "kt_new", turnId: "2000" }),
+    );
   });
 
   it("is silent and writes no state when create fails", async () => {

--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -40,7 +40,7 @@ vi.mock("../hooks/runtime", () => ({
 import { Client } from "../client/client";
 import { loadConfig, MODE_OSS } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
-import { loadState, saveState, type TicketState } from "../hooks/state";
+import { clearState, loadState, saveState, type TicketState } from "../hooks/state";
 import { requestCreateTicket, requestGetTicket, TicketHttpError } from "../hooks/ticket-client";
 import {
   collectDoctorChecks,
@@ -165,6 +165,7 @@ describe("runUserPromptSubmit", () => {
       1000,
     );
     expect(requestCreateTicket).not.toHaveBeenCalled();
+    expect(clearState).not.toHaveBeenCalled();
   });
 
   it("creates a fresh ticket when a pending ticket belongs to a previous turn", async () => {
@@ -187,6 +188,7 @@ describe("runUserPromptSubmit", () => {
       expect.anything(),
       expect.objectContaining({ turn_id: "turn-2", prompt: "new question" }),
     );
+    expect(clearState).toHaveBeenCalledWith("sess");
     expect(saveState).toHaveBeenCalledWith(
       expect.objectContaining({ ticketId: "kt_new", turnId: "turn-2" }),
     );
@@ -214,12 +216,24 @@ describe("runUserPromptSubmit", () => {
     );
   });
 
-  it("is silent and writes no state when create fails", async () => {
-    vi.mocked(loadState).mockReturnValue(null);
+  it("clears the previous turn when creating its replacement fails", async () => {
+    vi.mocked(loadState).mockReturnValue(pending({ turnId: "turn-1" }));
     vi.mocked(requestCreateTicket).mockRejectedValue(new TicketHttpError(500));
-    await runUserPromptSubmit({ session_id: "sess", prompt: "x" });
+    await runUserPromptSubmit({ session_id: "sess", turn_id: "turn-2", prompt: "x" });
+    expect(clearState).toHaveBeenCalledWith("sess");
     expect(saveState).not.toHaveBeenCalled();
     expect(stdout()).toBe("");
+  });
+
+  it("clears the previous turn before returning when configuration is missing", async () => {
+    vi.mocked(loadState).mockReturnValue(pending({ turnId: "turn-1" }));
+    vi.mocked(loadConfig).mockReturnValue(authed({ deployment_id: undefined }));
+
+    await runUserPromptSubmit({ session_id: "sess", turn_id: "turn-2", prompt: "x" });
+
+    expect(clearState).toHaveBeenCalledWith("sess");
+    expect(requestCreateTicket).not.toHaveBeenCalled();
+    expect(saveState).not.toHaveBeenCalled();
   });
 
   it("no-ops when the prompt field is absent entirely", async () => {

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -125,9 +125,18 @@ export async function runUserPromptSubmit(
     return;
   }
 
-  // One active ticket per session: reuse a live pending ticket; don't mint a second.
+  const turnId = input.turn_id ?? String(now);
+
+  // Reuse only a duplicate submit from the same turn. A new turn must replace
+  // the session's active ticket so its Stop hook cannot inject stale context.
   const existing = loadState(sessionId);
-  if (existing && existing.status === "pending" && now <= existing.expiresAt) {
+  if (
+    existing &&
+    existing.status === "pending" &&
+    now <= existing.expiresAt &&
+    input.turn_id !== undefined &&
+    existing.turnId === turnId
+  ) {
     logger.debug("hooks", `submit sid=${sid8(sessionId)} reuse tid=${existing.ticketId}`);
     return;
   }
@@ -146,7 +155,7 @@ export async function runUserPromptSubmit(
       deployment_id: cfg.active_account?.target?.deployment_id,
       agent,
       session_id: sessionId,
-      turn_id: input.turn_id ?? String(now),
+      turn_id: turnId,
       prompt,
       repo: repoSlug(input.cwd),
     });
@@ -158,7 +167,7 @@ export async function runUserPromptSubmit(
   saveState({
     ticketId: resp.ticket_id,
     sessionId,
-    turnId: input.turn_id ?? String(now),
+    turnId,
     status: "pending",
     createdAt: now,
     expiresAt: now + ttlMs(),

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -24,7 +24,7 @@ import { Argument, Command } from "commander";
 import { isAuthenticated, loadConfig, MODE_OSS } from "../config/config";
 import { logger } from "../debug/logger";
 import { STOP_PREFIX } from "../hooks/prompts";
-import { loadState, saveState, type TicketState } from "../hooks/state";
+import { clearState, loadState, saveState, type TicketState } from "../hooks/state";
 
 interface HookInput {
   session_id?: string;
@@ -140,6 +140,10 @@ export async function runUserPromptSubmit(
     logger.debug("hooks", `submit sid=${sid8(sessionId)} reuse tid=${existing.ticketId}`);
     return;
   }
+
+  // A new turn supersedes the session's prior ticket even if configuration or
+  // network failures prevent its replacement from being created.
+  if (existing) clearState(sessionId);
 
   const cfg = loadConfig();
   if (!cfg.active_account?.target?.api_key || !cfg.active_account?.target?.deployment_id) {


### PR DESCRIPTION
### Description

Pending knowledge tickets were reused by session without checking the turn, so a later prompt could receive context from an earlier turn.

- Reuse a pending ticket only for the same explicit `turn_id`
- Create and store a fresh ticket for new turns, including clients that omit `turn_id`

### Review

- [x] I self-reviewed this PR
- [ ] I reviewed the AI code review comments
- [x] I used a coding agent to generate (most of) this PR

### Testing

- [x] I added/updated tests
- [ ] I manually tested

- `bun run test`
- `bun run typecheck`
- `bun run check`
