### PR TITLE
feat(mcp): write stdio mcp-remote configs for Codex and Claude Desktop

### DIFF
--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -15,7 +15,6 @@ const {
   mockLoadConfig,
   mockSaveConfig,
   mockAllSetupProviders,
-  mockIsStdioOnly,
   mockClient,
   mockClientConstructor,
   mockFetchDosuRule,
@@ -32,7 +31,6 @@ const {
     mockLoadConfig: vi.fn(),
     mockSaveConfig: vi.fn(),
     mockAllSetupProviders: vi.fn(),
-    mockIsStdioOnly: vi.fn(),
     mockClient: {
       doRequestRaw: vi.fn(),
       refreshToken: vi.fn(),
@@ -64,10 +62,6 @@ vi.mock("../config/config", async (importOriginal) => ({
 
 vi.mock("../mcp/providers", () => ({
   allSetupProviders: mockAllSetupProviders,
-}));
-
-vi.mock("../setup/flow", () => ({
-  isStdioOnly: mockIsStdioOnly,
 }));
 
 vi.mock("../rules/installer", () => ({
@@ -146,22 +140,21 @@ describe("buildResumeCommand", () => {
 });
 
 describe("listAgentSupportedToolIDs", () => {
-  it("excludes stdio-only providers", () => {
+  it("lists every setup provider id, including Claude Desktop", () => {
     mockAllSetupProviders.mockReturnValue([
       makeProvider("claude"),
       makeProvider("claude-desktop"),
       makeProvider("cursor"),
     ]);
-    mockIsStdioOnly.mockImplementation((p: SetupProvider) => p.id() === "claude-desktop");
 
-    expect(listAgentSupportedToolIDs()).toEqual(["claude", "cursor"]);
+    expect(listAgentSupportedToolIDs()).toEqual(["claude", "claude-desktop", "cursor"]);
   });
 });
 
 describe("runAgentSetup", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
   let claudeProvider: SetupProvider;
-  let stdioProvider: SetupProvider;
+  let desktopProvider: SetupProvider;
 
   function emittedEvents(): Array<Record<string, unknown>> {
     return logSpy.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
@@ -174,7 +167,6 @@ describe("runAgentSetup", () => {
     mockLoadConfig.mockReset();
     mockSaveConfig.mockReset();
     mockAllSetupProviders.mockReset();
-    mockIsStdioOnly.mockReset();
     mockClientConstructor.mockReset();
     mockFetchDosuRule.mockReset();
     mockInstallRuleForAgent.mockReset();
@@ -186,10 +178,9 @@ describe("runAgentSetup", () => {
     for (const fn of Object.values(mockClient)) fn.mockReset();
 
     claudeProvider = makeProvider("claude", { name: () => "Claude Code" });
-    stdioProvider = makeProvider("claude-desktop", { name: () => "Claude Desktop" });
+    desktopProvider = makeProvider("claude-desktop", { name: () => "Claude Desktop" });
 
-    mockAllSetupProviders.mockReturnValue([claudeProvider, stdioProvider]);
-    mockIsStdioOnly.mockImplementation((p: SetupProvider) => p.id() === "claude-desktop");
+    mockAllSetupProviders.mockReturnValue([claudeProvider, desktopProvider]);
     mockLoadConfig.mockReturnValue(makeBaseConfig());
     mockFetchDosuRule.mockResolvedValue("canonical rule\n");
     mockIsRuleAgent.mockImplementation((agent: string) => agent === "claude");
@@ -223,19 +214,6 @@ describe("runAgentSetup", () => {
         status: "error",
         reason: "unknown_tool",
         agent_next_steps: expect.stringContaining("'nope' is not"),
-      }),
-    ]);
-  });
-
-  it("emits tool_unsupported error when the chosen tool is stdio-only", async () => {
-    const code = await runAgentSetup({ tool: "claude-desktop" });
-
-    expect(code).toBe(2);
-    expect(emittedEvents()).toEqual([
-      expect.objectContaining({
-        step: "setup",
-        status: "error",
-        reason: "tool_unsupported_in_agent_mode",
       }),
     ]);
   });

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -25,10 +25,9 @@ import {
 } from "../config/config";
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
-import { allSetupProviders, type SetupProvider } from "../mcp/providers";
+import { allSetupProviders } from "../mcp/providers";
 import { fetchDosuRule, installRuleForAgent, isRuleAgent } from "../rules/installer";
 import { inGitWorkTree, upsertDosuAgentsSection } from "../setup/agents-md-step";
-import { isStdioOnly } from "../setup/flow";
 import { emitError, emitNeedUserAction, emitStep } from "./output";
 
 export interface AgentSetupOptions {
@@ -57,7 +56,6 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   const provider = allSetupProviders().find((p) => p.id() === opts.tool.toLowerCase());
   if (!provider) {
     const available = allSetupProviders()
-      .filter((p) => !isStdioOnly(p))
       .map((p) => p.id())
       .join(", ");
     emitError({
@@ -67,15 +65,6 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     });
     return 2;
   }
-  if (isStdioOnly(provider)) {
-    emitError({
-      step: "setup",
-      reason: "tool_unsupported_in_agent_mode",
-      agent_next_steps: `${provider.name()} is not supported by agent setup. Tell the user to run 'dosu mcp add ${provider.id()}' manually after signing in.`,
-    });
-    return 2;
-  }
-
   // 1. Auth: redeem a ticket if one was provided, otherwise verify any
   //    existing session, otherwise mint a fresh ticket and exit so the
   //    agent can hand the URL to the user.
@@ -500,7 +489,5 @@ export function buildResumeCommand(tool: string, ticket: string, deploymentID?: 
 
 /** Provider listing for `--tool` validation. Exported for tests. */
 export function listAgentSupportedToolIDs(): string[] {
-  return allSetupProviders()
-    .filter((p: SetupProvider) => !isStdioOnly(p))
-    .map((p) => p.id());
+  return allSetupProviders().map((p) => p.id());
 }

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -49,6 +49,21 @@ export function mcpHeaders(apiKey: string | undefined): Record<string, string> {
 }
 
 /**
+ * Builds the `npx mcp-remote` argument list that proxies the remote HTTP MCP
+ * endpoint as a local stdio server. Hosts that only render MCP Apps for
+ * stdio servers (Codex desktop, Claude Desktop chat) need this form — a
+ * remote-HTTP entry serves tools fine but never shows the Session Knowledge
+ * card.
+ */
+export function mcpRemoteArgs(url: string, apiKey: string | undefined): string[] {
+  const headerArgs = Object.entries(mcpHeaders(apiKey)).flatMap(([key, value]) => [
+    "--header",
+    `${key}:${value}`,
+  ]);
+  return ["-y", "mcp-remote", url, ...headerArgs, "--transport", "http-only"];
+}
+
+/**
  * Reads and unmarshals a JSON config file. Returns an empty object if the file doesn't exist.
  * For .jsonc files, comments are stripped before parsing.
  */

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -49,18 +49,47 @@ export function mcpHeaders(apiKey: string | undefined): Record<string, string> {
 }
 
 /**
- * Builds the `npx mcp-remote` argument list that proxies the remote HTTP MCP
+ * Exact-pinned so npx never floats to a fresh release on user machines —
+ * mcp-remote is a third-party package on the agent hot path, and a floating
+ * tag would bypass the supply-chain delay this repo applies to its own
+ * dependencies (bunfig minimumReleaseAge). Bump deliberately.
+ */
+export const MCP_REMOTE_VERSION = "0.1.38";
+
+export interface McpRemoteServer {
+  args: string[];
+  env: Record<string, string>;
+}
+
+/**
+ * Builds the `npx mcp-remote` invocation that proxies the remote HTTP MCP
  * endpoint as a local stdio server. Hosts that only render MCP Apps for
  * stdio servers (Codex desktop, Claude Desktop chat) need this form — a
  * remote-HTTP entry serves tools fine but never shows the Session Knowledge
  * card.
+ *
+ * Header values are passed as `${VAR}` placeholders that mcp-remote expands
+ * from its environment, so the API key lives in the config entry's `env`
+ * block instead of argv (argv is visible to every local process via `ps`).
  */
-export function mcpRemoteArgs(url: string, apiKey: string | undefined): string[] {
-  const headerArgs = Object.entries(mcpHeaders(apiKey)).flatMap(([key, value]) => [
-    "--header",
-    `${key}:${value}`,
-  ]);
-  return ["-y", "mcp-remote", url, ...headerArgs, "--transport", "http-only"];
+export function mcpRemoteServer(url: string, apiKey: string | undefined): McpRemoteServer {
+  const env: Record<string, string> = {};
+  const headerArgs = Object.entries(mcpHeaders(apiKey)).flatMap(([key, value]) => {
+    const envKey = key.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+    env[envKey] = value;
+    return ["--header", `${key}:\${${envKey}}`];
+  });
+  return {
+    args: [
+      "-y",
+      `mcp-remote@${MCP_REMOTE_VERSION}`,
+      url,
+      ...headerArgs,
+      "--transport",
+      "http-only",
+    ],
+    env,
+  };
 }
 
 /**

--- a/src/mcp/detect.ts
+++ b/src/mcp/detect.ts
@@ -4,7 +4,7 @@
 
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 
 /**
  * Checks if any of the given paths exist on the filesystem.
@@ -46,3 +46,34 @@ export function appSupportDir(): string {
   }
 }
 /* v8 ignore stop */
+
+/**
+ * Locates `npx` by absolute path on the current (shell) PATH.
+ *
+ * GUI hosts that spawn config-file stdio servers (Codex desktop, Claude
+ * Desktop) launch them with the minimal launchd PATH that lacks
+ * Homebrew/nvm, so entries must reference npx absolutely and carry a PATH
+ * under which npx's `#!/usr/bin/env node` shebang resolves. Resolved at
+ * install time from the user's shell PATH.
+ */
+export function findNpx(): string {
+  /* v8 ignore next -- platform dispatch, win32 arm not exercised on POSIX CI */
+  const bin = platform() === "win32" ? "npx.cmd" : "npx";
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, bin);
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    "npx not found on PATH — Node.js is required (the MCP entry runs `npx mcp-remote`).",
+  );
+}
+
+/**
+ * PATH value for a spawned stdio entry: npx's own directory first (node
+ * lives beside npx in every common layout) plus the system dirs. The Unix
+ * fallbacks are harmless on Windows.
+ */
+export function npxPathEnv(npx: string): string {
+  return [dirname(npx), "/usr/bin", "/bin"].join(delimiter);
+}

--- a/src/mcp/providers.test.ts
+++ b/src/mcp/providers.test.ts
@@ -54,7 +54,7 @@ describe("provider registry", () => {
       { id: "cursor", name: "Cursor", local: true },
       { id: "vscode", name: "VS Code", local: true },
       { id: "gemini", name: "Gemini CLI", local: true },
-      { id: "codex", name: "Codex CLI", local: true },
+      { id: "codex", name: "Codex (CLI + Desktop)", local: true },
       { id: "windsurf", name: "Windsurf", local: false },
       { id: "zed", name: "Zed", local: true },
       { id: "cline", name: "Cline", local: false },

--- a/src/mcp/providers/claude-desktop.ts
+++ b/src/mcp/providers/claude-desktop.ts
@@ -1,38 +1,18 @@
-import { existsSync } from "node:fs";
-import { delimiter, dirname, join } from "node:path";
+import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
 import {
   installJSONServer,
   isJSONKeyConfigured,
   mcpBaseURL,
-  mcpRemoteArgs,
+  mcpRemoteServer,
   mcpURL,
   removeJSONServer,
 } from "../config-helpers";
-import { appSupportDir, isInstalled } from "../detect";
+import { appSupportDir, findNpx, isInstalled, npxPathEnv } from "../detect";
 import type { SetupProvider } from "../providers";
 
 function configPath(): string {
   return join(appSupportDir(), "Claude", "claude_desktop_config.json");
-}
-
-/**
- * Claude Desktop launches config-file MCP servers with a minimal environment
- * whose PATH lacks Homebrew/nvm, so `npx` must be referenced by absolute path
- * and the entry needs a PATH under which npx's `#!/usr/bin/env node` shebang
- * resolves. Resolved at install time from the user's shell PATH.
- */
-function findNpx(): string {
-  /* v8 ignore next -- platform dispatch, win32 arm not exercised on POSIX CI */
-  const bin = process.platform === "win32" ? "npx.cmd" : "npx";
-  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
-    if (!dir) continue;
-    const candidate = join(dir, bin);
-    if (existsSync(candidate)) return candidate;
-  }
-  throw new Error(
-    "npx not found on PATH — Node.js is required to configure Claude Desktop (the entry runs `npx mcp-remote`).",
-  );
 }
 
 export const ClaudeDesktopProvider = (): SetupProvider => ({
@@ -54,14 +34,19 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
         ? mcpBaseURL()
         : // biome-ignore lint/style/noNonNullAssertion: guaranteed by the guard above
           mcpURL(cfg.active_account!.target!.deployment_id!);
-    // Claude Desktop's chat surface only launches stdio servers (and only
-    // renders MCP Apps from them), so proxy the remote HTTP endpoint through
-    // `npx mcp-remote`.
+    // Claude Desktop's chat surface launches only stdio servers from this
+    // config file (and only renders MCP Apps from them); remote HTTP goes
+    // through the Connectors UI, which cannot be automated. Proxy the remote
+    // endpoint through `npx mcp-remote`, with an absolute npx path and an
+    // explicit PATH because Claude Desktop spawns servers with the minimal
+    // launchd PATH. Revert to a plain remote-HTTP entry if
+    // claude_desktop_config.json ever accepts one.
     const npx = findNpx();
+    const remote = mcpRemoteServer(url, cfg.active_account?.target?.api_key);
     installJSONServer(configPath(), "mcpServers", {
       command: npx,
-      args: mcpRemoteArgs(url, cfg.active_account?.target?.api_key),
-      env: { PATH: [dirname(npx), "/usr/bin", "/bin"].join(delimiter) },
+      args: remote.args,
+      env: { PATH: npxPathEnv(npx), ...remote.env },
     });
   },
 

--- a/src/mcp/providers/claude-desktop.ts
+++ b/src/mcp/providers/claude-desktop.ts
@@ -1,6 +1,39 @@
-import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
+import { type Config, MODE_OSS } from "../../config/config";
+import {
+  installJSONServer,
+  isJSONKeyConfigured,
+  mcpBaseURL,
+  mcpRemoteArgs,
+  mcpURL,
+  removeJSONServer,
+} from "../config-helpers";
 import { appSupportDir, isInstalled } from "../detect";
 import type { SetupProvider } from "../providers";
+
+function configPath(): string {
+  return join(appSupportDir(), "Claude", "claude_desktop_config.json");
+}
+
+/**
+ * Claude Desktop launches config-file MCP servers with a minimal environment
+ * whose PATH lacks Homebrew/nvm, so `npx` must be referenced by absolute path
+ * and the entry needs a PATH under which npx's `#!/usr/bin/env node` shebang
+ * resolves. Resolved at install time from the user's shell PATH.
+ */
+function findNpx(): string {
+  /* v8 ignore next -- platform dispatch, win32 arm not exercised on POSIX CI */
+  const bin = process.platform === "win32" ? "npx.cmd" : "npx";
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, bin);
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    "npx not found on PATH — Node.js is required to configure Claude Desktop (the entry runs `npx mcp-remote`).",
+  );
+}
 
 export const ClaudeDesktopProvider = (): SetupProvider => ({
   name: () => "Claude Desktop",
@@ -9,16 +42,31 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
   priority: () => 2,
   detectPaths: () => [join(appSupportDir(), "Claude")],
   isInstalled: () => isInstalled([join(appSupportDir(), "Claude")]),
-  globalConfigPath: () => join(appSupportDir(), "Claude", "claude_desktop_config.json"),
-  isConfigured: () => false,
-  install() {
-    throw new Error(
-      "this tool only supports local (stdio) servers and cannot be configured for remote MCP",
-    );
+  globalConfigPath: () => configPath(),
+  isConfigured: () => isJSONKeyConfigured(configPath(), "mcpServers"),
+
+  install(cfg: Config, global: boolean): void {
+    if (!global) throw new Error("Claude Desktop does not support local installation");
+    if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
+      throw new Error("deployment ID is required");
+    const url =
+      cfg.mode === MODE_OSS
+        ? mcpBaseURL()
+        : // biome-ignore lint/style/noNonNullAssertion: guaranteed by the guard above
+          mcpURL(cfg.active_account!.target!.deployment_id!);
+    // Claude Desktop's chat surface only launches stdio servers (and only
+    // renders MCP Apps from them), so proxy the remote HTTP endpoint through
+    // `npx mcp-remote`.
+    const npx = findNpx();
+    installJSONServer(configPath(), "mcpServers", {
+      command: npx,
+      args: mcpRemoteArgs(url, cfg.active_account?.target?.api_key),
+      env: { PATH: [dirname(npx), "/usr/bin", "/bin"].join(delimiter) },
+    });
   },
-  remove() {
-    throw new Error(
-      "this tool only supports local (stdio) servers and cannot be configured for remote MCP",
-    );
+
+  remove(global: boolean): void {
+    if (!global) throw new Error("Claude Desktop does not support local removal");
+    removeJSONServer(configPath(), "mcpServers");
   },
 });

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -1,5 +1,5 @@
 /**
- * Codex CLI provider — uses TOML config format.
+ * Codex provider — CLI and desktop app share ~/.codex/config.toml (TOML format).
  * Simplified: we write JSON-style to a TOML-like structure using manual serialization.
  * For full parity, we'd need a TOML library. For now, use JSON config as Codex also supports it.
  */
@@ -95,7 +95,7 @@ function removeDosuFromTOML(content: string): string {
 }
 
 export const CodexProvider = (): SetupProvider => ({
-  name: () => "Codex CLI",
+  name: () => "Codex (CLI + Desktop)",
   id: () => "codex",
   supportsLocal: () => true,
   priority: () => 8,

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -7,8 +7,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
-import { mcpBaseURL, mcpRemoteArgs, mcpURL, writeSecureFile } from "../config-helpers";
-import { expandHome, isInstalled } from "../detect";
+import { mcpBaseURL, mcpRemoteServer, mcpURL, writeSecureFile } from "../config-helpers";
+import { expandHome, findNpx, isInstalled, npxPathEnv } from "../detect";
 import type { SetupProvider } from "../providers";
 
 function codexHome(): string {
@@ -49,10 +49,25 @@ function installDosuToTOML(path: string, cfg: Config): void {
   // legacy [mcp_servers.dosu.http_headers] subtable from the remote-HTTP form)
   content = removeDosuFromTOML(content);
   // Codex desktop only renders MCP Apps (the Session Knowledge card) for
-  // stdio servers — a remote-HTTP entry serves tools fine but never shows
-  // the card — so proxy the endpoint through `npx mcp-remote`.
-  const args = mcpRemoteArgs(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
-  const section = `\n[mcp_servers.dosu]\ncommand = "npx"\nargs = [${args.map(tomlString).join(", ")}]\n`;
+  // locally spawned stdio servers — a remote-HTTP entry serves tools fine
+  // but never shows the card — so proxy the endpoint through `npx
+  // mcp-remote`. Revert to the remote-HTTP form (type = "http" + url +
+  // http_headers) once Codex desktop renders MCP Apps from remote servers
+  // (no upstream issue tracks that as of 2026-08; closest is the closed
+  // feature request openai/codex#28912). npx is written by absolute path
+  // with an explicit PATH because this config is shared with Codex desktop,
+  // which launches from the Dock with the minimal launchd PATH — the same
+  // pitfall as Claude Desktop.
+  const npx = findNpx();
+  const remote = mcpRemoteServer(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
+  const env: Record<string, string> = { PATH: npxPathEnv(npx), ...remote.env };
+  const envEntries = Object.entries(env)
+    .map(([key, value]) => `${key} = ${tomlString(value)}`)
+    .join("\n");
+  const args = remote.args.map(tomlString).join(", ");
+  const section =
+    `\n[mcp_servers.dosu]\ncommand = ${tomlString(npx)}\nargs = [${args}]\n` +
+    `\n[mcp_servers.dosu.env]\n${envEntries}\n`;
   content += section;
   writeTOML(path, content);
 }

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -7,7 +7,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
-import { mcpBaseURL, mcpHeaders, mcpURL, writeSecureFile } from "../config-helpers";
+import { mcpBaseURL, mcpRemoteArgs, mcpURL, writeSecureFile } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
 import type { SetupProvider } from "../providers";
 
@@ -39,18 +39,20 @@ function mcpEndpoint(cfg: Config): string {
   return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
+function tomlString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
 function installDosuToTOML(path: string, cfg: Config): void {
   let content = readTOML(path);
-  // Remove existing [mcp_servers.dosu] section if present
+  // Remove existing [mcp_servers.dosu] section if present (including the
+  // legacy [mcp_servers.dosu.http_headers] subtable from the remote-HTTP form)
   content = removeDosuFromTOML(content);
-  // Append new section
-  const url = mcpEndpoint(cfg);
-  const headers = mcpHeaders(cfg.active_account?.target?.api_key);
-  const headerEntries = Object.entries(headers)
-    .map(([k, v]) => `${k} = "${v}"`)
-    .join("\n");
-
-  const section = `\n[mcp_servers.dosu]\ntype = "http"\nurl = "${url}"\n\n[mcp_servers.dosu.http_headers]\n${headerEntries}\n`;
+  // Codex desktop only renders MCP Apps (the Session Knowledge card) for
+  // stdio servers — a remote-HTTP entry serves tools fine but never shows
+  // the card — so proxy the endpoint through `npx mcp-remote`.
+  const args = mcpRemoteArgs(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
+  const section = `\n[mcp_servers.dosu]\ncommand = "npx"\nargs = [${args.map(tomlString).join(", ")}]\n`;
   content += section;
   writeTOML(path, content);
 }

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -12,7 +12,7 @@ import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../../config/config.test-utils";
-import { loadJSONConfig } from "../config-helpers";
+import { loadJSONConfig, MCP_REMOTE_VERSION } from "../config-helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -245,6 +245,8 @@ describe("CodexProvider", () => {
   let tempDir: string;
   let origCodexHome: string | undefined;
   let origCwd: string;
+  let origPath: string | undefined;
+  let npxPath: string;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), "dosu-codex-test-"));
@@ -252,6 +254,12 @@ describe("CodexProvider", () => {
     process.env.CODEX_HOME = join(tempDir, "codex-home");
     origCwd = process.cwd();
     process.chdir(tempDir);
+    origPath = process.env.PATH;
+    const binDir = join(tempDir, "fake-bin");
+    mkdirSync(binDir, { recursive: true });
+    npxPath = join(binDir, "npx");
+    writeFileSync(npxPath, "#!/bin/sh\n", { mode: 0o755 });
+    process.env.PATH = binDir;
   });
 
   afterEach(() => {
@@ -261,6 +269,7 @@ describe("CodexProvider", () => {
     } else {
       delete process.env.CODEX_HOME;
     }
+    process.env.PATH = origPath;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -274,11 +283,19 @@ describe("CodexProvider", () => {
     expect(existsSync(configPath)).toBe(true);
     const content = readFileSync(configPath, "utf-8");
     expect(content).toContain("[mcp_servers.dosu]");
-    expect(content).toContain('command = "npx"');
-    expect(content).toContain("mcp-remote");
+    // Absolute npx + explicit PATH: config.toml is shared with Codex
+    // desktop, which launches from the Dock with the minimal launchd PATH.
+    expect(content).toContain(`command = "${npxPath}"`);
+    expect(content).toContain(`mcp-remote@${MCP_REMOTE_VERSION}`);
     expect(content).toContain("/deployments/dep-123");
-    expect(content).toContain("X-Dosu-API-Key:key-abc");
     expect(content).toContain("http-only");
+    // The API key rides in the env block as a ${VAR} placeholder the proxy
+    // expands — argv (visible via `ps`) never carries the raw key.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder expanded by mcp-remote
+    expect(content).toContain("X-Dosu-API-Key:${X_DOSU_API_KEY}");
+    expect(content).toContain("[mcp_servers.dosu.env]");
+    expect(content).toContain('X_DOSU_API_KEY = "key-abc"');
+    expect(content).not.toContain("X-Dosu-API-Key:key-abc");
     // Codex desktop only renders MCP Apps (the Session Knowledge card) for
     // stdio servers — a remote-HTTP entry works for tools but never shows
     // the card, so the provider must not write that form.
@@ -317,6 +334,15 @@ describe("CodexProvider", () => {
     expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
       "deployment ID is required",
     );
+  });
+
+  it("install throws a clear error when npx is not on PATH", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    process.env.PATH = join(tempDir, "no-bin");
+
+    expect(() => provider.install(makeCfg(), true)).toThrow(/npx/);
   });
 
   it("install replaces existing dosu section", async () => {
@@ -843,9 +869,13 @@ describe("ClaudeDesktopProvider", () => {
     // no Homebrew/nvm, so the entry needs an absolute npx plus a PATH env
     // that lets npx's node shebang resolve.
     expect(dosu.command).toBe(npxPath);
-    expect(dosu.args).toContain("mcp-remote");
+    expect(dosu.args).toContain(`mcp-remote@${MCP_REMOTE_VERSION}`);
     expect(dosu.args.join(" ")).toContain("/deployments/dep-123");
-    expect(dosu.args).toContain("X-Dosu-API-Key:key-abc");
+    // Key in env as a ${VAR} placeholder — never in argv.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder expanded by mcp-remote
+    expect(dosu.args).toContain("X-Dosu-API-Key:${X_DOSU_API_KEY}");
+    expect(dosu.args.join(" ")).not.toContain("key-abc");
+    expect(dosu.env.X_DOSU_API_KEY).toBe("key-abc");
     expect(dosu.args).toContain("http-only");
     expect(dosu.env.PATH).toContain(dirname(npxPath));
     expect(dosu.url).toBeUndefined();

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../../config/config.test-utils";
@@ -274,10 +274,16 @@ describe("CodexProvider", () => {
     expect(existsSync(configPath)).toBe(true);
     const content = readFileSync(configPath, "utf-8");
     expect(content).toContain("[mcp_servers.dosu]");
-    expect(content).toContain('type = "http"');
-    expect(content).toContain("dep-123");
-    expect(content).toContain("X-Dosu-API-Key");
-    expect(content).toContain("key-abc");
+    expect(content).toContain('command = "npx"');
+    expect(content).toContain("mcp-remote");
+    expect(content).toContain("/deployments/dep-123");
+    expect(content).toContain("X-Dosu-API-Key:key-abc");
+    expect(content).toContain("http-only");
+    // Codex desktop only renders MCP Apps (the Session Knowledge card) for
+    // stdio servers — a remote-HTTP entry works for tools but never shows
+    // the card, so the provider must not write that form.
+    expect(content).not.toContain('type = "http"');
+    expect(content).not.toContain("http_headers");
   });
 
   it("local install writes TOML config to .codex/config.toml in cwd", async () => {
@@ -330,6 +336,27 @@ describe("CodexProvider", () => {
     // Should only have one dosu section
     const matches = content.match(/\[mcp_servers\.dosu\]/g);
     expect(matches?.length).toBe(1);
+  });
+
+  it("install replaces a legacy remote-HTTP dosu section including http_headers", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+
+    const configPath = join(tempDir, "codex-home", "config.toml");
+    mkdirSync(join(tempDir, "codex-home"), { recursive: true });
+    writeFileSync(
+      configPath,
+      '[mcp_servers.dosu]\ntype = "http"\nurl = "https://old.example"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "old-key"\n',
+    );
+
+    provider.install(makeCfg(), true);
+
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).not.toContain('type = "http"');
+    expect(content).not.toContain("http_headers");
+    expect(content).not.toContain("old-key");
+    expect(content.match(/\[mcp_servers\.dosu\]/g)?.length).toBe(1);
+    expect(content).toContain("mcp-remote");
   });
 
   it("install preserves other TOML content", async () => {
@@ -772,20 +799,131 @@ describe("ManualProvider", () => {
 // ---------------------------------------------------------------------------
 
 describe("ClaudeDesktopProvider", () => {
-  it("install throws with stdio-only error", async () => {
+  let tempDir: string;
+  let origHome: string | undefined;
+  let origXdg: string | undefined;
+  let origPath: string | undefined;
+  let npxPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-claude-desktop-test-"));
+    origHome = process.env.HOME;
+    origXdg = process.env.XDG_CONFIG_HOME;
+    origPath = process.env.PATH;
+    process.env.HOME = tempDir;
+    process.env.XDG_CONFIG_HOME = join(tempDir, "xdg");
+    const binDir = join(tempDir, "fake-bin");
+    mkdirSync(binDir, { recursive: true });
+    npxPath = join(binDir, "npx");
+    writeFileSync(npxPath, "#!/bin/sh\n", { mode: 0o755 });
+    process.env.PATH = binDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    if (origXdg !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXdg;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    process.env.PATH = origPath;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes an absolute-npx mcp-remote stdio entry with PATH env", async () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.install(makeCfg(), true)).toThrow(
-      "this tool only supports local (stdio) servers",
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    const dosu = cfg.mcpServers.dosu;
+    expect(dosu).toBeDefined();
+    // Claude Desktop chat launches MCP servers with a minimal PATH that has
+    // no Homebrew/nvm, so the entry needs an absolute npx plus a PATH env
+    // that lets npx's node shebang resolve.
+    expect(dosu.command).toBe(npxPath);
+    expect(dosu.args).toContain("mcp-remote");
+    expect(dosu.args.join(" ")).toContain("/deployments/dep-123");
+    expect(dosu.args).toContain("X-Dosu-API-Key:key-abc");
+    expect(dosu.args).toContain("http-only");
+    expect(dosu.env.PATH).toContain(dirname(npxPath));
+    expect(dosu.url).toBeUndefined();
+  });
+
+  it("OSS mode install uses the base MCP URL", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    const args = cfg.mcpServers.dosu.args.join(" ");
+    expect(args).toContain("/v1/mcp");
+    expect(args).not.toContain("/deployments/");
+  });
+
+  it("install throws when deployment_id is missing", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
+      "deployment ID is required",
     );
   });
 
-  it("remove throws with stdio-only error", async () => {
+  it("install throws a clear error when npx is not on PATH", async () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.remove(true)).toThrow("this tool only supports local (stdio) servers");
+    process.env.PATH = join(tempDir, "no-bin");
+
+    expect(() => provider.install(makeCfg(), true)).toThrow(/npx/);
+  });
+
+  it("local install throws because Claude Desktop is global-only", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+  });
+
+  it("remove deletes the dosu entry", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    provider.install(makeCfg(), true);
+    provider.remove(true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+
+  it("local remove throws because Claude Desktop is global-only", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    expect(() => provider.remove(false)).toThrow("does not support local removal");
+  });
+
+  it("install skips empty PATH segments when resolving npx", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    process.env.PATH = `:${dirname(npxPath)}`;
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    expect(cfg.mcpServers.dosu.command).toBe(npxPath);
+  });
+
+  it("isConfigured reflects presence of the dosu entry", async () => {
+    const { ClaudeDesktopProvider } = await import("./claude-desktop");
+    const provider = ClaudeDesktopProvider();
+
+    expect(provider.isConfigured()).toBe(false);
+    provider.install(makeCfg(), true);
+    expect(provider.isConfigured()).toBe(true);
   });
 });
 

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -169,7 +169,6 @@ import { CursorProvider } from "../mcp/providers/cursor";
 import { OpenCodeProvider } from "../mcp/providers/opencode";
 import {
   type ConfigResult,
-  isStdioOnly,
   runInstallSkill,
   runSetup,
   stepConfigureTools,
@@ -238,6 +237,26 @@ function teardownTempEnv() {
   rmSync(tempDir, { recursive: true, force: true });
 }
 
+/** A SetupProvider whose install/remove always throw, for error-path tests. */
+function throwingProvider(): providersModule.SetupProvider {
+  return {
+    name: () => "Broken Tool",
+    id: () => "broken",
+    supportsLocal: () => false,
+    priority: () => 99,
+    detectPaths: () => [],
+    isInstalled: () => true,
+    isConfigured: () => false,
+    globalConfigPath: () => join(tempDir, "broken.json"),
+    install() {
+      throw new Error("boom: provider failure");
+    },
+    remove() {
+      throw new Error("boom: provider failure");
+    },
+  };
+}
+
 function makeCfg(overrides: Partial<FlatTestConfig> = {}): Config {
   return makeTestConfig({
     access_token: "tok",
@@ -269,28 +288,7 @@ function trackedCliOnboardingEvents() {
 }
 
 // ---------------------------------------------------------------------------
-// 1. isStdioOnly — pure function, real providers
-// ---------------------------------------------------------------------------
-
-describe("isStdioOnly", () => {
-  it("returns true for ClaudeDesktopProvider", () => {
-    const provider = ClaudeDesktopProvider();
-    expect(isStdioOnly(provider)).toBe(true);
-  });
-
-  it("returns false for CursorProvider", () => {
-    const provider = CursorProvider();
-    expect(isStdioOnly(provider)).toBe(false);
-  });
-
-  it("returns false for OpenCodeProvider", () => {
-    const provider = OpenCodeProvider();
-    expect(isStdioOnly(provider)).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 2. stepDetectTools — real providers, temp HOME
+// 1. stepDetectTools — real providers, temp HOME
 // ---------------------------------------------------------------------------
 
 describe("stepDetectTools", () => {
@@ -301,8 +299,9 @@ describe("stepDetectTools", () => {
   });
   afterEach(teardownTempEnv);
 
-  it("returns providers whose detect paths exist, excluding stdio-only", () => {
-    // Create Cursor detect path so it's "installed"
+  it("returns providers whose detect paths exist", () => {
+    // Create Cursor detect path so it's "installed"; Claude Desktop's app
+    // dir does not exist in the temp env, so it stays undetected.
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
 
     // Mock allSetupProviders to return real providers built in our temp env
@@ -313,6 +312,20 @@ describe("stepDetectTools", () => {
     const detected = stepDetectTools();
     expect(detected.length).toBe(1);
     expect(detected[0].id()).toBe("cursor");
+  });
+
+  it("includes Claude Desktop when its app dir exists", () => {
+    const desktop = ClaudeDesktopProvider();
+    for (const detectPath of desktop.detectPaths()) {
+      mkdirSync(detectPath, { recursive: true });
+    }
+
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => {
+      return [CursorProvider(), ClaudeDesktopProvider()];
+    });
+
+    const detected = stepDetectTools();
+    expect(detected.map((p2) => p2.id())).toEqual(["claude-desktop"]);
   });
 
   it("returns empty array when no providers are installed", () => {
@@ -426,11 +439,10 @@ describe("stepConfigureTools", () => {
   });
 
   it("handles install errors and records them in results", () => {
-    const claudeDesktop = ClaudeDesktopProvider();
+    const broken = throwingProvider();
     const cfg = makeCfg();
-    // ClaudeDesktopProvider.install() always throws
     const selection: ToolSelection = {
-      toInstall: [claudeDesktop],
+      toInstall: [broken],
       toRemove: [],
       skipped: [],
     };
@@ -440,18 +452,17 @@ describe("stepConfigureTools", () => {
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("install");
     expect(results[0].error).toBeDefined();
-    expect(results[0].error?.message).toContain("stdio");
+    expect(results[0].error?.message).toContain("boom");
     // p.log.error should have been called
-    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Claude Desktop"));
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Broken Tool"));
   });
 
   it("handles remove errors and records them in results", () => {
-    const claudeDesktop = ClaudeDesktopProvider();
+    const broken = throwingProvider();
     const cfg = makeCfg();
-    // ClaudeDesktopProvider.remove() always throws
     const selection: ToolSelection = {
       toInstall: [],
-      toRemove: [claudeDesktop],
+      toRemove: [broken],
       skipped: [],
     };
 
@@ -460,8 +471,8 @@ describe("stepConfigureTools", () => {
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("remove");
     expect(results[0].error).toBeDefined();
-    expect(results[0].error?.message).toContain("stdio");
-    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Claude Desktop"));
+    expect(results[0].error?.message).toContain("boom");
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Broken Tool"));
   });
 
   it("handles mixed install, remove, and skip in one call", () => {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -815,12 +815,8 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
   }
 }
 
-export function isStdioOnly(p: SetupProvider): boolean {
-  return p.id() === "claude-desktop";
-}
-
 export function stepDetectTools(): SetupProvider[] {
-  return allSetupProviders().filter((p) => p.isInstalled() && !isStdioOnly(p));
+  return allSetupProviders().filter((p) => p.isInstalled());
 }
 
 async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection | null> {


### PR DESCRIPTION
## Description

Codex desktop and Claude Desktop chat render MCP Apps (the Session Knowledge card) only for **locally spawned stdio servers** — a remote-HTTP entry serves tools fine but silently never shows the card (diagnosed in production via Logfire: finalize succeeded, zero `resources/read`).

- **codex**: write an `npx mcp-remote` stdio entry instead of the remote-HTTP form. Reinstall replaces the legacy `http_headers` form. Absolute npx path + explicit `PATH` env — `config.toml` is shared with Dock-launched Codex desktop, which gets the minimal launchd PATH.
- **claude-desktop**: implement the provider (was a stub that threw) via the same mcp-remote proxy — `claude_desktop_config.json` only accepts stdio servers.
- **Hardening**: `mcp-remote` exact-pinned (`0.1.38`) so npx never floats to a fresh release; API key passed as a `${X_DOSU_API_KEY}` env placeholder, never in argv (`ps`-visible); clear install-time error when npx is missing; revert-to-HTTP conditions documented in both providers.
- **Retire `isStdioOnly`**: Claude Desktop now appears in the setup wizard, `dosu mcp add claude-desktop`, and agent setup.
- Claude Code, Cursor, VS Code, etc. keep the remote-HTTP form — untouched.

## Testing

- 1630 tests pass (red/green TDD; new coverage: legacy-form replacement, npx-not-found, OSS mode, env placeholder never leaks the key into argv). Coverage gates, `tsc --noEmit`, `biome check` all clean.
- Live against production with the exact generated invocation: stdio handshake → initialize (`Dosu MCP 3.3.1`) advertising the `io.modelcontextprotocol/ui` extension; env-placeholder header verified end-to-end. Card render confirmed in Codex desktop and Claude Desktop with this invocation shape.

Follow-ups (not in this PR): print a "restart Codex / Claude Desktop" hint after install; sync the Notion MCP Setup Guide + app.dosu.dev/mcp Codex snippets; file an upstream openai/codex issue for remote-server MCP Apps rendering.
