### PR TITLE
feat(rules): instruct agents to finalize session knowledge receipts

### DIFF
--- a/rules/dosu.md
+++ b/rules/dosu.md
@@ -5,3 +5,5 @@ When `read_knowledge` is listed, call it before non-trivial code or documentatio
 When `write_knowledge` is listed, use it after the task for durable, non-obvious knowledge that future work would otherwise have to rediscover. Do not save task or PR summaries, progress, test results, obvious facts, speculation, duplicates, or sensitive data. **If nothing durable was learned, do not write.**
 
 Use `review_knowledge` only when the user asks to inspect or manage pending knowledge. Preview one item at a time and require explicit confirmation before making changes.
+
+When `read_knowledge` or `write_knowledge` returned a `receipt_item_id` this turn, call `finalize_session_knowledge` exactly once at the end of the turn — after completing the task, immediately before your final reply — passing all receipt_item_ids from this turn. Never call it when the current turn produced no receipt_item_id, and never call it more than once per turn.

--- a/src/rules/installer.ts
+++ b/src/rules/installer.ts
@@ -54,6 +54,8 @@ When \`read_knowledge\` is listed, call it before non-trivial code or documentat
 When \`write_knowledge\` is listed, use it after the task for durable, non-obvious knowledge that future work would otherwise have to rediscover. Do not save task or PR summaries, progress, test results, obvious facts, speculation, duplicates, or sensitive data. **If nothing durable was learned, do not write.**
 
 Use \`review_knowledge\` only when the user asks to inspect or manage pending knowledge. Preview one item at a time and require explicit confirmation before making changes.
+
+When \`read_knowledge\` or \`write_knowledge\` returned a \`receipt_item_id\` this turn, call \`finalize_session_knowledge\` exactly once at the end of the turn — after completing the task, immediately before your final reply — passing all receipt_item_ids from this turn. Never call it when the current turn produced no receipt_item_id, and never call it more than once per turn.
 `;
 
 function claudeConfigDir(): string {


### PR DESCRIPTION
The Dosu MCP server now issues one-time `receipt_item_id` values from `read_knowledge`/`write_knowledge` and renders the Session Knowledge card via `finalize_session_knowledge` (dosu-ai/dosu#11909). This adds the finalize rule to the installed agent rule — both the canonical `rules/dosu.md` (fetched at install time) and the embedded `FALLBACK_DOSU_RULE` — matching the server instructions verbatim. The existing consistency test keeps the two copies in sync.

Should merge after (or together with) dosu-ai/dosu#11909 so installed rules never reference a tool the server doesn't serve yet.