### PR TITLE
feat(hooks): exactly-once delivery and late-result harvest

### DIFF
--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -18,6 +18,8 @@ vi.mock("../hooks/state", () => ({
   loadState: vi.fn(),
   saveState: vi.fn(),
   clearState: vi.fn(),
+  claimState: vi.fn(),
+  releaseState: vi.fn(),
 }));
 
 vi.mock("../hooks/ticket-client", async (importOriginal) => {
@@ -47,7 +49,7 @@ vi.mock("../hooks/runtime", () => ({
 import { Client } from "../client/client";
 import { loadConfig, MODE_OSS } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
-import { clearState, loadState, saveState, type TicketState } from "../hooks/state";
+import { claimState, loadState, releaseState, saveState, type TicketState } from "../hooks/state";
 import { requestCreateTicket, requestGetTicket, TicketHttpError } from "../hooks/ticket-client";
 import {
   collectDoctorChecks,
@@ -106,6 +108,9 @@ function stdout(): string {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(loadConfig).mockReturnValue({ ...AUTHED });
+  // Default: a claim wins whatever loadState currently returns (tests override
+  // with mockReturnValue(null) to simulate a rival holder).
+  vi.mocked(claimState).mockImplementation((sid) => vi.mocked(loadState)(sid));
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 });
@@ -229,6 +234,80 @@ describe("runUserPromptSubmit", () => {
     expect(arg.branch).toBeUndefined();
   });
 
+  it("harvests a finished undelivered previous ticket with provenance", async () => {
+    vi.mocked(loadState).mockReturnValue(pending({ ticketId: "kt_old", turnId: "turn-1" }));
+    vi.mocked(requestGetTicket).mockResolvedValue(readyResp("OLD RESULT"));
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_new",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+
+    await runUserPromptSubmit(
+      { session_id: "sess", turn_id: "turn-2", prompt: "new question" },
+      2000,
+    );
+
+    // old result injected once, labeled as answering the PREVIOUS prompt
+    expect(requestGetTicket).toHaveBeenCalledWith(expect.anything(), "kt_old");
+    const printed = JSON.parse(logSpy.mock.calls[0][0]);
+    const context = printed.hookSpecificOutput.additionalContext;
+    expect(context).toContain("PREVIOUS prompt");
+    expect(context).toContain("OLD RESULT");
+    expect(context).toContain("background knowledge lookup"); // new lookup note too
+    // the old ticket is consumed, the new one registered
+    expect(releaseState).toHaveBeenCalledWith("sess", null);
+    expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ ticketId: "kt_new" }));
+  });
+
+  it("skips the harvest when the old lookup is still running", async () => {
+    vi.mocked(loadState).mockReturnValue(pending({ ticketId: "kt_old", turnId: "turn-1" }));
+    vi.mocked(requestGetTicket).mockResolvedValue({
+      ticket_id: "kt_old",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+      result: null,
+      error: null,
+    });
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_new",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+
+    await runUserPromptSubmit(
+      { session_id: "sess", turn_id: "turn-2", prompt: "new question" },
+      2000,
+    );
+
+    const printed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(printed.hookSpecificOutput.additionalContext).not.toContain("PREVIOUS prompt");
+    expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ ticketId: "kt_new" }));
+  });
+
+  it("creates the new ticket without harvesting when a rival holds the claim", async () => {
+    vi.mocked(loadState).mockReturnValue(pending({ ticketId: "kt_old", turnId: "turn-1" }));
+    vi.mocked(claimState).mockReturnValue(null); // delivery hook owns the old ticket
+    vi.mocked(requestCreateTicket).mockResolvedValue({
+      ticket_id: "kt_new",
+      status: "pending",
+      created_at: "x",
+      expires_at: "y",
+    });
+
+    await runUserPromptSubmit(
+      { session_id: "sess", turn_id: "turn-2", prompt: "new question" },
+      2000,
+    );
+
+    expect(requestGetTicket).not.toHaveBeenCalled();
+    expect(releaseState).not.toHaveBeenCalled();
+    expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ ticketId: "kt_new" }));
+  });
+
   it("reuses a live pending ticket from the same turn", async () => {
     vi.mocked(loadState).mockReturnValue(pending({ turnId: "turn-1", expiresAt: 999_999 }));
     await runUserPromptSubmit(
@@ -236,7 +315,7 @@ describe("runUserPromptSubmit", () => {
       1000,
     );
     expect(requestCreateTicket).not.toHaveBeenCalled();
-    expect(clearState).not.toHaveBeenCalled();
+    expect(claimState).not.toHaveBeenCalled();
   });
 
   it("creates a fresh ticket when a pending ticket belongs to a previous turn", async () => {
@@ -259,7 +338,8 @@ describe("runUserPromptSubmit", () => {
       expect.anything(),
       expect.objectContaining({ turn_id: "turn-2", prompt: "new question" }),
     );
-    expect(clearState).toHaveBeenCalledWith("sess");
+    expect(claimState).toHaveBeenCalledWith("sess");
+    expect(releaseState).toHaveBeenCalledWith("sess", null);
     expect(saveState).toHaveBeenCalledWith(
       expect.objectContaining({ ticketId: "kt_new", turnId: "turn-2" }),
     );
@@ -291,7 +371,7 @@ describe("runUserPromptSubmit", () => {
     vi.mocked(loadState).mockReturnValue(pending({ turnId: "turn-1" }));
     vi.mocked(requestCreateTicket).mockRejectedValue(new TicketHttpError(500));
     await runUserPromptSubmit({ session_id: "sess", turn_id: "turn-2", prompt: "x" });
-    expect(clearState).toHaveBeenCalledWith("sess");
+    expect(releaseState).toHaveBeenCalledWith("sess", null);
     expect(saveState).not.toHaveBeenCalled();
     expect(stdout()).toBe("");
   });
@@ -302,7 +382,7 @@ describe("runUserPromptSubmit", () => {
 
     await runUserPromptSubmit({ session_id: "sess", turn_id: "turn-2", prompt: "x" });
 
-    expect(clearState).toHaveBeenCalledWith("sess");
+    expect(releaseState).toHaveBeenCalledWith("sess", null);
     expect(requestCreateTicket).not.toHaveBeenCalled();
     expect(saveState).not.toHaveBeenCalled();
   });
@@ -374,7 +454,8 @@ describe("runPostToolUse", () => {
     vi.mocked(loadState).mockReturnValue(pending());
     vi.mocked(requestGetTicket).mockResolvedValue(readyResp("FAST PATH"));
     await runPostToolUse({ session_id: "sess" }, 50_000);
-    expect(saveState).toHaveBeenCalledWith(
+    expect(releaseState).toHaveBeenCalledWith(
+      "sess",
       expect.objectContaining({ status: "delivered", deliveredAt: 50_000 }),
     );
     const printed = JSON.parse(logSpy.mock.calls[0][0]);
@@ -409,7 +490,10 @@ describe("runPostToolUse", () => {
       error: null,
     });
     await runPostToolUse({ session_id: "sess" }, 50_000);
-    expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ status: "delivered" }));
+    expect(releaseState).toHaveBeenCalledWith(
+      "sess",
+      expect.objectContaining({ status: "delivered" }),
+    );
     expect(stdout()).toBe("");
   });
 
@@ -424,7 +508,10 @@ describe("runPostToolUse", () => {
       error: null,
     });
     await runPostToolUse({ session_id: "sess" }, 50_000);
-    expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ lastCheckedAt: 50_000 }));
+    expect(releaseState).toHaveBeenCalledWith(
+      "sess",
+      expect.objectContaining({ lastCheckedAt: 50_000 }),
+    );
     expect(stdout()).toBe("");
   });
 
@@ -432,21 +519,28 @@ describe("runPostToolUse", () => {
     vi.mocked(loadState).mockReturnValue(pending());
     vi.mocked(requestGetTicket).mockRejectedValueOnce(new TicketHttpError(503));
     await runPostToolUse({ session_id: "sess" }, 50_000);
-    expect(saveState).toHaveBeenLastCalledWith(
+    expect(releaseState).toHaveBeenLastCalledWith(
+      "sess",
       expect.objectContaining({ status: "pending", lastCheckedAt: 50_000 }),
     );
     expect(stdout()).toBe("");
 
     vi.mocked(requestGetTicket).mockRejectedValueOnce(new TicketHttpError(404));
     await runPostToolUse({ session_id: "sess" }, 60_000);
-    expect(saveState).toHaveBeenLastCalledWith(expect.objectContaining({ status: "failed" }));
+    expect(releaseState).toHaveBeenLastCalledWith(
+      "sess",
+      expect.objectContaining({ status: "failed" }),
+    );
   });
 
   it("treats a ready response with no result as failed (never injects empty context)", async () => {
     vi.mocked(loadState).mockReturnValue(pending());
     vi.mocked(requestGetTicket).mockResolvedValue({ ...readyResp(), result: null });
     await runPostToolUse({ session_id: "sess" }, 50_000);
-    expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
+    expect(releaseState).toHaveBeenCalledWith(
+      "sess",
+      expect.objectContaining({ status: "failed" }),
+    );
     expect(stdout()).toBe("");
   });
 
@@ -464,6 +558,7 @@ describe("runPostToolUse", () => {
       vi.clearAllMocks();
       vi.mocked(loadConfig).mockReturnValue({ ...AUTHED });
       vi.mocked(loadState).mockReturnValue(pending());
+      vi.mocked(claimState).mockImplementation((sid) => vi.mocked(loadState)(sid));
       vi.mocked(requestGetTicket).mockResolvedValue({
         ticket_id: "kt_1",
         status,
@@ -473,11 +568,21 @@ describe("runPostToolUse", () => {
         error: null,
       });
       await runPostToolUse({ session_id: "sess" }, 50_000);
-      expect(saveState).toHaveBeenCalledWith(
+      expect(releaseState).toHaveBeenCalledWith(
+        "sess",
         expect.objectContaining({ status, lastCheckedAt: 50_000 }),
       );
       expect(stdout()).toBe("");
     }
+  });
+
+  it("exits without polling when another hook holds the claim", async () => {
+    vi.mocked(loadState).mockReturnValue(pending());
+    vi.mocked(claimState).mockReturnValue(null); // rival delivery in flight
+    await runPostToolUse({ session_id: "sess" }, 50_000);
+    expect(requestGetTicket).not.toHaveBeenCalled();
+    expect(releaseState).not.toHaveBeenCalled();
+    expect(stdout()).toBe("");
   });
 
   it("honors a valid DOSU_HOOK_CHECK_COOLDOWN_MS override on the cooldown gate", async () => {
@@ -518,7 +623,10 @@ describe("runStop", () => {
     expect(printed.decision).toBe("block");
     expect(printed.reason).toContain("LATE CONTEXT");
     expect(printed.reason).toContain("Re-check");
-    expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ status: "delivered" }));
+    expect(releaseState).toHaveBeenCalledWith(
+      "sess",
+      expect.objectContaining({ status: "delivered" }),
+    );
   });
 
   it("consumes but does NOT block on a ready gap ticket (empty context)", async () => {
@@ -533,7 +641,10 @@ describe("runStop", () => {
     });
     await runStop({ session_id: "sess" }, 70_000);
     expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
-    expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ status: "delivered" }));
+    expect(releaseState).toHaveBeenCalledWith(
+      "sess",
+      expect.objectContaining({ status: "delivered" }),
+    );
   });
 
   it("continues (no block) when the ticket is still in flight after the wait", async () => {
@@ -548,7 +659,8 @@ describe("runStop", () => {
     });
     await runStop({ session_id: "sess" }, 70_000);
     expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({ continue: true });
-    expect(saveState).toHaveBeenCalledWith(
+    expect(releaseState).toHaveBeenCalledWith(
+      "sess",
       expect.objectContaining({ status: "pending", lastCheckedAt: 70_000 }),
     );
   });

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -25,7 +25,7 @@ import { Argument, Command } from "commander";
 import { isAuthenticated, loadConfig, MODE_OSS } from "../config/config";
 import { logger } from "../debug/logger";
 import { STOP_PREFIX } from "../hooks/prompts";
-import { clearState, loadState, saveState, type TicketState } from "../hooks/state";
+import { claimState, loadState, releaseState, saveState, type TicketState } from "../hooks/state";
 
 interface HookInput {
   session_id?: string;
@@ -169,17 +169,41 @@ export async function runUserPromptSubmit(
   }
 
   // A new turn supersedes the session's prior ticket even if configuration or
-  // network failures prevent its replacement from being created.
-  if (existing) clearState(sessionId);
+  // network failures prevent its replacement from being created. Claim it
+  // (atomic rename) so a concurrent delivery hook can't double-inject what we
+  // may harvest below; the claim is always discarded before the replacement.
+  const claimed = existing ? claimState(sessionId) : null;
 
   const cfg = loadConfig();
   if (!cfg.active_account?.target?.api_key || !cfg.active_account?.target?.deployment_id) {
+    if (claimed) releaseState(sessionId, null);
     logger.debug("hooks", "submit skipped reason=not-configured");
     return; // a hook never prompts the user; `doctor` surfaces this
   }
 
   const git = gitContext(input.cwd);
   const tc = await import("../hooks/ticket-client");
+
+  // Harvest: when the previous turn's lookup finished but was never delivered,
+  // inject it now with provenance instead of throwing the finished work away.
+  let lateBlock: string | undefined;
+  if (claimed && claimed.status === "pending" && now <= claimed.expiresAt) {
+    try {
+      const old = await tc.requestGetTicket(cfg, claimed.ticketId);
+      if (old.status === "ready" && old.result?.context.trim()) {
+        const { buildReadyEnvelope, LATE_RESULT_NOTE } = await import("../hooks/prompts");
+        lateBlock = `${LATE_RESULT_NOTE}\n\n${buildReadyEnvelope(
+          old.result.context,
+          old.result.save_recommended ?? false,
+        )}`;
+        logger.info("hooks", `harvest tid=${claimed.ticketId} delivered=late`);
+      }
+    } catch {
+      // best-effort — a failed harvest never blocks the new lookup
+    }
+  }
+  if (claimed) releaseState(sessionId, null);
+
   const startedAt = Date.now();
   let resp: import("../hooks/ticket-client").CreateTicketResponse;
   try {
@@ -211,7 +235,10 @@ export async function runUserPromptSubmit(
   );
 
   const { LOOKUP_STARTED_NOTE } = await import("../hooks/prompts");
-  printHookContext("UserPromptSubmit", LOOKUP_STARTED_NOTE);
+  printHookContext(
+    "UserPromptSubmit",
+    lateBlock ? `${lateBlock}\n\n${LOOKUP_STARTED_NOTE}` : LOOKUP_STARTED_NOTE,
+  );
 }
 
 /** PostToolUse: poll a pending ticket (throttled) and inject the route map exactly once. */
@@ -245,40 +272,54 @@ export async function runPostToolUse(input: HookInput, now: number = Date.now())
     return;
   }
 
+  // Exactly-once: take the claim before any network. Concurrent hooks (rapid
+  // tool completions racing within one HTTP round-trip) lose the rename and
+  // exit — the winner alone may poll and inject.
+  const claimed = claimState(sessionId);
+  if (!claimed) {
+    logger.debug("hooks", `poll tid=${state.ticketId} skipped=contended`);
+    return;
+  }
+
   const tc = await import("../hooks/ticket-client");
   const startedAt = Date.now();
   let resp: import("../hooks/ticket-client").TicketStatusResponse;
   try {
-    resp = await tc.requestGetTicket(cfg, state.ticketId);
+    resp = await tc.requestGetTicket(cfg, claimed.ticketId);
   } catch (err) {
     if (tc.isDefinitiveError(err)) {
-      saveState({ ...state, status: "failed", lastCheckedAt: now });
+      releaseState(sessionId, { ...claimed, status: "failed", lastCheckedAt: now });
       logger.warn("hooks", `error event=post-tool-use reason=${errMsg(err)} definitive`);
     } else {
-      saveState({ ...state, lastCheckedAt: now }); // transient → retry next tick
-      logger.debug("hooks", `poll tid=${state.ticketId} transient-error`);
+      releaseState(sessionId, { ...claimed, lastCheckedAt: now }); // transient → retry next tick
+      logger.debug("hooks", `poll tid=${claimed.ticketId} transient-error`);
     }
     return;
   }
 
   if (resp.status === "pending") {
-    saveState({ ...state, lastCheckedAt: now });
-    logger.debug("hooks", `poll tid=${state.ticketId} status=pending`);
+    releaseState(sessionId, { ...claimed, lastCheckedAt: now });
+    logger.debug("hooks", `poll tid=${claimed.ticketId} status=pending`);
     return;
   }
   if (resp.status === "failed" || resp.status === "expired") {
-    saveState({ ...state, status: resp.status, lastCheckedAt: now });
+    releaseState(sessionId, { ...claimed, status: resp.status, lastCheckedAt: now });
     return;
   }
   if (!resp.result) {
     // ready but no payload — defensive: treat as failed, never inject empty context.
-    saveState({ ...state, status: "failed", lastCheckedAt: now });
+    releaseState(sessionId, { ...claimed, status: "failed", lastCheckedAt: now });
     return;
   }
 
   // The single delivery moment. Persist `delivered` BEFORE printing so a crash
   // after disk fails toward "no duplicate injection" rather than a re-poll.
-  saveState({ ...state, status: "delivered", deliveredAt: now, lastCheckedAt: now });
+  releaseState(sessionId, {
+    ...claimed,
+    status: "delivered",
+    deliveredAt: now,
+    lastCheckedAt: now,
+  });
   const { buildReadyEnvelope } = await import("../hooks/prompts");
   const context = buildReadyEnvelope(resp.result.context, resp.result.save_recommended ?? false);
   if (context) {
@@ -314,6 +355,11 @@ export async function runStop(input: HookInput, now: number = Date.now()): Promi
   if (!cfg.active_account?.target?.api_key || !cfg.active_account?.target?.deployment_id)
     return printContinue();
 
+  // Exactly-once: hold the claim for the whole bounded wait so an in-flight
+  // PostToolUse from the turn's last tool can't double-inject the same ticket.
+  const claimed = claimState(sessionId);
+  if (!claimed) return printContinue();
+
   const tc = await import("../hooks/ticket-client");
   const pollMs = stopPollMs();
   const maxWaits = pollMs > 0 ? Math.floor(stopWaitMs() / pollMs) : 0;
@@ -321,9 +367,9 @@ export async function runStop(input: HookInput, now: number = Date.now()): Promi
   for (let waited = 0; ; waited++) {
     let resp: import("../hooks/ticket-client").TicketStatusResponse;
     try {
-      resp = await tc.requestGetTicket(cfg, state.ticketId);
+      resp = await tc.requestGetTicket(cfg, claimed.ticketId);
     } catch {
-      saveState({ ...state, lastCheckedAt: now }); // never hold the agent open
+      releaseState(sessionId, { ...claimed, lastCheckedAt: now }); // never hold the agent open
       return printContinue();
     }
 
@@ -331,7 +377,12 @@ export async function runStop(input: HookInput, now: number = Date.now()): Promi
       // Consume the ticket either way, but only BLOCK the agent for real knowledge.
       // A bare save nudge (knowledge gap, empty context) is not worth holding the
       // agent open at Stop — drop it rather than block on nothing actionable.
-      saveState({ ...state, status: "delivered", deliveredAt: now, lastCheckedAt: now });
+      releaseState(sessionId, {
+        ...claimed,
+        status: "delivered",
+        deliveredAt: now,
+        lastCheckedAt: now,
+      });
       if (resp.result.context.trim()) {
         const { buildReadyEnvelope, STOP_PREFIX } = await import("../hooks/prompts");
         const envelope = buildReadyEnvelope(
@@ -339,10 +390,10 @@ export async function runStop(input: HookInput, now: number = Date.now()): Promi
           resp.result.save_recommended ?? false,
         );
         console.log(JSON.stringify({ decision: "block", reason: `${STOP_PREFIX}\n\n${envelope}` }));
-        logger.info("hooks", `stop tid=${state.ticketId} delivered=true`);
+        logger.info("hooks", `stop tid=${claimed.ticketId} delivered=true`);
         return;
       }
-      logger.debug("hooks", `stop tid=${state.ticketId} delivered=true gap-no-block`);
+      logger.debug("hooks", `stop tid=${claimed.ticketId} delivered=true gap-no-block`);
       return printContinue();
     }
 
@@ -351,8 +402,8 @@ export async function runStop(input: HookInput, now: number = Date.now()): Promi
     await sleep(pollMs);
   }
 
-  saveState({ ...state, lastCheckedAt: now });
-  logger.debug("hooks", `stop tid=${state.ticketId} delivered=false`);
+  releaseState(sessionId, { ...claimed, lastCheckedAt: now });
+  logger.debug("hooks", `stop tid=${claimed.ticketId} delivered=false`);
   printContinue();
 }
 

--- a/src/hooks/prompts.ts
+++ b/src/hooks/prompts.ts
@@ -15,6 +15,11 @@ export const LOOKUP_STARTED_NOTE =
   "helps you.";
 
 /** Framing prefix prepended to the Stop hook's blocking reason. */
+export const LATE_RESULT_NOTE =
+  "Heads-up: the context below answers your PREVIOUS prompt — its lookup finished after " +
+  "that turn had already ended. Apply it only where it is still relevant to the current " +
+  "work; do not treat it as a response to the new prompt.";
+
 export const STOP_PREFIX =
   "Dosu knowledge finished after your last action. Re-check your current conclusion against " +
   "it, then continue or finish — do not redo work it merely confirms.";

--- a/src/hooks/state.test.ts
+++ b/src/hooks/state.test.ts
@@ -2,7 +2,16 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } f
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { clearState, getStateDir, loadState, sanitize, saveState, type TicketState } from "./state";
+import {
+  claimState,
+  clearState,
+  getStateDir,
+  loadState,
+  releaseState,
+  sanitize,
+  saveState,
+  type TicketState,
+} from "./state";
 
 function makeState(overrides: Partial<TicketState> = {}): TicketState {
   return {
@@ -16,6 +25,54 @@ function makeState(overrides: Partial<TicketState> = {}): TicketState {
 }
 
 describe("hooks/state", () => {
+  describe("claimState / releaseState", () => {
+    it("exactly one concurrent claimer wins", () => {
+      saveState(makeState());
+      const won = claimState("sess-1");
+      expect(won?.ticketId).toBe("kt_abc");
+      // the slot is empty while claimed: rivals lose, loadState sees nothing
+      expect(claimState("sess-1")).toBeNull();
+      expect(loadState("sess-1")).toBeNull();
+    });
+
+    it("returns null when no state exists", () => {
+      expect(claimState("sess-none")).toBeNull();
+    });
+
+    it("release restores the parked state when the slot is free", () => {
+      saveState(makeState());
+      const won = claimState("sess-1");
+      releaseState("sess-1", { ...(won as TicketState), lastCheckedAt: 1500 });
+      expect(loadState("sess-1")?.lastCheckedAt).toBe(1500);
+      // claim marker is gone — the next claim takes the restored state
+      expect(claimState("sess-1")?.lastCheckedAt).toBe(1500);
+    });
+
+    it("release never clobbers a newer state written meanwhile", () => {
+      saveState(makeState());
+      const won = claimState("sess-1");
+      // a new prompt registered a fresh ticket while we were polling
+      saveState(makeState({ ticketId: "kt_newer" }));
+      releaseState("sess-1", won as TicketState);
+      expect(loadState("sess-1")?.ticketId).toBe("kt_newer");
+    });
+
+    it("release with null discards the parked state", () => {
+      saveState(makeState());
+      claimState("sess-1");
+      releaseState("sess-1", null);
+      expect(loadState("sess-1")).toBeNull();
+      expect(claimState("sess-1")).toBeNull();
+    });
+
+    it("a stale claim from a crashed holder never blocks the next claim", () => {
+      saveState(makeState());
+      claimState("sess-1"); // holder "crashes": never releases
+      saveState(makeState({ ticketId: "kt_after_crash" }));
+      expect(claimState("sess-1")?.ticketId).toBe("kt_after_crash");
+    });
+  });
+
   let tempDir: string;
   let origStateDir: string | undefined;
   let origXdg: string | undefined;

--- a/src/hooks/state.ts
+++ b/src/hooks/state.ts
@@ -7,7 +7,7 @@
  * returns `null` and a write failure is swallowed — a hook must never throw.
  */
 
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getConfigDir } from "../config/config";
 
@@ -74,6 +74,47 @@ export function saveState(state: TicketState): void {
 export function clearState(sessionId: string): void {
   try {
     rmSync(stateFile(sessionId), { force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/** Atomically take exclusive ownership of a session's ticket state.
+ *
+ * `rename(2)` is atomic, so when several hook processes race, exactly one gets
+ * the state back and the rest get `null` (no state, or another holder). The
+ * state is parked in a `.claim` file until `releaseState`; a holder that
+ * crashes leaves only a stale park that the next claim overwrites. Never
+ * throws.
+ */
+export function claimState(sessionId: string): TicketState | null {
+  const file = stateFile(sessionId);
+  try {
+    renameSync(file, `${file}.claim`);
+    return JSON.parse(readFileSync(`${file}.claim`, "utf8")) as TicketState;
+  } catch {
+    return null;
+  }
+}
+
+/** Release a claim taken by `claimState`. Only the claim winner may call this.
+ *
+ * With a state, restores it — but never over a newer state written meanwhile
+ * (`wx` = exclusive create), so a finished old ticket can't resurrect over a
+ * newly registered one. With `null`, the parked state is discarded. Never
+ * throws.
+ */
+export function releaseState(sessionId: string, state: TicketState | null): void {
+  const file = stateFile(sessionId);
+  if (state) {
+    try {
+      writeFileSync(file, JSON.stringify(state, null, 2), { flag: "wx", mode: 0o600 });
+    } catch {
+      // a newer state owns the slot (or the write failed) — discard ours
+    }
+  }
+  try {
+    rmSync(`${file}.claim`, { force: true });
   } catch {
     // best-effort
   }


### PR DESCRIPTION
## Summary

Two changes to the knowledge-ticket delivery path, both built on one primitive — an atomic rename claim over the per-session state file:

- **Exactly-once delivery.** Concurrent hooks (rapid tool completions racing within one HTTP round-trip, or Stop overlapping the turn's last PostToolUse) could each poll the same ready ticket and inject the same context 2–4× (observed in real session logs). Delivery hooks now take the claim before any network: `rename(2)` guarantees exactly one winner; losers exit in microseconds. Not-ready outcomes restore state via an `O_EXCL` write-back, which also can never resurrect an old ticket over one a newer prompt just registered.
- **Late-result harvest.** When a new prompt supersedes a previous ticket whose lookup finished but was never delivered (the incident shape: retrieval outlives the turn), the submit hook now injects that finished result once, labeled as answering the PREVIOUS prompt, instead of discarding the completed work. Claiming first means a concurrent delivery hook can never double-inject what the submit harvests. Fail-closed semantics from 0.37.1 are preserved: the old ticket is always discarded before the replacement is created, even when configuration or the create request fails.

No timers, PIDs, or lock TTLs — a crashed claim holder leaves only a stale park file that the next claim overwrites.

## Testing

- `bun run test` (1,624 tests) — new coverage: single-winner claim semantics, no-clobber restore, stale-claim recovery, contended delivery/submit exits, harvest with provenance, harvest skip while still running
- `bun run typecheck`
- `bun run check`