### PR TITLE
feat(statusline): add Claude Code knowledge status line

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -19,6 +19,7 @@ import { orgCommand } from "../commands/org";
 import { reviewCommand } from "../commands/review";
 import { skillCommand } from "../commands/skill";
 import { sourcesCommand } from "../commands/sources";
+import { statuslineCommand } from "../commands/statusline";
 import { suggestCommand } from "../commands/suggest";
 import { threadsCommand } from "../commands/threads";
 import { topicsCommand } from "../commands/topics";
@@ -408,6 +409,7 @@ export function createProgram(): Command {
   program.addCommand(orgCommand());
   program.addCommand(reviewCommand());
   program.addCommand(sourcesCommand());
+  program.addCommand(statuslineCommand());
   program.addCommand(suggestCommand());
   program.addCommand(topicsCommand());
   program.addCommand(threadsCommand());

--- a/src/commands/hooks.test.ts
+++ b/src/commands/hooks.test.ts
@@ -38,6 +38,14 @@ vi.mock("../client/client", () => ({
   }),
 }));
 
+// Status-line accounting writes per-session state under the real home dir;
+// mock it so hook tests never touch ~/.dosu and the calls are assertable.
+vi.mock("../statusline/state", () => ({
+  countKnowledge: vi.fn(() => ({ pages: 1, notes: 2 })),
+  recordKnowledgeCounts: vi.fn(),
+  loadToolResponseText: vi.fn((v: unknown) => String(v)),
+}));
+
 // Deterministic hook runtime: the real resolver probes PATH and can
 // materialize a bundle into the config dir.
 vi.mock("../hooks/runtime", () => ({
@@ -51,6 +59,7 @@ import { loadConfig, MODE_OSS } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { claimState, loadState, releaseState, saveState, type TicketState } from "../hooks/state";
 import { requestCreateTicket, requestGetTicket, TicketHttpError } from "../hooks/ticket-client";
+import { countKnowledge, loadToolResponseText, recordKnowledgeCounts } from "../statusline/state";
 import {
   collectDoctorChecks,
   hooksCommand,
@@ -259,6 +268,9 @@ describe("runUserPromptSubmit", () => {
     // the old ticket is consumed, the new one registered
     expect(releaseState).toHaveBeenCalledWith("sess", null);
     expect(saveState).toHaveBeenCalledWith(expect.objectContaining({ ticketId: "kt_new" }));
+    // the late delivery still counts for the status line
+    expect(countKnowledge).toHaveBeenCalledWith("OLD RESULT");
+    expect(recordKnowledgeCounts).toHaveBeenCalledWith("sess", { pages: 1, notes: 2 });
   });
 
   it("skips the harvest when the old lookup is still running", async () => {
@@ -464,6 +476,47 @@ describe("runPostToolUse", () => {
     expect(printed.hookSpecificOutput.additionalContext).toContain("verify adjacent");
   });
 
+  it("records status-line counts for an explicit read_knowledge call", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    await runPostToolUse({
+      session_id: "sess",
+      tool_name: "mcp__dosu__read_knowledge",
+      tool_response: { result: "payload" },
+    });
+    expect(loadToolResponseText).toHaveBeenCalledWith({ result: "payload" });
+    expect(recordKnowledgeCounts).toHaveBeenCalledWith("sess", { pages: 1, notes: 2 });
+  });
+
+  it("matches plugin-style read_knowledge tool names", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    await runPostToolUse({
+      session_id: "sess",
+      tool_name: "mcp__plugin_foo_dosu__read_knowledge",
+      tool_response: "payload",
+    });
+    expect(recordKnowledgeCounts).toHaveBeenCalled();
+  });
+
+  it("does not record counts for other tools or subagent lookups", async () => {
+    vi.mocked(loadState).mockReturnValue(null);
+    await runPostToolUse({ session_id: "sess", tool_name: "Bash", tool_response: "x" });
+    await runPostToolUse({
+      session_id: "sess",
+      tool_name: "mcp__dosu__read_knowledge",
+      tool_response: "x",
+      agent_id: "sub-1",
+    });
+    expect(recordKnowledgeCounts).not.toHaveBeenCalled();
+  });
+
+  it("records status-line counts when injecting ready context", async () => {
+    vi.mocked(loadState).mockReturnValue(pending());
+    vi.mocked(requestGetTicket).mockResolvedValue(readyResp("INJECTED"));
+    await runPostToolUse({ session_id: "sess" }, 50_000);
+    expect(countKnowledge).toHaveBeenCalledWith("INJECTED");
+    expect(recordKnowledgeCounts).toHaveBeenCalledWith("sess", { pages: 1, notes: 2 });
+  });
+
   it("appends a save nudge when the server recommends saving", async () => {
     vi.mocked(loadState).mockReturnValue(pending());
     vi.mocked(requestGetTicket).mockResolvedValue({
@@ -627,6 +680,8 @@ describe("runStop", () => {
       "sess",
       expect.objectContaining({ status: "delivered" }),
     );
+    expect(countKnowledge).toHaveBeenCalledWith("LATE CONTEXT");
+    expect(recordKnowledgeCounts).toHaveBeenCalledWith("sess", { pages: 1, notes: 2 });
   });
 
   it("consumes but does NOT block on a ready gap ticket (empty context)", async () => {

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -35,6 +35,11 @@ interface HookInput {
   hook_event_name?: string;
   prompt?: string;
   stop_hook_active?: boolean;
+  /** Set when the hook fired inside a subagent (shares the parent session_id). */
+  agent_id?: string;
+  /** PostToolUse only: the tool that just ran and what it returned. */
+  tool_name?: string;
+  tool_response?: unknown;
 }
 
 type HookEvent = "user-prompt-submit" | "post-tool-use" | "stop";
@@ -131,6 +136,23 @@ function gitContext(cwd?: string): { repo?: string; branch?: string } {
 }
 
 // ---------------------------------------------------------------------------
+// Status-line accounting (purely cosmetic — must never disturb the hook)
+// ---------------------------------------------------------------------------
+
+/** Explicit read_knowledge MCP calls, whatever the server registration name. */
+const READ_KNOWLEDGE_TOOL_RE = /^mcp__.*dosu.*__read_knowledge$/;
+
+/** Record a knowledge delivery for the `dosu statusline` row. Best-effort. */
+async function recordKnowledgeForStatusline(sessionId: string, text: string): Promise<void> {
+  try {
+    const { countKnowledge, recordKnowledgeCounts } = await import("../statusline/state");
+    recordKnowledgeCounts(sessionId, countKnowledge(text));
+  } catch (err) {
+    logger.debug("statusline", `record failed: ${errMsg(err)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Hook entrypoint handlers (exported for direct unit testing)
 // ---------------------------------------------------------------------------
 
@@ -196,6 +218,7 @@ export async function runUserPromptSubmit(
           old.result.context,
           old.result.save_recommended ?? false,
         )}`;
+        await recordKnowledgeForStatusline(sessionId, old.result.context);
         logger.info("hooks", `harvest tid=${claimed.ticketId} delivered=late`);
       }
     } catch {
@@ -245,6 +268,13 @@ export async function runUserPromptSubmit(
 export async function runPostToolUse(input: HookInput, now: number = Date.now()): Promise<void> {
   const sessionId = input.session_id;
   if (!sessionId) return;
+
+  // Status-line accounting for explicit read_knowledge calls. Subagents share
+  // the parent session_id — never let their lookups overwrite the main row.
+  if (!input.agent_id && input.tool_name && READ_KNOWLEDGE_TOOL_RE.test(input.tool_name)) {
+    const { loadToolResponseText } = await import("../statusline/state");
+    await recordKnowledgeForStatusline(sessionId, loadToolResponseText(input.tool_response));
+  }
 
   const state = loadState(sessionId);
   if (!state) {
@@ -324,6 +354,7 @@ export async function runPostToolUse(input: HookInput, now: number = Date.now())
   const context = buildReadyEnvelope(resp.result.context, resp.result.save_recommended ?? false);
   if (context) {
     printHookContext("PostToolUse", context);
+    await recordKnowledgeForStatusline(sessionId, resp.result.context);
     logger.info(
       "hooks",
       `deliver tid=${state.ticketId} latency=${Date.now() - startedAt}ms bytes=${context.length}`,
@@ -390,6 +421,7 @@ export async function runStop(input: HookInput, now: number = Date.now()): Promi
           resp.result.save_recommended ?? false,
         );
         console.log(JSON.stringify({ decision: "block", reason: `${STOP_PREFIX}\n\n${envelope}` }));
+        await recordKnowledgeForStatusline(sessionId, resp.result.context);
         logger.info("hooks", `stop tid=${claimed.ticketId} delivered=true`);
         return;
       }

--- a/src/commands/statusline.test.ts
+++ b/src/commands/statusline.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}));
+
+vi.mock("../statusline/install", () => ({
+  writeStatuslineScripts: vi.fn(),
+  installStatuslineSettings: vi.fn(),
+  uninstallStatusline: vi.fn(),
+  inspectStatusline: vi.fn(),
+}));
+
+import { spawnSync } from "node:child_process";
+import {
+  inspectStatusline,
+  installStatuslineSettings,
+  uninstallStatusline,
+  writeStatuslineScripts,
+} from "../statusline/install";
+import {
+  python3OnPath,
+  runStatuslineInstall,
+  runStatuslineStatus,
+  runStatuslineUninstall,
+  statuslineCommand,
+} from "./statusline";
+
+let log: MockInstance;
+let error: MockInstance;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+  log = vi.spyOn(console, "log").mockImplementation(() => {});
+  error = vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  log.mockRestore();
+  error.mockRestore();
+  process.exitCode = undefined;
+});
+
+function logged(): string {
+  return log.mock.calls.map((c) => c.join(" ")).join("\n");
+}
+
+const INSTALL_OK = {
+  settingsPath: "/home/u/.claude/settings.json",
+  statusLine: "installed" as const,
+  warnings: [],
+};
+
+describe("python3OnPath", () => {
+  it("is true when the probe exits 0", () => {
+    expect(python3OnPath()).toBe(true);
+  });
+
+  it("is false when the probe fails or throws", () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
+    expect(python3OnPath()).toBe(false);
+    vi.mocked(spawnSync).mockImplementation(() => {
+      throw new Error("no shell");
+    });
+    expect(python3OnPath()).toBe(false);
+  });
+});
+
+describe("runStatuslineInstall", () => {
+  it("writes scripts and reports a fresh install", async () => {
+    vi.mocked(installStatuslineSettings).mockReturnValue(INSTALL_OK);
+    await runStatuslineInstall({});
+    expect(writeStatuslineScripts).toHaveBeenCalled();
+    expect(installStatuslineSettings).toHaveBeenCalledWith(undefined, { force: undefined });
+    expect(logged()).toContain("✓ Installed the Dosu knowledge status line.");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("reports a refresh on re-install", async () => {
+    vi.mocked(installStatuslineSettings).mockReturnValue({ ...INSTALL_OK, statusLine: "updated" });
+    await runStatuslineInstall({});
+    expect(logged()).toContain("Refreshed");
+  });
+
+  it("reports a conflict without touching the existing status line", async () => {
+    vi.mocked(installStatuslineSettings).mockReturnValue({
+      ...INSTALL_OK,
+      statusLine: "conflict",
+      existingCommand: "~/mine.sh",
+    });
+    await runStatuslineInstall({});
+    expect(process.exitCode).toBe(1);
+    expect(logged()).toContain("~/mine.sh");
+    expect(logged()).toContain("--force");
+  });
+
+  it("reports a forced replace", async () => {
+    vi.mocked(installStatuslineSettings).mockReturnValue({
+      ...INSTALL_OK,
+      statusLine: "replaced",
+      existingCommand: "~/mine.sh",
+    });
+    await runStatuslineInstall({ force: true });
+    expect(installStatuslineSettings).toHaveBeenCalledWith(undefined, { force: true });
+    expect(logged()).toContain("Replaced");
+  });
+
+  it("warns when python3 is missing and surfaces settings warnings", async () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>);
+    vi.mocked(installStatuslineSettings).mockReturnValue({
+      ...INSTALL_OK,
+      warnings: ["disableAllHooks is set"],
+    });
+    await runStatuslineInstall({});
+    expect(logged()).toContain("python3 was not found");
+    expect(logged()).toContain("disableAllHooks is set");
+  });
+
+  it("emits JSON when asked", async () => {
+    vi.mocked(installStatuslineSettings).mockReturnValue(INSTALL_OK);
+    await runStatuslineInstall({ json: true });
+    const line = JSON.parse(log.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "statusline-install", status_line: "installed" });
+  });
+
+  it("sets exit code 1 on a JSON conflict", async () => {
+    vi.mocked(installStatuslineSettings).mockReturnValue({ ...INSTALL_OK, statusLine: "conflict" });
+    await runStatuslineInstall({ json: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports write failures", async () => {
+    vi.mocked(installStatuslineSettings).mockImplementation(() => {
+      throw new Error("refusing to modify");
+    });
+    await runStatuslineInstall({});
+    expect(process.exitCode).toBe(1);
+    expect(error.mock.calls[0][0]).toContain("refusing to modify");
+  });
+
+  it("reports write failures as JSON", async () => {
+    vi.mocked(installStatuslineSettings).mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    await runStatuslineInstall({ json: true });
+    expect(process.exitCode).toBe(1);
+    const line = JSON.parse(log.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "statusline-install", reason: "write_failed" });
+  });
+});
+
+describe("runStatuslineUninstall", () => {
+  const REMOVED = {
+    settingsPath: "/home/u/.claude/settings.json",
+    statusLineRemoved: true,
+    statusLineRestored: false,
+  };
+
+  it("reports a removal", async () => {
+    vi.mocked(uninstallStatusline).mockReturnValue(REMOVED);
+    await runStatuslineUninstall({});
+    expect(logged()).toContain("✓ Removed");
+  });
+
+  it("mentions a restored status line", async () => {
+    vi.mocked(uninstallStatusline).mockReturnValue({ ...REMOVED, statusLineRestored: true });
+    await runStatuslineUninstall({});
+    expect(logged()).toContain("Restored your previous status line");
+  });
+
+  it("reports a no-op", async () => {
+    vi.mocked(uninstallStatusline).mockReturnValue({ ...REMOVED, statusLineRemoved: false });
+    await runStatuslineUninstall({});
+    expect(logged()).toContain("No Dosu status line was installed.");
+  });
+
+  it("emits JSON when asked", async () => {
+    vi.mocked(uninstallStatusline).mockReturnValue(REMOVED);
+    await runStatuslineUninstall({ json: true });
+    const line = JSON.parse(log.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "statusline-uninstall", status_line_removed: true });
+  });
+});
+
+describe("runStatuslineStatus", () => {
+  const INFO = {
+    scriptInstalled: true,
+    statusLineConfigured: true,
+    settingsParseError: false,
+    warnings: [],
+  };
+
+  it("prints a check per component", async () => {
+    vi.mocked(inspectStatusline).mockReturnValue(INFO);
+    await runStatuslineStatus({});
+    expect(logged()).toContain("✓ renderer installed");
+    expect(logged()).toContain("✓ statusLine configured");
+    expect(logged()).toContain("✓ python3 on PATH");
+    expect(logged()).toContain("dosu hooks doctor");
+  });
+
+  it("flags a parse error and warnings", async () => {
+    vi.mocked(inspectStatusline).mockReturnValue({
+      ...INFO,
+      settingsParseError: true,
+      warnings: ["allowManagedHooksOnly is set"],
+    });
+    await runStatuslineStatus({});
+    expect(logged()).toContain("not valid JSON");
+    expect(logged()).toContain("⚠ allowManagedHooksOnly is set");
+  });
+
+  it("emits JSON when asked", async () => {
+    vi.mocked(inspectStatusline).mockReturnValue(INFO);
+    await runStatuslineStatus({ json: true });
+    const line = JSON.parse(log.mock.calls[0][0]);
+    expect(line).toMatchObject({ step: "statusline-status", python3_on_path: true });
+  });
+});
+
+describe("statuslineCommand", () => {
+  it("registers install, uninstall, and status subcommands", () => {
+    const cmd = statuslineCommand();
+    expect(cmd.name()).toBe("statusline");
+    expect(cmd.commands.map((c) => c.name())).toEqual(["install", "uninstall", "status"]);
+  });
+
+  it("dispatches install through the command", async () => {
+    vi.mocked(installStatuslineSettings).mockReturnValue(INSTALL_OK);
+    await statuslineCommand().parseAsync(["install"], { from: "user" });
+    expect(writeStatuslineScripts).toHaveBeenCalled();
+  });
+
+  it("dispatches uninstall through the command", async () => {
+    vi.mocked(uninstallStatusline).mockReturnValue({
+      settingsPath: "p",
+      statusLineRemoved: false,
+      statusLineRestored: false,
+    });
+    await statuslineCommand().parseAsync(["uninstall"], { from: "user" });
+    expect(uninstallStatusline).toHaveBeenCalled();
+  });
+
+  it("dispatches status through the command", async () => {
+    vi.mocked(inspectStatusline).mockReturnValue({
+      scriptInstalled: false,
+      statusLineConfigured: false,
+      settingsParseError: false,
+      warnings: [],
+    });
+    await statuslineCommand().parseAsync(["status"], { from: "user" });
+    expect(inspectStatusline).toHaveBeenCalled();
+  });
+});

--- a/src/commands/statusline.ts
+++ b/src/commands/statusline.ts
@@ -1,0 +1,179 @@
+/**
+ * `dosu statusline` — Claude Code status line showing Dosu knowledge counts.
+ *
+ * Installs a renderer script (Python 3, stdlib only) into `~/.dosu/claude/`
+ * and wires it into the user's `~/.claude/settings.json`. The per-session
+ * counts it renders are recorded by `dosu hooks post-tool-use` / `stop`
+ * (installed per project via `dosu hooks install claude-code`), covering both
+ * explicit `read_knowledge` calls and hook-injected knowledge. The row renders
+ * `Knowledge 📚 3 pages · 📝 77 notes` after a delivery and prints nothing
+ * before one — an empty pre-delivery state is deliberate.
+ */
+
+import { spawnSync } from "node:child_process";
+import { Command } from "commander";
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** The renderer is Python 3, stdlib only. Without it the install is inert. */
+export function python3OnPath(): boolean {
+  const cmd = process.platform === "win32" ? "where" : "which";
+  try {
+    return spawnSync(cmd, ["python3"], { stdio: "ignore" }).status === 0;
+  } catch {
+    return false;
+  }
+}
+
+export interface StatuslineInstallOptions {
+  force?: boolean;
+  json?: boolean;
+}
+
+export async function runStatuslineInstall(opts: StatuslineInstallOptions): Promise<void> {
+  const { installStatuslineSettings, writeStatuslineScripts } = await import(
+    "../statusline/install"
+  );
+  const warnings: string[] = [];
+  if (!python3OnPath()) {
+    warnings.push("python3 was not found on PATH — the status line will not render without it");
+  }
+  try {
+    writeStatuslineScripts();
+    const result = installStatuslineSettings(undefined, { force: opts.force });
+    warnings.push(...result.warnings);
+    if (opts.json) {
+      const { emitStep } = await import("../agent/output");
+      emitStep({
+        step: "statusline-install",
+        path: result.settingsPath,
+        status_line: result.statusLine,
+        existing_command: result.existingCommand,
+        warnings,
+      });
+      if (result.statusLine === "conflict") process.exitCode = 1;
+      return;
+    }
+    if (result.statusLine === "conflict") {
+      process.exitCode = 1;
+      console.log("⚠ You already have a Claude Code status line configured:");
+      console.log(`    ${result.existingCommand}`);
+      console.log("  Left it untouched. Re-run with --force to replace it (the original");
+      console.log("  is backed up and restored on 'dosu statusline uninstall').");
+    } else if (result.statusLine === "replaced") {
+      console.log("✓ Replaced your existing status line (original backed up):");
+      console.log(`    ${result.existingCommand}`);
+    } else {
+      console.log(
+        result.statusLine === "updated"
+          ? "✓ Refreshed the Dosu knowledge status line."
+          : "✓ Installed the Dosu knowledge status line.",
+      );
+    }
+    console.log(`  → ${result.settingsPath}`);
+    console.log("  Counts are recorded by the Dosu hooks — run 'dosu hooks install claude-code'");
+    console.log("  in each project. The row appears after the next knowledge delivery in a new");
+    console.log("  session; it deliberately prints nothing until then.");
+    for (const w of warnings) console.log(`⚠ ${w}`);
+  } catch (err) {
+    process.exitCode = 1;
+    if (opts.json) {
+      const { emitError } = await import("../agent/output");
+      emitError({
+        step: "statusline-install",
+        reason: "write_failed",
+        agent_next_steps: errMsg(err),
+      });
+    } else {
+      console.error(`Failed to install status line: ${errMsg(err)}`);
+    }
+  }
+}
+
+export async function runStatuslineUninstall(opts: { json?: boolean }): Promise<void> {
+  const { uninstallStatusline } = await import("../statusline/install");
+  const result = uninstallStatusline();
+  if (opts.json) {
+    const { emitStep } = await import("../agent/output");
+    emitStep({
+      step: "statusline-uninstall",
+      path: result.settingsPath,
+      status_line_removed: result.statusLineRemoved,
+      status_line_restored: result.statusLineRestored,
+    });
+    return;
+  }
+  if (result.statusLineRemoved) {
+    console.log(`✓ Removed the Dosu knowledge status line from ${result.settingsPath}.`);
+    if (result.statusLineRestored) {
+      console.log("  Restored your previous status line from backup.");
+    }
+  } else {
+    console.log("No Dosu status line was installed.");
+  }
+}
+
+export async function runStatuslineStatus(opts: { json?: boolean }): Promise<void> {
+  const { inspectStatusline } = await import("../statusline/install");
+  const info = inspectStatusline();
+  const python3 = python3OnPath();
+  if (opts.json) {
+    const { emitStep } = await import("../agent/output");
+    emitStep({ step: "statusline-status", ...info, python3_on_path: python3 });
+    return;
+  }
+  const icon = (ok: boolean) => (ok ? "✓" : "✗");
+  console.log(`${icon(info.scriptInstalled)} renderer installed (~/.dosu/claude/)`);
+  console.log(`${icon(info.statusLineConfigured)} statusLine configured (~/.claude/settings.json)`);
+  console.log(`${icon(python3)} python3 on PATH`);
+  if (info.settingsParseError) {
+    console.log("✗ ~/.claude/settings.json exists but is not valid JSON");
+  }
+  for (const w of info.warnings) console.log(`⚠ ${w}`);
+  console.log(
+    "ℹ Counts are recorded by the Dosu hooks — check 'dosu hooks doctor' in your project.",
+  );
+}
+
+export function statuslineCommand(): Command {
+  const cmd = new Command("statusline").description(
+    "Claude Code status line showing Dosu knowledge counts",
+  );
+
+  cmd
+    .command("install")
+    .description("Install the Dosu knowledge status line for Claude Code (user scope)")
+    .option("--force", "Replace an existing status line (original is backed up)", false)
+    .option("--json", "Emit machine-readable JSON", false)
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Shows how much knowledge Dosu last delivered to the session, e.g.:",
+        "  Knowledge 📚 3 pages · 📝 77 notes",
+        "",
+        "Counts are recorded by the Dosu hooks ('dosu hooks install claude-code'),",
+        "covering explicit read_knowledge calls and hook-injected knowledge alike.",
+        "The row prints nothing until a delivery happens — that is deliberate.",
+        "Requires python3 on PATH. Installs into ~/.claude/settings.json and",
+        "~/.dosu/claude/; never overwrites an existing status line without --force.",
+      ].join("\n"),
+    )
+    .action((opts: StatuslineInstallOptions) => runStatuslineInstall(opts));
+
+  cmd
+    .command("uninstall")
+    .description("Remove the Dosu knowledge status line (restores any replaced status line)")
+    .option("--json", "Emit machine-readable JSON", false)
+    .action((opts: { json?: boolean }) => runStatuslineUninstall(opts));
+
+  cmd
+    .command("status")
+    .description("Show whether the Dosu status line is installed and able to run")
+    .option("--json", "Emit machine-readable JSON", false)
+    .action((opts: { json?: boolean }) => runStatuslineStatus(opts));
+
+  return cmd;
+}

--- a/src/statusline/assets.ts
+++ b/src/statusline/assets.ts
@@ -1,0 +1,77 @@
+/**
+ * Embedded Claude Code status-line renderer.
+ *
+ * The npm package ships as a single bundled file and the native release as a
+ * single compiled binary, so this script must be embedded rather than read
+ * from the repository at runtime. Two hard constraints on the embedded source:
+ *
+ *  - No backticks — they terminate the String.raw template (and escaping
+ *    doesn't help, since String.raw keeps the backslash).
+ *  - ASCII only — Bun's transpiler rewrites non-ASCII characters into JS
+ *    \u{...} escapes even inside String.raw, so a literal emoji ships as the
+ *    escape text and breaks the Python. Use Python's own \uXXXX / \UXXXXXXXX
+ *    escapes instead (they pass through String.raw untouched).
+ *
+ * The per-session state it renders is written by 'dosu hooks post-tool-use' /
+ * 'stop' (src/statusline/state.ts) — STATE_DIR here must match
+ * knowledgeStateDir() exactly.
+ */
+
+export const STATUS_LINE_SOURCE = String.raw`#!/usr/bin/env python3
+"""Claude Code status line: Dosu knowledge only.
+
+Shows how much knowledge Dosu last delivered to this session: org-knowledge
+pages and branch notes. Prints nothing until a delivery happens (that empty
+pre-delivery state is deliberate).
+
+Populated by 'dosu hooks post-tool-use' / 'dosu hooks stop'.
+"""
+
+import json
+import os
+import sys
+
+STATE_DIR = os.path.expanduser("~/.dosu/statusline-state")
+SEPARATOR = " \u00b7 "
+BOOKS = "\U0001f4da"
+MEMO = "\U0001f4dd"
+
+
+def plural(count, word):
+    return f"{count} {word}" if count == 1 else f"{count} {word}s"
+
+
+def knowledge_row(session_id):
+    path = os.path.join(STATE_DIR, f"{session_id}.knowledge.json")
+    try:
+        with open(path) as handle:
+            state = json.load(handle)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return None
+
+    parts = []
+    if state.get("pages"):
+        parts.append(BOOKS + " " + plural(state["pages"], "page"))
+    # Absent whenever the lookup omitted repo/branch, so only show when present.
+    if state.get("notes"):
+        parts.append(MEMO + " " + plural(state["notes"], "note"))
+
+    if not parts:
+        return None
+    return "\033[2mKnowledge\033[0m " + SEPARATOR.join(parts)
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError, TypeError):
+        return
+
+    row = knowledge_row(data.get("session_id") or "")
+    if row:
+        print(row)
+
+
+if __name__ == "__main__":
+    main()
+`;

--- a/src/statusline/install.test.ts
+++ b/src/statusline/install.test.ts
@@ -1,0 +1,291 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  claudeUserSettingsPath,
+  inspectStatusline,
+  installStatuslineSettings,
+  statusLineScriptPath,
+  statuslineBackupPath,
+  statuslineScriptsDir,
+  uninstallStatusline,
+  writeStatuslineScripts,
+} from "./install";
+import { knowledgeStateDir } from "./state";
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "dosu-statusline-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+// biome-ignore lint/suspicious/noExplicitAny: settings JSON is inherently untyped
+function readSettings(): any {
+  return JSON.parse(readFileSync(claudeUserSettingsPath(home), "utf-8"));
+}
+
+/** A settings file with the retired standalone Python hook wired in. */
+function legacySettings(): Record<string, unknown> {
+  return {
+    hooks: {
+      PostToolUse: [
+        {
+          matcher: "mcp__.*dosu.*__read_knowledge",
+          hooks: [
+            {
+              type: "command",
+              command: join(statuslineScriptsDir(home), "dosu-knowledge-hook.py"),
+              timeout: 10,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe("writeStatuslineScripts", () => {
+  it("writes the renderer executable", () => {
+    writeStatuslineScripts(home);
+    const path = statusLineScriptPath(home);
+    expect(statSync(path).mode & 0o755).toBe(0o755);
+    expect(readFileSync(path, "utf-8")).toContain("#!/usr/bin/env python3");
+  });
+
+  it("is idempotent on re-run", () => {
+    writeStatuslineScripts(home);
+    writeStatuslineScripts(home);
+    expect(existsSync(statusLineScriptPath(home))).toBe(true);
+  });
+});
+
+describe("installStatuslineSettings", () => {
+  it("creates settings.json with statusLine when absent", () => {
+    const result = installStatuslineSettings(home);
+    expect(result.statusLine).toBe("installed");
+    expect(readSettings().statusLine).toEqual({
+      type: "command",
+      command: statusLineScriptPath(home),
+      padding: 1,
+    });
+  });
+
+  it("refreshes its own statusLine on re-run", () => {
+    installStatuslineSettings(home);
+    expect(installStatuslineSettings(home).statusLine).toBe("updated");
+  });
+
+  it("preserves unrelated hooks and settings", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      claudeUserSettingsPath(home),
+      JSON.stringify({
+        permissions: { allow: ["Bash"] },
+        hooks: {
+          PostToolUse: [
+            { matcher: "*", hooks: [{ type: "command", command: "dosu hooks post-tool-use" }] },
+          ],
+        },
+      }),
+    );
+    installStatuslineSettings(home);
+    const cfg = readSettings();
+    expect(cfg.permissions).toEqual({ allow: ["Bash"] });
+    expect(cfg.hooks.PostToolUse).toHaveLength(1);
+    expect(cfg.hooks.PostToolUse[0].hooks[0].command).toBe("dosu hooks post-tool-use");
+  });
+
+  it("removes a legacy standalone-hook entry left by a hand install", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudeUserSettingsPath(home), JSON.stringify(legacySettings()));
+    installStatuslineSettings(home);
+    expect(readSettings().hooks).toBeUndefined();
+  });
+
+  it("does not overwrite a foreign statusLine without force", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      claudeUserSettingsPath(home),
+      JSON.stringify({ statusLine: { type: "command", command: "~/my-statusline.sh" } }),
+    );
+    const result = installStatuslineSettings(home);
+    expect(result.statusLine).toBe("conflict");
+    expect(result.existingCommand).toBe("~/my-statusline.sh");
+    expect(readSettings().statusLine.command).toBe("~/my-statusline.sh");
+  });
+
+  it("replaces a foreign statusLine with force, backing up the original", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      claudeUserSettingsPath(home),
+      JSON.stringify({ statusLine: { type: "command", command: "~/my-statusline.sh" } }),
+    );
+    const result = installStatuslineSettings(home, { force: true });
+    expect(result.statusLine).toBe("replaced");
+    expect(result.existingCommand).toBe("~/my-statusline.sh");
+    expect(readSettings().statusLine.command).toBe(statusLineScriptPath(home));
+    const backup = JSON.parse(readFileSync(statuslineBackupPath(home), "utf-8"));
+    expect(backup.command).toBe("~/my-statusline.sh");
+  });
+
+  it("reports a command-less foreign statusLine as JSON", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudeUserSettingsPath(home), JSON.stringify({ statusLine: { type: "static" } }));
+    const result = installStatuslineSettings(home);
+    expect(result.statusLine).toBe("conflict");
+    expect(result.existingCommand).toBe('{"type":"static"}');
+  });
+
+  it("refuses to modify an unparseable settings file", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudeUserSettingsPath(home), "{not json");
+    expect(() => installStatuslineSettings(home)).toThrow(/not valid JSON/);
+    expect(readFileSync(claudeUserSettingsPath(home), "utf-8")).toBe("{not json");
+  });
+
+  it("treats an empty settings file as empty config", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudeUserSettingsPath(home), "  ");
+    expect(installStatuslineSettings(home).statusLine).toBe("installed");
+  });
+
+  it("warns on disableAllHooks and allowManagedHooksOnly", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      claudeUserSettingsPath(home),
+      JSON.stringify({ disableAllHooks: true, allowManagedHooksOnly: true }),
+    );
+    const result = installStatuslineSettings(home);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0]).toMatch(/disableAllHooks/);
+    expect(result.warnings[1]).toMatch(/allowManagedHooksOnly/);
+  });
+});
+
+describe("uninstallStatusline", () => {
+  it("removes our statusLine, renderer, and state", () => {
+    writeStatuslineScripts(home);
+    installStatuslineSettings(home);
+    mkdirSync(knowledgeStateDir(home), { recursive: true });
+    writeFileSync(join(knowledgeStateDir(home), "abc.knowledge.json"), "{}");
+
+    const result = uninstallStatusline(home);
+    expect(result.statusLineRemoved).toBe(true);
+    expect(result.statusLineRestored).toBe(false);
+    expect(readSettings().statusLine).toBeUndefined();
+    expect(existsSync(statusLineScriptPath(home))).toBe(false);
+    expect(existsSync(knowledgeStateDir(home))).toBe(false);
+  });
+
+  it("removes a legacy standalone-hook entry", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudeUserSettingsPath(home), JSON.stringify(legacySettings()));
+    uninstallStatusline(home);
+    expect(readSettings().hooks).toBeUndefined();
+  });
+
+  it("restores a backed-up statusLine after a forced replace", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      claudeUserSettingsPath(home),
+      JSON.stringify({ statusLine: { type: "command", command: "~/my-statusline.sh" } }),
+    );
+    installStatuslineSettings(home, { force: true });
+    const result = uninstallStatusline(home);
+    expect(result.statusLineRestored).toBe(true);
+    expect(readSettings().statusLine.command).toBe("~/my-statusline.sh");
+  });
+
+  it("leaves a statusLine the user replaced since install", () => {
+    installStatuslineSettings(home);
+    const cfg = readSettings();
+    cfg.statusLine = { type: "command", command: "~/new-statusline.sh" };
+    writeFileSync(claudeUserSettingsPath(home), JSON.stringify(cfg));
+    const result = uninstallStatusline(home);
+    expect(result.statusLineRemoved).toBe(false);
+    expect(readSettings().statusLine.command).toBe("~/new-statusline.sh");
+  });
+
+  it("preserves other PostToolUse groups", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      claudeUserSettingsPath(home),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            { matcher: "*", hooks: [{ type: "command", command: "dosu hooks post-tool-use" }] },
+          ],
+        },
+      }),
+    );
+    installStatuslineSettings(home);
+    uninstallStatusline(home);
+    const cfg = readSettings();
+    expect(cfg.hooks.PostToolUse).toHaveLength(1);
+    expect(cfg.hooks.PostToolUse[0].hooks[0].command).toBe("dosu hooks post-tool-use");
+  });
+
+  it("is a no-op on a machine with nothing installed", () => {
+    const result = uninstallStatusline(home);
+    expect(result.statusLineRemoved).toBe(false);
+    expect(existsSync(claudeUserSettingsPath(home))).toBe(false);
+  });
+
+  it("never clobbers an unparseable settings file but still removes our files", () => {
+    writeStatuslineScripts(home);
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudeUserSettingsPath(home), "{not json");
+    const result = uninstallStatusline(home);
+    expect(result.statusLineRemoved).toBe(false);
+    expect(readFileSync(claudeUserSettingsPath(home), "utf-8")).toBe("{not json");
+    expect(existsSync(statusLineScriptPath(home))).toBe(false);
+  });
+
+  it("ignores a corrupt backup and just removes our statusLine", () => {
+    installStatuslineSettings(home);
+    mkdirSync(statuslineScriptsDir(home), { recursive: true });
+    writeFileSync(statuslineBackupPath(home), "{corrupt");
+    const result = uninstallStatusline(home);
+    expect(result.statusLineRemoved).toBe(true);
+    expect(result.statusLineRestored).toBe(false);
+    expect(readSettings().statusLine).toBeUndefined();
+  });
+});
+
+describe("inspectStatusline", () => {
+  it("reports nothing installed on a clean machine", () => {
+    expect(inspectStatusline(home)).toEqual({
+      scriptInstalled: false,
+      statusLineConfigured: false,
+      settingsParseError: false,
+      warnings: [],
+    });
+  });
+
+  it("reports a full install", () => {
+    writeStatuslineScripts(home);
+    installStatuslineSettings(home);
+    const info = inspectStatusline(home);
+    expect(info.scriptInstalled).toBe(true);
+    expect(info.statusLineConfigured).toBe(true);
+  });
+
+  it("reports a settings parse error", () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudeUserSettingsPath(home), "{not json");
+    expect(inspectStatusline(home).settingsParseError).toBe(true);
+  });
+});

--- a/src/statusline/install.ts
+++ b/src/statusline/install.ts
@@ -1,0 +1,276 @@
+/**
+ * Claude Code status-line installer (Dosu knowledge row).
+ *
+ * The row (`Knowledge 📚 3 pages · 📝 77 notes`) is rendered by an embedded
+ * Python script from per-session state that `dosu hooks post-tool-use` / `stop`
+ * write whenever knowledge is delivered (explicit `read_knowledge` calls and
+ * hook-injected context alike — see src/statusline/state.ts). This module only
+ * installs the renderer under `~/.dosu/claude/` and wires `statusLine` into the
+ * user's `~/.claude/settings.json`.
+ *
+ * The main install hazard: `statusLine` is single-valued. Overwriting a user's
+ * existing status line silently is worse than not installing, so an existing
+ * foreign command is never replaced without `force` — the caller gets a
+ * "conflict" result and reports it. The original command is backed up before a
+ * forced replace so uninstall can restore it.
+ */
+
+import { chmodSync, existsSync, readFileSync, rmSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { saveJSONConfig, writeSecureFile } from "../mcp/config-helpers";
+import { STATUS_LINE_SOURCE } from "./assets";
+import { knowledgeStateDir } from "./state";
+
+// biome-ignore lint/suspicious/noExplicitAny: settings JSON is inherently untyped
+type JsonConfig = Record<string, any>;
+
+/** An earlier standalone-hook design installed this; installs/uninstalls clean it up. */
+const LEGACY_HOOK_FILE = "dosu-knowledge-hook.py";
+const STATUS_LINE_FILE = "dosu-statusline.py";
+
+/** `~/.dosu/claude/` — ours alone, so uninstall is a single directory removal. */
+export function statuslineScriptsDir(home: string = homedir()): string {
+  return join(home, ".dosu", "claude");
+}
+
+export function claudeUserSettingsPath(home: string = homedir()): string {
+  return join(home, ".claude", "settings.json");
+}
+
+/** Where a replaced statusLine value is saved so uninstall can restore it. */
+export function statuslineBackupPath(home: string = homedir()): string {
+  return join(statuslineScriptsDir(home), "statusline-backup.json");
+}
+
+export function statusLineScriptPath(home: string = homedir()): string {
+  return join(statuslineScriptsDir(home), STATUS_LINE_FILE);
+}
+
+function legacyHookScriptPath(home: string): string {
+  return join(statuslineScriptsDir(home), LEGACY_HOOK_FILE);
+}
+
+/** Write the embedded renderer, executable. Idempotent (refreshes on reinstall). */
+export function writeStatuslineScripts(home: string = homedir()): void {
+  const path = statusLineScriptPath(home);
+  writeSecureFile(path, STATUS_LINE_SOURCE);
+  chmodSync(path, 0o755); // must be executable — settings.json invokes it directly
+}
+
+/**
+ * Read a settings file, refusing to clobber a file that exists but does not
+ * parse — a malformed settings.json silently disables every setting in it,
+ * so we must never be the ones who make it worse.
+ */
+function readSettingsOrThrow(path: string): JsonConfig {
+  if (!existsSync(path)) return {};
+  const raw = readFileSync(path, "utf-8").trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as JsonConfig;
+  } catch {
+    throw new Error(`refusing to modify ${path}: file exists but is not valid JSON`);
+  }
+}
+
+function isOurStatusLine(statusLine: unknown): boolean {
+  return (
+    !!statusLine &&
+    typeof statusLine === "object" &&
+    typeof (statusLine as JsonConfig).command === "string" &&
+    (statusLine as JsonConfig).command.includes(STATUS_LINE_FILE)
+  );
+}
+
+function isLegacyHookGroup(group: unknown): boolean {
+  if (!group || typeof group !== "object") return false;
+  const hooks = (group as JsonConfig).hooks;
+  return (
+    Array.isArray(hooks) &&
+    hooks.some(
+      (h) => h && typeof h.command === "string" && (h.command as string).includes(LEGACY_HOOK_FILE),
+    )
+  );
+}
+
+/** Strip the legacy standalone hook's PostToolUse entry, if present. */
+function removeLegacyHookEntries(cfg: JsonConfig): boolean {
+  if (!Array.isArray(cfg.hooks?.PostToolUse)) return false;
+  const preserved = cfg.hooks.PostToolUse.filter((g: unknown) => !isLegacyHookGroup(g));
+  const removed = preserved.length !== cfg.hooks.PostToolUse.length;
+  if (preserved.length === 0) {
+    delete cfg.hooks.PostToolUse;
+  } else {
+    cfg.hooks.PostToolUse = preserved;
+  }
+  if (cfg.hooks && Object.keys(cfg.hooks).length === 0) delete cfg.hooks;
+  return removed;
+}
+
+export type StatusLineOutcome = "installed" | "updated" | "conflict" | "replaced";
+
+export interface InstallResult {
+  settingsPath: string;
+  statusLine: StatusLineOutcome;
+  /** The pre-existing foreign command, when statusLine is "conflict" or "replaced". */
+  existingCommand?: string;
+  warnings: string[];
+}
+
+/**
+ * Wire the renderer into `~/.claude/settings.json` (user scope).
+ *
+ * `statusLine` absent → write ours. Ours already → refresh. Foreign →
+ * conflict (skip) unless `force`, which backs the original up and replaces.
+ * Also removes the legacy standalone-hook PostToolUse entry when found.
+ */
+export function installStatuslineSettings(
+  home: string = homedir(),
+  opts: { force?: boolean } = {},
+): InstallResult {
+  const settingsPath = claudeUserSettingsPath(home);
+  const cfg = readSettingsOrThrow(settingsPath);
+  const warnings = collectSettingsWarnings(cfg);
+
+  let statusLine: StatusLineOutcome;
+  let existingCommand: string | undefined;
+  const ours = {
+    type: "command",
+    command: statusLineScriptPath(home),
+    padding: 1,
+  };
+  if (cfg.statusLine === undefined) {
+    cfg.statusLine = ours;
+    statusLine = "installed";
+  } else if (isOurStatusLine(cfg.statusLine)) {
+    cfg.statusLine = ours;
+    statusLine = "updated";
+  } else {
+    existingCommand =
+      typeof (cfg.statusLine as JsonConfig)?.command === "string"
+        ? (cfg.statusLine as JsonConfig).command
+        : JSON.stringify(cfg.statusLine);
+    if (opts.force) {
+      // Save the original so uninstall can restore it.
+      writeSecureFile(statuslineBackupPath(home), JSON.stringify(cfg.statusLine, null, 2));
+      cfg.statusLine = ours;
+      statusLine = "replaced";
+    } else {
+      statusLine = "conflict";
+    }
+  }
+
+  removeLegacyHookEntries(cfg);
+  saveJSONConfig(settingsPath, cfg);
+  return { settingsPath, statusLine, existingCommand, warnings };
+}
+
+/** Environments where the install would be inert — detect and warn, don't guess. */
+export function collectSettingsWarnings(cfg: JsonConfig): string[] {
+  const warnings: string[] = [];
+  if (cfg.disableAllHooks === true) {
+    warnings.push(
+      "disableAllHooks is set in ~/.claude/settings.json — hooks and the status line are disabled until it is removed",
+    );
+  }
+  if (cfg.allowManagedHooksOnly === true) {
+    warnings.push(
+      "allowManagedHooksOnly is set — user hooks are blocked, so knowledge counts will never be recorded",
+    );
+  }
+  return warnings;
+}
+
+export interface UninstallResult {
+  settingsPath: string;
+  statusLineRemoved: boolean;
+  statusLineRestored: boolean;
+}
+
+/**
+ * Reverse the install. Removes `statusLine` only if it still points at our
+ * script (the user may have replaced it since), restoring any backed-up
+ * original; deletes our files and state; strips any legacy hook entry.
+ */
+export function uninstallStatusline(home: string = homedir()): UninstallResult {
+  const settingsPath = claudeUserSettingsPath(home);
+  const result: UninstallResult = {
+    settingsPath,
+    statusLineRemoved: false,
+    statusLineRestored: false,
+  };
+
+  let cfg: JsonConfig | null = null;
+  try {
+    cfg = readSettingsOrThrow(settingsPath);
+  } catch {
+    cfg = null; // never clobber an unparseable file; still remove our own files below
+  }
+
+  if (cfg) {
+    if (isOurStatusLine(cfg.statusLine)) {
+      const backup = statuslineBackupPath(home);
+      let restored: JsonConfig | undefined;
+      if (existsSync(backup)) {
+        try {
+          restored = JSON.parse(readFileSync(backup, "utf-8")) as JsonConfig;
+        } catch {
+          restored = undefined;
+        }
+      }
+      if (restored) {
+        cfg.statusLine = restored;
+        result.statusLineRestored = true;
+      } else {
+        delete cfg.statusLine;
+      }
+      result.statusLineRemoved = true;
+    }
+
+    const legacyRemoved = removeLegacyHookEntries(cfg);
+    if (result.statusLineRemoved || legacyRemoved) {
+      saveJSONConfig(settingsPath, cfg);
+    }
+  }
+
+  for (const path of [
+    statusLineScriptPath(home),
+    legacyHookScriptPath(home),
+    statuslineBackupPath(home),
+  ]) {
+    try {
+      unlinkSync(path);
+    } catch {
+      // already gone
+    }
+  }
+  try {
+    rmSync(knowledgeStateDir(home), { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+  return result;
+}
+
+/** Read-only inspection for `statusline status`. Never throws. */
+export function inspectStatusline(home: string = homedir()): {
+  scriptInstalled: boolean;
+  statusLineConfigured: boolean;
+  settingsParseError: boolean;
+  warnings: string[];
+} {
+  let cfg: JsonConfig = {};
+  let settingsParseError = false;
+  try {
+    cfg = readSettingsOrThrow(claudeUserSettingsPath(home));
+  } catch {
+    settingsParseError = true;
+  }
+  return {
+    scriptInstalled: existsSync(statusLineScriptPath(home)),
+    statusLineConfigured: isOurStatusLine(cfg.statusLine),
+    settingsParseError,
+    warnings: collectSettingsWarnings(cfg),
+  };
+}

--- a/src/statusline/scripts.test.ts
+++ b/src/statusline/scripts.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Behavior tests for the embedded Python status-line renderer (spec contract).
+ *
+ * Runs the real script under python3 with fixture state and stdin and a temp
+ * HOME, covering the render shapes and the fail-silent contract. Skipped when
+ * python3 is not on PATH. The counting logic that populates the state lives in
+ * TypeScript now — see state.test.ts.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { STATUS_LINE_SOURCE } from "./assets";
+
+const python3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+let home: string;
+let statuslinePath: string;
+
+function stateDir(): string {
+  return join(home, ".dosu", "statusline-state");
+}
+
+function statePath(sessionId: string): string {
+  return join(stateDir(), `${sessionId}.knowledge.json`);
+}
+
+function run(stdin: string): { status: number | null; stdout: string } {
+  const res = spawnSync("python3", [statuslinePath], {
+    input: stdin,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home },
+  });
+  return { status: res.status, stdout: res.stdout };
+}
+
+function writeState(state: Record<string, unknown>): void {
+  mkdirSync(stateDir(), { recursive: true });
+  writeFileSync(statePath("sess-1"), JSON.stringify(state));
+}
+
+const stdin = JSON.stringify({ session_id: "sess-1" });
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "dosu-statusline-py-"));
+  statuslinePath = join(home, "dosu-statusline.py");
+  writeFileSync(statuslinePath, STATUS_LINE_SOURCE);
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("embedded source constraints", () => {
+  it("is ASCII-only and backtick-free", () => {
+    // Bun's transpiler rewrites non-ASCII chars into JS \u{...} escapes even
+    // inside String.raw, shipping the escape text instead of the character —
+    // the emoji must live as Python \UXXXXXXXX escapes. Backticks would
+    // terminate the template.
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: ASCII guard
+    expect(STATUS_LINE_SOURCE).toMatch(/^[\x00-\x7f]*$/);
+    expect(STATUS_LINE_SOURCE).not.toContain("`");
+  });
+});
+
+describe.skipIf(!python3)("dosu-statusline.py", () => {
+  it("renders pages and notes with plurals and dim label", () => {
+    writeState({ pages: 3, notes: 77 });
+    expect(run(stdin).stdout).toBe("\x1b[2mKnowledge\x1b[0m 📚 3 pages · 📝 77 notes\n");
+  });
+
+  it("uses singular forms for a count of one", () => {
+    writeState({ pages: 1, notes: 1 });
+    expect(run(stdin).stdout).toContain("📚 1 page · 📝 1 note");
+  });
+
+  it("omits notes when the delivery had none", () => {
+    writeState({ pages: 3, notes: 0 });
+    const out = run(stdin).stdout;
+    expect(out).toContain("📚 3 pages");
+    expect(out).not.toContain("📝");
+  });
+
+  it("renders notes only", () => {
+    writeState({ pages: 0, notes: 12 });
+    expect(run(stdin).stdout).toContain("📝 12 notes");
+  });
+
+  it("prints nothing when both counts are zero", () => {
+    writeState({ pages: 0, notes: 0 });
+    expect(run(stdin).stdout).toBe("");
+  });
+
+  it("prints nothing with no state file (pre-delivery: deliberately empty)", () => {
+    const res = run(stdin);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe("");
+  });
+
+  it("prints nothing on corrupt state JSON", () => {
+    mkdirSync(stateDir(), { recursive: true });
+    writeFileSync(statePath("sess-1"), "{corrupt");
+    const res = run(stdin);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe("");
+  });
+
+  it("prints nothing on garbage stdin", () => {
+    const res = run("garbage");
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe("");
+  });
+});

--- a/src/statusline/state.test.ts
+++ b/src/statusline/state.test.ts
@@ -1,0 +1,156 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  countKnowledge,
+  knowledgeStateDir,
+  knowledgeStatePath,
+  loadToolResponseText,
+  recordKnowledgeCounts,
+} from "./state";
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "dosu-statusline-state-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+const UUID = "123e4567-e89b-12d3-a456-426614174000";
+
+/** A read_knowledge result: branch notes first, then org knowledge (real payload order). */
+function knowledgeText(opts: { pages: string[]; notes: number; duplicatePage?: boolean }): string {
+  const noteBlocks = Array.from(
+    { length: opts.notes },
+    (_, i) => `### Note ${i + 1}\nauthor_id: ${UUID}\ncontent: something learned`,
+  );
+  const notesSection = opts.notes > 0 ? `## Branch notes\n\n${noteBlocks.join("\n\n")}\n\n` : "";
+  const pages = opts.duplicatePage ? [...opts.pages, ...opts.pages] : opts.pages;
+  const sources = pages
+    .map((url) => `<source url="${url}" title="Doc" lines="1-17" has_more="False">body</source>`)
+    .join("\n");
+  return `${notesSection}## Org knowledge\n\n${sources}\n`;
+}
+
+describe("countKnowledge", () => {
+  it("counts distinct pages and branch notes", () => {
+    const text = knowledgeText({
+      pages: ["https://app.dosu.dev/doc/1", "https://app.dosu.dev/doc/2"],
+      notes: 77,
+    });
+    expect(countKnowledge(text)).toEqual({ pages: 2, notes: 77 });
+  });
+
+  it("dedupes a document matching at several line ranges", () => {
+    const text = knowledgeText({
+      pages: ["https://app.dosu.dev/doc/1"],
+      notes: 0,
+      duplicatePage: true,
+    });
+    expect(countKnowledge(text)).toEqual({ pages: 1, notes: 0 });
+  });
+
+  it("counts zero notes when there is no branch-notes section", () => {
+    const text = knowledgeText({ pages: ["https://app.dosu.dev/doc/1"], notes: 0 });
+    expect(countKnowledge(text)).toEqual({ pages: 1, notes: 0 });
+  });
+
+  it("does not count author_id-like prose outside the notes section", () => {
+    const text = `## Org knowledge\n\nauthor_id: ${UUID}\n<source url="https://app.dosu.dev/doc/1" title="Doc">x</source>`;
+    expect(countKnowledge(text)).toEqual({ pages: 1, notes: 0 });
+  });
+
+  it("returns zeros for text with no knowledge", () => {
+    expect(countKnowledge("No knowledge found.")).toEqual({ pages: 0, notes: 0 });
+  });
+});
+
+describe("loadToolResponseText", () => {
+  it("unwraps string, result, content, and text shapes", () => {
+    expect(loadToolResponseText("plain")).toBe("plain");
+    expect(loadToolResponseText({ result: "r" })).toBe("r");
+    expect(loadToolResponseText({ content: "c" })).toBe("c");
+    expect(loadToolResponseText({ text: "t" })).toBe("t");
+    expect(loadToolResponseText({ other: 1 })).toBe('{"other":1}');
+  });
+
+  it("follows an offload pointer to a raw-JSON file (the common case)", () => {
+    const text = knowledgeText({ pages: ["https://app.dosu.dev/doc/1"], notes: 3 });
+    const offload = join(home, "offload-read_knowledge-1.txt");
+    writeFileSync(offload, JSON.stringify({ result: text }));
+    const loaded = loadToolResponseText(`Tool result was too large, saved to ${offload}`);
+    expect(countKnowledge(loaded)).toEqual({ pages: 1, notes: 3 });
+  });
+
+  it("falls back to unescaping when the offload file is truncated JSON", () => {
+    const text = knowledgeText({ pages: ["https://app.dosu.dev/doc/1"], notes: 2 });
+    const offload = join(home, "offload-truncated.txt");
+    writeFileSync(offload, JSON.stringify({ result: text }).slice(0, -10));
+    const loaded = loadToolResponseText(`saved to ${offload}`);
+    expect(countKnowledge(loaded)).toEqual({ pages: 1, notes: 2 });
+  });
+
+  it("normalizes inline escaped-JSON text when the pointer file is missing", () => {
+    const text = knowledgeText({ pages: ["https://app.dosu.dev/doc/1"], notes: 1 });
+    const escaped = JSON.stringify(text).slice(1, -1); // escaped, no surrounding quotes
+    expect(countKnowledge(loadToolResponseText(`saved to /nonexistent/x.txt ${escaped}`))).toEqual({
+      pages: 1,
+      notes: 1,
+    });
+  });
+});
+
+describe("recordKnowledgeCounts", () => {
+  it("writes the state file for the session", () => {
+    recordKnowledgeCounts("sess-1", { pages: 3, notes: 77 }, home);
+    expect(JSON.parse(readFileSync(knowledgeStatePath("sess-1", home), "utf-8"))).toEqual({
+      pages: 3,
+      notes: 77,
+    });
+  });
+
+  it("overwrites with the latest delivery", () => {
+    recordKnowledgeCounts("sess-1", { pages: 3, notes: 77 }, home);
+    recordKnowledgeCounts("sess-1", { pages: 1, notes: 0 }, home);
+    expect(JSON.parse(readFileSync(knowledgeStatePath("sess-1", home), "utf-8"))).toEqual({
+      pages: 1,
+      notes: 0,
+    });
+  });
+
+  it("writes nothing for all-zero counts or a missing session id", () => {
+    recordKnowledgeCounts("sess-1", { pages: 0, notes: 0 }, home);
+    recordKnowledgeCounts("", { pages: 1, notes: 0 }, home);
+    expect(existsSync(knowledgeStateDir(home))).toBe(false);
+  });
+
+  it("prunes state files older than the TTL on write", () => {
+    mkdirSync(knowledgeStateDir(home), { recursive: true });
+    const stale = knowledgeStatePath("old-session", home);
+    const fresh = knowledgeStatePath("fresh-session", home);
+    writeFileSync(stale, "{}");
+    writeFileSync(fresh, "{}");
+    const eightDaysAgo = (Date.now() - 8 * 24 * 60 * 60 * 1000) / 1000;
+    utimesSync(stale, eightDaysAgo, eightDaysAgo);
+    recordKnowledgeCounts("sess-1", { pages: 1, notes: 0 }, home);
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+  });
+
+  it("never throws when the state dir is unwritable", () => {
+    writeFileSync(join(home, ".dosu"), "a file where the dir should be");
+    expect(() => recordKnowledgeCounts("sess-1", { pages: 1, notes: 0 }, home)).not.toThrow();
+  });
+});

--- a/src/statusline/state.ts
+++ b/src/statusline/state.ts
@@ -1,0 +1,144 @@
+/**
+ * Status-line state: how much Dosu knowledge the session last received.
+ *
+ * Written from inside `dosu hooks post-tool-use` / `stop` (which already run on
+ * the agent's hot path and hold the knowledge payloads) and rendered by the
+ * embedded Python status-line script. Two delivery paths feed it:
+ *
+ *  1. Explicit `read_knowledge` MCP tool calls — counted from the PostToolUse
+ *     payload's `tool_response`.
+ *  2. Hook-injected knowledge — counted from the ticket result context at each
+ *     delivery point (PostToolUse injection, Stop, late harvest).
+ *
+ * Everything here is best-effort and must never throw into the hook hot path:
+ * the row is purely cosmetic. State files self-prune after 7 days — nothing
+ * else cleans the directory up.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "../debug/logger";
+import { writeSecureFile } from "../mcp/config-helpers";
+
+const STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Distinct documents, so a doc matching at several line ranges counts once. */
+const PAGE_RE = /url="(https:\/\/app\.dosu\.dev\/[^"]+)"/g;
+/** One per branch note. UUID-shaped, so note prose can't produce a false match. */
+const NOTE_RE = /^author_id: [0-9a-f-]{36}\s*$/gm;
+/** Oversized tool results are offloaded to disk; the response is just a pointer. */
+const OFFLOAD_RE = /saved to (?<path>\/\S+\.txt)/;
+
+/** Must match the STATE_DIR baked into the Python status-line script. */
+export function knowledgeStateDir(home: string = homedir()): string {
+  return join(home, ".dosu", "statusline-state");
+}
+
+export function knowledgeStatePath(sessionId: string, home: string = homedir()): string {
+  return join(knowledgeStateDir(home), `${sessionId}.knowledge.json`);
+}
+
+export interface KnowledgeCounts {
+  pages: number;
+  notes: number;
+}
+
+/** Coerce an MCP tool response of unknown shape into searchable text. */
+function unwrap(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    for (const key of ["result", "content", "text"]) {
+      const v = (value as Record<string, unknown>)[key];
+      if (typeof v === "string") return v;
+    }
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** Undo JSON string escaping if the text arrived as raw JSON. */
+function normalize(text: string): string {
+  if (!text.includes('\\"') && !text.includes("\\n")) return text;
+  return text.replaceAll("\\n", "\n").replaceAll('\\"', '"');
+}
+
+/**
+ * The searchable text of a tool response, following an offload pointer when
+ * present. Every real repo+branch lookup measured took the offload path (the
+ * payloads reach ~140KB), and the on-disk copy is raw JSON with escaped quotes
+ * — a truncated file falls back to matching against the escaped text.
+ */
+export function loadToolResponseText(toolResponse: unknown): string {
+  const text = unwrap(toolResponse);
+  const hit = OFFLOAD_RE.exec(text);
+  const path = hit?.groups?.path;
+  if (!path || !existsSync(path)) return normalize(text);
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return normalize(text);
+  }
+  try {
+    return unwrap(JSON.parse(raw));
+  } catch {
+    return normalize(raw); // truncated or partial file
+  }
+}
+
+/** Distinct knowledge pages, and branch notes from the notes section only. */
+export function countKnowledge(text: string): KnowledgeCounts {
+  const pages = new Set<string>();
+  for (const m of text.matchAll(PAGE_RE)) pages.add(m[1]);
+  // Notes are returned only when the lookup had both repo and branch; the
+  // notes section precedes org knowledge in the payload.
+  const notesSection = text.includes("## Branch notes") ? text.split("## Org knowledge")[0] : "";
+  const notes = notesSection.match(NOTE_RE)?.length ?? 0;
+  return { pages: pages.size, notes };
+}
+
+/** Drop state from sessions that ended long ago; nothing else cleans up. */
+function prune(dir: string, now: number): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (!name.endsWith(".knowledge.json")) continue;
+    const path = join(dir, name);
+    try {
+      if (now - statSync(path).mtimeMs > STATE_TTL_MS) rmSync(path, { force: true });
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/**
+ * Record a knowledge delivery for the status line (latest delivery wins).
+ * Zero counts are not written — "no notes returned" usually means the lookup
+ * omitted repo/branch, and the row must never render an all-zero state.
+ */
+export function recordKnowledgeCounts(
+  sessionId: string,
+  counts: KnowledgeCounts,
+  home: string = homedir(),
+  now: number = Date.now(),
+): void {
+  if (!sessionId || (!counts.pages && !counts.notes)) return;
+  try {
+    const dir = knowledgeStateDir(home);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    prune(dir, now);
+    writeSecureFile(knowledgeStatePath(sessionId, home), JSON.stringify(counts));
+  } catch (err) {
+    // Cosmetic feature: never let a state write disturb the hook.
+    logger.debug("statusline", `state write failed: ${err instanceof Error ? err.message : err}`);
+  }
+}


### PR DESCRIPTION
Adds `dosu statusline install|uninstall|status`, which wires a status line into Claude Code showing how much knowledge Dosu last delivered to the session (e.g. `Knowledge 📚 3 pages · 📝 77 notes`), rendered by an embedded Python script installed to `~/.dosu/claude/` and configured in user-scope `~/.claude/settings.json`. Per-session counts are recorded in TypeScript from inside the existing `dosu hooks post-tool-use`/`stop` entrypoints, covering both explicit `read_knowledge` MCP calls (including offloaded-to-disk results) and hook-injected knowledge at every delivery point, with 7-day self-pruning state. The installer never overwrites an existing status line without `--force` (backing up and restoring the original on uninstall), refuses to touch unparseable settings files, cleans up legacy standalone-hook entries, and warns on `disableAllHooks`/`allowManagedHooksOnly`/missing python3. The embedded script is constrained to ASCII with a regression test, since Bun's transpiler corrupts non-ASCII characters inside `String.raw` templates. The row deliberately prints nothing until a knowledge delivery happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)