### PR TITLE
fix(ask): honor --timeout beyond the runtime's 300s fetch default

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "semantic-release": "^25.0.5",
         "superjson": "^2.2.6",
         "typescript": "^6.0.3",
+        "undici": "^8.9.0",
         "vitest": "^4.1.9",
         "write-file-atomic": "^8.0.0",
       },
@@ -750,7 +751,7 @@
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@8.9.0", "", {}, "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -811,6 +812,8 @@
     "@semantic-release/github/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
 
     "@semantic-release/github/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
+
+    "@semantic-release/github/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "@semantic-release/npm/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "semantic-release": "^25.0.5",
     "superjson": "^2.2.6",
     "typescript": "^6.0.3",
+    "undici": "^8.9.0",
     "vitest": "^4.1.9",
     "write-file-atomic": "^8.0.0"
   }

--- a/src/client/long-fetch.test.ts
+++ b/src/client/long-fetch.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mockUndiciFetch = vi.fn();
+const mockAgent = vi.fn(function (this: { opts: unknown }, opts: unknown) {
+  this.opts = opts;
+});
+vi.mock("undici", () => ({
+  fetch: (...args: unknown[]) => mockUndiciFetch(...args),
+  Agent: mockAgent,
+}));
+
+import { longFetch } from "./long-fetch";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  mockUndiciFetch.mockReset();
+  mockAgent.mockReset();
+});
+
+describe("longFetch", () => {
+  it("on Node, uses undici fetch with headers/body timeouts disabled", async () => {
+    const bunDescriptor = Object.getOwnPropertyDescriptor(process.versions, "bun");
+    Object.defineProperty(process.versions, "bun", { value: undefined, configurable: true });
+    const resp = new Response("ok");
+    mockUndiciFetch.mockResolvedValueOnce(resp);
+
+    const controller = new AbortController();
+    let result: Response;
+    try {
+      result = await longFetch("https://api.test.dev/ask", {
+        method: "POST",
+        signal: controller.signal,
+      });
+    } finally {
+      if (bunDescriptor) {
+        Object.defineProperty(process.versions, "bun", bunDescriptor);
+      } else {
+        delete (process.versions as Record<string, unknown>).bun;
+      }
+    }
+
+    expect(result).toBe(resp);
+    expect(mockAgent).toHaveBeenCalledWith({ headersTimeout: 0, bodyTimeout: 0 });
+    const [url, init] = mockUndiciFetch.mock.calls[0] as [string, Record<string, unknown>];
+    expect(url).toBe("https://api.test.dev/ask");
+    expect(init.method).toBe("POST");
+    expect(init.signal).toBe(controller.signal);
+    expect(init.dispatcher).toBeInstanceOf(mockAgent);
+  });
+
+  it("on Bun, uses global fetch with the default idle timeout disabled", async () => {
+    const bunDescriptor = Object.getOwnPropertyDescriptor(process.versions, "bun");
+    Object.defineProperty(process.versions, "bun", { value: "1.0.0", configurable: true });
+    const resp = new Response("ok");
+    const globalFetch = vi.fn().mockResolvedValueOnce(resp);
+    vi.stubGlobal("fetch", globalFetch);
+
+    try {
+      const result = await longFetch("https://api.test.dev/ask", { method: "POST" });
+
+      expect(result).toBe(resp);
+      const [url, init] = globalFetch.mock.calls[0] as [string, Record<string, unknown>];
+      expect(url).toBe("https://api.test.dev/ask");
+      expect(init.method).toBe("POST");
+      expect(init.timeout).toBe(false);
+      expect(mockUndiciFetch).not.toHaveBeenCalled();
+    } finally {
+      if (bunDescriptor) {
+        Object.defineProperty(process.versions, "bun", bunDescriptor);
+      } else {
+        delete (process.versions as Record<string, unknown>).bun;
+      }
+    }
+  });
+});

--- a/src/client/long-fetch.ts
+++ b/src/client/long-fetch.ts
@@ -1,0 +1,28 @@
+/**
+ * fetch for long-running requests (e.g. /ask, which responds only when the
+ * synchronous research workflow finishes).
+ *
+ * Both runtimes impose a hidden ~300s timeout underneath any AbortSignal the
+ * caller passes, which made `--timeout 600` die at ~5 minutes:
+ * - Node's fetch (undici) aborts if response headers haven't arrived within
+ *   `headersTimeout` (default 300s).
+ * - Bun's fetch has a 300s idle/connection timeout of its own.
+ *
+ * This wrapper disables those runtime defaults so the caller's AbortSignal is
+ * the only timeout in effect. Callers MUST pass a signal.
+ */
+
+export async function longFetch(url: string, init: RequestInit): Promise<Response> {
+  if (process.versions.bun) {
+    // Bun extension: `timeout: false` disables the default idle timeout.
+    return fetch(url, { ...init, timeout: false } as RequestInit);
+  }
+  // Use the bundled undici's own fetch — Node's global fetch does not accept
+  // a dispatcher constructed from a different undici copy.
+  const { Agent, fetch: undiciFetch } = await import("undici");
+  const dispatcher = new Agent({ headersTimeout: 0, bodyTimeout: 0 });
+  return (await undiciFetch(url, {
+    ...init,
+    dispatcher,
+  } as Parameters<typeof undiciFetch>[1])) as unknown as Response;
+}

--- a/src/commands/ask.test.ts
+++ b/src/commands/ask.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
+vi.mock("../client/long-fetch", () => ({
+  longFetch: (...args: unknown[]) => mockFetch(...args),
+}));
 
 const mockLoadConfig = vi.fn();
 vi.mock("../config/config", () => ({

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -7,6 +7,7 @@
 
 import { Command } from "commander";
 import pc from "picocolors";
+import { longFetch } from "../client/long-fetch";
 import { loadConfig } from "../config/config";
 import { getBackendURL } from "../config/constants";
 import { logger } from "../debug/logger";
@@ -62,7 +63,7 @@ export function askCommand(): Command {
         const timeout = setTimeout(() => controller.abort(), timeoutSeconds * 1_000);
 
         try {
-          const resp = await fetch(`${backendURL}/ask`, {
+          const resp = await longFetch(`${backendURL}/ask`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

Customer report: `dosu ask --timeout 600` was timing out at ~300s. Both runtimes impose a hidden ~300s timeout underneath the caller's `AbortSignal` — Node's fetch (undici) aborts if response headers haven't arrived within `headersTimeout` (default 300s), and Bun's fetch has its own 300s idle timeout — and since `/ask` only sends headers when the research workflow finishes, long questions died at 5 minutes regardless of the flag.

This adds `longFetch()` (`src/client/long-fetch.ts`), which disables those runtime defaults (Bun's `timeout: false` extension; undici's own fetch with `headersTimeout: 0, bodyTimeout: 0` on Node) so the `--timeout`-driven `AbortController` is the only timeout in effect, and switches `dosu ask` to it. `undici` is added to `devDependencies` and gets inlined into the npm bundle per the zero-runtime-deps packaging convention (verified in the built `bin/dosu.js`).

## Testing

Typecheck, Biome, and all 1626 tests pass; new tests cover both the Node and Bun branches of `longFetch`, and `build:npm` produces a working bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)