### PR TITLE
docs: document Homebrew 6 tap trust in the Homebrew install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,15 @@ dosu setup
 brew install dosu-ai/dosu/dosu
 ```
 
-Or tap first:
+The fully qualified name works on every Homebrew version: it taps the repo if needed and, on Homebrew 6.0+, records trust for just the `dosu` formula. To use tapped short names instead:
 
 ```bash
 brew tap dosu-ai/dosu
+brew trust dosu-ai/dosu   # Homebrew 6.0+ only — skip on older versions
 brew install dosu
 ```
+
+**Homebrew 6.0+ only** ([tap trust](https://docs.brew.sh/Tap-Trust), since June 2026): third-party taps start untrusted, so short-name installs or upgrades — including on machines that tapped `dosu-ai/dosu` before upgrading Homebrew — fail with `Error: Refusing to load formula dosu-ai/dosu/dosu from untrusted tap dosu-ai/dosu` until a one-time `brew trust dosu-ai/dosu` (the tap also ships [decant](https://github.com/dosu-ai/decant)). Homebrew 5 and earlier has no trust step and needs none. Tap trust is Homebrew's own consent step, separate from the macOS Gatekeeper warning below — Homebrew installs never trigger Gatekeeper.
 
 ### Manual Download
 


### PR DESCRIPTION
## Summary

Document Homebrew 6's [tap trust](https://docs.brew.sh/Tap-Trust) in the README's Homebrew section. The fully qualified `brew install dosu-ai/dosu/dosu` stays the primary instruction — it works on every Homebrew version (on 6.0+ it taps the repo if needed and records trust for just the `dosu` formula) — and the `brew trust` step is scoped to the Homebrew 6.0+ tapped/short-name flow, with a line separating tap trust from the existing macOS Gatekeeper note. Matches the pattern the Databricks and coveralls taps adopted.

## Why

Since Homebrew 6.0 (June 2026), third-party taps start untrusted and short-name installs or upgrades fail with `Error: Refusing to load formula dosu-ai/dosu/dosu from untrusted tap dosu-ai/dosu` — including on machines that tapped before upgrading Homebrew. Homebrew 5 and earlier has no trust step (`brew trust` only exists from 5.1.15), so the step is explicitly marked "Homebrew 6.0+ only" rather than unconditional.

## Validation

Docs-only. Verified on Homebrew 6.0.14 against the live tap: short-name install on the untrusted tap refuses with the error above; fully qualified install auto-taps, installs non-interactively, and records formula-only trust; `brew trust` is idempotent.

https://claude.ai/code/session_01EDD3rCJYjmQVVsBWcnZGSP
