### PR TITLE
feat(setup): collapse setup onto the single /cli/auth handshake

### DIFF
--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -370,7 +370,9 @@ async function resolveDeployment(
         step: "deployment",
         reason: "no_deployments",
         agent_next_steps:
-          "No Dosu deployments are accessible to this account. Tell the user to create one at https://app.dosu.dev before retrying.",
+          "No Dosu deployments are accessible to this account. The CLI may be signed in to a " +
+          "different account than the user expects — have them run 'dosu logout' and retry, or " +
+          "create a deployment at https://app.dosu.dev before retrying.",
       });
       return { code: 1, cfg };
     }
@@ -382,7 +384,10 @@ async function resolveDeployment(
         step: "deployment",
         reason: "no_mcp_deployment",
         agent_next_steps:
-          "Account has deployments but none of them back an MCP server. Tell the user to create an MCP deployment at https://app.dosu.dev, or pass --deployment <id> to target a specific deployment.",
+          "Account has deployments but none of them back an MCP server. The CLI may be signed in " +
+          "to a different account than the user expects — have them run 'dosu logout' and retry, " +
+          "create an MCP deployment at https://app.dosu.dev, or pass --deployment <id> to target " +
+          "a specific deployment.",
       });
       return { code: 1, cfg };
     }

--- a/src/auth/flow.test.ts
+++ b/src/auth/flow.test.ts
@@ -39,7 +39,6 @@ function createMockServer(): CallbackServer {
   return {
     port: 12345,
     close: mockClose,
-    setNext: vi.fn(),
   };
 }
 
@@ -239,11 +238,27 @@ describe("startOAuthFlow", () => {
 
     const flowPromise = startOAuthFlow();
 
-    await expect(flowPromise).rejects.toThrow(
-      "Authentication did not complete within 8 minutes. The OAuth state may have expired",
-    );
+    await expect(flowPromise).rejects.toThrow("Authentication did not complete within 8 minutes.");
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 8 * 60 * 1000);
     expect(mockClose).toHaveBeenCalledOnce();
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("honors a caller-supplied timeout window (the setup handshake is longer)", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((callback) => {
+      queueMicrotask(() => {
+        if (typeof callback === "function") callback();
+      });
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    const flowPromise = startOAuthFlow(undefined, "/cli/auth", {}, undefined, {
+      timeoutMs: 30 * 60 * 1000,
+    });
+
+    await expect(flowPromise).rejects.toThrow("Authentication did not complete within 30 minutes.");
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 30 * 60 * 1000);
 
     setTimeoutSpy.mockRestore();
   });
@@ -275,55 +290,22 @@ describe("startOAuthFlow", () => {
     expect(r).toMatchObject({ browserOpened: true });
   });
 
-  it("holdNext keeps the server open and hands it over on the result", async () => {
+  it("passes the successVariant through to the callback server and always closes it", async () => {
     const token: TokenResponse = { access_token: "tok", refresh_token: "ref", expires_in: 3600 };
 
-    const flowPromise = startOAuthFlow(undefined, "/cli/auth", {}, undefined, { holdNext: true });
-    await flowReady();
-
-    resolveToken(token);
-    const result = await flowPromise;
-
-    expect(result).toMatchObject({ browserOpened: true, token });
-    expect((result as { server?: CallbackServer }).server).toBe(mockServer);
-    // Server ownership transferred to the caller — not closed here.
-    expect(mockClose).not.toHaveBeenCalled();
-    expect(mockStartCallbackServer).toHaveBeenCalledWith(
-      expect.objectContaining({ nextHold: true }),
-    );
-  });
-
-  it("holdNext still closes the server on failure (no handover happened)", async () => {
-    const flowPromise = startOAuthFlow(undefined, "/cli/auth", {}, undefined, { holdNext: true });
-    await flowReady();
-
-    rejectToken(new Error("boom"));
-    await flowPromise.catch(() => {});
-
-    expect(mockClose).toHaveBeenCalledOnce();
-  });
-
-  it("suppressBrowserOpen completes the flow without opening a browser", async () => {
-    const token: TokenResponse = { access_token: "tok", refresh_token: "ref", expires_in: 3600 };
-
-    const flowPromise = startOAuthFlow(undefined, "/onboarding/connections", {}, undefined, {
-      suppressBrowserOpen: true,
+    const flowPromise = startOAuthFlow(undefined, "/cli/auth", {}, undefined, {
       successVariant: "onboarding",
     });
-    // flowReady() waits on open(), which never fires here — wait on the
-    // callback server instead, plus a macrotask barrier for the race arming.
-    await vi.waitFor(() => expect(mockStartCallbackServer).toHaveBeenCalled());
-    await new Promise((r) => setImmediate(r));
+    await flowReady();
 
     resolveToken(token);
     const result = await flowPromise;
 
     expect(result).toMatchObject({ browserOpened: true, token });
-    expect(mockOpenDefault).not.toHaveBeenCalled();
     expect(mockStartCallbackServer).toHaveBeenCalledWith(
       expect.objectContaining({ successVariant: "onboarding" }),
     );
-    // No holdNext → the flow still owns and closes the server.
+    // The flow always owns and closes the server — there is no handover.
     expect(mockClose).toHaveBeenCalledOnce();
   });
 });

--- a/src/auth/flow.ts
+++ b/src/auth/flow.ts
@@ -4,16 +4,16 @@
 
 import { getWebAppURL } from "../config/constants";
 import { logger } from "../debug/logger";
-import {
-  type CallbackServer,
-  type SuccessVariant,
-  startCallbackServer,
-  type TokenResponse,
-} from "./server";
+import { type SuccessVariant, startCallbackServer, type TokenResponse } from "./server";
 
 export type OAuthFlowResult =
-  | { browserOpened: true; token: TokenResponse; server?: CallbackServer }
+  | { browserOpened: true; token: TokenResponse }
   | { browserOpened: false };
+
+/** Default wait for a plain auth roundtrip: under Supabase's ~10 min OAuth
+ * state TTL, so we surface a useful message before users hit a stale-state
+ * error. */
+const DEFAULT_TIMEOUT_MS = 8 * 60 * 1000;
 
 export interface OAuthFlowOptions {
   /** Called with the auth URL before the browser open is attempted. */
@@ -25,17 +25,12 @@ export interface OAuthFlowOptions {
    */
   waitWithoutBrowser?: boolean;
   /**
-   * Keep the callback server alive after the token arrives and return it on
-   * the result, so the caller can steer the success page's tab onward via
-   * `server.setNext(url)`. The caller owns closing the server.
+   * How long to wait for the callback. Defaults to 8 minutes (a plain auth
+   * roundtrip). The setup handshake passes a much longer window: with
+   * `intent=setup` the browser trip can contain the whole onboarding wizard
+   * — including a GitHub App install that may sit on an org-admin approval.
    */
-  holdNext?: boolean;
-  /**
-   * Don't open a browser — the caller navigates an already-open tab to the
-   * auth URL itself (e.g. via a previous server's `setNext`). `onAuthURL`
-   * still fires so the caller has the URL.
-   */
-  suppressBrowserOpen?: boolean;
+  timeoutMs?: number;
   /** Success-page copy variant served on the callback. Defaults to "auth". */
   successVariant?: SuccessVariant;
 }
@@ -63,12 +58,10 @@ export async function startOAuthFlow(
   options: OAuthFlowOptions = {},
 ): Promise<OAuthFlowResult> {
   const { server, tokenPromise } = await startCallbackServer({
-    nextHold: options.holdNext,
     successVariant: options.successVariant,
   });
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  let handedOver = false;
 
   try {
     const callbackURL = `http://localhost:${server.port}/callback`;
@@ -78,24 +71,18 @@ export async function startOAuthFlow(
     options.onAuthURL?.(authURL);
 
     let browserOpened = false;
-    if (options.suppressBrowserOpen) {
-      // The caller navigates an existing tab to authURL itself.
+    // Open browser — dynamic import to avoid bundling issues
+    const open = await import("open");
+    try {
+      await open.default(authURL);
       browserOpened = true;
-      logger.info("auth.flow", "Browser open suppressed — caller steers an existing tab");
-    } else {
-      // Open browser — dynamic import to avoid bundling issues
-      const open = await import("open");
-      try {
-        await open.default(authURL);
-        browserOpened = true;
-        logger.info("auth.flow", "Browser open command executed");
-        onAuthURL?.(authURL);
-      } catch (openErr) {
-        logger.warn(
-          "auth.flow",
-          `Could not open browser automatically: ${openErr instanceof Error ? openErr.message : String(openErr)}`,
-        );
-      }
+      logger.info("auth.flow", "Browser open command executed");
+      onAuthURL?.(authURL);
+    } catch (openErr) {
+      logger.warn(
+        "auth.flow",
+        `Could not open browser automatically: ${openErr instanceof Error ? openErr.message : String(openErr)}`,
+      );
     }
 
     if (!browserOpened && !options.waitWithoutBrowser) {
@@ -104,20 +91,18 @@ export async function startOAuthFlow(
       // Note: server.close() is called by the finally block below
     }
 
-    // 8 min < Supabase's ~10 min OAuth state TTL, so we surface a useful
-    // message before users hit a stale-state error.
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const timeoutMinutes = Math.round(timeoutMs / 60_000);
     const timeout = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(
-        () => {
-          logger.warn("auth.flow", "Authentication timed out (8min)");
-          reject(
-            new Error(
-              "Authentication did not complete within 8 minutes. The OAuth state may have expired — please run `dosu login` again.",
-            ),
-          );
-        },
-        8 * 60 * 1000,
-      );
+      timeoutId = setTimeout(() => {
+        logger.warn("auth.flow", `Authentication timed out (${timeoutMinutes}min)`);
+        reject(
+          new Error(
+            `Authentication did not complete within ${timeoutMinutes} minutes. ` +
+              "If you finished in the browser after the timeout, just re-run the command.",
+          ),
+        );
+      }, timeoutMs);
     });
 
     const abort = signal
@@ -131,18 +116,11 @@ export async function startOAuthFlow(
 
     const token = await Promise.race([tokenPromise, timeout, abort]);
     logger.info("auth.flow", "Token received");
-    if (options.holdNext) {
-      // Caller takes over the server to steer the tab (and close it).
-      handedOver = true;
-      return { browserOpened: true, token, server };
-    }
     return { browserOpened: true, token };
   } finally {
     clearTimeout(timeoutId);
-    if (!handedOver) {
-      server.close();
-      logger.debug("auth.flow", "Cleaning up: timeout cleared, server closed");
-    }
+    server.close();
+    logger.debug("auth.flow", "Cleaning up: timeout cleared, server closed");
   }
 }
 

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -274,7 +274,7 @@ describe("auth callback server", () => {
   });
 });
 
-describe("auth callback server — nextHold tab steering", () => {
+describe("auth callback server — single-purpose listener & success copy", () => {
   let server: CallbackServer | null = null;
 
   afterEach(() => {

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -284,51 +284,19 @@ describe("auth callback server — nextHold tab steering", () => {
     }
   });
 
-  it("serves the /next poll script on the success page only when nextHold is set", async () => {
-    const held = await startCallbackServer({ nextHold: true });
-    server = held.server;
-    const heldResp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
-    const heldHtml = await heldResp.text();
-    expect(heldHtml).toContain("fetch('/next')");
-    // Steered tabs announce the next step instead of "close this tab".
-    expect(heldHtml).toContain("Hang tight");
-    expect(heldHtml).toContain("ready to connect your data sources");
-    expect(heldHtml).toContain("Redirecting...");
-    await held.tokenPromise;
-    server.close();
-
-    const plain = await startCallbackServer();
-    server = plain.server;
-    const plainResp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
-    expect(await plainResp.text()).not.toContain("fetch('/next')");
-    await plain.tokenPromise;
-  });
-
-  it("answers /next: 204 while undecided, 200 with the URL after setNext, 410 after dismissal", async () => {
-    const result = await startCallbackServer({ nextHold: true });
-    server = result.server;
-    const base = `http://localhost:${server.port}`;
-
-    const undecided = await fetch(`${base}/next`);
-    expect(undecided.status).toBe(204);
-
-    server.setNext("https://app.test/onboarding/connections?source=cli");
-    const decided = await fetch(`${base}/next`);
-    expect(decided.status).toBe(200);
-    expect(await decided.json()).toEqual({
-      url: "https://app.test/onboarding/connections?source=cli",
-    });
-
-    server.setNext(null);
-    const dismissed = await fetch(`${base}/next`);
-    expect(dismissed.status).toBe(410);
-  });
-
-  it("keeps /next a 404 when the server was started without nextHold", async () => {
+  it("keeps every non-callback path a 404 (single-purpose listener)", async () => {
     const result = await startCallbackServer();
     server = result.server;
     const resp = await fetch(`http://localhost:${server.port}/next`);
     expect(resp.status).toBe(404);
+  });
+
+  it("never serves auxiliary scripts on the success page", async () => {
+    const result = await startCallbackServer();
+    server = result.server;
+    const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
+    expect(await resp.text()).not.toContain("fetch('/next')");
+    await result.tokenPromise;
   });
 
   it("serves onboarding-specific success copy for the onboarding variant", async () => {
@@ -343,7 +311,7 @@ describe("auth callback server — nextHold tab steering", () => {
   });
 
   it("defaults to the auth success copy", async () => {
-    const result = await startCallbackServer({ nextHold: true });
+    const result = await startCallbackServer();
     server = result.server;
     const resp = await fetch(`http://localhost:${server.port}/callback?access_token=tok`);
     expect(await resp.text()).toContain("Authentication Successful");

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -399,7 +399,7 @@ export async function startCallbackServer(opts: CallbackServerOptions = {}): Pro
       port: addr.port,
       close: () => {
         httpServer.close();
-        // Sever any keep-alive sockets so close completes promptly.
+        // Sever any keep-alive sockets so close completes promptly
         httpServer.closeAllConnections?.();
       },
     },

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -155,72 +155,9 @@ const SUCCESS_COPY: Record<SuccessVariant, { title: string; heading: string; clo
   },
 };
 
-/**
- * Injected when the server was started with `nextHold`: the success page
- * polls GET /next so the CLI can steer this same tab onward (e.g. into the
- * web onboarding wizard) instead of opening a second one. Polling stops on
- * 410 (CLI decided there's nowhere to go — the page then settles to
- * `settleMsg`, the variant's regular close message), after ~3 minutes, or
- * once the server is clearly gone (several consecutive fetch failures —
- * covers both a closed server and a 410 whose response was cut off
- * mid-flush). A single transient error never ends the loop, because giving
- * up early would strand a handoff the CLI is still preparing (it may spend
- * several network round-trips deciding before calling setNext).
- *
- * When the steer arrives (200), the page announces the next step — first-run
- * users are about to see the data-source connection wizard, so saying
- * "authentication successful, close this tab" right before that would be
- * confusing — then navigates.
- */
-function buildNextPollScript(settleMsg: string): string {
-  return `<script>
-(function () {
-  var tries = 0;
-  var misses = 0;
-  var setCopy = function (heading, msg) {
-    var h = document.getElementById('heading');
-    var m = document.getElementById('close-msg');
-    if (h && heading) h.textContent = heading;
-    if (m && msg) m.textContent = msg;
-  };
-  var settle = function () { setCopy(null, ${JSON.stringify(settleMsg)}); };
-  var timer = setInterval(function () {
-    tries += 1;
-    if (tries > 720) { clearInterval(timer); settle(); return; }
-    fetch('/next').then(function (res) {
-      misses = 0;
-      if (res.status === 200) {
-        clearInterval(timer);
-        res.json().then(function (body) {
-          if (body && body.url) {
-            setCopy("You're ready to connect your data sources", 'Redirecting...');
-            window.location.replace(body.url);
-          }
-        });
-      } else if (res.status === 410) {
-        clearInterval(timer);
-        settle();
-      }
-    }).catch(function () {
-      misses += 1;
-      if (misses >= 8) { clearInterval(timer); settle(); }
-    });
-  }, 250);
-})();
-</script>`;
-}
-
-function buildSuccessHtml(
-  email?: string,
-  variant: SuccessVariant = "auth",
-  withNextPoll = false,
-): string {
+function buildSuccessHtml(email?: string, variant: SuccessVariant = "auth"): string {
   const copy = SUCCESS_COPY[variant];
-  // While the /next poller is live, don't invite the user to close the tab —
-  // the CLI may be about to steer it onward. The poll script swaps in the
-  // regular close message once the CLI dismisses the hold (410) or the
-  // budget runs out.
-  const closeMsg = withNextPoll ? "Hang tight — this tab will continue automatically." : copy.close;
+  const closeMsg = copy.close;
   const emailLine = email
     ? `<p class="email">Signed in as <strong>${email.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")}</strong></p>`
     : "";
@@ -340,7 +277,6 @@ h1 {
     <span class="tip-label">Did you know?</span>
     You can use Dosu to make your coding agents faster and cheaper. Just ask your agent to use Dosu to update your AGENTS.md.
 </div>
-${withNextPoll ? buildNextPollScript(copy.close) : ""}
 </body>
 </html>`;
 }
@@ -348,21 +284,9 @@ ${withNextPoll ? buildNextPollScript(copy.close) : ""}
 export interface CallbackServer {
   port: number;
   close: () => void;
-  /**
-   * Steer the success page's tab onward (requires `nextHold`): a URL makes
-   * the page navigate there in place; `null` tells it to stop polling and
-   * stay put. No-op when the page never polls (server started without
-   * `nextHold`) or already navigated.
-   */
-  setNext: (url: string | null) => void;
 }
 
 export interface CallbackServerOptions {
-  /**
-   * Serve the success page with the /next poller so the CLI can redirect
-   * the tab afterwards via `server.setNext(url)`.
-   */
-  nextHold?: boolean;
   /** Success-page copy variant. Defaults to "auth". */
   successVariant?: SuccessVariant;
 }
@@ -383,9 +307,6 @@ export async function startCallbackServer(opts: CallbackServerOptions = {}): Pro
     rejectToken = reject;
   });
 
-  // undefined = undecided (keep polling), string = navigate, null = dismissed.
-  let nextTarget: string | null | undefined;
-
   const http = require("node:http") as typeof import("node:http");
 
   const httpServer = http.createServer((req, res) => {
@@ -397,21 +318,6 @@ export async function startCallbackServer(opts: CallbackServerOptions = {}): Pro
       "auth.server",
       `Request: ${req.method} ${url.pathname} cookie-len=${cookieLen} ua=${ua} has-token=${url.searchParams.has("access_token")}`,
     );
-
-    if (opts.nextHold && url.pathname === "/next") {
-      if (nextTarget === undefined) {
-        res.writeHead(204);
-        res.end();
-      } else if (nextTarget === null) {
-        res.writeHead(410);
-        res.end();
-      } else {
-        logger.info("auth.server", "Handing tab onward via /next");
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ url: nextTarget }));
-      }
-      return;
-    }
 
     if (url.pathname !== "/callback") {
       logger.debug("auth.server", `404: ${url.pathname}`);
@@ -474,9 +380,7 @@ export async function startCallbackServer(opts: CallbackServerOptions = {}): Pro
 
     logger.info("auth.server", "Served success HTML");
     res.writeHead(200, { "Content-Type": "text/html" });
-    res.end(
-      buildSuccessHtml(email ?? undefined, opts.successVariant ?? "auth", Boolean(opts.nextHold)),
-    );
+    res.end(buildSuccessHtml(email ?? undefined, opts.successVariant ?? "auth"));
   });
 
   // Listen on random port and wait for it to be ready
@@ -495,13 +399,8 @@ export async function startCallbackServer(opts: CallbackServerOptions = {}): Pro
       port: addr.port,
       close: () => {
         httpServer.close();
-        // The success page's /next poller keeps a keep-alive socket open;
-        // plain close() would wait for it to drain. Sever it so close
-        // completes promptly.
+        // Sever any keep-alive sockets so close completes promptly.
         httpServer.closeAllConnections?.();
-      },
-      setNext: (url) => {
-        nextTarget = url;
       },
     },
     tokenPromise,

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1805,8 +1805,14 @@ describe("runSetup checkpoint behavior", () => {
       "/cli/auth",
       expect.objectContaining({ intent: "setup" }),
       undefined,
-      expect.objectContaining({ waitWithoutBrowser: true }),
+      expect.objectContaining({
+        waitWithoutBrowser: true,
+        timeoutMs: 30 * 60 * 1000,
+      }),
     );
+    // The setup flow never deep-links a web product page.
+    const paths = mockStartOAuthFlow.mock.calls.map((call) => call[1]);
+    expect(paths).not.toContain("/onboarding/connections");
     expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
   });
 
@@ -2347,8 +2353,6 @@ describe("runSetup additional branches", () => {
 // always comes back — with a session for whoever is really in the browser.
 // ---------------------------------------------------------------------------
 
-const SETUP_HANDSHAKE_TIMEOUT_MS = 30 * 60 * 1000;
-
 describe("runSetup single-handshake protocol", () => {
   const mockClient = vi.mocked(Client);
   const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
@@ -2407,28 +2411,6 @@ describe("runSetup single-handshake protocol", () => {
       },
     });
   }
-
-  it("hands a first-run user to /cli/auth with intent=setup and a 30-minute window", async () => {
-    saveConfig(makeCfg());
-    setupAuthed();
-    firstRunThenOnboarded();
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    expect(mockStartOAuthFlow).toHaveBeenCalledWith(
-      undefined,
-      "/cli/auth",
-      expect.objectContaining({ intent: "setup" }),
-      undefined,
-      expect.objectContaining({
-        waitWithoutBrowser: true,
-        timeoutMs: SETUP_HANDSHAKE_TIMEOUT_MS,
-      }),
-    );
-    const paths = mockStartOAuthFlow.mock.calls.map((call) => call[1]);
-    expect(paths).not.toContain("/onboarding/connections");
-  });
 
   it("rebinds to the account the browser handed back (cross-account self-heal)", async () => {
     saveConfig(makeCfg());
@@ -2568,31 +2550,6 @@ describe("runSetup single-handshake protocol", () => {
           e.properties?.reason === "onboarding_incomplete_after_handshake",
       ),
     ).toBe(true);
-  });
-
-  it("sends intent=setup on the first browser hop for cloud mode", async () => {
-    // No stored session at all → stepAuthenticate goes to the browser.
-    setupAuthed();
-    mockStartOAuthFlow.mockResolvedValue({
-      browserOpened: true,
-      token: {
-        access_token: "tok-fresh",
-        refresh_token: "ref-fresh",
-        expires_in: 3600,
-        email: "fresh@example.com",
-      },
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    expect(mockStartOAuthFlow).toHaveBeenCalledWith(
-      undefined,
-      "/cli/auth",
-      expect.objectContaining({ intent: "setup" }),
-      undefined,
-      expect.objectContaining({ timeoutMs: SETUP_HANDSHAKE_TIMEOUT_MS }),
-    );
   });
 
   it("keeps the OSS first hop free of the setup intent", async () => {

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1778,14 +1778,20 @@ describe("runSetup checkpoint behavior", () => {
     expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
   });
 
-  it("hands first-run users to the web onboarding wizard even when the legacy CLI flag is disabled", async () => {
+  it("hands first-run users to the /cli/auth handshake even when the legacy CLI flag is disabled", async () => {
     saveConfig(makeCfg());
     setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: false,
-    });
+    mockTrpc.user.getCliOnboardingContext.query
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: false,
+        cli_onboarding_enabled: false,
+      })
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      });
     mockStartOAuthFlow.mockResolvedValue({
       browserOpened: true,
       token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
@@ -1796,8 +1802,8 @@ describe("runSetup checkpoint behavior", () => {
 
     expect(mockStartOAuthFlow).toHaveBeenCalledWith(
       undefined,
-      "/onboarding/connections",
-      expect.objectContaining({ source: "cli" }),
+      "/cli/auth",
+      expect.objectContaining({ intent: "setup" }),
       undefined,
       expect.objectContaining({ waitWithoutBrowser: true }),
     );
@@ -1838,9 +1844,10 @@ describe("runSetup checkpoint behavior", () => {
 
     await runSetup();
 
-    expect(p.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("Finish onboarding there, then re-run `dosu setup`."),
-    );
+    // The timeout guidance names the likeliest cause (account mismatch) and
+    // its cure — never a bare "go finish in the browser" loop.
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("`dosu logout`"));
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("re-run `dosu setup`"));
     expect(trackedCliOnboardingEvents()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -1854,54 +1861,11 @@ describe("runSetup checkpoint behavior", () => {
     expect(p.multiselect).not.toHaveBeenCalled();
   });
 
-  it("binds first-run onboarding to the owner org instead of stale local config", async () => {
-    saveConfig(
-      makeCfg({
-        deployment_id: "old-dep",
-        deployment_name: "Old Deploy",
-        org_id: "old-org",
-        space_id: "old-space",
-      }),
-    );
-    setupAuthed({
-      getDeployments: vi.fn().mockResolvedValue([
-        makeDeployment({
-          deployment_id: "dep-old",
-          org_id: "old-org",
-          org_name: "Old Org",
-          space_id: "space-old",
-        }),
-        makeDeployment({
-          deployment_id: "dep-owner",
-          org_id: "owner-org",
-          org_name: "Owner Org",
-          space_id: "space-owner",
-        }),
-      ]),
-    });
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    mockTrpc.organization.getOrganizations.query.mockResolvedValue([
-      { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
-    ]);
-    mockStartOAuthFlow.mockResolvedValue({
-      browserOpened: true,
-      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    const saved = loadConfig();
-    expect(saved.active_account?.target?.org_id).toBe("owner-org");
-    expect(saved.active_account?.target?.space_id).toBe("space-owner");
-    expect(saved.active_account?.target?.deployment_id).toBe("dep-owner");
-  });
-
-  it("re-resolves onboarding state when the browser hands back a different account", async () => {
+  it("re-resolves everything when the handshake hands back a different account", async () => {
+    // The twin-account incident shape: the CLI held account A's session and
+    // stale target; the browser is signed in as account B. The handshake
+    // returns B's minted session — the stale target must be dropped and B's
+    // MCP bound, with a fresh API key (never A's).
     saveConfig(
       makeCfg({
         access_token: "account-a-token",
@@ -1914,13 +1878,8 @@ describe("runSetup checkpoint behavior", () => {
       }),
     );
     const methods = setupAuthed({
+      getOrgs: vi.fn().mockResolvedValue([{ org_id: "account-b-org", name: "Account B Org" }]),
       getDeployments: vi.fn().mockResolvedValue([
-        makeDeployment({
-          deployment_id: "account-a-deployment",
-          org_id: "account-a-org",
-          org_name: "Account A Org",
-          space_id: "account-a-space",
-        }),
         makeDeployment({
           deployment_id: "account-b-deployment",
           org_id: "account-b-org",
@@ -1929,18 +1888,17 @@ describe("runSetup checkpoint behavior", () => {
         }),
       ]),
     });
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "account-a-user",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    mockTrpc.organization.getOrganizations.query
-      .mockResolvedValueOnce([
-        { org_id: "account-a-org", name: "Account A Org", user_role: "OWNER" },
-      ])
-      .mockResolvedValueOnce([
-        { org_id: "account-b-org", name: "Account B Org", user_role: "OWNER" },
-      ]);
+    mockTrpc.user.getCliOnboardingContext.query
+      .mockResolvedValueOnce({
+        user_id: "account-a-user",
+        finished_onboarding: false,
+        cli_onboarding_enabled: false,
+      })
+      .mockResolvedValueOnce({
+        user_id: "account-b-user",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      });
     mockStartOAuthFlow.mockResolvedValue({
       browserOpened: true,
       token: {
@@ -1954,6 +1912,7 @@ describe("runSetup checkpoint behavior", () => {
     await runSetup();
 
     const saved = loadConfig();
+    expect(saved.active_account?.user_id).toBe("account-b-user");
     expect(saved.active_account?.session.access_token).toBe("account-b-token");
     expect(saved.active_account?.session.refresh_token).toBe("account-b-refresh");
     expect(saved.active_account?.target?.org_id).toBe("account-b-org");
@@ -1982,64 +1941,31 @@ describe("runSetup checkpoint behavior", () => {
     expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
   });
 
-  it("steers the auth tab into the web wizard instead of opening a second one", async () => {
-    // Fresh config → browser auth happens this run, so an auth tab exists.
+  it("completes a fresh first-run in a single browser trip (wizard rides the auth hop)", async () => {
+    // Fresh config → the auth hop itself carries `intent=setup`, so the web
+    // side routes the wizard inside that same trip. There is no second
+    // browser flow and no tab-steering machinery.
     saveConfig(makeCfg({ access_token: "", refresh_token: "", expires_at: 0 }));
     setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: false,
-    });
-    const authTab = { port: 1, close: vi.fn(), setNext: vi.fn() };
-    mockStartOAuthFlow
-      .mockResolvedValueOnce({
-        browserOpened: true,
-        token: { access_token: "tok-auth", refresh_token: "ref-auth", expires_in: 3600 },
-        server: authTab,
-      })
-      .mockImplementationOnce(async (_signal, _path, _params, _onAuthURL, options) => {
-        options?.onAuthURL?.("https://app.test/onboarding/connections?source=cli&callback=x");
-        return {
-          browserOpened: true,
-          token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
-        };
-      });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    // The existing tab was steered to the wizard URL…
-    expect(authTab.setNext).toHaveBeenCalledWith(
-      "https://app.test/onboarding/connections?source=cli&callback=x",
-    );
-    // …and the wizard call suppressed its own browser open.
-    const handoffOptions = mockStartOAuthFlow.mock.calls[1]?.[4];
-    expect(handoffOptions).toMatchObject({
-      suppressBrowserOpen: true,
-      successVariant: "onboarding",
-    });
-    expect(authTab.close).toHaveBeenCalled();
-  });
-
-  it("releases the auth tab when the profile is already onboarded", async () => {
-    saveConfig(makeCfg({ access_token: "", refresh_token: "", expires_at: 0 }));
-    setupAuthed();
-    // installRemoteSetupDefaults: finished_onboarding=true → ordinary setup.
-    const authTab = { port: 1, close: vi.fn(), setNext: vi.fn() };
+    // By the time the CLI queries its context, the browser-side wizard has
+    // already finished — the flag comes back true.
     mockStartOAuthFlow.mockResolvedValueOnce({
       browserOpened: true,
       token: { access_token: "tok-auth", refresh_token: "ref-auth", expires_in: 3600 },
-      server: authTab,
     });
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
 
-    // Tab dismissed (stops polling) and the server closed; no second flow.
-    expect(authTab.setNext).toHaveBeenCalledWith(null);
-    expect(authTab.close).toHaveBeenCalled();
     expect(mockStartOAuthFlow).toHaveBeenCalledTimes(1);
+    expect(mockStartOAuthFlow).toHaveBeenCalledWith(
+      undefined,
+      "/cli/auth",
+      expect.objectContaining({ intent: "setup" }),
+      undefined,
+      expect.objectContaining({ timeoutMs: 30 * 60 * 1000 }),
+    );
+    expect(p.outro).toHaveBeenCalled();
   });
 
   it("honors --deployment over the web onboarding handoff for unfinished profiles", async () => {
@@ -2142,45 +2068,20 @@ describe("runSetup additional branches", () => {
     expect(p.outro).not.toHaveBeenCalled();
   });
 
-  it("aborts onboarding when no target org can be determined", async () => {
+  it("aborts when the handshake account has no organizations", async () => {
     saveConfig(makeCfg());
-    setupAuthed();
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    // No accessible orgs → resolveOnboardingTargetOrg returns null.
-    mockTrpc.organization.getOrganizations.query.mockResolvedValue([]);
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    expect(p.log.error).toHaveBeenCalledWith("Could not determine your onboarding organization.");
-    expect(p.outro).not.toHaveBeenCalled();
-  });
-
-  it("falls back to the first accessible org when none has the OWNER role", async () => {
-    saveConfig(makeCfg());
-    setupAuthed({
-      getDeployments: vi.fn().mockResolvedValue([
-        makeDeployment({
-          deployment_id: "dep-member",
-          org_id: "member-org",
-          org_name: "Member Org",
-          space_id: "space-member",
-        }),
-      ]),
-    });
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    // No OWNER role anywhere → falls back to accessibleOrgs[0].
-    mockTrpc.organization.getOrganizations.query.mockResolvedValue([
-      { org_id: "member-org", name: "Member Org", user_role: "MEMBER" },
-    ]);
+    setupAuthed({ getOrgs: vi.fn().mockResolvedValue([]) });
+    mockTrpc.user.getCliOnboardingContext.query
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: false,
+        cli_onboarding_enabled: false,
+      })
+      .mockResolvedValueOnce({
+        user_id: "user-b",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      });
     vi.mocked(startOAuthFlow).mockResolvedValue({
       browserOpened: true,
       token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
@@ -2189,67 +2090,37 @@ describe("runSetup additional branches", () => {
 
     await runSetup();
 
-    const saved = loadConfig();
-    expect(saved.active_account?.target?.org_id).toBe("member-org");
-    expect(saved.active_account?.target?.deployment_id).toBe("dep-member");
-  });
-
-  it("aborts onboarding when no deployment exists for the target org", async () => {
-    saveConfig(makeCfg());
-    // Deployments exist but none belong to the onboarding org.
-    setupAuthed({
-      getDeployments: vi
-        .fn()
-        .mockResolvedValue([makeDeployment({ deployment_id: "dep-other", org_id: "other-org" })]),
-    });
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    mockTrpc.organization.getOrganizations.query.mockResolvedValue([
-      { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
-    ]);
-    vi.mocked(startOAuthFlow).mockResolvedValue({
-      browserOpened: true,
-      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
-    });
-    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
-
-    await runSetup();
-
-    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No MCP found for Owner Org"));
+    expect(p.log.error).toHaveBeenCalledWith("No organizations found for your account");
     expect(p.outro).not.toHaveBeenCalled();
     expect(
       trackedCliOnboardingEvents().some(
         (e) =>
           e.event === "cli_onboarding_failed" &&
-          e.properties?.reason === "onboarding_deployment_failed",
+          e.properties?.reason === "deployment_resolution_failed",
       ),
     ).toBe(true);
   });
 
-  it("picks the first org deployment when none matches the dosu_mcp provider slug", async () => {
+  it("aborts when the handshake account's org has no MCPs", async () => {
     saveConfig(makeCfg());
+    // Deployments exist but none belong to the handshake account's org.
     setupAuthed({
-      getDeployments: vi.fn().mockResolvedValue([
-        makeDeployment({
-          deployment_id: "dep-fallback",
-          org_id: "owner-org",
-          org_name: "Owner Org",
-          space_id: "space-fallback",
-          provider_slug: "some_other_provider",
-        }),
-      ]),
+      getOrgs: vi.fn().mockResolvedValue([{ org_id: "org-b", name: "Org B" }]),
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "dep-other", org_id: "other-org" })]),
     });
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
-    mockTrpc.organization.getOrganizations.query.mockResolvedValue([
-      { org_id: "owner-org", name: "Owner Org", user_role: "OWNER" },
-    ]);
+    mockTrpc.user.getCliOnboardingContext.query
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: false,
+        cli_onboarding_enabled: false,
+      })
+      .mockResolvedValueOnce({
+        user_id: "user-b",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      });
     vi.mocked(startOAuthFlow).mockResolvedValue({
       browserOpened: true,
       token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
@@ -2258,8 +2129,60 @@ describe("runSetup additional branches", () => {
 
     await runSetup();
 
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No MCPs found for Org B"));
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_failed" &&
+          e.properties?.reason === "deployment_resolution_failed",
+      ),
+    ).toBe(true);
+  });
+
+  it("asks instead of guessing when the org has several deployments but no dosu_mcp", async () => {
+    // The old flow silently grabbed the first deployment regardless of slug;
+    // with repo-deployments in the mix that guess is usually wrong. When no
+    // single MCP disambiguates, show the picker.
+    saveConfig(makeCfg());
+    setupAuthed({
+      getOrgs: vi.fn().mockResolvedValue([{ org_id: "org-b", name: "Org B" }]),
+      getDeployments: vi.fn().mockResolvedValue([
+        makeDeployment({
+          deployment_id: "dep-x",
+          org_id: "org-b",
+          provider_slug: "some_other_provider",
+        }),
+        makeDeployment({
+          deployment_id: "dep-y",
+          org_id: "org-b",
+          provider_slug: "github",
+        }),
+      ]),
+    });
+    vi.mocked(p.select).mockResolvedValue("dep-x");
+    mockTrpc.user.getCliOnboardingContext.query
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: false,
+        cli_onboarding_enabled: false,
+      })
+      .mockResolvedValueOnce({
+        user_id: "user-b",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      });
+    vi.mocked(startOAuthFlow).mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.select).toHaveBeenCalledWith(expect.objectContaining({ message: "Select an MCP" }));
     const saved = loadConfig();
-    expect(saved.active_account?.target?.deployment_id).toBe("dep-fallback");
+    expect(saved.active_account?.target?.deployment_id).toBe("dep-x");
   });
 
   it("does not emit the removed component-selection telemetry event", async () => {
@@ -2383,17 +2306,23 @@ describe("runSetup additional branches", () => {
     expect(p.outro).not.toHaveBeenCalled();
   });
 
-  it("tracks MCP configuration after the web onboarding handback", async () => {
-    // First-run: the web wizard hands back, then the MCP tool configuration
-    // still runs (and is tracked) in the terminal.
+  it("tracks MCP configuration after the setup handshake hands back", async () => {
+    // First-run: the browser handshake hands back, then the MCP tool
+    // configuration still runs (and is tracked) in the terminal.
     saveConfig(makeCfg());
     setupAuthed();
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
-    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
-      user_id: "test-user-id",
-      finished_onboarding: false,
-      cli_onboarding_enabled: true,
-    });
+    mockTrpc.user.getCliOnboardingContext.query
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: false,
+        cli_onboarding_enabled: false,
+      })
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      });
     vi.mocked(startOAuthFlow).mockResolvedValue({
       browserOpened: true,
       token: { access_token: "tok-web", refresh_token: "ref-web", expires_in: 3600 },
@@ -2406,5 +2335,220 @@ describe("runSetup additional branches", () => {
     const events = trackedCliOnboardingEvents().map((input) => input.event);
     expect(events).toContain("cli_onboarding_mcp_configured");
     expect(events).toContain("cli_onboarding_completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Single-handshake protocol: /cli/auth owns onboarding routing.
+//
+// The CLI no longer decides "first run" by itself and never deep-links a web
+// product page: it expresses `intent=setup` on the ONE browser entry
+// (/cli/auth) and the web routes by the *browser* user's state. The callback
+// always comes back — with a session for whoever is really in the browser.
+// ---------------------------------------------------------------------------
+
+const SETUP_HANDSHAKE_TIMEOUT_MS = 30 * 60 * 1000;
+
+describe("runSetup single-handshake protocol", () => {
+  const mockClient = vi.mocked(Client);
+  const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
+
+  beforeEach(() => {
+    setupTempEnv();
+    vi.resetAllMocks();
+    installSetupStepDefaults();
+    installRemoteSetupDefaults();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+    installMultiselectDefault();
+    mockInstallSkill.mockResolvedValue({ success: true, sha: "test-sha" });
+  });
+  afterEach(() => {
+    process.exitCode = undefined;
+    teardownTempEnv();
+  });
+
+  function setupAuthed(overrides: Record<string, unknown> = {}) {
+    const methods = {
+      doRequestRaw: vi.fn().mockResolvedValue({ status: 200 }),
+      refreshToken: vi.fn(),
+      getOrgs: vi.fn().mockResolvedValue([{ org_id: "o1", name: "Org1" }]),
+      getDeployments: vi.fn().mockResolvedValue([makeDeployment()]),
+      validateAPIKey: vi.fn().mockResolvedValue(true),
+      createAPIKey: vi.fn().mockResolvedValue({ api_key: "new-key" }),
+      ...overrides,
+    };
+    mockClient.mockImplementation(function () {
+      return methods as unknown as Client;
+    });
+    return methods;
+  }
+
+  function firstRunThenOnboarded() {
+    // CLI-session user is not onboarded; the account the browser hands back
+    // is a different, already-onboarded one (the twin-account incident).
+    mockTrpc.user.getCliOnboardingContext.query
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: false,
+        cli_onboarding_enabled: false,
+      })
+      .mockResolvedValueOnce({
+        user_id: "user-b",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      });
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: {
+        access_token: "tok-b",
+        refresh_token: "ref-b",
+        expires_in: 3600,
+        email: "b@example.com",
+      },
+    });
+  }
+
+  it("hands a first-run user to /cli/auth with intent=setup and a 30-minute window", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    firstRunThenOnboarded();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockStartOAuthFlow).toHaveBeenCalledWith(
+      undefined,
+      "/cli/auth",
+      expect.objectContaining({ intent: "setup" }),
+      undefined,
+      expect.objectContaining({
+        waitWithoutBrowser: true,
+        timeoutMs: SETUP_HANDSHAKE_TIMEOUT_MS,
+      }),
+    );
+    const paths = mockStartOAuthFlow.mock.calls.map((call) => call[1]);
+    expect(paths).not.toContain("/onboarding/connections");
+  });
+
+  it("rebinds to the account the browser handed back (cross-account self-heal)", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    firstRunThenOnboarded();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.active_account?.user_id).toBe("user-b");
+    expect(saved.active_account?.session.access_token).toBe("tok-b");
+    // The wizard creates one repo-deployment per connected repo — the MCP
+    // deployment must still be auto-bound without an interactive picker.
+    expect(saved.active_account?.target?.deployment_id).toBe("d1");
+    expect(p.outro).toHaveBeenCalled();
+  });
+
+  it("auto-binds the single dosu_mcp deployment even among repo deployments", async () => {
+    saveConfig(makeCfg());
+    setupAuthed({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([
+          makeDeployment({ deployment_id: "repo-1", provider_slug: "github", name: "my-repo" }),
+          makeDeployment(),
+          makeDeployment({ deployment_id: "repo-2", provider_slug: "gitlab", name: "my-lib" }),
+        ]),
+    });
+    firstRunThenOnboarded();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.select).not.toHaveBeenCalled();
+    const saved = loadConfig();
+    expect(saved.active_account?.target?.deployment_id).toBe("d1");
+  });
+
+  it("aborts once with guidance when the handshake returns a still-not-onboarded account", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: false,
+    });
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: { access_token: "tok-x", refresh_token: "ref-x", expires_in: 3600 },
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    // Exactly one browser trip — never a handshake loop.
+    expect(mockStartOAuthFlow).toHaveBeenCalledTimes(1);
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_failed" &&
+          e.properties?.reason === "onboarding_incomplete_after_handshake",
+      ),
+    ).toBe(true);
+  });
+
+  it("sends intent=setup on the first browser hop for cloud mode", async () => {
+    // No stored session at all → stepAuthenticate goes to the browser.
+    setupAuthed();
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: {
+        access_token: "tok-fresh",
+        refresh_token: "ref-fresh",
+        expires_in: 3600,
+        email: "fresh@example.com",
+      },
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockStartOAuthFlow).toHaveBeenCalledWith(
+      undefined,
+      "/cli/auth",
+      expect.objectContaining({ intent: "setup" }),
+      undefined,
+      expect.objectContaining({ timeoutMs: SETUP_HANDSHAKE_TIMEOUT_MS }),
+    );
+  });
+
+  it("keeps the OSS first hop free of the setup intent", async () => {
+    setupAuthed();
+    // OSS mode never queries the cloud profile, so the account identity must
+    // come from the JWT itself (as it does with real tokens).
+    const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ sub: "oss-user" })).toString("base64url");
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: {
+        access_token: `${header}.${payload}.signature`,
+        refresh_token: "ref-oss",
+        expires_in: 3600,
+      },
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup({ mode: "oss" });
+
+    const [, , params] = mockStartOAuthFlow.mock.calls[0];
+    expect(params).not.toHaveProperty("intent");
+  });
+
+  it("keeps the setup flow's only web-app path /cli/auth (source contract)", () => {
+    // The 2026-08-05 deadlock began with the CLI deep-linking a web product
+    // page whose middleware owed it nothing. The setup flow may only ever
+    // link the protocol endpoint.
+    const source = readFileSync(new URL("./flow.ts", import.meta.url), "utf8");
+    expect(source).not.toContain("/onboarding/");
   });
 });

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -2468,6 +2468,79 @@ describe("runSetup single-handshake protocol", () => {
     expect(saved.active_account?.target?.deployment_id).toBe("d1");
   });
 
+  it("surfaces the browser's real reason when the handshake calls back with an error", async () => {
+    // An `?error=` callback is an ANSWER, not silence: show the web side's
+    // message instead of the generic "didn't hear back" + logout advice.
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockTrpc.user.getCliOnboardingContext.query.mockResolvedValue({
+      user_id: "test-user-id",
+      finished_onboarding: false,
+      cli_onboarding_enabled: false,
+    });
+    const { OAuthCallbackError } = await import("../auth/errors");
+    mockStartOAuthFlow.mockRejectedValue(
+      new OAuthCallbackError("cli_mint_failed", {
+        error: "cli_mint_failed",
+        errorDescription: "The authentication service rejected the request",
+      }),
+    );
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("The authentication service rejected the request"),
+    );
+    expect(p.log.warn).not.toHaveBeenCalledWith(expect.stringContaining("Didn't hear back"));
+    expect(
+      trackedCliOnboardingEvents().some(
+        (e) =>
+          e.event === "cli_onboarding_failed" &&
+          e.properties?.reason === "web_onboarding_incomplete",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the same account's stored target after the handshake (everyday semantics)", async () => {
+    // The sibling branch of the cross-account rebind above: when the SAME
+    // account comes back (now onboarded), the stored deployment is
+    // deliberately reused — no picker, no re-resolution. Note: the token must
+    // be JWT-shaped so replaceLoginSession can see it is the same user.
+    saveConfig(makeCfg());
+    setupAuthed();
+    const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ sub: "test-user-id" })).toString("base64url");
+    mockTrpc.user.getCliOnboardingContext.query
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: false,
+        cli_onboarding_enabled: false,
+      })
+      .mockResolvedValueOnce({
+        user_id: "test-user-id",
+        finished_onboarding: true,
+        cli_onboarding_enabled: false,
+      });
+    mockStartOAuthFlow.mockResolvedValue({
+      browserOpened: true,
+      token: {
+        access_token: `${header}.${payload}.signature`,
+        refresh_token: "ref-same",
+        expires_in: 3600,
+      },
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    const saved = loadConfig();
+    expect(saved.active_account?.user_id).toBe("test-user-id");
+    expect(saved.active_account?.target?.deployment_id).toBe("dep-123");
+    expect(p.select).not.toHaveBeenCalled();
+    expect(p.outro).toHaveBeenCalled();
+  });
+
   it("aborts once with guidance when the handshake returns a still-not-onboarded account", async () => {
     saveConfig(makeCfg());
     setupAuthed();

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -143,7 +143,15 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     // session; never reuse anything across an authentication boundary.
     apiClient = new Client(cfg);
     const refreshed = await resolveCloudSetupContext(cfg);
-    if (!refreshed || !refreshed.finishedOnboarding) {
+    if (refreshed === null) {
+      // Context load failed (it already printed the real error) — this is a
+      // transient/API problem, not an onboarding state.
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+        reason: "cloud_setup_context_failed",
+      });
+      return;
+    }
+    if (!refreshed.finishedOnboarding) {
       // At most one trip per process — never a handshake loop. This is the
       // permanent guard for a web tier that didn't route the wizard
       // (deploy skew): tell the user, exit cleanly, let a re-run retry.
@@ -153,6 +161,8 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
         reason: "onboarding_incomplete_after_handshake",
       });
+      // The one deliberately non-zero setup exit: scripts chaining
+      // `dosu setup && …` must not proceed on a half-onboarded account.
       process.exitCode = 1;
       return;
     }
@@ -542,6 +552,13 @@ async function stepSetupHandshake(cfg: Config, onboardingRunID: string): Promise
     const msg = err instanceof Error ? err.message : String(err);
     logger.warn("setup", `Setup handshake did not complete: ${msg}`);
     s.stop("Setup not completed");
+    // An `?error=` callback IS an answer — surface the browser's real reason
+    // instead of pretending we heard nothing.
+    const { OAuthCallbackError } = await import("../auth/errors");
+    if (err instanceof OAuthCallbackError) {
+      p.log.error(err.userMessage);
+      return false;
+    }
     p.log.warn(
       "Didn't hear back from the browser. If it opened the Dosu app instead of the setup " +
         "wizard, your CLI and browser may be signed in to different accounts — run " +

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -4,9 +4,7 @@
 
 import { randomUUID } from "node:crypto";
 import * as p from "@clack/prompts";
-import type { CallbackServer } from "../auth/server";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
-import type { TypedClient } from "../client/trpc";
 import { installSkill, skillInstallTargetForProvider } from "../commands/skill";
 import {
   bindAccountIdentity,
@@ -47,18 +45,16 @@ export interface ToolSelection {
   skipped: SetupProvider[];
 }
 
-type SetupFlowKind = "onboarding" | "setup";
-
 interface CloudSetupContext {
-  kind: SetupFlowKind;
   profileUserID: string;
-  targetOrg?: OwnedOrg;
-}
-
-interface OwnedOrg {
-  org_id: string;
-  name: string;
-  user_role?: string | null;
+  /**
+   * Analytics + handshake trigger only — never a flow decider. The CLI's
+   * view of this flag can be stale or belong to the wrong account (the
+   * 2026-08-05 twin-account deadlock); a wrong value here costs at most one
+   * redundant `/cli/auth` roundtrip, never a wrong irreversible branch. The
+   * browser side owns the real onboarding routing.
+   */
+  finishedOnboarding: boolean;
 }
 
 interface CliOnboardingProfile {
@@ -92,17 +88,12 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     saveConfig(cfg);
   }
 
-  // Authenticate — always runs so we can verify/refresh tokens. When the
-  // browser was involved, `authTab` steers that same tab onward (into the
-  // web onboarding wizard) instead of opening a second one.
+  // Authenticate — always runs so we can verify/refresh tokens. In cloud
+  // mode the browser hop carries `intent=setup`, so a first-run user
+  // completes the onboarding wizard inside that same trip.
   const authed = await stepAuthenticate(cfg, onboardingRunID);
   if (!authed) return;
   cfg = authed.cfg;
-  const authTab = authed.authTab;
-  const releaseAuthTab = () => {
-    authTab?.setNext(null);
-    authTab?.close();
-  };
   await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_auth_completed");
 
   let apiClient = new Client(cfg);
@@ -117,56 +108,63 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
         reason: "cloud_setup_context_failed",
       });
       s.stop("Workspace load failed");
-      releaseAuthTab();
       return;
     }
     s.stop("Workspace loaded");
   }
   await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_started", {
-    flow_kind: cloudSetupContext?.kind ?? "oss",
+    flow_kind: cloudSetupContext
+      ? cloudSetupContext.finishedOnboarding
+        ? "setup"
+        : "onboarding"
+      : "oss",
   });
 
-  // First-run web onboarding applies to cloud-mode users who haven't
-  // finished onboarding — unless they passed `--deployment`, which is an
-  // explicit "just wire me to this deployment" escape hatch that must never
-  // be silently overridden by the onboarding auto-bind.
-  const firstRunOnboarding =
-    cfg.mode !== MODE_OSS && cloudSetupContext?.kind === "onboarding" && !opts.deploymentID;
+  // The CLI-side flag only TRIGGERS one browser handshake — the browser
+  // decides whether the wizard is actually needed (it knows who is really
+  // signed in there). `--deployment` stays an explicit escape hatch that
+  // must never be overridden.
+  const needsHandshake =
+    cfg.mode !== MODE_OSS &&
+    cloudSetupContext !== null &&
+    !cloudSetupContext.finishedOnboarding &&
+    !opts.deploymentID;
 
-  // Only the first-run web-onboarding handoff can steer the auth tab; every
-  // other path lets the success page settle where it is.
-  if (!firstRunOnboarding) {
-    releaseAuthTab();
-  }
-
-  // Deployment: first-run onboarding binds the user's default deployment.
-  // Otherwise we only run the interactive picker when we don't already have
-  // a deployment id locked in, OR when the caller passed `--deployment` to
-  // explicitly switch. Everyday re-runs reuse the stored deployment silently.
-  if (firstRunOnboarding && cloudSetupContext) {
-    // First-run: repo connection + docs import live in the web onboarding
-    // wizard (the one code path we trust). Hand the browser over, wait for
-    // the wizard to finish, then bind the deployment context it left behind.
-    const onboarded = await stepWebOnboarding(cfg, onboardingRunID, authTab);
-    if (!onboarded) {
+  if (needsHandshake) {
+    const handshook = await stepSetupHandshake(cfg, onboardingRunID);
+    if (!handshook) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
         reason: "web_onboarding_incomplete",
       });
       return;
     }
-    // The browser may have completed onboarding under a different account.
-    // Resolve the target again with the returned session; never reuse the
-    // pre-handoff organization or client across an authentication boundary.
+    // The browser may have handed back a different account — that is the
+    // point: it knows who is really signed in. Re-resolve with the returned
+    // session; never reuse anything across an authentication boundary.
     apiClient = new Client(cfg);
-    const targetOrg = await resolveCurrentOnboardingTargetOrg(cfg);
-    const ok = await bindOnboardingDeployment(apiClient, cfg, targetOrg);
-    if (!ok) {
+    const refreshed = await resolveCloudSetupContext(cfg);
+    if (!refreshed || !refreshed.finishedOnboarding) {
+      // At most one trip per process — never a handshake loop. This is the
+      // permanent guard for a web tier that didn't route the wizard
+      // (deploy skew): tell the user, exit cleanly, let a re-run retry.
+      p.log.warn(
+        "Your account still needs onboarding. Finish it in the browser at the Dosu app, then re-run `dosu setup`.",
+      );
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
-        reason: "onboarding_deployment_failed",
+        reason: "onboarding_incomplete_after_handshake",
       });
+      process.exitCode = 1;
       return;
     }
-  } else if (!cfg.active_account?.target?.deployment_id || opts.deploymentID) {
+    cloudSetupContext = refreshed;
+  }
+
+  // Deployment: run the picker only when nothing is locked in yet, or when
+  // `--deployment` explicitly asks to switch. Everyday re-runs reuse the
+  // stored deployment silently. (After an account change the handshake
+  // dropped the old target, so the fresh account resolves here —
+  // stepSelectDeployment auto-picks the single real MCP.)
+  if (!cfg.active_account?.target?.deployment_id || opts.deploymentID) {
     const ok = await resolveDeployment(apiClient, cfg, opts);
     if (!ok) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
@@ -361,12 +359,6 @@ export async function runInstallSkill(providers: readonly SetupProvider[]): Prom
 
 interface AuthenticatedSetup {
   cfg: Config;
-  /**
-   * Present when this run authenticated via the browser: the still-open
-   * callback server whose success page polls /next, letting the setup flow
-   * steer that same tab onward (web onboarding) instead of opening another.
-   */
-  authTab?: CallbackServer;
 }
 
 async function stepAuthenticate(
@@ -419,16 +411,22 @@ async function openBrowserForSetup(
   try {
     const { startOAuthFlow } = await import("../auth/flow");
     const s = p.spinner();
+    // Cloud mode declares `intent=setup`: the web side routes a first-run
+    // *browser* user through the onboarding wizard inside this same trip, so
+    // the window must be handshake-sized. OSS users may never onboard — no
+    // intent, plain auth timeout.
+    const isCloud = cfg.mode !== MODE_OSS;
     const result = await startOAuthFlow(
       undefined,
       "/cli/auth",
-      onboardingRunID ? { onboarding_run_id: onboardingRunID } : {},
+      {
+        ...(isCloud ? { intent: "setup" } : {}),
+        ...(onboardingRunID ? { onboarding_run_id: onboardingRunID } : {}),
+      },
       undefined,
       {
         waitWithoutBrowser: true,
-        // Keep the callback server alive so the success page's tab can be
-        // steered into the web onboarding wizard for first-run users.
-        holdNext: true,
+        ...(isCloud ? { timeoutMs: SETUP_HANDSHAKE_TIMEOUT_MS } : {}),
         onAuthURL: (url) => {
           p.log.message(browserFallbackHint(url));
           s.start("Waiting for authentication...");
@@ -441,7 +439,10 @@ async function openBrowserForSetup(
       return null;
     }
     const token = result.token;
-    s.stop("Authenticated");
+    // Show WHICH account authenticated — a stale or twin-account session is
+    // caught by eye here long before it can misroute anything. (SSO PKCE
+    // callbacks carry no email; fall back to the generic word.)
+    s.stop(token.email ? `Authenticated as ${token.email}` : "Authenticated");
     logger.info("setup", "Browser auth completed");
 
     replaceLoginSession(cfg, {
@@ -450,7 +451,7 @@ async function openBrowserForSetup(
       expires_at: Math.floor(Date.now() / 1000) + token.expires_in,
     });
     saveConfig(cfg);
-    return { cfg, authTab: result.server };
+    return { cfg };
   } catch (err: unknown) {
     /* v8 ignore next 2 -- err is always Error in practice */
     const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
@@ -476,44 +477,44 @@ async function openBrowserForSetup(
 }
 
 /**
- * First-run onboarding handoff: repo connection + docs import happen in the
- * web onboarding wizard, not the terminal. Opens the browser at
- * `/onboarding/connections?source=cli&callback=…` — the wizard detects the
- * CLI flow, skips its "set up the CLI" step, marks onboarding finished on
- * the server, and redirects back to the local callback with a freshly
- * minted CLI session (same payload shape as the auth callback, so
- * `startOAuthFlow` provides the listener, browser open, and timeout).
- *
- * Returns `true` once the wizard handed back, `false` on timeout/failure
- * (with a hint to finish in the browser and re-run `dosu setup`).
- *
- * When `authTab` is present (this run authenticated via the browser), the
- * auth success page is steered straight into the wizard via `setNext` — one
- * tab for the whole journey. Without it, a fresh tab is opened.
+ * The setup handshake may contain the whole onboarding wizard — including a
+ * GitHub App install that can sit on an org-admin approval — so it gets a
+ * far longer window than a plain auth roundtrip.
  */
-async function stepWebOnboarding(
-  cfg: Config,
-  onboardingRunID: string,
-  authTab?: CallbackServer,
-): Promise<boolean> {
-  logger.info("setup", "Step: web onboarding handoff");
-  p.log.info("Almost there — connect your repos in the browser and we'll pick up from here.");
+const SETUP_HANDSHAKE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * One browser handshake against the ONE protocol endpoint, `/cli/auth`.
+ *
+ * `intent=setup` tells the web side to route the *browser* user through the
+ * onboarding wizard first when that user still needs it; either way the
+ * callback comes back with a freshly minted session for whoever is really
+ * signed in there — possibly a different account than the CLI held (the
+ * caller re-resolves everything after). The CLI never deep-links a web
+ * product page: the 2026-08-05 deadlock began with a wizard URL whose
+ * middleware owed the CLI nothing.
+ *
+ * Returns `true` once the browser handed a session back, `false` on
+ * timeout/failure.
+ */
+async function stepSetupHandshake(cfg: Config, onboardingRunID: string): Promise<boolean> {
+  logger.info("setup", "Step: setup handshake");
+  p.log.info("Almost there — finish setting up in the browser and we'll pick up from here.");
   const s = p.spinner();
   try {
     const { startOAuthFlow } = await import("../auth/flow");
     const result = await startOAuthFlow(
       undefined,
-      "/onboarding/connections",
-      { source: "cli", onboarding_run_id: onboardingRunID },
+      "/cli/auth",
+      { intent: "setup", onboarding_run_id: onboardingRunID },
       undefined,
       {
         waitWithoutBrowser: true,
-        suppressBrowserOpen: Boolean(authTab),
         successVariant: "onboarding",
+        timeoutMs: SETUP_HANDSHAKE_TIMEOUT_MS,
         onAuthURL: (url) => {
-          authTab?.setNext(url);
           p.log.message(browserFallbackHint(url));
-          s.start("Waiting for onboarding to finish in the browser...");
+          s.start("Waiting for the browser...");
         },
       },
     );
@@ -522,31 +523,31 @@ async function stepWebOnboarding(
       s.stop("Could not open a browser");
       return false;
     }
-    // The wizard may hand back a session for a different browser account.
-    // Replace the account aggregate: same-account auth keeps its target, while
-    // an account change drops the old target before resolving the new one.
+    // The browser may hand back a session for a different account. Replace
+    // the account aggregate: same-account auth keeps its target, while an
+    // account change drops the old target before resolving the new one.
     replaceLoginSession(cfg, {
       access_token: result.token.access_token,
       refresh_token: result.token.refresh_token,
       expires_at: Math.floor(Date.now() / 1000) + result.token.expires_in,
     });
     saveConfig(cfg);
-    s.stop("Onboarding finished in the browser");
-    logger.info("setup", "Web onboarding handoff completed");
+    s.stop(
+      result.token.email ? `Authenticated as ${result.token.email}` : "Browser setup finished",
+    );
+    logger.info("setup", "Setup handshake completed");
     return true;
   } catch (err: unknown) {
     /* v8 ignore next -- err is always Error in practice */
     const msg = err instanceof Error ? err.message : String(err);
-    logger.warn("setup", `Web onboarding handoff did not complete: ${msg}`);
-    s.stop("Onboarding not completed");
+    logger.warn("setup", `Setup handshake did not complete: ${msg}`);
+    s.stop("Setup not completed");
     p.log.warn(
-      "Didn't hear back from the browser. Finish onboarding there, then re-run `dosu setup`.",
+      "Didn't hear back from the browser. If it opened the Dosu app instead of the setup " +
+        "wizard, your CLI and browser may be signed in to different accounts — run " +
+        "`dosu logout`, then retry. Otherwise finish in the browser and re-run `dosu setup`.",
     );
     return false;
-  } finally {
-    // The auth tab either navigated into the wizard already or was closed by
-    // the user; either way its server has served its purpose.
-    authTab?.close();
   }
 }
 
@@ -563,28 +564,9 @@ async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext 
     bindAccountIdentity(cfg, profile.user_id);
     saveConfig(cfg);
 
-    // First-run detection is driven purely by `finished_onboarding`. The old
-    // `cli_onboarding_enabled` flag gated a terminal-local onboarding path
-    // that no longer exists — first-run users now finish onboarding in the
-    // web wizard via `stepWebOnboarding`.
-    if (profile.finished_onboarding === true) {
-      return {
-        kind: "setup",
-        profileUserID: profile.user_id,
-      };
-    }
-
-    const targetOrg = await resolveOnboardingTargetOrg(trpc);
-    if (!targetOrg) {
-      p.log.error("Could not determine your onboarding organization.");
-      return null;
-    }
-
-    logger.info("setup", `First-run onboarding detected for org ${targetOrg.org_id}`);
     return {
-      kind: "onboarding",
       profileUserID: profile.user_id,
-      targetOrg,
+      finishedOnboarding: profile.finished_onboarding === true,
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -592,71 +574,6 @@ async function resolveCloudSetupContext(cfg: Config): Promise<CloudSetupContext 
     p.log.error(`Could not load your onboarding state: ${msg}`);
     return null;
   }
-}
-
-async function resolveOnboardingTargetOrg(trpc: TypedClient): Promise<OwnedOrg | null> {
-  const accessibleOrgs: OwnedOrg[] = await trpc.organization.getOrganizations.query();
-  const ownerOrg = accessibleOrgs.find((org) => org.user_role === "OWNER");
-  if (ownerOrg) {
-    return ownerOrg;
-  }
-  return accessibleOrgs[0] ?? null;
-}
-
-async function resolveCurrentOnboardingTargetOrg(cfg: Config): Promise<OwnedOrg | null> {
-  try {
-    const { createTypedClient } = await import("../client/trpc");
-    const trpc = createTypedClient(cfg);
-    const profile: CliOnboardingProfile | null = await trpc.user.getCliOnboardingContext.query();
-    if (!profile?.user_id) return null;
-    bindAccountIdentity(cfg, profile.user_id);
-    saveConfig(cfg);
-    return await resolveOnboardingTargetOrg(trpc);
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    logger.error("setup", `Failed to resolve post-onboarding organization: ${msg}`);
-    p.log.error(`Could not determine your onboarding organization: ${msg}`);
-    return null;
-  }
-}
-
-async function bindOnboardingDeployment(
-  apiClient: Client,
-  cfg: Config,
-  targetOrg: OwnedOrg | null,
-): Promise<boolean> {
-  if (!targetOrg) {
-    p.log.error("Could not determine your onboarding organization.");
-    return false;
-  }
-
-  const deployment = await resolveOnboardingDeployment(apiClient, targetOrg);
-  if (!deployment) {
-    p.log.error(`No MCP found for ${targetOrg.name}.`);
-    return false;
-  }
-
-  cfg.mode = undefined;
-  applyDeployment(cfg, deployment);
-  logger.info(
-    "setup",
-    `Bound onboarding context org=${targetOrg.org_id} deployment=${deployment.deployment_id}`,
-  );
-  p.log.success(`Organization\n${dim(targetOrg.name)}`);
-  return true;
-}
-
-async function resolveOnboardingDeployment(
-  apiClient: Client,
-  targetOrg: OwnedOrg,
-): Promise<Deployment | null> {
-  const deployments = await fetchDeployments(apiClient);
-  const orgDeployments = deployments.filter((deployment) => deployment.org_id === targetOrg.org_id);
-  return (
-    orgDeployments.find((deployment) => deployment.provider_slug === MCP_PROVIDER_SLUG) ??
-    orgDeployments[0] ??
-    null
-  );
 }
 
 /**
@@ -769,6 +686,16 @@ async function stepSelectDeployment(apiClient: Client, org: Org): Promise<Deploy
       logger.info("setup", `Selected deployment: ${deployments[0].name} (auto, only one)`);
       p.log.success(`Using MCP\n${dim(deployments[0].name)}`);
       return deployments[0];
+    }
+    // The onboarding wizard creates one repo-deployment per connected repo,
+    // so a freshly onboarded org always has several deployments — but only
+    // one real MCP. Never show users a picker full of their own repo names
+    // when the answer is unambiguous.
+    const mcpDeployments = deployments.filter((d) => d.provider_slug === MCP_PROVIDER_SLUG);
+    if (mcpDeployments.length === 1) {
+      logger.info("setup", `Selected deployment: ${mcpDeployments[0].name} (auto, single MCP)`);
+      p.log.success(`Using MCP\n${dim(mcpDeployments[0].name)}`);
+      return mcpDeployments[0];
     }
     const selected = await p.select({
       message: "Select an MCP",


### PR DESCRIPTION
### Description

**Companion to [dosu#11968](https://github.com/dosu-ai/dosu/pull/11968) — the protocol-collapse half.** Root cause & incident write-up live there (2026-08-05 setup deadlock: twin-account session + deep-linked wizard URL + middleware bounce = 8-minute hang).

**What changes (net −97 lines):**

- **One browser entry, ever**: every setup browser hop is `/cli/auth?intent=setup` (cloud only; OSS exempt). The CLI *expresses intent*; the web side — the only party that knows who is really signed in — decides whether the wizard is needed and always ends the trip with a callback. A source-contract test pins that `src/setup/flow.ts` contains no `/onboarding/` path, so the next onboarding redesign cannot re-break the CLI.
- **`finished_onboarding` demoted** from flow decider to handshake trigger: a stale/wrong-account value now costs one redundant roundtrip instead of a wrong irreversible branch — and the handback **self-heals the account binding** (existing `replaceLoginSession` + re-resolve from #129/#133).
- **Skew guard**: at most one handshake per process; if the returned account still isn't onboarded (older web tier), print clear guidance and `exit 1` — never a loop, never a hang.
- **30-minute handshake window** (the trip can contain the whole wizard incl. a GitHub App install waiting on org-admin approval); plain auth keeps 8. Timeout copy now names the account-mismatch cause and the `dosu logout` cure.
- **Deployment picker sanity**: deleted the four onboarding-only helpers; the generic picker auto-selects the single `dosu_mcp` deployment (the wizard creates one repo-deployment per connected repo — users must never see a picker full of their own repo names). Multiple ambiguous deployments → ask, don't guess.
- **authTab machinery deleted** (`holdNext`/`setNext`/`/next` polling, ~170 lines): it only existed to chain the two browser trips the old protocol needed.
- `Authenticated as <email>` on the success spinner (twin-account sessions get caught by eye; SSO PKCE callbacks carry no email → generic fallback); agent-flow deployment errors mention `dosu logout`.

**Tests** — red-first: 7 new red tests written & confirmed red before implementation (handshake URL/intent/window, cross-account self-heal, single-MCP auto-bind, skew abort, first-hop intent, OSS exemption, source contract). Full suite **1632/1632** green; coverage 98.05% stmts / 93.29% branch (thresholds hold after the net deletion). Declared red-list: 18 legacy cases across `flow.test.ts` / `auth/flow.test.ts` / `auth/server.test.ts` asserting the deleted machinery — each rewritten to pin the new semantics or removed with its machinery (list in review thread on request).

**Analytics**: event names/shape unchanged; `flow_kind` = `finishedOnboarding ? "setup" : "onboarding"` (OSS `"oss"`). Three semantic drifts to note for dashboard 1531244: the *onboarding* population narrows to skew/anomaly residue once first-hop wizard rides the auth trip; `auth_completed` timing moves after the wizard for first-runs; `onboarding_deployment_failed` reason retires (replaced by `deployment_resolution_failed` / `onboarding_incomplete_after_handshake`). Funnel step 3 (`cli_onboarding_options_selected`) was already stale and should be repointed.

**Rollout (do not merge before):**
1. dosu#11968 merged **and manually dispatched to production** (mercury CD is daily-cron/manual, not push-triggered) + smoked.
2. Recommended: sync `alpha` with `main`, retarget/merge this into `alpha` first → dogfood `@dosu/cli@alpha` against production web for a day or two → graduate to `main`. (Merging to `main` publishes to `latest` immediately and auto-advances Homebrew — effectively unrollbackable for installed users; the skew guard above is the permanent safety net either way.)

### Review Tasks - Only request review after completing these.

* [ ] I self-reviewed this PR
* [ ] Testing is adequate for this change
* [ ] I reviewed AI-generated code and resolved suggestions

### Details (for context) - Not tasks; tooling uses tasks to determine review readiness

- Generated with AI: Claude
- Manual testing: N (unit 1632/1632 + coverage; live E2E matrix — old-CLI self-heal / fresh first-run / SSO PKCE / new-CLI-vs-old-web via *_OVERRIDE — planned during alpha dogfood)
- Tests updated: Y