### PR TITLE
feat(hooks): send git remote and branch with knowledge tickets

### DIFF
--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -1,7 +1,14 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(() => {
+    throw new Error("git unavailable");
+  }),
+}));
 
 vi.mock("../debug/logger", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), init: vi.fn() },
@@ -156,6 +163,70 @@ describe("runUserPromptSubmit", () => {
     await runUserPromptSubmit({ session_id: "s", prompt: "real" });
     expect(requestCreateTicket).not.toHaveBeenCalled();
     expect(stdout()).toBe("");
+  });
+
+  it("sends the git remote url and current branch when available", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_git",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce("git@github.com:dosu-ai/dosu.git\n")
+      .mockReturnValueOnce("feat-x\n");
+
+    await runUserPromptSubmit({
+      session_id: "sess",
+      prompt: "investigate X",
+      cwd: "/Users/me/work/myrepo",
+    });
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      "git",
+      ["remote", "get-url", "origin"],
+      expect.objectContaining({ cwd: "/Users/me/work/myrepo" }),
+    );
+    expect(requestCreateTicket).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ repo: "git@github.com:dosu-ai/dosu.git", branch: "feat-x" }),
+    );
+  });
+
+  it("omits branch on detached HEAD but keeps the remote url", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_detached",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce("git@github.com:dosu-ai/dosu.git\n")
+      .mockReturnValueOnce("");
+
+    await runUserPromptSubmit({ session_id: "sess", prompt: "x", cwd: "/w/myrepo" });
+
+    const arg = vi.mocked(requestCreateTicket).mock.calls[0][1];
+    expect(arg.repo).toBe("git@github.com:dosu-ai/dosu.git");
+    expect(arg.branch).toBeUndefined();
+  });
+
+  it("falls back to the cwd basename when git is unavailable", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_nogit",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+
+    await runUserPromptSubmit({ session_id: "sess", prompt: "x", cwd: "/w/myrepo" });
+
+    const arg = vi.mocked(requestCreateTicket).mock.calls[0][1];
+    expect(arg.repo).toBe("myrepo");
+    expect(arg.branch).toBeUndefined();
   });
 
   it("reuses a live pending ticket from the same turn", async () => {

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -18,6 +18,7 @@
  * poll is actually required.
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { Argument, Command } from "commander";
@@ -103,6 +104,32 @@ function repoSlug(cwd?: string): string | undefined {
   return cwd ? basename(cwd) : undefined;
 }
 
+/** Git context for retrieval scoping — remote URL + current branch. Best-effort:
+ * a non-git cwd, missing origin, or detached HEAD degrades gracefully (callers
+ * fall back to the basename-only repo slug). Sends the remote identity only,
+ * never a local path. */
+function gitContext(cwd?: string): { repo?: string; branch?: string } {
+  if (!cwd) return {};
+  const run = (args: string[]): string | undefined => {
+    try {
+      const out = execFileSync("git", args, {
+        cwd,
+        timeout: 1500,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      return out.toString().trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  const repo = run(["remote", "get-url", "origin"]);
+  if (!repo) return {};
+  // Empty on detached HEAD — the server aggregates branch notes only when
+  // both repo and branch are present.
+  return { repo, branch: run(["branch", "--show-current"]) };
+}
+
 // ---------------------------------------------------------------------------
 // Hook entrypoint handlers (exported for direct unit testing)
 // ---------------------------------------------------------------------------
@@ -151,6 +178,7 @@ export async function runUserPromptSubmit(
     return; // a hook never prompts the user; `doctor` surfaces this
   }
 
+  const git = gitContext(input.cwd);
   const tc = await import("../hooks/ticket-client");
   const startedAt = Date.now();
   let resp: import("../hooks/ticket-client").CreateTicketResponse;
@@ -161,7 +189,8 @@ export async function runUserPromptSubmit(
       session_id: sessionId,
       turn_id: turnId,
       prompt,
-      repo: repoSlug(input.cwd),
+      repo: git.repo ?? repoSlug(input.cwd),
+      branch: git.branch,
     });
   } catch (err) {
     logger.warn("hooks", `error event=user-prompt-submit reason=${errMsg(err)}`);

--- a/src/hooks/ticket-client.ts
+++ b/src/hooks/ticket-client.ts
@@ -25,6 +25,7 @@ export interface CreateTicketRequest {
   prompt: string;
   cwd?: string | null;
   repo?: string | null;
+  branch?: string | null;
   data_source_ids?: string[] | null;
 }
 


### PR DESCRIPTION
## Summary

- knowledge-ticket hooks now send the repo's `git remote get-url origin` and current branch with each ticket, so the server can aggregate branch-scoped notes into hook injections (server side: dosu-ai/dosu#11892)
- best-effort with graceful degradation: non-git cwd, missing origin, or a failing git binary falls back to the existing basename-only `repo`; detached HEAD sends the remote without a branch
- privacy unchanged: the remote identity is sent, never a local path

## Testing

- `bun run test` (1,614 tests) — new cases cover remote+branch sent, detached-HEAD omitting branch, and the no-git basename fallback
- `bun run typecheck`
- `bun run check`