### PR TITLE
feat(setup): scope agent setup to projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
               $startInfo.ArgumentList.Add($argument)
             }
             $outer = [Diagnostics.Process]::Start($startInfo)
-            if (-not $outer.WaitForExit(30_000)) {
+            if (-not $outer.WaitForExit(30000)) {
               throw "packed project proxy did not settle after SIGINT"
             }
             if ($outer.ExitCode -ne 0) { throw "project proxy exited $($outer.ExitCode)" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,10 @@ jobs:
           npm install --ignore-scripts --no-audit --no-fund --prefix "$packageRoot" "$pkg"
           if ($LASTEXITCODE -ne 0) { throw "could not install packed CLI" }
           $dosuBin = Join-Path $packageRoot "node_modules/@dosu/cli/bin/dosu.js"
+          $signalInjectorURL = [Uri]::new($env:DOSU_SIGNAL_INJECTOR).AbsoluteUri
+          if (-not $signalInjectorURL.StartsWith("file:")) {
+            throw "could not convert the signal injector to a file URL"
+          }
 
           $outer = $null
           try {
@@ -235,7 +239,7 @@ jobs:
             $startInfo.UseShellExecute = $false
             foreach ($argument in @(
               "--import",
-              $env:DOSU_SIGNAL_INJECTOR,
+              $signalInjectorURL,
               $dosuBin,
               "mcp",
               "proxy",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,178 @@ jobs:
           $pkg = Get-ChildItem -Filter "dosu-cli-*.tgz" | Select-Object -First 1 -ExpandProperty Name
           npm exec --yes --package "./$pkg" dosu -- --version
 
+      - name: Exercise project proxy from a spaced Windows PATH
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $smokeRoot = Join-Path $env:RUNNER_TEMP "dosu proxy smoke"
+          $fakeBin = Join-Path $smokeRoot "node tools"
+          $configRoot = Join-Path $smokeRoot "config"
+          $dosuConfig = Join-Path $configRoot "dosu-cli"
+          $credentialStore = Join-Path $dosuConfig "project-mcp-credentials.v1"
+          $packageRoot = Join-Path $smokeRoot "installed package"
+          New-Item -ItemType Directory -Force -Path @($fakeBin, $credentialStore, $packageRoot) | Out-Null
+
+          $env:XDG_CONFIG_HOME = $configRoot
+          $env:DOSU_PROXY_CAPTURE = Join-Path $smokeRoot "proxy-capture.txt"
+          $env:DOSU_PROXY_DESCENDANT_PID = Join-Path $smokeRoot "descendant.pid"
+          $env:DOSU_FAKE_NPX_PID = Join-Path $smokeRoot "fake-npx.pid"
+          $env:DOSU_FAKE_NPX_SCRIPT = Join-Path $smokeRoot "fake-npx.mjs"
+          $env:DOSU_SIGNAL_INJECTOR = Join-Path $smokeRoot "signal-packed-proxy.mjs"
+          $env:DOSU_NODE_EXE = (Get-Command node).Source
+          $env:PATH = "$fakeBin;$env:PATH"
+
+          @'
+          import { spawn } from "node:child_process";
+          import { writeFileSync } from "node:fs";
+
+          writeFileSync(
+            process.env.DOSU_PROXY_CAPTURE,
+            `${process.argv.slice(2).join(" ")}\n${process.env.X_DOSU_API_KEY ?? ""}\n`,
+          );
+          writeFileSync(process.env.DOSU_FAKE_NPX_PID, String(process.pid));
+          const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+            detached: true,
+            stdio: "ignore",
+            windowsHide: true,
+          });
+          if (!descendant.pid) process.exit(92);
+          writeFileSync(process.env.DOSU_PROXY_DESCENDANT_PID, String(descendant.pid));
+          descendant.unref();
+          setInterval(() => {}, 1_000);
+          '@ | Set-Content -Encoding utf8 $env:DOSU_FAKE_NPX_SCRIPT
+
+          @'
+          import { existsSync } from "node:fs";
+
+          // GitHub's Windows shell is non-interactive, so inject the same Node
+          // SIGINT event only after the packed proxy owns its signal listener.
+          const deadline = Date.now() + 15_000;
+          let descendantReadyAt;
+          const timer = setInterval(() => {
+            if (existsSync(process.env.DOSU_PROXY_DESCENDANT_PID)) {
+              descendantReadyAt ??= Date.now();
+            }
+            if (
+              descendantReadyAt &&
+              Date.now() - descendantReadyAt >= 100 &&
+              process.listenerCount("SIGINT") > 0
+            ) {
+              clearInterval(timer);
+              process.emit("SIGINT");
+              return;
+            }
+            if (Date.now() >= deadline) {
+              clearInterval(timer);
+              console.error("packed proxy never became ready for the shutdown signal");
+              process.exit(91);
+            }
+          }, 25);
+          '@ | Set-Content -Encoding utf8 $env:DOSU_SIGNAL_INJECTOR
+
+          @'
+          @echo off
+          "%DOSU_NODE_EXE%" "%DOSU_FAKE_NPX_SCRIPT%" %*
+          '@ | Set-Content -Encoding ascii (Join-Path $fakeBin "npx.cmd")
+
+          $userID = "windows-smoke-user"
+          $targetKey = "deployment:windows-smoke-dep"
+          @{
+            schema_version = 2
+            active_account = @{
+              user_id = $userID
+              session = @{
+                access_token = "smoke-token"
+                refresh_token = "smoke-refresh"
+                expires_at = 4102444800
+              }
+            }
+          } | ConvertTo-Json -Depth 6 | Set-Content -Encoding utf8 (Join-Path $dosuConfig "config.json")
+
+          $identity = [Text.Encoding]::UTF8.GetBytes("$userID`0$targetKey")
+          $recordName = "$([Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($identity)).ToLower()).json"
+          @{
+            schema_version = 1
+            user_id = $userID
+            target_key = $targetKey
+            credential = @{
+              endpoint = "https://api.dosu.dev/v1/mcp/deployments/windows-smoke-dep"
+              api_key = "windows-smoke-secret"
+            }
+          } | ConvertTo-Json -Depth 6 | Set-Content -Encoding utf8 (Join-Path $credentialStore $recordName)
+
+          $pkg = Get-ChildItem -Filter "dosu-cli-*.tgz" | Select-Object -First 1 -ExpandProperty FullName
+          npm install --ignore-scripts --no-audit --no-fund --prefix "$packageRoot" "$pkg"
+          if ($LASTEXITCODE -ne 0) { throw "could not install packed CLI" }
+          $dosuBin = Join-Path $packageRoot "node_modules/@dosu/cli/bin/dosu.js"
+
+          $outer = $null
+          try {
+            $startInfo = [Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $env:DOSU_NODE_EXE
+            $startInfo.UseShellExecute = $false
+            foreach ($argument in @(
+              "--import",
+              $env:DOSU_SIGNAL_INJECTOR,
+              $dosuBin,
+              "mcp",
+              "proxy",
+              "--deployment",
+              "windows-smoke-dep"
+            )) {
+              $startInfo.ArgumentList.Add($argument)
+            }
+            $outer = [Diagnostics.Process]::Start($startInfo)
+            if (-not $outer.WaitForExit(30_000)) {
+              throw "packed project proxy did not settle after SIGINT"
+            }
+            if ($outer.ExitCode -ne 0) { throw "project proxy exited $($outer.ExitCode)" }
+
+            if (-not (Test-Path $env:DOSU_PROXY_DESCENDANT_PID)) {
+              throw "fake npx did not launch its persistent descendant"
+            }
+            $descendantPID = [int](Get-Content $env:DOSU_PROXY_DESCENDANT_PID -Raw)
+            $descendantGone = $false
+            for ($attempt = 0; $attempt -lt 50; $attempt++) {
+              if (-not (Get-Process -Id $descendantPID -ErrorAction SilentlyContinue)) {
+                $descendantGone = $true
+                break
+              }
+              Start-Sleep -Milliseconds 100
+            }
+            if (-not $descendantGone) {
+              throw "taskkill returned but descendant PID $descendantPID survived"
+            }
+
+            $capture = Get-Content $env:DOSU_PROXY_CAPTURE
+            if ($capture.Count -lt 2) { throw "fake npx did not capture argv and env" }
+            if ($capture[0] -notmatch "mcp-remote@0\.1\.38") { throw "proxy did not invoke pinned mcp-remote" }
+            if ($capture[0] -match "windows-smoke-secret") { throw "proxy exposed its key in argv" }
+            if ($capture[1].Trim() -ne "windows-smoke-secret") { throw "proxy did not pass its key through env" }
+
+            # A save interrupted after fsync leaves this exact temporary shape.
+            # Exercise the packed CLI against Windows/libuv's real stat mode.
+            $crashTemporary = Join-Path $credentialStore "$recordName.4321.abcdef012345.tmp"
+            Copy-Item (Join-Path $credentialStore $recordName) $crashTemporary
+            & $env:DOSU_NODE_EXE $dosuBin logout | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "packed logout rejected its own crash temporary" }
+            if (Test-Path $credentialStore) {
+              throw "packed logout left the proven crash credential temporary behind"
+            }
+          } finally {
+            if ($outer -and -not $outer.HasExited) { $outer.Kill($true) }
+            if (Test-Path $env:DOSU_FAKE_NPX_PID) {
+              $fakeNpxPID = [int](Get-Content $env:DOSU_FAKE_NPX_PID -Raw)
+              if (Get-Process -Id $fakeNpxPID -ErrorAction SilentlyContinue) {
+                & taskkill.exe /PID $fakeNpxPID /T /F 2>&1 | Out-Null
+              }
+            }
+            if (Test-Path $env:DOSU_PROXY_DESCENDANT_PID) {
+              $cleanupPID = [int](Get-Content $env:DOSU_PROXY_DESCENDANT_PID -Raw)
+              Stop-Process -Id $cleanupPID -Force -ErrorAction SilentlyContinue
+            }
+          }
+
   release:
     needs:
       - lint

--- a/README.md
+++ b/README.md
@@ -13,7 +13,25 @@
 curl -fsSL https://cli.dosu.dev/install | sh
 ```
 
-The interactive wizard authenticates you via browser OAuth, lets you pick a Dosu deployment (or OSS / public-library mode), mints an API key, detects which AI tools you have installed, and writes the Dosu MCP server entry into each one's config. Restart your AI tool and Dosu is available.
+Run the wizard from inside the Git project you want to configure. It authenticates
+you via browser OAuth, lets you pick a Dosu deployment (or OSS / public-library
+mode), mints an API key, detects installed AI tools, and writes their supported
+MCP, instruction, and skill files into that project. Credentials stay in the
+private Dosu user config and are never written into the repository.
+
+Project MCP entries launch a pinned Dosu CLI through `npx`, so Node.js 22+ and
+`npx` must also be available when the AI tool starts. See the
+[project-scoped setup contract](docs/project-scoped-agent-setup.md) for paths,
+migration safety, and clients that only support global configuration.
+
+On a re-run, an exact Dosu project entry keeps the project pinned to its existing
+deployment even if another deployment is active globally; an explicit target is
+required to retarget it. After the project MCP completes an initialize check and
+the whole project bundle is re-read successfully, setup removes only exact,
+proven legacy Dosu MCP and rule globals. Ambiguous or unsupported entries are
+preserved; old global skills are always kept because setup and explicit standalone
+installs cannot be distinguished. Recoverable backups and receipts stay in the
+private Dosu config directory.
 
 Run `dosu` with no arguments any time to open the interactive menu.
 
@@ -129,7 +147,20 @@ Run `dosu <command> --help` for subcommands and flags.
 
 ### Supported AI tools
 
-`dosu mcp add <id>` and the setup wizard support:
+The setup wizard supports project-scoped configuration for `claude`, `cursor`,
+`vscode`, `codex`, `gemini`, `zed`, `copilot`, `opencode`, `antigravity`,
+`mcporter`, and `factory`. `dosu mcp add <id> --global` remains available as an
+explicit opt-in for global-only clients such as Claude Desktop, Windsurf, and
+Cline; the wizard does not silently fall back to global scope.
+The `manual` ID only prints connection values for a user-managed client; it does
+not accept `--global` because the CLI has no target path on which to record safe
+ownership intent.
+
+Project-default `dosu mcp add <id>` checks every supported client in the
+repository before writing, so it cannot create conflicting project targets. Use
+`--retarget` only to replace that agent's existing Dosu pin (and any client that
+shares the same project MCP file); use `dosu setup` when several independent
+project agents must move together.
 
 | ID | Tool |
 |---|---|
@@ -162,7 +193,12 @@ Combine with `dosu login --request` / `--check <ticket>` for human-in-the-loop a
 
 ## Configuration
 
-Credentials and the selected deployment live in `~/.config/dosu-cli/config.json`. Set `DOSU_DEV=true` to isolate config under `~/.config/dosu-cli-dev/`.
+The login session and active deployment live in
+`~/.config/dosu-cli/config.json`. Project MCP credentials are stored separately as
+private per-user, per-target records under
+`~/.config/dosu-cli/project-mcp-credentials.v1/`; repository files contain no API
+key or endpoint. `dosu logout` clears both credential stores. Set `DOSU_DEV=true`
+to isolate config under `~/.config/dosu-cli-dev/`.
 
 To repoint a published build at a different backend without rebuilding, set any of these runtime overrides:
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,9 +15,11 @@
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "commander": "^15.0.0",
+        "jsonc-parser": "^3.3.1",
         "open": "^11.0.0",
         "picocolors": "^1.1.1",
         "semantic-release": "^25.0.5",
+        "smol-toml": "^1.7.1",
         "superjson": "^2.2.6",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
@@ -502,6 +504,8 @@
 
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
@@ -673,6 +677,8 @@
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "skin-tone": ["skin-tone@2.0.0", "", { "dependencies": { "unicode-emoji-modifier-base": "^1.0.0" } }, "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA=="],
+
+    "smol-toml": ["smol-toml@1.7.1", "", {}, "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/docs/project-scoped-agent-setup.md
+++ b/docs/project-scoped-agent-setup.md
@@ -1,0 +1,238 @@
+# Project-scoped agent setup
+
+This change moves the automatic Dosu agent bundle from user-global files into the
+current Git project. The project receives only non-secret MCP launch metadata,
+instructions, and supported skills. Authentication remains in the user's private
+Dosu config.
+
+The released `v0.43.0` behavior being migrated installed MCP entries, rules, and
+skills globally, while its `AGENTS.md` block was already project-local:
+[setup flow](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/src/setup/flow.ts#L805-L839),
+[rules](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/src/rules/installer.ts#L17-L105),
+[skills](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/src/commands/skill.ts#L13-L115).
+Hooks were available through a separate, explicit project command but were never
+installed by setup, so this migration has no legacy hook footprint:
+[hooks command](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/src/commands/hooks.ts#L491-L559).
+
+## Current project bundle
+
+`dosu setup` must run inside a Git worktree and resolves the canonical repository
+root before writing anything. The implementation is split between the
+[project-root resolver](https://github.com/dosu-ai/dosu-cli/blob/main/src/setup/project-root.ts),
+[project MCP providers](https://github.com/dosu-ai/dosu-cli/blob/main/src/mcp/providers.ts),
+[instruction adapters](https://github.com/dosu-ai/dosu-cli/blob/main/src/setup/project-instructions.ts), and
+[skill installer](https://github.com/dosu-ai/dosu-cli/blob/main/src/commands/skill.ts).
+
+| Agent/client | Project MCP written by this branch | Project instructions | Dosu skill |
+| --- | --- | --- | --- |
+| Claude Code | `.mcp.json` | `AGENTS.md` plus a marker-owned `CLAUDE.md` bridge containing `@AGENTS.md` | `.claude/skills/dosu` (direct for Claude alone; a link to `.agents/skills/dosu` when shared) |
+| Cursor | `.cursor/mcp.json` | `AGENTS.md` | `.agents/skills/dosu` |
+| VS Code / Copilot extension | `.vscode/mcp.json` | `AGENTS.md` | `.agents/skills/dosu` |
+| Gemini CLI | `.gemini/settings.json` | `AGENTS.md` plus a marker-owned `GEMINI.md` bridge containing `@AGENTS.md` | `.agents/skills/dosu` |
+| Codex CLI, app, and IDE | `.codex/config.toml` | `AGENTS.md` | `.agents/skills/dosu` |
+| Zed | `.zed/settings.json` | `AGENTS.md` | `.agents/skills/dosu` |
+| GitHub Copilot CLI | `.mcp.json` | `AGENTS.md` | `.agents/skills/dosu` |
+| OpenCode | `opencode.json` | `AGENTS.md` | `.agents/skills/dosu` |
+| Antigravity 2.0 | `.agents/mcp_config.json` | `AGENTS.md` plus `.agents/rules/dosu.md` | `.agents/skills/dosu` |
+| Factory / Droid | `.factory/mcp.json` | `AGENTS.md` | `.factory/skills/dosu` (direct for Factory alone; a link to `.agents/skills/dosu` when shared) |
+| MCPorter | `config/mcporter.json` | N/A: MCP router, not an agent | N/A |
+
+These paths follow the clients' documented project contracts: [Claude](https://code.claude.com/docs/en/mcp),
+[Cursor](https://cursor.com/docs/mcp),
+[VS Code](https://code.visualstudio.com/docs/agent-customization/mcp-servers),
+[Gemini](https://geminicli.com/docs/reference/configuration/),
+[Codex](https://developers.openai.com/codex/mcp),
+[Zed](https://zed.dev/docs/ai/mcp),
+[Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers),
+[OpenCode](https://opencode.ai/docs/mcp-servers),
+[Antigravity](https://antigravity.google/docs/mcp),
+[Factory](https://docs.factory.ai/harness/mcp), and
+[MCPorter](https://github.com/openclaw/mcporter/blob/main/docs/config.md).
+The shared `AGENTS.md` and skill paths are likewise documented by
+[Codex](https://developers.openai.com/codex/guides/agents-md),
+[Claude](https://code.claude.com/docs/en/memory),
+[Gemini](https://geminicli.com/docs/cli/gemini-md/),
+[Cursor](https://cursor.com/docs/skills), and
+[VS Code](https://code.visualstudio.com/docs/agent-customization/agent-skills). Factory documents
+repository skills at `<repo>/.factory/skills/<skill-name>/SKILL.md` in its
+[Droid skill configuration](https://docs.factory.ai/cli/configuration/skills), and the pinned
+[`skills@1.5.22` agent table](https://github.com/vercel-labs/skills/blob/v1.5.22/README.md#L269-L273)
+maps agent ID `droid` to `.factory/skills/` for project installs.
+
+Claude Code and Copilot CLI both read the root `.mcp.json`. Dosu therefore writes
+one compatible `stdio` entry rather than competing provider-specific entries.
+Project trust/approval is still controlled by each client; writing a valid file is
+not proof that the client has approved or started it.
+
+## Secretless MCP proxy
+
+The checked-in project entry contains only an exact CLI version and either a
+deployment identifier or `--oss`:
+
+```text
+npx -y @dosu/cli@<exact-version> mcp proxy --deployment <deployment-id>
+```
+
+At agent startup, the proxy:
+
+1. uses the authenticated user and project target to read a private per-target
+   credential record from `<Dosu config dir>/project-mcp-credentials.v1/`;
+2. rejects a missing key or an endpoint whose exact path does not match the
+   project deployment (or OSS target); and
+3. starts the pinned HTTP-to-stdio bridge, passing the key through the child
+   process environment rather than the repository file or command arguments.
+
+See the [proxy implementation](https://github.com/dosu-ai/dosu-cli/blob/main/src/mcp/project-proxy.ts) and
+[credential store](https://github.com/dosu-ai/dosu-cli/blob/main/src/mcp/project-credential-store.ts). The released CLI's
+private credential model and remote endpoint shape are visible in the fixed
+[config source](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/src/config/config.ts#L71-L97)
+and [MCP helpers](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/src/mcp/config-helpers.ts#L27-L49).
+
+Records are separated by authenticated user and target, so switching the active
+deployment does not break another project's saved target. The directory is mode
+`0700` and records are mode `0600` on POSIX systems; `dosu logout` clears the
+store, including a strictly validated temporary record left by an interrupted
+save. A malformed, foreign, nested, or symlinked entry makes logout preserve the
+whole credential directory instead of guessing. Credentials remain user-private because project files are commonly
+committed, copied, and reviewed. A remote container or another user's checkout
+does not inherit them; the proxy fails closed and that user must run `dosu setup`
+in their own environment.
+
+### Existing project target and retargeting
+
+Without an explicit target, setup recognizes only the exact secretless Dosu proxy
+shape emitted by a released CLI version and reuses that project's deployment or
+OSS target. This takes precedence over a different globally active deployment.
+Any foreign, invalid, or ambiguous project entry named `dosu` stops setup before
+authentication or project writes. Conflicting exact pins across client files, or
+a project deployment unavailable to the signed-in account, also stop before
+project writes. An explicit `--deployment <id>` or `--mode oss|cloud` authorizes
+retargeting only the clients selected in that run (and clients sharing their
+canonical project file); an unselected client that would retain a different pin
+stops the run. Ordinary re-runs do not silently switch a project. See the
+[project-target resolver](https://github.com/dosu-ai/dosu-cli/blob/main/src/setup/project-target.ts).
+
+### Runtime prerequisite and known limitation
+
+The project entry requires `npx`, and the npm package requires Node.js 22 or later.
+Before writing project files, setup starts the exact pinned command that it plans
+to write, sends an MCP `initialize` request, validates the response, and requires
+the complete spawned process tree to disappear after graceful and forced
+shutdown. POSIX uses a dedicated process group; Windows uses `taskkill /T /F`.
+SIGINT, SIGTERM, and SIGHUP wait for this cleanup, and an early direct-child exit
+does not count as proof that descendants are gone. The round trip has an
+eight-second deadline; failure leaves project files and legacy global files
+unchanged. See the [preflight implementation](https://github.com/dosu-ai/dosu-cli/blob/main/src/mcp/project-proxy-preflight.ts),
+the fixed
+[installation instructions](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/README.md#L22-L48)
+and [Node engine requirement](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/package.json#L34-L36).
+On Windows, Node requires `.cmd` launchers such as `npx.cmd` to run through a
+shell; Dosu takes that path only after validating the fixed command and the
+restricted deployment identifier ([Node child-process contract](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows)).
+
+This proves the command can initialize in setup's terminal environment. It cannot
+prove that a GUI client inherits the same `PATH`, has already trusted the project,
+or will use the same startup timeout. Users may still need to restart/reload the
+client and approve the project MCP server.
+
+Replacing or removing an existing project config also requires same-directory
+hard links so Dosu can retain a no-clobber recovery reference during the atomic
+mutation. Filesystems without that capability fail before the original entry is
+moved; creating a brand-new project file is unaffected.
+
+## Legacy global migration
+
+Global cleanup runs only after the runtime preflight succeeds and the selected
+provider's project MCP, instructions, and applicable skill have all been written
+and re-read as one exact bundle. Ordinary targets re-check that bundle before
+their mutation. Cleanup is automatic for proven Dosu-owned MCP and instruction
+data and conservative for anything ambiguous.
+
+The migration removes only:
+
+- a child/table named `dosu` whose complete provider-specific shape matches a
+  released Dosu MCP entry, including the released production origin and an exact `/v1/mcp` or
+  `/v1/mcp/deployments/<id>` path and the expected Dosu API-key header; legacy
+  stdio entries also require the exact released pinned bridge shape;
+- one complete Dosu marker block in a known global instruction file, or a
+  standalone legacy rule whose full content matches a known released version.
+
+The migration preserves:
+
+- every sibling MCP server and all unrelated bytes, comments, and formatting;
+- same-named entries with extra fields, edited rules, real skill directories,
+  foreign links, duplicate keys/tables, invalid files, and any other ownership
+  ambiguity;
+- legacy entries pointed at dev, staging, localhost, or a runtime backend
+  override, because origin provenance cannot be proven safely;
+- global entries for clients without a verified project equivalent;
+- every legacy global Dosu skill, because the old setup flow and the
+  public standalone `dosu skill install` command produced indistinguishable
+  lock metadata and files. The migration never touches global skill paths or
+  creates a skill migration receipt;
+- the user's Dosu login, API key, endpoint, deployment selection, and all other
+  private CLI state; and
+- all hooks. Released setup never installed a global hook, so there is no legacy
+  global hook footprint to clean.
+
+Cleanup must also stop for a target if backup creation fails or if the source file
+changes between planning and mutation. Per-target locks and pending receipts make
+an interrupted run recoverable. Successful, not-found, and preserved terminal
+receipts prevent a later user-created global entry from being mistaken for the old
+one; a pre-mutation failure is retried only when the complete file still equals its
+recorded `beforeHash`. The
+historical shapes are grounded in the fixed
+[provider sources](https://github.com/dosu-ai/dosu-cli/tree/84f5d6f392add23e30a636506efa73148acf57ad/src/mcp/providers),
+[rule installer](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/src/rules/installer.ts#L17-L105), and
+[skill installer](https://github.com/dosu-ai/dosu-cli/blob/84f5d6f392add23e30a636506efa73148acf57ad/src/commands/skill.ts#L53-L115).
+
+### Backup, receipt, and recovery entry
+
+Migration state is a flat, deterministic directory under the private Dosu config:
+
+```text
+<Dosu config dir>/migrations/project-scope-v1/
+  target-<target-path-hash>.receipt.json
+  <target-id>-<target-path-hash>-<preimage-hash>.bak
+<Dosu config dir>/migrations/global-mcp-intent-v1/
+  <provider>-<target-path-hash>.json
+```
+
+Before each mutation, the migration saves and verifies the exact preimage. Each
+receipt records the original absolute path, outcome/reason, hashes, and backup
+path without duplicating the file contents. Backups can contain the original
+secret-bearing global configuration, so the receipt root is private (`0700`) and
+receipt/regular backup files are mode `0600` on POSIX systems. Setup reports the
+absolute receipt root when it removes or preserves legacy data.
+
+An explicit `dosu mcp add <id> --global` writes its private intent marker before
+touching the client config, then binds it to the installed file hash. Pending,
+damaged, replaced, or content-mismatched markers all preserve the global target;
+only an absent marker leaves a v0.43 entry eligible for strict legacy cleanup.
+The project-default `dosu mcp add <id>` also scans every supported project client
+before writing, refuses mixed or ambiguous targets, and requires `--retarget` to
+replace that agent's existing Dosu pin plus any client sharing its project MCP
+file.
+
+Recovery is deliberately manual: inspect the target's receipt, verify that the
+current target has not since been edited, then restore its recorded backup to the
+original path. There is no `dosu restore` command.
+
+## Unsupported clients are preserved
+
+| Client | Why project-only MCP is not configured | Safe behavior |
+| --- | --- | --- |
+| Claude Desktop | Its documented local-server config is application/user scoped, not repository scoped. | Leave any existing global Dosu entry untouched. [Docs](https://modelcontextprotocol.io/docs/develop/connect-local-servers) |
+| Legacy Windsurf Cascade | Its documented MCP file is `~/.codeium/windsurf/mcp_config.json`; the project-scoped `.devin` contract belongs to the newer Devin Local Agent surface. | Keep the legacy global entry. Do not silently relabel it as Devin. [Cascade](https://docs.windsurf.com/windsurf/cascade/mcp) · [Devin](https://docs.devin.ai/cli/extensibility/mcp/configuration) |
+| Cline IDE / Cline CLI | Official documentation exposes user/application MCP settings but no stable repository MCP file. | Keep the global entry; project instructions/skills alone are not an equivalent migration. [MCP](https://docs.cline.bot/mcp/mcp-overview) · [scopes](https://docs.cline.bot/getting-started/config) |
+| Devin Local Agent | It supports project MCP, but this branch does not yet model it as a separate provider from legacy Windsurf. | Do not claim it was configured. Add a separate detected provider in a later change. [Docs](https://docs.devin.ai/cli/extensibility/mcp/configuration) |
+
+If product policy later requires deleting every global entry regardless of client
+support, these clients will lose Dosu MCP access. That would be an explicit
+breaking decision, not this migration's behavior. Users who intentionally want a
+global install can still opt in with `dosu mcp add <id> --global`. The CLI records
+that intent in its private migration state so the first later project setup does
+not mistake the current-version install for a v0.43 legacy entry. Setup never
+silently falls back from project scope to global scope. The `manual` ID only
+prints connection values and rejects `--global`, because it has no canonical file
+path to bind to an ownership marker.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dosu": "bin/dosu.js"
   },
   "files": [
-    "bin/dosu.js"
+    "bin/dosu.js",
+    "docs/project-scoped-agent-setup.md"
   ],
   "scripts": {
     "dev": "bun run src/index.ts",
@@ -45,9 +46,11 @@
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "commander": "^15.0.0",
+    "jsonc-parser": "^3.3.1",
     "open": "^11.0.0",
     "picocolors": "^1.1.1",
     "semantic-release": "^25.0.5",
+    "smol-toml": "^1.7.1",
     "superjson": "^2.2.6",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",

--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -8,6 +8,7 @@ import {
   testTarget,
 } from "../config/config.test-utils";
 import type { SetupProvider } from "../mcp/providers";
+import { VERSION } from "../version/version";
 
 const {
   mockMintTicket,
@@ -24,6 +25,10 @@ const {
   mockSkillAgentIDsForProviders,
   mockInGitWorkTree,
   mockUpsertDosuAgentsSection,
+  mockRequireProjectRoot,
+  mockInstallProjectInstructions,
+  mockResolveProjectProof,
+  mockRunProjectScopeMigration,
 } = vi.hoisted(() => {
   return {
     mockMintTicket: vi.fn(),
@@ -46,12 +51,39 @@ const {
     mockSkillAgentIDsForProviders: vi.fn(),
     mockInGitWorkTree: vi.fn(),
     mockUpsertDosuAgentsSection: vi.fn(),
+    mockRequireProjectRoot: vi.fn(),
+    mockInstallProjectInstructions: vi.fn(),
+    mockResolveProjectProof: vi.fn(),
+    mockRunProjectScopeMigration: vi.fn(),
   };
 });
 
 vi.mock("../auth/ticket", () => ({
   mintTicket: mockMintTicket,
   exchangeTicket: mockExchangeTicket,
+}));
+
+vi.mock("../mcp/project-credential-store", () => ({
+  saveProjectMcpCredential: vi.fn(),
+  readProjectMcpCredential: vi.fn(),
+}));
+
+const { mockPreflightProjectProxy } = vi.hoisted(() => ({
+  mockPreflightProjectProxy: vi.fn(),
+}));
+vi.mock("../mcp/project-proxy-preflight", () => ({
+  preflightProjectProxy: (...args: unknown[]) => mockPreflightProjectProxy(...args),
+}));
+
+vi.mock("../migration", () => ({
+  resolveProjectProof: (...args: unknown[]) => mockResolveProjectProof(...args),
+}));
+
+const { mockResolveProjectPinnedTarget } = vi.hoisted(() => ({
+  mockResolveProjectPinnedTarget: vi.fn(),
+}));
+vi.mock("../setup/project-target", () => ({
+  resolveProjectPinnedTarget: (...args: unknown[]) => mockResolveProjectPinnedTarget(...args),
 }));
 
 vi.mock("../config/config", async (importOriginal) => ({
@@ -78,6 +110,19 @@ vi.mock("../commands/skill", () => ({
 vi.mock("../setup/agents-md-step", () => ({
   inGitWorkTree: mockInGitWorkTree,
   upsertDosuAgentsSection: mockUpsertDosuAgentsSection,
+}));
+
+vi.mock("../setup/project-root", () => ({
+  requireProjectRoot: mockRequireProjectRoot,
+}));
+
+vi.mock("../setup/project-scope-migration", () => ({
+  runProjectScopeMigration: (...args: unknown[]) => mockRunProjectScopeMigration(...args),
+}));
+
+vi.mock("../setup/project-instructions", () => ({
+  installProjectInstructions: mockInstallProjectInstructions,
+  providerUsesProjectInstructions: (providerID: string) => providerID !== "mcporter",
 }));
 
 vi.mock("../client/client", () => ({
@@ -111,6 +156,8 @@ function makeProvider(id: string, opts: Partial<SetupProvider> = {}): SetupProvi
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => `/tmp/${id}/mcp.json`,
+    projectConfigPath: (root) => `${root}/.${id}/mcp.json`,
+    isProjectConfigured: () => false,
     priority: () => 0,
     ...opts,
   };
@@ -137,17 +184,24 @@ describe("buildResumeCommand", () => {
       "npx @dosu/cli@latest setup --agent --tool cursor --login-ticket tkt-2 --deployment dep-9",
     );
   });
+
+  it("preserves an explicit mode in the resume command", () => {
+    const cmd = buildResumeCommand("codex", "tkt-3", undefined, "oss");
+    expect(cmd).toBe(
+      "npx @dosu/cli@latest setup --agent --tool codex --login-ticket tkt-3 --mode oss",
+    );
+  });
 });
 
 describe("listAgentSupportedToolIDs", () => {
-  it("lists every setup provider id, including Claude Desktop", () => {
+  it("lists only providers with an official project MCP scope", () => {
     mockAllSetupProviders.mockReturnValue([
       makeProvider("claude"),
-      makeProvider("claude-desktop"),
+      makeProvider("claude-desktop", { supportsLocal: () => false }),
       makeProvider("cursor"),
     ]);
 
-    expect(listAgentSupportedToolIDs()).toEqual(["claude", "claude-desktop", "cursor"]);
+    expect(listAgentSupportedToolIDs()).toEqual(["claude", "cursor"]);
   });
 });
 
@@ -175,10 +229,19 @@ describe("runAgentSetup", () => {
     mockSkillAgentIDsForProviders.mockReset();
     mockInGitWorkTree.mockReset();
     mockUpsertDosuAgentsSection.mockReset();
+    mockRequireProjectRoot.mockReset();
+    mockInstallProjectInstructions.mockReset();
+    mockResolveProjectProof.mockReset();
+    mockRunProjectScopeMigration.mockReset();
+    mockPreflightProjectProxy.mockReset();
+    mockResolveProjectPinnedTarget.mockReset();
     for (const fn of Object.values(mockClient)) fn.mockReset();
 
     claudeProvider = makeProvider("claude", { name: () => "Claude Code" });
-    desktopProvider = makeProvider("claude-desktop", { name: () => "Claude Desktop" });
+    desktopProvider = makeProvider("claude-desktop", {
+      name: () => "Claude Desktop",
+      supportsLocal: () => false,
+    });
 
     mockAllSetupProviders.mockReturnValue([claudeProvider, desktopProvider]);
     mockLoadConfig.mockReturnValue(makeBaseConfig());
@@ -198,6 +261,25 @@ describe("runAgentSetup", () => {
       action: "created",
       path: "/tmp/repo/AGENTS.md",
     });
+    mockRequireProjectRoot.mockReturnValue("/tmp/repo");
+    mockInstallProjectInstructions.mockReturnValue({
+      agentsMd: { action: "created", path: "/tmp/repo/AGENTS.md" },
+      adapters: [{ provider: "claude", action: "created", path: "/tmp/repo/CLAUDE.md" }],
+    });
+    mockResolveProjectProof.mockReturnValue({
+      ok: true,
+      proof: { root: "/tmp/repo", cwd: "/tmp/repo" },
+    });
+    mockRunProjectScopeMigration.mockReturnValue({
+      ok: true,
+      cleanupAttempted: true,
+      runtimeVerified: true,
+      receiptRoot: "/tmp/dosu-migration-receipts",
+      counts: { removed: 0, not_found: 3, preserved: 0, failed: 0, total: 3 },
+      warnings: [],
+    });
+    mockPreflightProjectProxy.mockResolvedValue({ ok: true, reason: "initialize_ok" });
+    mockResolveProjectPinnedTarget.mockReturnValue({ ok: true, providers: [] });
   });
 
   afterEach(() => {
@@ -279,7 +361,7 @@ describe("runAgentSetup", () => {
       "mcp_install",
       "rule_install",
       "skill_install",
-      "agents_md_install",
+      "legacy_migration",
       "done",
     ]);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
@@ -293,9 +375,40 @@ describe("runAgentSetup", () => {
       status: "ok",
       agent_next_steps: expect.stringMatching(/Claude Code.*dosu status --json/),
     });
-    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n");
-    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
-    expect(mockUpsertDosuAgentsSection).toHaveBeenCalledWith(process.cwd(), "canonical rule\n");
+    expect(events.at(-2)).toMatchObject({
+      step: "legacy_migration",
+      status: "ok",
+      receipt_root: "/tmp/dosu-migration-receipts",
+      counts: { removed: 0, not_found: 3, preserved: 0, failed: 0, total: 3 },
+    });
+    expect(JSON.stringify(events)).not.toContain("sk_user_x");
+    expect(mockInstallProjectInstructions).toHaveBeenCalledWith({
+      projectRoot: "/tmp/repo",
+      providerIDs: ["claude"],
+      content: "canonical rule\n",
+    });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], {
+      quiet: true,
+      projectRoot: "/tmp/repo",
+    });
+    expect(mockResolveProjectProof).toHaveBeenCalledWith("/tmp/repo");
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith({
+      project: { root: "/tmp/repo", cwd: "/tmp/repo" },
+      providerIDs: ["claude"],
+      proxy: { packageVersion: VERSION, deploymentID: "dep-1" },
+      instructionContent: "canonical rule\n",
+      runtimeVerified: true,
+    });
+    const preflightOrder = mockPreflightProjectProxy.mock.invocationCallOrder[0];
+    const mcpOrder = (claudeProvider.install as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    const instructionOrder = mockInstallProjectInstructions.mock.invocationCallOrder[0];
+    const skillOrder = mockInstallSkill.mock.invocationCallOrder[0];
+    const migrationOrder = mockRunProjectScopeMigration.mock.invocationCallOrder[0];
+    expect(preflightOrder).toBeLessThan(mcpOrder);
+    expect(mcpOrder).toBeLessThan(instructionOrder);
+    expect(instructionOrder).toBeLessThan(skillOrder);
+    expect(skillOrder).toBeLessThan(migrationOrder);
   });
 
   it("errors with multiple_deployments when the user has more than one dosu_mcp", async () => {
@@ -519,6 +632,12 @@ describe("runAgentSetup", () => {
     const code = await runAgentSetup({ tool: "claude", deploymentID: "dep-B" });
 
     expect(code).toBe(0);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, desktopProvider],
+      "/tmp/repo",
+      { mode: "cloud", deploymentID: "dep-B" },
+      ["claude"],
+    );
     const events = emittedEvents();
     const depEvent = events.find((e) => e.step === "deployment");
     expect(depEvent).toMatchObject({
@@ -661,6 +780,305 @@ describe("runAgentSetup", () => {
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
   });
 
+  it("prefers the exact project-pinned deployment over another globally active target", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-global-b",
+        deployment_name: "acme/global-b",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.getDeployments.mockResolvedValue([
+      {
+        deployment_id: "dep-project-a",
+        name: "acme/project-a",
+        provider_slug: "dosu_mcp",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-1",
+      },
+    ]);
+    mockClient.validateAPIKey.mockResolvedValue(false);
+    mockClient.createAPIKey.mockResolvedValue({ api_key: "key-a" });
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["claude"],
+      target: { deploymentID: "dep-project-a" },
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(0);
+    expect(emittedEvents().find((event) => event.step === "deployment")).toMatchObject({
+      deployment_id: "dep-project-a",
+    });
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.objectContaining({
+        active_account: expect.objectContaining({
+          target: expect.objectContaining({ deployment_id: "dep-project-a" }),
+        }),
+      }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: false },
+    );
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerIDs: ["claude"],
+        proxy: { packageVersion: VERSION, deploymentID: "dep-project-a" },
+        runtimeVerified: true,
+      }),
+    );
+  });
+
+  it("fails closed on conflicting pins from any project-supported provider", async () => {
+    const undetectedCodex = makeProvider("codex", { isInstalled: () => false });
+    mockAllSetupProviders.mockReturnValue([claudeProvider, undetectedCodex, desktopProvider]);
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-global",
+        deployment_name: "acme/global",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "conflicting_project_targets",
+      providers: ["claude", "codex"],
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, undetectedCodex, desktopProvider],
+      "/tmp/repo",
+    );
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "project_target",
+      status: "error",
+      reason: "conflicting_project_targets",
+      providers: ["claude", "codex"],
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+  });
+
+  it("fails on an ambiguous project entry before ticket redemption or session verification", async () => {
+    mockLoadConfig.mockReturnValue(makeBaseConfig());
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ["claude"],
+      paths: ["/tmp/repo/.mcp.json"],
+    });
+
+    const code = await runAgentSetup({
+      tool: "claude",
+      loginTicket: "ticket-must-not-be-redeemed",
+    });
+
+    expect(code).toBe(1);
+    expect(mockExchangeTicket).not.toHaveBeenCalled();
+    expect(mockClient.doRequestRaw).not.toHaveBeenCalled();
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "project_target",
+      status: "error",
+      reason: "ambiguous_project_config",
+      providers: ["claude"],
+      paths: ["/tmp/repo/.mcp.json"],
+    });
+  });
+
+  it("rejects an explicit OSS split-brain in an undetected client before authentication", async () => {
+    const undetectedCodex = makeProvider("codex", { isInstalled: () => false });
+    mockAllSetupProviders.mockReturnValue([claudeProvider, undetectedCodex, desktopProvider]);
+    mockLoadConfig.mockReturnValue(makeBaseConfig());
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: ["codex"],
+      paths: ["/tmp/repo/.codex/config.toml"],
+    });
+
+    const code = await runAgentSetup({ tool: "claude", mode: "oss" });
+
+    expect(code).toBe(1);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, undetectedCodex, desktopProvider],
+      "/tmp/repo",
+      { mode: "oss" },
+      ["claude"],
+    );
+    expect(mockMintTicket).not.toHaveBeenCalled();
+    expect(mockClient.doRequestRaw).not.toHaveBeenCalled();
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("passes the exact OSS project proxy expectation to legacy migration", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-global",
+        deployment_name: "acme/global",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["claude"],
+      target: { oss: true },
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(0);
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "oss" }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: false },
+    );
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: { packageVersion: VERSION, oss: true },
+        runtimeVerified: true,
+      }),
+    );
+  });
+
+  it("honors an explicit OSS mode and authorizes that project retarget", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-cloud",
+        deployment_name: "acme/cloud",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+
+    const code = await runAgentSetup({ tool: "claude", mode: "oss" });
+
+    expect(code).toBe(0);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, desktopProvider],
+      "/tmp/repo",
+      { mode: "oss" },
+      ["claude"],
+    );
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "oss" }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: true },
+    );
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: { packageVersion: VERSION, oss: true },
+        runtimeVerified: true,
+      }),
+    );
+  });
+
+  it("honors an explicit cloud mode when the saved mode is OSS", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-cloud",
+        deployment_name: "acme/cloud",
+        api_key: "sk_existing",
+        mode: "oss",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+
+    const code = await runAgentSetup({ tool: "claude", mode: "cloud" });
+
+    expect(code).toBe(0);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, desktopProvider],
+      "/tmp/repo",
+      { mode: "cloud", deploymentID: "dep-cloud" },
+      ["claude"],
+    );
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.not.objectContaining({ mode: "oss" }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: true },
+    );
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: { packageVersion: VERSION, deploymentID: "dep-cloud" },
+        runtimeVerified: true,
+      }),
+    );
+  });
+
+  it("uses the Cloud picker instead of recovering a selected client's old OSS pin", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        api_key: "sk_existing",
+        mode: "oss",
+      }),
+    );
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["claude"],
+    });
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.getDeployments.mockResolvedValue([
+      {
+        deployment_id: "dep-cloud-picked",
+        name: "acme/cloud-picked",
+        provider_slug: "dosu_mcp",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-1",
+      },
+    ]);
+    mockClient.validateAPIKey.mockResolvedValue(true);
+
+    const code = await runAgentSetup({ tool: "claude", mode: "cloud" });
+
+    expect(code).toBe(0);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, desktopProvider],
+      "/tmp/repo",
+      { mode: "cloud", deploymentID: undefined },
+      ["claude"],
+    );
+    expect(mockClient.getDeployments).toHaveBeenCalled();
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: undefined,
+        active_account: expect.objectContaining({
+          target: expect.objectContaining({ deployment_id: "dep-cloud-picked" }),
+        }),
+      }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: true },
+    );
+  });
+
   it("reuses a still-valid API key without minting a new one", async () => {
     mockLoadConfig.mockReturnValue(
       makeBaseConfig({
@@ -712,6 +1130,35 @@ describe("runAgentSetup", () => {
     expect(claudeProvider.install).not.toHaveBeenCalled();
   });
 
+  it("fails before project writes when the exact proxy cannot initialize", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockPreflightProjectProxy.mockResolvedValue({ ok: false, reason: "timeout" });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "mcp_preflight",
+      status: "error",
+      reason: "timeout",
+      agent_next_steps: expect.stringContaining("no project files"),
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+    expect(mockInstallProjectInstructions).not.toHaveBeenCalled();
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+  });
+
   it("emits install_failed when the provider install throws", async () => {
     mockLoadConfig.mockReturnValue(
       makeBaseConfig({
@@ -756,7 +1203,7 @@ describe("runAgentSetup", () => {
     );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.validateAPIKey.mockResolvedValue(true);
-    mockInstallRuleForAgent.mockImplementation(() => {
+    mockInstallProjectInstructions.mockImplementation(() => {
       throw new Error("rule directory is read-only");
     });
 
@@ -792,16 +1239,17 @@ describe("runAgentSetup", () => {
 
     expect(code).toBe(1);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
-    expect(mockInstallRuleForAgent).toHaveBeenCalledTimes(1);
+    expect(mockInstallProjectInstructions).toHaveBeenCalledTimes(1);
     expect(emittedEvents().at(-1)).toMatchObject({
       step: "skill_install",
       status: "error",
       reason: "install_failed",
       agent_next_steps: expect.stringContaining("idempotent"),
     });
+    expect(mockRunProjectScopeMigration).not.toHaveBeenCalled();
   });
 
-  it("reports an AGENTS.md failure after preserving the other bundled installs", async () => {
+  it("fails closed and reports receipt counts when safe legacy migration cannot finish", async () => {
     mockLoadConfig.mockReturnValue(
       makeBaseConfig({
         access_token: ticketAccessToken,
@@ -814,8 +1262,78 @@ describe("runAgentSetup", () => {
     );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.validateAPIKey.mockResolvedValue(true);
-    mockInGitWorkTree.mockReturnValue(true);
-    mockUpsertDosuAgentsSection.mockImplementation(() => {
+    mockRunProjectScopeMigration.mockReturnValue({
+      ok: false,
+      cleanupAttempted: true,
+      runtimeVerified: true,
+      reason: "migration_failed",
+      receiptRoot: "/tmp/dosu-migration-receipts/run-1",
+      counts: { removed: 1, not_found: 2, preserved: 1, failed: 1, total: 5 },
+      warnings: ["ambiguous legacy entry preserved"],
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+    expect(mockInstallProjectInstructions).toHaveBeenCalledTimes(1);
+    expect(mockInstallSkill).toHaveBeenCalledTimes(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "legacy_migration",
+      status: "error",
+      reason: "migration_failed",
+      receipt_root: "/tmp/dosu-migration-receipts/run-1",
+      counts: { removed: 1, not_found: 2, preserved: 1, failed: 1, total: 5 },
+      agent_next_steps: expect.stringContaining("1 proven global item(s) were already backed up"),
+    });
+    expect(emittedEvents().some((event) => event.step === "done")).toBe(false);
+    expect(JSON.stringify(emittedEvents())).not.toContain("sk_existing");
+  });
+
+  it("preserves globals when the project cannot be re-proven after bundle installation", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockResolveProjectProof.mockReturnValue({ ok: false, reason: "git_probe_failed" });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(mockRunProjectScopeMigration).not.toHaveBeenCalled();
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "legacy_migration",
+      status: "error",
+      reason: "project_reverification_failed",
+      project_reason: "git_probe_failed",
+      receipt_root: null,
+      counts: { removed: 0, not_found: 0, preserved: 0, failed: 0, total: 0 },
+    });
+    expect(emittedEvents().some((event) => event.step === "done")).toBe(false);
+  });
+
+  it("reports a project instruction failure before attempting the skill", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockInstallProjectInstructions.mockImplementation(() => {
       throw new Error("AGENTS.md is read-only");
     });
 
@@ -823,10 +1341,10 @@ describe("runAgentSetup", () => {
 
     expect(code).toBe(1);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
-    expect(mockInstallRuleForAgent).toHaveBeenCalledTimes(1);
-    expect(mockInstallSkill).toHaveBeenCalledTimes(1);
+    expect(mockInstallProjectInstructions).toHaveBeenCalledTimes(1);
+    expect(mockInstallSkill).not.toHaveBeenCalled();
     expect(emittedEvents().at(-1)).toMatchObject({
-      step: "agents_md_install",
+      step: "rule_install",
       status: "error",
       reason: "install_failed",
       agent_next_steps: expect.stringContaining("idempotent"),

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -19,21 +19,34 @@ import { installSkill, skillAgentIDsForProviders } from "../commands/skill";
 import {
   type Config,
   loadConfig,
+  MODE_OSS,
   replaceLoginSession,
+  type SetupMode,
   saveConfig,
   updateTarget,
 } from "../config/config";
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
+import { recordProjectProxyEndpoint } from "../mcp/project-proxy";
+import { preflightProjectProxy } from "../mcp/project-proxy-preflight";
 import { allSetupProviders } from "../mcp/providers";
-import { fetchDosuRule, installRuleForAgent, isRuleAgent } from "../rules/installer";
-import { inGitWorkTree, upsertDosuAgentsSection } from "../setup/agents-md-step";
+import { type ProviderId, resolveProjectProof } from "../migration";
+import { fetchDosuRule } from "../rules/installer";
+import {
+  installProjectInstructions,
+  providerUsesProjectInstructions,
+} from "../setup/project-instructions";
+import { requireProjectRoot } from "../setup/project-root";
+import { runProjectScopeMigration } from "../setup/project-scope-migration";
+import { type RequestedProjectTarget, resolveProjectPinnedTarget } from "../setup/project-target";
+import { VERSION } from "../version/version";
 import { emitError, emitNeedUserAction, emitStep } from "./output";
 
 export interface AgentSetupOptions {
   tool: string;
   loginTicket?: string;
   deploymentID?: string;
+  mode?: SetupMode | "cloud";
 }
 
 const NPX_INVOCATION = "npx @dosu/cli@latest";
@@ -53,9 +66,13 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   // 0. Resolve the requested tool up front. We do this before any auth so
   //    the agent gets a usage error immediately instead of after a login
   //    round-trip.
-  const provider = allSetupProviders().find((p) => p.id() === opts.tool.toLowerCase());
+  const setupProviders = allSetupProviders();
+  const provider = setupProviders.find(
+    (candidate) => candidate.id() === opts.tool.toLowerCase() && candidate.supportsLocal(),
+  );
   if (!provider) {
-    const available = allSetupProviders()
+    const available = setupProviders
+      .filter((candidate) => candidate.supportsLocal())
       .map((p) => p.id())
       .join(", ");
     emitError({
@@ -65,10 +82,38 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     });
     return 2;
   }
+  let projectRoot: string;
+  try {
+    projectRoot = requireProjectRoot();
+  } catch (err) {
+    emitError({
+      step: "setup",
+      reason: "project_required",
+      agent_next_steps: err instanceof Error ? err.message : String(err),
+    });
+    return 1;
+  }
+  let cfg = loadConfig();
+  const requestedTarget = requestedProjectTarget(opts, cfg);
+  const projectTarget = requestedTarget
+    ? resolveProjectPinnedTarget(setupProviders, projectRoot, requestedTarget, [provider.id()])
+    : resolveProjectPinnedTarget(setupProviders, projectRoot);
+  if (!projectTarget.ok) {
+    emitError({
+      step: "project_target",
+      reason: projectTarget.reason,
+      providers: projectTarget.providers,
+      paths: projectTarget.paths,
+      agent_next_steps:
+        projectTarget.reason === "ambiguous_project_config"
+          ? "One or more project Dosu entries are foreign or invalid. Inspect the listed paths and remove or repair only those entries, then retry. No authentication or project write was attempted."
+          : "The project's clients do not all match one Dosu target. Make every listed client use the same target before retrying. No authentication or project write was attempted.",
+    });
+    return 1;
+  }
   // 1. Auth: redeem a ticket if one was provided, otherwise verify any
   //    existing session, otherwise mint a fresh ticket and exit so the
   //    agent can hand the URL to the user.
-  let cfg = loadConfig();
   if (opts.loginTicket) {
     const redeemed = await redeemTicket(opts.loginTicket, cfg);
     if (redeemed.code !== 0 || redeemed.exit) return redeemed.code;
@@ -79,10 +124,29 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     cfg = verified.cfg;
   }
 
+  // Match the interactive contract: an explicit deployment always means
+  // Cloud; otherwise an explicit mode overrides saved/global state and
+  // authorizes retargeting this project's owned Dosu entry.
+  if (opts.deploymentID) {
+    cfg.mode = undefined;
+    saveConfig(cfg);
+  } else if (opts.mode) {
+    cfg.mode = opts.mode === "oss" ? MODE_OSS : undefined;
+    saveConfig(cfg);
+  }
+
   // 2. Resolve the deployment. Agent mode never prompts — if there are
   //    multiple options the agent must surface that to the user.
   const client = new Client(cfg);
-  const deploymentResult = await resolveDeployment(client, cfg, opts);
+  let deploymentOptions = opts;
+  if (!opts.deploymentID && opts.mode !== "oss") {
+    if (projectTarget.target?.deploymentID) {
+      deploymentOptions = { ...opts, deploymentID: projectTarget.target.deploymentID };
+    } else if (projectTarget.target?.oss) {
+      cfg.mode = MODE_OSS;
+    }
+  }
+  const deploymentResult = await resolveDeployment(client, cfg, deploymentOptions);
   if (deploymentResult.code !== 0) return deploymentResult.code;
   cfg = deploymentResult.cfg;
 
@@ -90,15 +154,31 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   const keyResult = await ensureAPIKey(client, cfg);
   if (keyResult.code !== 0) return keyResult.code;
   cfg = keyResult.cfg;
+  recordProjectProxyEndpoint(cfg);
+  saveConfig(cfg);
+
+  const preflight = await preflightProjectProxy(cfg, projectRoot);
+  if (!preflight.ok) {
+    emitError({
+      step: "mcp_preflight",
+      reason: preflight.reason,
+      agent_next_steps:
+        "The exact project MCP command could not initialize, so no project files or legacy globals were changed. Check Node.js 22+ and npx, then retry.",
+    });
+    return 1;
+  }
 
   // 4. Install Dosu MCP into the requested tool.
   try {
-    provider.install(cfg, /* global */ true);
+    provider.install(cfg, /* global */ false, {
+      projectRoot,
+      allowProjectRetarget: Boolean(opts.deploymentID || opts.mode),
+    });
     emitStep({
       step: "mcp_install",
       tool: provider.id(),
       tool_name: provider.name(),
-      config_path: provider.globalConfigPath(),
+      config_path: provider.projectConfigPath(projectRoot) ?? "",
     });
   } catch (err: unknown) {
     emitError({
@@ -111,32 +191,35 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     return 1;
   }
 
-  // 5. Install the matching always-on rule when this agent is part of the
-  // mainstream rule matrix. Unsupported MCP clients simply skip this step.
-  let instruction: string | undefined;
-  try {
-    if (isRuleAgent(provider.id())) {
-      instruction = await fetchDosuRule();
-      const rule = installRuleForAgent(provider.id(), instruction);
-      if (rule) {
-        emitStep({
-          step: "rule_install",
-          tool: provider.id(),
-          tool_name: provider.name(),
-          rule_path: rule.path,
-          action: rule.action,
-        });
-      }
+  // 5. Install the canonical project instructions plus the provider's thin adapter.
+  // Keep the exact fetched body: legacy cleanup re-verifies the checked-in
+  // project bundle against it before removing anything outside the project.
+  let instructionContent = "";
+  if (providerUsesProjectInstructions(provider.id())) {
+    try {
+      instructionContent = await fetchDosuRule();
+      const installed = installProjectInstructions({
+        projectRoot,
+        providerIDs: [provider.id()],
+        content: instructionContent,
+      });
+      emitStep({
+        step: "rule_install",
+        tool: provider.id(),
+        tool_name: provider.name(),
+        rule_path: installed.agentsMd.path,
+        action: installed.agentsMd.action,
+      });
+    } catch (err: unknown) {
+      emitError({
+        step: "rule_install",
+        reason: "install_failed",
+        agent_next_steps: `Dosu MCP was installed, but its rule could not be installed for ${provider.name()}: ${
+          err instanceof Error ? err.message : String(err)
+        }. Re-run this setup command; installation is idempotent.`,
+      });
+      return 1;
     }
-  } catch (err: unknown) {
-    emitError({
-      step: "rule_install",
-      reason: "install_failed",
-      agent_next_steps: `Dosu MCP was installed, but its rule could not be installed for ${provider.name()}: ${
-        err instanceof Error ? err.message : String(err)
-      }. Re-run this setup command; installation is idempotent.`,
-    });
-    return 1;
   }
 
   // 6. Install the remote Dosu skill only for the requested agent. Keep the
@@ -144,7 +227,7 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   // stdout contract.
   if (skillAgentIDsForProviders([provider.id()]).length > 0) {
     try {
-      const skill = await installSkill([provider.id()], { quiet: true });
+      const skill = await installSkill([provider.id()], { quiet: true, projectRoot });
       if (!skill.success) {
         throw new Error("the skills installer failed");
       }
@@ -166,35 +249,80 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     }
   }
 
-  // 7. Add the project-level pointer when setup runs from a git work tree.
-  // Use the low-level writer instead of the clack wrapper so stdout stays
-  // valid NDJSON.
-  if (inGitWorkTree()) {
-    try {
-      instruction ??= await fetchDosuRule();
-      const agentsMd = upsertDosuAgentsSection(process.cwd(), instruction);
-      emitStep({
-        step: "agents_md_install",
-        path: agentsMd.path,
-        action: agentsMd.action,
-      });
-    } catch (err: unknown) {
-      emitError({
-        step: "agents_md_install",
-        reason: "install_failed",
-        agent_next_steps: `Dosu's agent integrations were installed, but AGENTS.md could not be updated: ${
-          err instanceof Error ? err.message : String(err)
-        }. Re-run this setup command; installation is idempotent.`,
-      });
-      return 1;
-    }
+  // 7. Re-prove and re-verify the complete project bundle before touching any
+  // legacy global state. The successful runtime preflight above is the only
+  // authority that permits the migration layer to remove exact owned entries.
+  const project = resolveProjectProof(projectRoot);
+  if (!project.ok) {
+    emitError({
+      step: "legacy_migration",
+      reason: "project_reverification_failed",
+      project_reason: project.reason,
+      receipt_root: null,
+      counts: { removed: 0, not_found: 0, preserved: 0, failed: 0, total: 0 },
+      agent_next_steps:
+        "Project setup succeeded, but the Git project could not be re-verified, so legacy global configuration was preserved. Re-run setup from the same project root.",
+    });
+    return 1;
   }
+
+  const proxy =
+    cfg.mode === MODE_OSS
+      ? ({ packageVersion: VERSION, oss: true } as const)
+      : {
+          packageVersion: VERSION,
+          deploymentID: cfg.active_account?.target?.deployment_id as string,
+        };
+  const migration = runProjectScopeMigration({
+    project: project.proof,
+    providerIDs: [provider.id() as ProviderId],
+    proxy,
+    instructionContent,
+    runtimeVerified: true,
+  });
+  for (const warning of migration.warnings) logger.warn("agent.flow", warning);
+  if (!migration.ok) {
+    const cleanupProgress =
+      migration.counts.removed > 0
+        ? `${migration.counts.removed} proven global item(s) were already backed up and removed before cleanup stopped.`
+        : "No global item was removed.";
+    emitError({
+      step: "legacy_migration",
+      reason: migration.reason,
+      receipt_root: migration.receiptRoot,
+      counts: migration.counts,
+      agent_next_steps:
+        `Project setup succeeded, but safe legacy cleanup could not finish. ${cleanupProgress} ` +
+        "Nothing ambiguous was deleted. Re-run setup; use the receipt path for recovery if needed.",
+    });
+    return 1;
+  }
+  emitStep({
+    step: "legacy_migration",
+    receipt_root: migration.receiptRoot,
+    counts: migration.counts,
+  });
 
   emitStep({
     step: "done",
-    agent_next_steps: `Dosu is configured for ${provider.name()}. Tell the user setup is complete and they can ask their agent a Dosu question. Run 'dosu status --json' to verify.`,
+    agent_next_steps: `Dosu project files were written for ${provider.name()}. Tell the user to restart or reload the client, approve the project's MCP server if prompted, and then ask a Dosu question. 'dosu status --json' verifies authentication, not the client runtime.`,
   });
   return 0;
+}
+
+function requestedProjectTarget(
+  opts: AgentSetupOptions,
+  cfg: Config,
+): RequestedProjectTarget | undefined {
+  if (opts.deploymentID) return { mode: "cloud", deploymentID: opts.deploymentID };
+  if (opts.mode === "oss") return { mode: "oss" };
+  if (opts.mode === "cloud") {
+    return {
+      mode: "cloud",
+      deploymentID: cfg.active_account?.target?.deployment_id,
+    };
+  }
+  return undefined;
 }
 
 async function redeemTicket(
@@ -283,7 +411,7 @@ async function verifyOrMint(
       step: "auth",
       url: minted.url,
       ticket: minted.ticket,
-      resume_command: buildResumeCommand(opts.tool, minted.ticket, opts.deploymentID),
+      resume_command: buildResumeCommand(opts.tool, minted.ticket, opts.deploymentID, opts.mode),
       expires_in: minted.expires_in,
       agent_next_steps:
         "Give the URL to the user so they can sign in. Wait for the user to confirm they've signed in, then run resume_command to finish setup.",
@@ -484,15 +612,25 @@ async function ensureAPIKey(client: Client, cfg: Config): Promise<{ code: number
  * Build the exact command the agent should run after the user signs in.
  * Mirrors the marketing one-liner so the agent can copy/paste it back.
  */
-export function buildResumeCommand(tool: string, ticket: string, deploymentID?: string): string {
+export function buildResumeCommand(
+  tool: string,
+  ticket: string,
+  deploymentID?: string,
+  mode?: SetupMode | "cloud",
+): string {
   const parts = [NPX_INVOCATION, "setup", "--agent", "--tool", tool, "--login-ticket", ticket];
   if (deploymentID) {
     parts.push("--deployment", deploymentID);
+  }
+  if (mode) {
+    parts.push("--mode", mode);
   }
   return parts.join(" ");
 }
 
 /** Provider listing for `--tool` validation. Exported for tests. */
 export function listAgentSupportedToolIDs(): string[] {
-  return allSetupProviders().map((p) => p.id());
+  return allSetupProviders()
+    .filter((provider) => provider.supportsLocal())
+    .map((provider) => provider.id());
 }

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -1,4 +1,13 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,7 +15,13 @@ import { OAuthCallbackError } from "../auth/errors";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
 import { makeTestConfig, testSession, testTarget } from "../config/config.test-utils";
+import {
+  getProjectMcpCredentialStorePath,
+  readProjectMcpCredential,
+  saveProjectMcpCredential,
+} from "../mcp/project-credential-store";
 import { allProviders } from "../mcp/providers";
+import { globalMcpIntentMarkerPath, inspectGlobalMcpIntent } from "../migration/global-intent";
 import { createProgram } from "./cli";
 
 // ── Mocks (true external boundaries only) ───────────────────────────────────
@@ -65,6 +80,12 @@ vi.mock("../setup/flow", () => ({
   runSetup: (...args: unknown[]) => mockRunSetup(...args),
 }));
 
+const mockRunAgentSetup = vi.fn();
+vi.mock("../agent/flow", () => ({
+  runAgentSetup: (...args: unknown[]) => mockRunAgentSetup(...args),
+  listAgentSupportedToolIDs: () => ["claude", "codex"],
+}));
+
 const { mockLoggerGetLogPath } = vi.hoisted(() => ({
   mockLoggerGetLogPath: vi.fn(),
 }));
@@ -85,14 +106,36 @@ vi.mock("../debug/logger", () => ({
 let tempDir: string;
 let origXDG: string | undefined;
 let origHome: string | undefined;
+let origDosuDev: string | undefined;
+let origCwd: string;
+let origExitCode: typeof process.exitCode;
 let logSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "dosu-cli-test-"));
   origXDG = process.env.XDG_CONFIG_HOME;
   origHome = process.env.HOME;
+  origDosuDev = process.env.DOSU_DEV;
+  origCwd = process.cwd();
+  origExitCode = process.exitCode;
+  process.exitCode = undefined;
   process.env.XDG_CONFIG_HOME = tempDir;
   process.env.HOME = tempDir;
+  delete process.env.DOSU_DEV;
+
+  // Keep every CLI action offline: fresh caches prevent the fire-and-forget
+  // npm/GitHub update checks from starting real network requests.
+  const configDir = join(tempDir, "dosu-cli");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(
+    join(configDir, "update-check.json"),
+    JSON.stringify({ lastCheck: Date.now(), latestVersion: "0.0.0" }),
+  );
+  writeFileSync(
+    join(configDir, "skill-update-check.json"),
+    JSON.stringify({ lastCheck: Date.now(), latestSha: "same", installedSha: "same" }),
+  );
+  writeFileSync(join(configDir, "pending-tasks.json"), JSON.stringify({ tasks: [] }));
 
   vi.clearAllMocks();
   mockIsHeadless.mockReturnValue(false);
@@ -101,10 +144,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  process.chdir(origCwd);
+  process.exitCode = origExitCode;
   if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
   else delete process.env.XDG_CONFIG_HOME;
   if (origHome !== undefined) process.env.HOME = origHome;
   else delete process.env.HOME;
+  if (origDosuDev !== undefined) process.env.DOSU_DEV = origDosuDev;
+  else delete process.env.DOSU_DEV;
   rmSync(tempDir, { recursive: true, force: true });
   logSpy.mockRestore();
 });
@@ -464,6 +511,11 @@ describe("CLI actions", () => {
   describe("logout", () => {
     it("clears credentials in real config file", async () => {
       saveConfig(authenticatedConfig());
+      saveProjectMcpCredential({
+        userID: "user-1",
+        targetKey: "deployment-1",
+        credential: { endpoint: "https://api.dosu.dev/mcp", api_key: "secret" },
+      });
 
       await run("logout");
 
@@ -472,13 +524,21 @@ describe("CLI actions", () => {
       // Read back the real config file and verify credentials are cleared
       const cfg = loadConfig();
       expect(cfg.active_account).toBeUndefined();
+      expect(existsSync(getProjectMcpCredentialStorePath())).toBe(false);
     });
 
     it("prints not-logged-in when config has no credentials", async () => {
       // No config file on disk = empty config
+      saveProjectMcpCredential({
+        userID: "user-1",
+        targetKey: "deployment-1",
+        credential: { endpoint: "https://api.dosu.dev/mcp", api_key: "secret" },
+      });
+
       await run("logout");
 
       expect(logSpy).toHaveBeenCalledWith("You are not logged in.");
+      expect(existsSync(getProjectMcpCredentialStorePath())).toBe(false);
     });
   });
 
@@ -675,16 +735,16 @@ describe("CLI actions", () => {
       for (const p of providers) {
         if (p.id() === "manual") {
           // Manual provider should have NO scope label
-          // Check that the line with "manual" does not include "(global only)" or "(local + global)"
+          // Check that the line with "manual" does not include a scope label.
           const lines = output.split("\n");
           const manualLine = lines.find((l: string) => l.includes("manual"));
           expect(manualLine).toBeDefined();
           expect(manualLine).not.toContain("(global only)");
-          expect(manualLine).not.toContain("(local + global)");
+          expect(manualLine).not.toContain("(project + global)");
         } else if (!p.supportsLocal()) {
           expect(output).toContain("(global only)");
         } else {
-          expect(output).toContain("(local + global)");
+          expect(output).toContain("(project + global)");
         }
       }
 
@@ -695,6 +755,70 @@ describe("CLI actions", () => {
   // ── mcp add ─────────────────────────────────────────────────────────────
 
   describe("mcp add", () => {
+    it("installs a secretless proxy only in the current Git project by default", async () => {
+      const projectRoot = join(tempDir, "project");
+      mkdirSync(projectRoot);
+      execFileSync("git", ["init", "--quiet"], { cwd: projectRoot, stdio: "ignore" });
+      process.chdir(projectRoot);
+      saveConfig(authenticatedConfig());
+
+      await run("mcp", "add", "cursor");
+
+      const projectConfigPath = join(projectRoot, ".cursor", "mcp.json");
+      const projectConfig = readFileSync(projectConfigPath, "utf8");
+      expect(projectConfig).toContain("@dosu/cli@");
+      expect(projectConfig).toContain("dep_123");
+      expect(projectConfig).not.toContain("key_abc");
+      expect(projectConfig).not.toContain("/v1/mcp/deployments/");
+      expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
+      expect(
+        readProjectMcpCredential({
+          userID: "test-user-id",
+          targetKey: "deployment:dep_123",
+        }),
+      ).toMatchObject({ api_key: "key_abc" });
+      expect(allLogOutput()).toContain("current project");
+    });
+
+    it("refuses to create split-brain project targets across agents", async () => {
+      const projectRoot = join(tempDir, "project");
+      mkdirSync(projectRoot);
+      execFileSync("git", ["init", "--quiet"], { cwd: projectRoot, stdio: "ignore" });
+      process.chdir(projectRoot);
+      const cfg = authenticatedConfig();
+      saveConfig(cfg);
+      await run("mcp", "add", "codex");
+
+      testTarget(cfg).deployment_id = "dep_456";
+      testTarget(cfg).api_key = "key_updated";
+      saveConfig(cfg);
+
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow(/pinned to a different/i);
+      expect(existsSync(join(projectRoot, ".cursor", "mcp.json"))).toBe(false);
+      expect(readFileSync(join(projectRoot, ".codex", "config.toml"), "utf8")).toContain("dep_123");
+    });
+
+    it("retargets one existing project agent only with explicit authorization", async () => {
+      const projectRoot = join(tempDir, "project");
+      mkdirSync(projectRoot);
+      execFileSync("git", ["init", "--quiet"], { cwd: projectRoot, stdio: "ignore" });
+      process.chdir(projectRoot);
+      const cfg = authenticatedConfig();
+      saveConfig(cfg);
+      await run("mcp", "add", "cursor");
+
+      testTarget(cfg).deployment_id = "dep_456";
+      testTarget(cfg).api_key = "key_updated";
+      saveConfig(cfg);
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow(/pinned to a different/i);
+
+      await run("mcp", "add", "cursor", "--retarget");
+
+      const content = readFileSync(join(projectRoot, ".cursor", "mcp.json"), "utf8");
+      expect(content).toContain("dep_456");
+      expect(content).not.toContain("dep_123");
+    });
+
     it("creates real cursor config file with --global", async () => {
       const cfg = authenticatedConfig();
       saveConfig(cfg);
@@ -709,10 +833,67 @@ describe("CLI actions", () => {
       expect(cursorConfig.mcpServers.dosu.url).toContain("dep_123");
       expect(cursorConfig.mcpServers.dosu.headers).toBeDefined();
       expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key_abc");
+      expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath: cursorConfigPath })).toEqual({
+        status: "preserve",
+        reason: "explicit_global_intent",
+      });
 
       expect(logSpy).toHaveBeenCalledWith(
         expect.stringContaining("Successfully added Dosu MCP to Cursor"),
       );
+    });
+
+    it("updates explicit global intent when the user reinstalls a different target", async () => {
+      const cfg = authenticatedConfig();
+      saveConfig(cfg);
+      await run("mcp", "add", "cursor", "--global");
+      const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+      const markerPath = globalMcpIntentMarkerPath({
+        provider: "cursor",
+        targetPath: cursorConfigPath,
+      });
+      const firstHash = JSON.parse(readFileSync(markerPath, "utf8")).contentHash;
+
+      testTarget(cfg).deployment_id = "dep_456";
+      testTarget(cfg).api_key = "key_updated";
+      saveConfig(cfg);
+      await run("mcp", "add", "cursor", "--global");
+
+      const secondHash = JSON.parse(readFileSync(markerPath, "utf8")).contentHash;
+      expect(secondHash).not.toBe(firstHash);
+      expect(readFileSync(cursorConfigPath, "utf8")).toContain("dep_456");
+      expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath: cursorConfigPath })).toEqual({
+        status: "preserve",
+        reason: "explicit_global_intent",
+      });
+    });
+
+    it("does not modify global config when pending intent cannot be written safely", async () => {
+      saveConfig(authenticatedConfig());
+      const intentRoot = join(tempDir, "dosu-cli", "migrations", "global-mcp-intent-v1");
+      const foreign = join(tempDir, "foreign-intent-root");
+      mkdirSync(join(intentRoot, ".."), { recursive: true });
+      mkdirSync(foreign);
+      symlinkSync(foreign, intentRoot, "dir");
+
+      await expect(run("mcp", "add", "cursor", "--global")).rejects.toThrow(/unsafe/i);
+
+      expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
+    });
+
+    it("releases shared migration exclusion but keeps pending intent when global install fails", async () => {
+      saveConfig(authenticatedConfig());
+      const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+      mkdirSync(cursorConfigPath, { recursive: true });
+
+      await expect(run("mcp", "add", "cursor", "--global")).rejects.toThrow();
+
+      expect(existsSync(`${cursorConfigPath}.dosu-migration.lock`)).toBe(false);
+      expect(existsSync(cursorConfigPath)).toBe(true);
+      expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath: cursorConfigPath })).toEqual({
+        status: "preserve",
+        reason: "global_intent_pending",
+      });
     });
 
     it("throws error for unknown tool", async () => {
@@ -801,15 +982,28 @@ describe("CLI actions", () => {
       expect(allLogOutput()).toContain("key_abc");
     });
 
-    it("auto-sets global when provider does not support local", async () => {
+    it("rejects an untrackable manual global install", async () => {
       saveConfig(authenticatedConfig());
 
-      // Windsurf only supports global installation
-      await run("mcp", "add", "windsurf");
+      await expect(run("mcp", "add", "manual", "--global")).rejects.toThrow(
+        /cannot be recorded safely/i,
+      );
+      expect(allLogOutput()).not.toContain("api.dosu.dev");
+    });
 
-      const output = allLogOutput();
-      expect(output).toContain("only supports global installation");
-      expect(output).toContain("Successfully added Dosu MCP to Windsurf");
+    it("refuses to silently fall back to global when project scope is unsupported", async () => {
+      saveConfig(authenticatedConfig());
+
+      await expect(run("mcp", "add", "windsurf")).rejects.toThrow(/will not silently fall back/i);
+      expect(allLogOutput()).not.toContain("Successfully added Dosu MCP to Windsurf");
+    });
+
+    it("still allows an explicit global install for an unsupported project client", async () => {
+      saveConfig(authenticatedConfig());
+
+      await run("mcp", "add", "windsurf", "--global");
+
+      expect(allLogOutput()).toContain("Successfully added Dosu MCP to Windsurf");
     });
 
     it("installs globally when --global flag is passed", async () => {
@@ -825,7 +1019,43 @@ describe("CLI actions", () => {
 
   // ── setup ───────────────────────────────────────────────────────────────
 
+  describe("mcp proxy", () => {
+    it("rejects both missing and conflicting target selectors before starting the proxy", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        await run("mcp", "proxy");
+        expect(process.exitCode).toBe(2);
+
+        process.exitCode = undefined;
+        await run("mcp", "proxy", "--deployment", "dep_123", "--oss");
+        expect(process.exitCode).toBe(2);
+        expect(errorSpy).toHaveBeenCalledTimes(2);
+        expect(errorSpy).toHaveBeenCalledWith("Exactly one of --deployment or --oss is required.");
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+  });
+
   describe("setup", () => {
+    it("emits a structured error when agent setup omits --tool", async () => {
+      await run("setup", "--agent");
+
+      expect(process.exitCode).toBe(2);
+      expect(allLogOutput()).toContain('"reason":"missing_tool"');
+      expect(allLogOutput()).toContain("Supported ids: claude, codex");
+      expect(mockRunAgentSetup).not.toHaveBeenCalled();
+    });
+
+    it("rejects agent-only flags outside agent setup", async () => {
+      await expect(run("setup", "--tool", "codex")).rejects.toThrow(
+        "--tool and --login-ticket require --agent",
+      );
+
+      expect(mockRunSetup).not.toHaveBeenCalled();
+      expect(mockRunAgentSetup).not.toHaveBeenCalled();
+    });
+
     it("runs setup flow", async () => {
       mockRunSetup.mockResolvedValue(undefined);
 
@@ -844,6 +1074,27 @@ describe("CLI actions", () => {
       expect(mockRunSetup).toHaveBeenCalledWith({
         deploymentID: "dep_456",
       });
+    });
+
+    it("passes a validated mode to agent setup", async () => {
+      mockRunAgentSetup.mockResolvedValue(0);
+
+      await run("setup", "--agent", "--tool", "codex", "--mode", "oss");
+
+      expect(mockRunAgentSetup).toHaveBeenCalledWith({
+        tool: "codex",
+        loginTicket: undefined,
+        deploymentID: undefined,
+        mode: "oss",
+      });
+    });
+
+    it("rejects an invalid mode before starting agent setup", async () => {
+      await expect(
+        run("setup", "--agent", "--tool", "codex", "--mode", "nonsense"),
+      ).rejects.toThrow("invalid --mode value 'nonsense'");
+
+      expect(mockRunAgentSetup).not.toHaveBeenCalled();
     });
   });
 

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -64,6 +64,17 @@ describe("CLI", () => {
     expect(mcpCmd?.commands.find((c) => c.name() === "list")).toBeDefined();
   });
 
+  it("registers the internal project proxy without advertising it in help", () => {
+    const program = createProgram();
+    const mcpCmd = program.commands.find((c) => c.name() === "mcp");
+    const proxy = mcpCmd?.commands.find((c) => c.name() === "proxy");
+
+    expect(proxy).toBeDefined();
+    expect(proxy?.options.find((o) => o.long === "--deployment")).toBeDefined();
+    expect(proxy?.options.find((o) => o.long === "--oss")).toBeDefined();
+    expect(mcpCmd?.helpInformation()).not.toContain("proxy");
+  });
+
   it("has setup command with --deployment option", () => {
     const program = createProgram();
     const cmd = program.commands.find((c) => c.name() === "setup");

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -34,7 +34,20 @@ import {
   saveConfig,
 } from "../config/config";
 import { logger } from "../debug/logger";
-import { allProviders, getProvider, type Provider } from "../mcp/providers";
+import { clearProjectMcpCredentials } from "../mcp/project-credential-store";
+import {
+  recordProjectProxyEndpoint,
+  runProjectProxy,
+  sameProjectProxyTarget,
+} from "../mcp/project-proxy";
+import { allProviders, allSetupProviders, getProvider, type Provider } from "../mcp/providers";
+import {
+  finalizeGlobalMcpIntent,
+  prepareGlobalMcpIntent,
+  releaseGlobalMcpIntent,
+} from "../migration/global-intent";
+import { requireProjectRoot } from "../setup/project-root";
+import { resolveProjectPinnedTarget } from "../setup/project-target";
 import { browserFallbackHint } from "../setup/styles";
 import { checkForReadyTasks } from "../version/pending-tasks-check";
 import { checkForSkillUpdates } from "../version/skill-update-check";
@@ -47,9 +60,11 @@ import { getVersionString } from "../version/version";
  * are noise on the hot path and the background fetch can delay process exit).
  */
 const HOOK_ENTRYPOINTS = new Set(["user-prompt-submit", "post-tool-use", "stop"]);
-function isHookEntrypointInvocation(argv: string[]): boolean {
+function isHotPathInvocation(argv: string[]): boolean {
   const i = argv.indexOf("hooks");
-  return i >= 0 && HOOK_ENTRYPOINTS.has(argv[i + 1] ?? "");
+  if (i >= 0 && HOOK_ENTRYPOINTS.has(argv[i + 1] ?? "")) return true;
+  const mcpIndex = argv.indexOf("mcp");
+  return mcpIndex >= 0 && argv[mcpIndex + 1] === "proxy";
 }
 
 /** Suggest the closest registered command name for a mistyped one, if any is close enough. */
@@ -94,7 +109,7 @@ export function createProgram(): Command {
     .hook("preAction", (thisCommand) => {
       const opts = thisCommand.optsWithGlobals();
       logger.init({ debug: opts.debug });
-      if (!isHookEntrypointInvocation(process.argv)) {
+      if (!isHotPathInvocation(process.argv)) {
         checkForUpdates();
         checkForSkillUpdates();
         checkForReadyTasks();
@@ -235,11 +250,13 @@ export function createProgram(): Command {
     .action(() => {
       const cfg = loadConfig();
       if (!isAuthenticated(cfg)) {
+        clearProjectMcpCredentials();
         console.log("You are not logged in.");
         return;
       }
       clearConfigInPlace(cfg);
       saveConfig(cfg);
+      clearProjectMcpCredentials();
       console.log("Successfully logged out.");
     });
 
@@ -333,52 +350,145 @@ export function createProgram(): Command {
     .command("add <agent>")
     .description("Add Dosu MCP to an AI tool")
     .option("-g, --global", "Add globally (all projects) instead of project-local", false)
+    .option("--retarget", "Replace this agent's existing project Dosu target", false)
     .option("--show-secret", "Print full manual configuration secrets", false)
-    .action(async (toolId: string, opts: { global: boolean; showSecret: boolean }) => {
-      let provider: Provider;
-      try {
-        provider = getProvider(toolId.toLowerCase());
-      } catch {
-        throw new Error(`unknown tool '${toolId}'. Use 'dosu mcp list' to see available tools`);
-      }
-      const cfg = loadConfig();
+    .action(
+      async (toolId: string, opts: { global: boolean; retarget: boolean; showSecret: boolean }) => {
+        let provider: Provider;
+        try {
+          provider = getProvider(toolId.toLowerCase());
+        } catch {
+          throw new Error(`unknown tool '${toolId}'. Use 'dosu mcp list' to see available tools`);
+        }
+        const cfg = loadConfig();
 
-      if (!isAuthenticated(cfg)) {
-        throw new Error("not logged in. Run 'dosu login' first");
-      }
-      if (isTokenExpired(cfg) && !(await ensureFreshSession(cfg))) {
-        throw new Error("session expired. Run 'dosu login' to re-authenticate");
-      }
-      if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id) {
-        throw new Error("no MCP selected. Run 'dosu' to open the TUI and select an MCP");
-      }
-      if (!cfg.active_account?.target?.api_key) {
-        throw new Error("no API key available. Run 'dosu setup' to create one");
-      }
+        if (!isAuthenticated(cfg)) {
+          throw new Error("not logged in. Run 'dosu login' first");
+        }
+        if (isTokenExpired(cfg) && !(await ensureFreshSession(cfg))) {
+          throw new Error("session expired. Run 'dosu login' to re-authenticate");
+        }
+        if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id) {
+          throw new Error("no MCP selected. Run 'dosu' to open the TUI and select an MCP");
+        }
+        if (!cfg.active_account?.target?.api_key) {
+          throw new Error("no API key available. Run 'dosu setup' to create one");
+        }
 
-      if (provider.id() === "manual") {
-        provider.install(cfg, false, { showSecret: opts.showSecret });
+        if (opts.retarget && (opts.global || provider.id() === "manual")) {
+          throw new Error("--retarget is only valid for a project-scoped agent configuration");
+        }
+
+        if (provider.id() === "manual") {
+          if (opts.global) {
+            throw new Error(
+              "--global cannot be recorded safely for manual configuration; choose a supported agent ID instead",
+            );
+          }
+          provider.install(cfg, false, { showSecret: opts.showSecret });
+          return;
+        }
+
+        if (!provider.supportsLocal() && !opts.global) {
+          throw new Error(
+            `${provider.name()} has no official project-scoped MCP config. ` +
+              "Dosu will not silently fall back to a global install; use --global explicitly if you accept that scope.",
+          );
+        }
+
+        let projectRoot: string | undefined;
+        if (!opts.global) {
+          projectRoot = requireProjectRoot();
+          const configuredTarget =
+            cfg.mode === MODE_OSS
+              ? ({ oss: true } as const)
+              : { deploymentID: cfg.active_account?.target?.deployment_id as string };
+          const projectTarget = opts.retarget
+            ? resolveProjectPinnedTarget(
+                allSetupProviders(),
+                projectRoot,
+                cfg.mode === MODE_OSS
+                  ? { mode: "oss" }
+                  : {
+                      mode: "cloud",
+                      deploymentID: cfg.active_account?.target?.deployment_id,
+                    },
+                [provider.id()],
+              )
+            : resolveProjectPinnedTarget(allSetupProviders(), projectRoot);
+          if (!projectTarget.ok) {
+            const locations = projectTarget.paths.join(", ");
+            throw new Error(
+              `Cannot safely update this project's Dosu MCP (${projectTarget.reason}): ${locations}. ` +
+                "Run `dosu setup` to reconcile every project agent together.",
+            );
+          }
+          if (
+            !opts.retarget &&
+            projectTarget.target &&
+            !sameProjectProxyTarget(projectTarget.target, configuredTarget)
+          ) {
+            throw new Error(
+              "This project is pinned to a different Dosu target. Run `dosu setup` to add this agent " +
+                "without splitting the project's MCP target, or pass --retarget only when no other project agent must stay on the old target.",
+            );
+          }
+          recordProjectProxyEndpoint(cfg);
+          saveConfig(cfg);
+        }
+
+        const global = opts.global;
+        const scope = global ? "global (all projects)" : "current project";
+        console.log(`Adding Dosu MCP to ${provider.name()} (${scope})...`);
+
+        if (global && !("globalConfigPath" in provider)) {
+          throw new Error(`${provider.name()} does not expose a canonical global config path`);
+        }
+        const globalIntent = global
+          ? prepareGlobalMcpIntent({
+              provider: provider.id(),
+              targetPath: (
+                provider as Provider & { globalConfigPath(): string }
+              ).globalConfigPath(),
+            })
+          : null;
+        try {
+          provider.install(cfg, global, {
+            showSecret: opts.showSecret,
+            projectRoot,
+            allowProjectRetarget: opts.retarget,
+          });
+        } catch (error) {
+          if (globalIntent) releaseGlobalMcpIntent(globalIntent);
+          throw error;
+        }
+        if (globalIntent) finalizeGlobalMcpIntent(globalIntent);
+
+        console.log(`\n✓ Successfully added Dosu MCP to ${provider.name()}!`);
+        if (global) {
+          console.log(`\nStart ${provider.name()} in any project to use the Dosu MCP.`);
+        } else {
+          console.log(`\nStart ${provider.name()} in this project directory to use the Dosu MCP.`);
+        }
+      },
+    );
+
+  const proxyCommand = new Command("proxy")
+    .description("Internal project MCP credential bridge")
+    .option("--deployment <id>", "Expected project deployment")
+    .option("--oss", "Use the configured public-libraries endpoint", false)
+    .action(async (opts: { deployment?: string; oss: boolean }) => {
+      if (Boolean(opts.deployment) === opts.oss) {
+        console.error("Exactly one of --deployment or --oss is required.");
+        process.exitCode = 2;
         return;
       }
-
-      let global = opts.global;
-      if (!provider.supportsLocal() && !global) {
-        console.log(`Note: ${provider.name()} only supports global installation.\n`);
-        global = true;
-      }
-
-      const scope = global ? "global (all projects)" : "project-local";
-      console.log(`Adding Dosu MCP to ${provider.name()} (${scope})...`);
-
-      provider.install(cfg, global, { showSecret: opts.showSecret });
-
-      console.log(`\n✓ Successfully added Dosu MCP to ${provider.name()}!`);
-      if (global) {
-        console.log(`\nStart ${provider.name()} in any project to use the Dosu MCP.`);
-      } else {
-        console.log(`\nStart ${provider.name()} in this project directory to use the Dosu MCP.`);
-      }
+      process.exitCode = await runProjectProxy({
+        deploymentID: opts.deployment,
+        oss: opts.oss,
+      });
     });
+  mcp.addCommand(proxyCommand, { hidden: true });
 
   mcp
     .command("list")
@@ -386,7 +496,7 @@ export function createProgram(): Command {
     .action(() => {
       console.log("Available AI tools:\n");
       for (const p of allProviders()) {
-        let scope = "(local + global)";
+        let scope = "(project + global)";
         if (!p.supportsLocal()) scope = "(global only)";
         if (p.id() === "manual") scope = "";
         console.log(`  ${p.id().padEnd(10)} ${p.name()} ${scope}`);
@@ -436,6 +546,15 @@ export function createProgram(): Command {
         tool?: string;
         loginTicket?: string;
       }) => {
+        let mode: "oss" | "cloud" | undefined;
+        if (opts.mode !== undefined) {
+          const normalized = opts.mode.toLowerCase();
+          if (normalized !== "oss" && normalized !== "cloud") {
+            throw new Error(`invalid --mode value '${opts.mode}' (expected 'oss' or 'cloud')`);
+          }
+          mode = normalized;
+        }
+
         if (opts.agent) {
           if (!opts.tool) {
             const { emitError } = await import("../agent/output");
@@ -453,6 +572,7 @@ export function createProgram(): Command {
             tool: opts.tool,
             loginTicket: opts.loginTicket,
             deploymentID: opts.deployment,
+            mode,
           });
           return;
         }
@@ -463,14 +583,6 @@ export function createProgram(): Command {
         }
 
         const { runSetup } = await import("../setup/flow");
-        let mode: "oss" | "cloud" | undefined;
-        if (opts.mode !== undefined) {
-          const normalized = opts.mode.toLowerCase();
-          if (normalized !== "oss" && normalized !== "cloud") {
-            throw new Error(`invalid --mode value '${opts.mode}' (expected 'oss' or 'cloud')`);
-          }
-          mode = normalized;
-        }
         await runSetup({ deploymentID: opts.deployment, mode });
       },
     );

--- a/src/cli/signal-policy.test.ts
+++ b/src/cli/signal-policy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  dispatchCliSignal,
+  installsImmediateSigintHandler,
+  registerCliSignalCleanup,
+} from "./signal-policy";
+
+describe("SIGINT policy", () => {
+  it("lets the project MCP proxy forward shutdown to its child", () => {
+    expect(installsImmediateSigintHandler(["node", "dosu", "mcp", "proxy", "--oss"])).toBe(false);
+  });
+
+  it("keeps immediate Ctrl+C handling for interactive commands", () => {
+    expect(installsImmediateSigintHandler(["dosu", "setup"])).toBe(true);
+  });
+
+  it("keeps ordinary Ctrl+C immediate when no guarded operation is active", async () => {
+    const exit = vi.fn();
+
+    await dispatchCliSignal("SIGINT", exit);
+
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it.each([
+    ["SIGINT", 0],
+    ["SIGTERM", 143],
+    ["SIGHUP", 129],
+  ] as const)("waits for guarded cleanup before exiting on %s", async (signal, exitCode) => {
+    let finishCleanup: (() => void) | undefined;
+    const cleanup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCleanup = resolve;
+        }),
+    );
+    const unregister = registerCliSignalCleanup(cleanup);
+    const exit = vi.fn();
+
+    const dispatched = dispatchCliSignal(signal, exit);
+    await Promise.resolve();
+    expect(cleanup).toHaveBeenCalledWith(signal);
+    expect(exit).not.toHaveBeenCalled();
+
+    finishCleanup?.();
+    await dispatched;
+    expect(exit).toHaveBeenCalledWith(exitCode);
+    unregister();
+  });
+
+  it("coalesces repeated signals while cleanup is in progress", async () => {
+    let finishCleanup: (() => void) | undefined;
+    const unregister = registerCliSignalCleanup(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCleanup = resolve;
+        }),
+    );
+    const exit = vi.fn();
+
+    const first = dispatchCliSignal("SIGTERM", exit);
+    const second = dispatchCliSignal("SIGINT", exit);
+    await Promise.resolve();
+    finishCleanup?.();
+    await Promise.all([first, second]);
+
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(143);
+    unregister();
+  });
+
+  it("exits with failure when guarded cleanup cannot be confirmed", async () => {
+    const unregister = registerCliSignalCleanup(async () => {
+      throw new Error("shutdown unconfirmed");
+    });
+    const exit = vi.fn();
+
+    await dispatchCliSignal("SIGINT", exit);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    unregister();
+  });
+});

--- a/src/cli/signal-policy.ts
+++ b/src/cli/signal-policy.ts
@@ -1,0 +1,58 @@
+export const CLI_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+
+export type CliSignal = (typeof CLI_SIGNALS)[number];
+export type CliSignalCleanup = (signal: CliSignal) => Promise<void> | void;
+type ExitProcess = (code: number) => void;
+
+const activeCleanups = new Set<CliSignalCleanup>();
+let pendingDispatch: Promise<void> | undefined;
+
+function exitCodeForSignal(signal: CliSignal): number {
+  if (signal === "SIGINT") return 0;
+  if (signal === "SIGTERM") return 143;
+  return 129;
+}
+
+/**
+ * Guard a short-lived operation whose children must be reaped before the CLI
+ * exits. The returned function removes only this exact registration.
+ */
+export function registerCliSignalCleanup(cleanup: CliSignalCleanup): () => void {
+  activeCleanups.add(cleanup);
+  return () => {
+    activeCleanups.delete(cleanup);
+  };
+}
+
+/**
+ * Keep ordinary prompt cancellation immediate, but wait for any active
+ * guarded operation before exiting. Repeated signals share one cleanup pass.
+ */
+export function dispatchCliSignal(
+  signal: CliSignal,
+  exit: ExitProcess = (code) => process.exit(code),
+): Promise<void> {
+  if (pendingDispatch) return pendingDispatch;
+  const cleanups = [...activeCleanups];
+  if (cleanups.length === 0) {
+    exit(exitCodeForSignal(signal));
+    return Promise.resolve();
+  }
+
+  pendingDispatch = Promise.allSettled(
+    cleanups.map((cleanup) => Promise.resolve().then(() => cleanup(signal))),
+  )
+    .then((results) => {
+      exit(results.some((result) => result.status === "rejected") ? 1 : exitCodeForSignal(signal));
+    })
+    .finally(() => {
+      pendingDispatch = undefined;
+    });
+  return pendingDispatch;
+}
+
+/** The long-lived MCP proxy owns signal forwarding to its child bridge. */
+export function installsImmediateSigintHandler(argv: readonly string[]): boolean {
+  const mcpIndex = argv.indexOf("mcp");
+  return !(mcpIndex >= 0 && argv[mcpIndex + 1] === "proxy");
+}

--- a/src/commands/project-skill-ownership.test.ts
+++ b/src/commands/project-skill-ownership.test.ts
@@ -1,0 +1,507 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assertProjectSkillInstallSafe,
+  projectSkillEvidenceUnchanged,
+  verifyProjectSkillInstallation,
+} from "./project-skill-ownership";
+
+let root: string;
+const extraRoots: string[] = [];
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "dosu-project-skill-ownership-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  for (const extraRoot of extraRoots.splice(0)) {
+    rmSync(extraRoot, { recursive: true, force: true });
+  }
+});
+
+function writeOwnedSkill(target: string): void {
+  const content = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  mkdirSync(target, { recursive: true });
+  writeFileSync(join(target, "SKILL.md"), content);
+  const computedHash = createHash("sha256").update("SKILL.md").update(content).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+function writeLock(computedHash: string, skills: Record<string, unknown> = {}): void {
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        ...skills,
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+describe("project skill ownership", () => {
+  it("verifies the actual Claude-only direct layout from skills@1.5.22", () => {
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(claude);
+
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: claude, symlink: false }],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("verifies the actual mixed canonical plus Claude symlink layout", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", claude, "dir");
+
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [
+          { path: canonical, symlink: false },
+          { path: claude, symlink: true },
+        ],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("verifies the actual Factory-only direct layout from skills@1.5.22", () => {
+    const factory = join(root, ".factory", "skills", "dosu");
+    writeOwnedSkill(factory);
+
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: factory, symlink: false }],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("verifies the mixed Factory symlink and accepts a later Factory-only rerun", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const factory = join(root, ".factory", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".factory", "skills"), { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", factory, "dir");
+    const mixedTargets = [
+      { path: canonical, symlink: false },
+      { path: factory, symlink: true },
+    ];
+
+    expect(
+      verifyProjectSkillInstallation({ projectRoot: root, targets: mixedTargets }),
+    ).toMatchObject({ ok: true });
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: factory, symlink: false }],
+      }),
+    ).not.toThrow();
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: factory, symlink: false }],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("rejects a foreign Factory skill symlink before install", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const factory = join(root, ".factory", "skills", "dosu");
+    const external = mkdtempSync(join(tmpdir(), "dosu-foreign-factory-skill-"));
+    extraRoots.push(external);
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".factory", "skills"), { recursive: true });
+    symlinkSync(external, factory, "dir");
+
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: factory, symlink: false }],
+      }),
+    ).toThrow(/ownership/i);
+  });
+
+  it("accepts a Claude-only rerun of the previously owned mixed layout", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", claude, "dir");
+    const claudeOnlyTargets = [{ path: claude, symlink: false }];
+
+    expect(() =>
+      assertProjectSkillInstallSafe({ projectRoot: root, targets: claudeOnlyTargets }),
+    ).not.toThrow();
+    expect(
+      verifyProjectSkillInstallation({ projectRoot: root, targets: claudeOnlyTargets }),
+    ).toMatchObject({
+      ok: true,
+      evidence: expect.arrayContaining([
+        expect.objectContaining({ kind: "directory", path: canonical }),
+        expect.objectContaining({ kind: "symlink", path: claude }),
+      ]),
+    });
+  });
+
+  it("rejects foreign and edited shared layouts during a Claude-only rerun", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+
+    const external = mkdtempSync(join(tmpdir(), "dosu-foreign-shared-skill-"));
+    extraRoots.push(external);
+    const externalSkill = join(external, "dosu");
+    mkdirSync(externalSkill, { recursive: true });
+    writeFileSync(
+      join(externalSkill, "SKILL.md"),
+      "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n",
+    );
+    symlinkSync(externalSkill, claude, "dir");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: claude, symlink: false }],
+      }),
+    ).toThrow(/ownership/i);
+
+    rmSync(claude);
+    symlinkSync("../../.agents/skills/dosu", claude, "dir");
+    writeFileSync(join(canonical, "SKILL.md"), "---\nname: dosu\n---\nuser edited\n");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: claude, symlink: false }],
+      }),
+    ).toThrow(/ownership/i);
+  });
+
+  it("rejects a duplicate-key lock and a foreign mixed-layout symlink", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    const validLock = `{"version":1,"skills":{"dosu":${JSON.stringify({
+      source: "dosu-ai/dosu-skill",
+      sourceType: "github",
+      skillPath: "skills/dosu/SKILL.md",
+      computedHash: "a".repeat(64),
+    })},"dosu":{}}}`;
+    writeFileSync(join(root, "skills-lock.json"), validLock);
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: canonical, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_lock_mismatch" });
+
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync("../../../foreign", claude, "dir");
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [
+          { path: canonical, symlink: false },
+          { path: claude, symlink: true },
+        ],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_foreign_symlink" });
+  });
+
+  it("allows a clean install but rejects pre-existing skill content without an ownership lock", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).not.toThrow();
+
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), "user-authored");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toThrow(/cannot prove ownership/i);
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_lock_mismatch" });
+  });
+
+  it("treats an unclaimed lock as safe only while no Dosu target exists", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    writeFileSync(
+      join(root, "skills-lock.json"),
+      JSON.stringify({ version: 1, skills: { other: { source: "example" } } }),
+    );
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).not.toThrow();
+
+    mkdirSync(target, { recursive: true });
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toThrow(/cannot prove ownership/i);
+  });
+
+  it("rejects malformed, symlinked, and semantically foreign ownership locks", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    const lockPath = join(root, "skills-lock.json");
+    writeFileSync(lockPath, "not-json");
+    expect(() => assertProjectSkillInstallSafe({ projectRoot: root, targets: [] })).toThrow(
+      /cannot prove ownership/i,
+    );
+
+    rmSync(lockPath);
+    writeFileSync(join(root, "foreign-lock.json"), '{"version":1,"skills":{}}');
+    symlinkSync(join(root, "foreign-lock.json"), lockPath);
+    expect(verifyProjectSkillInstallation({ projectRoot: root, targets: [] })).toMatchObject({
+      ok: false,
+      reason: "project_skill_lock_mismatch",
+    });
+
+    rmSync(lockPath);
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        version: 1,
+        skills: {
+          dosu: {
+            source: "someone/else",
+            sourceType: "github",
+            skillPath: "skills/dosu/SKILL.md",
+            computedHash: "a".repeat(64),
+          },
+        },
+      }),
+    );
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toThrow(/cannot prove ownership/i);
+  });
+
+  it("hashes nested regular files deterministically while ignoring package and VCS metadata", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+    mkdirSync(join(target, "references"), { recursive: true });
+    mkdirSync(join(target, ".git"), { recursive: true });
+    mkdirSync(join(target, "node_modules"), { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), skill);
+    writeFileSync(join(target, "references", "guide.md"), "guide");
+    writeFileSync(join(target, ".git", "ignored"), "changes freely");
+    writeFileSync(join(target, "node_modules", "ignored"), "changes freely");
+    const computedHash = createHash("sha256")
+      .update("references/guide.md")
+      .update("guide")
+      .update("SKILL.md")
+      .update(skill)
+      .digest("hex");
+    writeLock(computedHash);
+
+    const verification = verifyProjectSkillInstallation({
+      projectRoot: root,
+      targets: [{ path: target, symlink: false }],
+    });
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+    expect(verification.evidence.some((item) => item.kind === "directory")).toBe(true);
+
+    writeFileSync(join(target, ".git", "ignored"), "still ignored");
+    for (const evidence of verification.evidence) {
+      expect(projectSkillEvidenceUnchanged(evidence, root)).toBe(true);
+    }
+    writeFileSync(join(target, "references", "guide.md"), "user edit");
+    expect(verification.evidence.some((item) => !projectSkillEvidenceUnchanged(item, root))).toBe(
+      true,
+    );
+  });
+
+  it("rejects missing targets, ordinary files, bad frontmatter, and nested symlinks", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    writeLock("a".repeat(64));
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_missing", path: target });
+
+    mkdirSync(join(root, ".agents", "skills"), { recursive: true });
+    writeFileSync(target, "ordinary file", { flag: "w" });
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+
+    rmSync(target);
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), "---\nname: other\n---\n");
+    const other = readFileSync(join(target, "SKILL.md"));
+    writeLock(createHash("sha256").update("SKILL.md").update(other).digest("hex"));
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+
+    writeFileSync(join(target, "SKILL.md"), "---\nname: dosu\n---\n");
+    symlinkSync(join(root, "foreign-lock.json"), join(target, "nested-link"));
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+  });
+
+  it("revalidates mixed-layout symlink and lock evidence after verification", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", claude, "dir");
+    const verification = verifyProjectSkillInstallation({
+      projectRoot: root,
+      targets: [
+        { path: canonical, symlink: false },
+        { path: claude, symlink: true },
+      ],
+    });
+    if (!verification.ok) throw new Error(verification.reason);
+
+    const lockEvidence = verification.evidence.find((item) => item.kind === "file");
+    const symlinkEvidence = verification.evidence.find((item) => item.kind === "symlink");
+    expect(lockEvidence && projectSkillEvidenceUnchanged(lockEvidence, root)).toBe(true);
+    expect(symlinkEvidence && projectSkillEvidenceUnchanged(symlinkEvidence, root)).toBe(true);
+
+    writeFileSync(join(root, "skills-lock.json"), '{"version":1,"skills":{}}');
+    expect(lockEvidence && projectSkillEvidenceUnchanged(lockEvidence, root)).toBe(false);
+    rmSync(claude);
+    symlinkSync("../../.agents/skills", claude, "dir");
+    expect(symlinkEvidence && projectSkillEvidenceUnchanged(symlinkEvidence, root)).toBe(false);
+  });
+
+  it("allows an owned reinstall when present targets are intact and missing adapters are optional", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const optionalClaude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [
+          { path: canonical, symlink: false },
+          { path: optionalClaude, symlink: true },
+        ],
+      }),
+    ).not.toThrow();
+
+    writeFileSync(join(canonical, "SKILL.md"), "user changed");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: canonical, symlink: false }],
+      }),
+    ).toThrow(/cannot prove ownership/i);
+  });
+
+  it("rejects an ordinary target that resolves outside the verified project root", () => {
+    const external = mkdtempSync(join(tmpdir(), "dosu-external-skill-"));
+    extraRoots.push(external);
+    const externalSkill = join(external, "skills", "dosu");
+    const content = "---\nname: dosu\n---\n";
+    mkdirSync(externalSkill, { recursive: true });
+    writeFileSync(join(externalSkill, "SKILL.md"), content);
+    const computedHash = createHash("sha256").update("SKILL.md").update(content).digest("hex");
+    writeLock(computedHash);
+    symlinkSync(external, join(root, ".agents"), "dir");
+
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: join(root, ".agents", "skills", "dosu"), symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+  });
+
+  it("rejects an empty directory even when its digest matches because SKILL.md is required", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    mkdirSync(target, { recursive: true });
+    writeLock(createHash("sha256").digest("hex"));
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+  });
+
+  it("treats replaced and removed evidence as changed", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    writeOwnedSkill(target);
+    const verification = verifyProjectSkillInstallation({
+      projectRoot: root,
+      targets: [{ path: target, symlink: false }],
+    });
+    if (!verification.ok) throw new Error(verification.reason);
+    const lockEvidence = verification.evidence.find((item) => item.kind === "file");
+    const directoryEvidence = verification.evidence.find((item) => item.kind === "directory");
+    if (!lockEvidence || !directoryEvidence)
+      throw new Error("expected lock and directory evidence");
+
+    const lockPath = join(root, "skills-lock.json");
+    const foreignLock = join(root, "foreign-lock.json");
+    writeFileSync(foreignLock, readFileSync(lockPath));
+    rmSync(lockPath);
+    symlinkSync(foreignLock, lockPath);
+    expect(projectSkillEvidenceUnchanged(lockEvidence, root)).toBe(false);
+
+    rmSync(target, { recursive: true });
+    expect(projectSkillEvidenceUnchanged(directoryEvidence, root)).toBe(false);
+  });
+});

--- a/src/commands/project-skill-ownership.ts
+++ b/src/commands/project-skill-ownership.ts
@@ -1,0 +1,332 @@
+import { createHash } from "node:crypto";
+import { type Dirent, lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import {
+  getNodeValue,
+  type Node as JsonNode,
+  type ParseError,
+  parseTree,
+} from "jsonc-parser/lib/esm/main.js";
+import { assertSafeProjectPath } from "../setup/project-path";
+
+const LOCK_NAME = "skills-lock.json";
+const DOSU_SOURCE = "dosu-ai/dosu-skill";
+const DOSU_SKILL_PATH = "skills/dosu/SKILL.md";
+
+export interface ProjectSkillTarget {
+  path: string;
+  symlink: boolean;
+}
+
+export type ProjectSkillEvidence =
+  | { kind: "file"; path: string; realPath: string; hash: string }
+  | { kind: "directory"; path: string; realPath: string; hash: string }
+  | { kind: "symlink"; path: string; realPath: string };
+
+export type ProjectSkillVerification =
+  | { ok: true; evidence: ProjectSkillEvidence[] }
+  | { ok: false; reason: string; path?: string };
+
+interface OwnedLock {
+  kind: "owned";
+  computedHash: string;
+  evidence: ProjectSkillEvidence;
+}
+
+type LockInspection =
+  | { kind: "absent" }
+  | { kind: "unclaimed"; evidence: ProjectSkillEvidence }
+  | OwnedLock
+  | { kind: "invalid"; path: string };
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  const separator = process.platform === "win32" ? "\\" : "/";
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${separator}`) && !isAbsolute(rel));
+}
+
+function entryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function duplicateJsonKey(node: JsonNode): boolean {
+  if (node.type === "object") {
+    const seen = new Set<string>();
+    for (const property of node.children ?? []) {
+      const keyNode = property.children?.[0];
+      const key = keyNode ? getNodeValue(keyNode) : undefined;
+      if (typeof key !== "string") continue;
+      if (seen.has(key)) return true;
+      seen.add(key);
+    }
+  }
+  return (node.children ?? []).some(duplicateJsonKey);
+}
+
+function parseStrictJsonObject(content: string): Record<string, unknown> | null {
+  const errors: ParseError[] = [];
+  const root = parseTree(content, errors, { allowTrailingComma: false, disallowComments: true });
+  if (root?.type !== "object" || errors.length > 0 || duplicateJsonKey(root)) return null;
+  const value: unknown = getNodeValue(root);
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function inspectLock(projectRoot: string): LockInspection {
+  const path = join(projectRoot, LOCK_NAME);
+  if (!entryExists(path)) return { kind: "absent" };
+  try {
+    const stat = lstatSync(path);
+    const realRoot = realpathSync(projectRoot);
+    const realPath = realpathSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || !isInside(realRoot, realPath)) {
+      return { kind: "invalid", path };
+    }
+    const content = readFileSync(path, "utf8");
+    const parsed = parseStrictJsonObject(content);
+    if (parsed?.version !== 1 || !isRecord(parsed.skills)) {
+      return { kind: "invalid", path };
+    }
+    const evidence: ProjectSkillEvidence = {
+      kind: "file",
+      path,
+      realPath,
+      hash: createHash("sha256").update(content).digest("hex"),
+    };
+    if (!Object.hasOwn(parsed.skills, "dosu")) return { kind: "unclaimed", evidence };
+    const entry = parsed.skills.dosu;
+    if (
+      !isRecord(entry) ||
+      entry.source !== DOSU_SOURCE ||
+      entry.sourceType !== "github" ||
+      entry.skillPath !== DOSU_SKILL_PATH ||
+      typeof entry.computedHash !== "string" ||
+      !/^[a-f0-9]{64}$/.test(entry.computedHash)
+    ) {
+      return { kind: "invalid", path };
+    }
+    return { kind: "owned", computedHash: entry.computedHash, evidence };
+  } catch {
+    return { kind: "invalid", path };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectDirectoryFiles(
+  base: string,
+  current: string,
+  files: Array<{ relativePath: string; content: Buffer }>,
+): boolean {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(current, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (entry.name === ".git" || entry.name === "node_modules") continue;
+    if (entry.isSymbolicLink()) return false;
+    const path = join(current, entry.name);
+    if (entry.isDirectory()) {
+      if (!collectDirectoryFiles(base, path, files)) return false;
+    } else if (entry.isFile()) {
+      files.push({
+        relativePath: relative(base, path).split("\\").join("/"),
+        content: readFileSync(path),
+      });
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+function inspectDirectory(
+  path: string,
+  projectRoot: string,
+  expectedHash: string,
+): Extract<ProjectSkillEvidence, { kind: "directory" }> | null {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+    const realRoot = realpathSync(projectRoot);
+    const realPath = realpathSync(path);
+    if (!isInside(realRoot, realPath)) return null;
+    const files: Array<{ relativePath: string; content: Buffer }> = [];
+    if (!collectDirectoryFiles(path, path, files)) return null;
+    files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+    const hash = createHash("sha256");
+    for (const file of files) hash.update(file.relativePath).update(file.content);
+    const digest = hash.digest("hex");
+    if (digest !== expectedHash) return null;
+    const skillPath = join(path, "SKILL.md");
+    const frontmatter = readFileSync(skillPath, "utf8").match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1];
+    if (!frontmatter?.split(/\r?\n/).some((line) => /^name:\s*dosu\s*$/.test(line))) return null;
+    return { kind: "directory", path, realPath, hash: digest };
+  } catch {
+    return null;
+  }
+}
+
+function inspectTargets(input: {
+  projectRoot: string;
+  targets: readonly ProjectSkillTarget[];
+  expectedHash: string;
+  requireAll: boolean;
+}): ProjectSkillVerification {
+  const uniqueTargets = [
+    ...new Map(input.targets.map((target) => [resolve(target.path), target])).values(),
+  ];
+  const evidence: ProjectSkillEvidence[] = [];
+  const directRealPaths = new Set<string>();
+  const sharedCanonicalPath = join(input.projectRoot, ".agents", "skills", "dosu");
+  const claudeTargetPath = join(input.projectRoot, ".claude", "skills", "dosu");
+  const factoryTargetPath = join(input.projectRoot, ".factory", "skills", "dosu");
+  const reusableCanonicalAdapterPaths = new Set(
+    [claudeTargetPath, factoryTargetPath].map((path) => resolve(path)),
+  );
+  let sharedCanonical: Extract<ProjectSkillEvidence, { kind: "directory" }> | null | undefined;
+  const inspectSharedCanonical = () => {
+    if (sharedCanonical === undefined) {
+      sharedCanonical = inspectDirectory(
+        sharedCanonicalPath,
+        input.projectRoot,
+        input.expectedHash,
+      );
+    }
+    return sharedCanonical;
+  };
+
+  for (const target of uniqueTargets) {
+    if (!entryExists(target.path)) {
+      if (input.requireAll)
+        return { ok: false, reason: "project_skill_missing", path: target.path };
+      continue;
+    }
+    const stat = lstatSync(target.path);
+    if (stat.isSymbolicLink()) continue;
+    const directory = inspectDirectory(target.path, input.projectRoot, input.expectedHash);
+    if (!directory) return { ok: false, reason: "project_skill_modified", path: target.path };
+    directRealPaths.add(directory.realPath);
+    evidence.push(directory);
+  }
+
+  for (const target of uniqueTargets) {
+    if (!entryExists(target.path) || !lstatSync(target.path).isSymbolicLink()) continue;
+    try {
+      const realPath = realpathSync(target.path);
+      if (!directRealPaths.has(realPath)) {
+        // A prior multi-agent install uses `.agents/skills/dosu` as the owned
+        // canonical directory and makes a non-universal agent's target a
+        // symlink to it. A later single-agent run asks skills@1.5.22 for a
+        // direct target, but the existing exact Claude or Factory layout is
+        // still ours and must remain idempotent.
+        if (target.symlink || !reusableCanonicalAdapterPaths.has(resolve(target.path))) {
+          return { ok: false, reason: "project_skill_foreign_symlink", path: target.path };
+        }
+        let canonicalRealPath: string;
+        try {
+          canonicalRealPath = realpathSync(sharedCanonicalPath);
+        } catch {
+          return { ok: false, reason: "project_skill_foreign_symlink", path: target.path };
+        }
+        if (realPath !== canonicalRealPath) {
+          return { ok: false, reason: "project_skill_foreign_symlink", path: target.path };
+        }
+        const canonical = inspectSharedCanonical();
+        if (!canonical) {
+          return { ok: false, reason: "project_skill_modified", path: sharedCanonicalPath };
+        }
+        directRealPaths.add(canonical.realPath);
+        if (!evidence.some((item) => item.path === canonical.path)) evidence.push(canonical);
+      }
+      evidence.push({ kind: "symlink", path: target.path, realPath });
+    } catch {
+      return { ok: false, reason: "project_skill_foreign_symlink", path: target.path };
+    }
+  }
+
+  return { ok: true, evidence };
+}
+
+export function assertProjectSkillInstallSafe(input: {
+  projectRoot: string;
+  targets: readonly ProjectSkillTarget[];
+}): void {
+  const lockPath = join(input.projectRoot, LOCK_NAME);
+  assertSafeProjectPath(input.projectRoot, lockPath);
+  for (const target of input.targets) {
+    assertSafeProjectPath(input.projectRoot, join(target.path, ".."));
+  }
+
+  const lock = inspectLock(input.projectRoot);
+  const anyTargetExists = input.targets.some((target) => entryExists(target.path));
+  if (lock.kind === "invalid" || (lock.kind === "absent" && anyTargetExists)) {
+    throw new Error("Cannot prove ownership of the existing project Dosu skill");
+  }
+  if (lock.kind === "unclaimed" && anyTargetExists) {
+    throw new Error("Cannot prove ownership of the existing project Dosu skill");
+  }
+  if (lock.kind !== "owned") return;
+
+  const targets = inspectTargets({
+    ...input,
+    expectedHash: lock.computedHash,
+    requireAll: false,
+  });
+  if (!targets.ok) throw new Error("Cannot prove ownership of the existing project Dosu skill");
+}
+
+export function verifyProjectSkillInstallation(input: {
+  projectRoot: string;
+  targets: readonly ProjectSkillTarget[];
+}): ProjectSkillVerification {
+  const lock = inspectLock(input.projectRoot);
+  if (lock.kind !== "owned") {
+    return {
+      ok: false,
+      reason: "project_skill_lock_mismatch",
+      path: join(input.projectRoot, LOCK_NAME),
+    };
+  }
+  const targets = inspectTargets({
+    ...input,
+    expectedHash: lock.computedHash,
+    requireAll: true,
+  });
+  return targets.ok ? { ok: true, evidence: [lock.evidence, ...targets.evidence] } : targets;
+}
+
+export function projectSkillEvidenceUnchanged(
+  evidence: ProjectSkillEvidence,
+  projectRoot: string,
+): boolean {
+  try {
+    const stat = lstatSync(evidence.path);
+    if (evidence.kind === "symlink") {
+      return stat.isSymbolicLink() && realpathSync(evidence.path) === evidence.realPath;
+    }
+    if (stat.isSymbolicLink() || realpathSync(evidence.path) !== evidence.realPath) return false;
+    if (evidence.kind === "file") {
+      return (
+        stat.isFile() &&
+        createHash("sha256").update(readFileSync(evidence.path)).digest("hex") === evidence.hash
+      );
+    }
+    return Boolean(inspectDirectory(evidence.path, projectRoot, evidence.hash));
+  } catch {
+    return false;
+  }
+}

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +13,8 @@ vi.mock("node:child_process", () => ({
 
 import {
   installSkill,
+  projectSkillInstallTargetsForProviders,
+  SKILLS_CLI_VERSION,
   skillAgentIDsForProviders,
   skillCommand,
   skillInstallTargetForProvider,
@@ -83,13 +86,13 @@ afterEach(() => {
 });
 
 describe("skill install", () => {
-  it("runs npx skills add with correct args", async () => {
+  it("passes every agent through the installer's single variadic agent flag", async () => {
     await run("install");
     expect(mockExecSync).toHaveBeenCalledWith(
       [
-        "npx skills add dosu-ai/dosu-skill -g",
-        "-a claude-code -a cursor -a gemini-cli -a codex -a windsurf",
-        "-a zed -a cline -a github-copilot -a opencode -a antigravity",
+        `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -g`,
+        "-a claude-code cursor gemini-cli codex windsurf",
+        "zed cline github-copilot opencode antigravity",
         "-s dosu -y",
       ].join(" "),
       {
@@ -122,9 +125,12 @@ describe("skill install", () => {
 describe("skill remove", () => {
   it("runs npx skills remove with correct args", async () => {
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g -s dosu -y", {
-      stdio: "inherit",
-    });
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `npx -y skills@${SKILLS_CLI_VERSION} remove -g -s dosu -y`,
+      {
+        stdio: "inherit",
+      },
+    );
   });
 
   it("prints success message", async () => {
@@ -145,7 +151,7 @@ describe("skill update", () => {
   it("reinstalls via npx skills add (update can't follow repo-layout moves)", async () => {
     await run("update");
     expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringContaining("npx skills add dosu-ai/dosu-skill -g"),
+      expect.stringContaining(`npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -g`),
       { stdio: "inherit" },
     );
     expect(mockExecSync).not.toHaveBeenCalledWith(
@@ -185,13 +191,175 @@ describe("skill update", () => {
 });
 
 describe("installSkill helper", () => {
+  function writeOwnedProjectSkill(
+    projectRoot: string,
+    relativeTarget = ".agents/skills/dosu",
+  ): string {
+    const target = join(projectRoot, relativeTarget);
+    const content = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), content);
+    const computedHash = createHash("sha256").update("SKILL.md").update(content).digest("hex");
+    writeFileSync(
+      join(projectRoot, "skills-lock.json"),
+      JSON.stringify({
+        version: 1,
+        skills: {
+          dosu: {
+            source: "dosu-ai/dosu-skill",
+            sourceType: "github",
+            skillPath: "skills/dosu/SKILL.md",
+            computedHash,
+          },
+        },
+      }),
+    );
+    return computedHash;
+  }
+
   it("installs only for the selected MCP providers", async () => {
     const result = await installSkill(["claude", "codex"]);
 
     expect(result.success).toBe(true);
     expect(mockExecSync).toHaveBeenCalledWith(
-      "npx skills add dosu-ai/dosu-skill -g -a claude-code -a codex -s dosu -y",
+      `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -g -a claude-code codex -s dosu -y`,
       { stdio: "inherit" },
+    );
+  });
+
+  it("installs selected skills into the project when a project root is provided", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    const result = await installSkill(["claude", "codex"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -a claude-code codex -s dosu -y`,
+      { stdio: "inherit", cwd: projectRoot },
+    );
+  });
+
+  it("installs the Factory skill with the pinned Droid agent ID", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+
+    const result = await installSkill(["factory"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -a droid -s dosu -y`,
+      { stdio: "inherit", cwd: projectRoot },
+    );
+  });
+
+  it("refuses a project skill parent symlink before invoking the third-party installer", async () => {
+    const projectRoot = join(tempDir, "repo");
+    const outside = join(tempDir, "outside");
+    mkdirSync(projectRoot);
+    mkdirSync(outside);
+    symlinkSync(outside, join(projectRoot, ".agents"));
+
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/symbolic link/i);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("refuses dangling project skill and lock symlinks before invoking the installer", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(join(projectRoot, ".agents", "skills"), { recursive: true });
+    symlinkSync(join(tempDir, "missing-skill"), join(projectRoot, ".agents", "skills", "dosu"));
+
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/ownership/i);
+    expect(mockExecSync).not.toHaveBeenCalled();
+
+    rmSync(join(projectRoot, ".agents", "skills", "dosu"));
+    symlinkSync(join(tempDir, "missing-lock"), join(projectRoot, "skills-lock.json"));
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/symbolic link/i);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("refuses to overwrite a foreign project skill directory without a Dosu lock receipt", async () => {
+    const projectRoot = join(tempDir, "repo");
+    const target = join(projectRoot, ".agents", "skills", "dosu");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), "user-owned\n");
+
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/ownership/i);
+    expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("user-owned\n");
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("refuses a foreign Dosu lock entry even when the target directory is absent", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeFileSync(
+      join(projectRoot, "skills-lock.json"),
+      JSON.stringify({
+        version: 1,
+        skills: {
+          dosu: {
+            source: "someone-else/dosu",
+            sourceType: "github",
+            skillPath: "skills/dosu/SKILL.md",
+            computedHash: "a".repeat(64),
+          },
+        },
+      }),
+    );
+
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/ownership/i);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("allows an exact lock-backed project skill to be refreshed", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeOwnedProjectSkill(projectRoot);
+
+    const result = await installSkill(["codex"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledOnce();
+  });
+
+  it("allows the actual Claude-only direct project layout", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeOwnedProjectSkill(projectRoot, ".claude/skills/dosu");
+
+    const result = await installSkill(["claude"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledOnce();
+  });
+
+  it("allows the actual mixed canonical plus Claude symlink layout", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeOwnedProjectSkill(projectRoot);
+    const claudeParent = join(projectRoot, ".claude", "skills");
+    mkdirSync(claudeParent, { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", join(claudeParent, "dosu"), "dir");
+
+    const result = await installSkill(["claude", "codex"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledOnce();
+  });
+
+  it("allows a Claude-only refresh after an owned mixed-layout install", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeOwnedProjectSkill(projectRoot);
+    const claudeParent = join(projectRoot, ".claude", "skills");
+    mkdirSync(claudeParent, { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", join(claudeParent, "dosu"), "dir");
+
+    const result = await installSkill(["claude"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -a claude-code -s dosu -y`,
+      { stdio: "inherit", cwd: projectRoot },
     );
   });
 
@@ -199,6 +367,7 @@ describe("installSkill helper", () => {
     expect(
       skillAgentIDsForProviders(["vscode", "copilot", "cline", "cline-cli", "manual"]),
     ).toEqual(["github-copilot", "cline"]);
+    expect(skillAgentIDsForProviders(["factory", "factory"])).toEqual(["droid"]);
   });
 
   it("reports the Claude symlink target and respects CLAUDE_CONFIG_DIR", () => {
@@ -215,6 +384,31 @@ describe("installSkill helper", () => {
       path: join(homedir(), ".agents", "skills", "dosu"),
       symlink: false,
     });
+  });
+
+  it("reports project-local adapter paths when a project root is provided", () => {
+    expect(skillInstallTargetForProvider("claude", "/repo")).toEqual({
+      path: "/repo/.claude/skills/dosu",
+      symlink: false,
+    });
+    expect(skillInstallTargetForProvider("codex", "/repo")).toEqual({
+      path: "/repo/.agents/skills/dosu",
+      symlink: false,
+    });
+    expect(skillInstallTargetForProvider("factory", "/repo")).toEqual({
+      path: "/repo/.factory/skills/dosu",
+      symlink: false,
+    });
+  });
+
+  it("models the pinned Factory-only and mixed Droid project layouts", () => {
+    expect(projectSkillInstallTargetsForProviders(["factory"], "/repo")).toEqual([
+      { path: "/repo/.factory/skills/dosu", symlink: false },
+    ]);
+    expect(projectSkillInstallTargetsForProviders(["factory", "codex"], "/repo")).toEqual([
+      { path: "/repo/.agents/skills/dosu", symlink: false },
+      { path: "/repo/.factory/skills/dosu", symlink: true },
+    ]);
   });
 
   it("reports the Windsurf symlink target", () => {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -9,10 +9,15 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { logger } from "../debug/logger";
 import { fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
+import { assertProjectSkillInstallSafe, type ProjectSkillTarget } from "./project-skill-ownership";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
 const SKILL_NAME = "dosu";
-const SUPPORTED_SKILL_AGENTS = [
+export const SKILLS_CLI_VERSION = "1.5.22";
+// The standalone `dosu skill install` command remains an explicit global
+// legacy operation. Project setup passes its selected provider IDs instead,
+// so new project-only mappings do not silently broaden that global footprint.
+const DEFAULT_GLOBAL_SKILL_AGENTS = [
   "claude-code",
   "cursor",
   "gemini-cli",
@@ -38,6 +43,7 @@ const SKILL_AGENT_BY_PROVIDER: Readonly<Record<string, string>> = {
   copilot: "github-copilot",
   opencode: "opencode",
   antigravity: "antigravity",
+  factory: "droid",
 };
 
 export function skillAgentIDsForProviders(providerIDs: readonly string[]): string[] {
@@ -55,37 +61,93 @@ export interface SkillInstallTarget {
   symlink: boolean;
 }
 
-export function skillInstallTargetForProvider(providerID: string): SkillInstallTarget | null {
+export function skillInstallTargetForProvider(
+  providerID: string,
+  projectRoot?: string,
+): SkillInstallTarget | null {
   const agentID = SKILL_AGENT_BY_PROVIDER[providerID];
   if (!agentID) return null;
 
   if (agentID === "claude-code") {
+    if (projectRoot) {
+      return { path: join(projectRoot, ".claude", "skills", SKILL_NAME), symlink: false };
+    }
     const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude");
     return { path: join(claudeConfigDir, "skills", SKILL_NAME), symlink: true };
   }
 
   if (agentID === "windsurf") {
+    if (projectRoot) {
+      return { path: join(projectRoot, ".windsurf", "skills", SKILL_NAME), symlink: false };
+    }
     return {
       path: join(homedir(), ".codeium", "windsurf", "skills", SKILL_NAME),
       symlink: true,
     };
   }
 
+  if (agentID === "droid") {
+    return {
+      path: projectRoot
+        ? join(projectRoot, ".factory", "skills", SKILL_NAME)
+        : join(homedir(), ".factory", "skills", SKILL_NAME),
+      symlink: !projectRoot,
+    };
+  }
+
   return {
-    path: join(homedir(), ".agents", "skills", SKILL_NAME),
+    path: projectRoot
+      ? join(projectRoot, ".agents", "skills", SKILL_NAME)
+      : join(homedir(), ".agents", "skills", SKILL_NAME),
     symlink: false,
   };
 }
 
-function skillAgentArgs(providerIDs?: readonly string[]): string {
-  const agents =
-    providerIDs === undefined ? SUPPORTED_SKILL_AGENTS : skillAgentIDsForProviders(providerIDs);
-  return agents.map((agent) => `-a ${agent}`).join(" ");
+/** Exact paths that pinned skills@1.5.22 mutates for a project install. */
+export function projectSkillInstallTargetsForProviders(
+  providerIDs: readonly string[],
+  projectRoot: string,
+): ProjectSkillTarget[] {
+  const agents = skillAgentIDsForProviders(providerIDs);
+  if (agents.length === 0) return [];
+  if (agents.length === 1) {
+    if (agents[0] === "claude-code") {
+      return [{ path: join(projectRoot, ".claude", "skills", SKILL_NAME), symlink: false }];
+    }
+    if (agents[0] === "windsurf") {
+      return [{ path: join(projectRoot, ".windsurf", "skills", SKILL_NAME), symlink: false }];
+    }
+    if (agents[0] === "droid") {
+      return [{ path: join(projectRoot, ".factory", "skills", SKILL_NAME), symlink: false }];
+    }
+    return [{ path: join(projectRoot, ".agents", "skills", SKILL_NAME), symlink: false }];
+  }
+
+  const targets: ProjectSkillTarget[] = [
+    { path: join(projectRoot, ".agents", "skills", SKILL_NAME), symlink: false },
+  ];
+  if (agents.includes("claude-code")) {
+    targets.push({ path: join(projectRoot, ".claude", "skills", SKILL_NAME), symlink: true });
+  }
+  if (agents.includes("droid")) {
+    targets.push({ path: join(projectRoot, ".factory", "skills", SKILL_NAME), symlink: true });
+  }
+  return targets;
 }
 
-function execQuiet(command: string): Promise<void> {
+function skillAgentArgs(providerIDs?: readonly string[]): string {
+  const agents =
+    providerIDs === undefined
+      ? DEFAULT_GLOBAL_SKILL_AGENTS
+      : skillAgentIDsForProviders(providerIDs);
+  // skills@1.5.22 defines --agent as one variadic option. Repeating `-a`
+  // replaces the previous value, so only the final agent would be installed.
+  return agents.length > 0 ? `-a ${agents.join(" ")}` : "";
+}
+
+function execQuiet(command: string, cwd?: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    exec(command, { windowsHide: true }, (error) => {
+    exec(command, { windowsHide: true, ...(cwd ? { cwd } : {}) }, (error) => {
       if (error) reject(error);
       else resolve();
     });
@@ -101,7 +163,7 @@ function execQuiet(command: string): Promise<void> {
  */
 export async function installSkill(
   providerIDs?: readonly string[],
-  options: { quiet?: boolean } = {},
+  options: { quiet?: boolean; projectRoot?: string } = {},
 ): Promise<{ success: boolean; sha?: string }> {
   const agentArgs = skillAgentArgs(providerIDs);
   if (!agentArgs) {
@@ -109,10 +171,23 @@ export async function installSkill(
     return { success: true };
   }
 
+  if (options.projectRoot) {
+    const targets = projectSkillInstallTargetsForProviders(
+      providerIDs ?? Object.keys(SKILL_AGENT_BY_PROVIDER),
+      options.projectRoot,
+    );
+    assertProjectSkillInstallSafe({ projectRoot: options.projectRoot, targets });
+  }
+
   try {
-    const command = `npx skills add ${SKILL_REPO} -g ${agentArgs} -s ${SKILL_NAME} -y`;
-    if (options.quiet) await execQuiet(command);
-    else execSync(command, { stdio: "inherit" });
+    const scope = options.projectRoot ? "" : " -g";
+    const command = `npx -y skills@${SKILLS_CLI_VERSION} add ${SKILL_REPO}${scope} ${agentArgs} -s ${SKILL_NAME} -y`;
+    if (options.quiet) await execQuiet(command, options.projectRoot);
+    else
+      execSync(command, {
+        stdio: "inherit",
+        ...(options.projectRoot ? { cwd: options.projectRoot } : {}),
+      });
   } catch (err) {
     logger.error("skill", `Failed to install skill: ${err}`);
     return { success: false };
@@ -154,7 +229,7 @@ export function skillCommand(): Command {
     .action(() => {
       console.log(`Removing ${SKILL_NAME} skill...`);
       try {
-        execSync(`npx skills remove -g -s ${SKILL_NAME} -y`, {
+        execSync(`npx -y skills@${SKILLS_CLI_VERSION} remove -g -s ${SKILL_NAME} -y`, {
           stdio: "inherit",
         });
         console.log(pc.green(`\n✓ Skill "${SKILL_NAME}" removed.`));

--- a/src/config/config.test-utils.ts
+++ b/src/config/config.test-utils.ts
@@ -8,6 +8,7 @@ export interface FlatTestConfig {
   deployment_id?: string;
   deployment_name?: string;
   api_key?: string;
+  mcp_endpoint?: string;
   org_id?: string;
   space_id?: string;
   mode?: SetupMode;
@@ -19,6 +20,7 @@ export function makeTestConfig(flat: FlatTestConfig): Config {
     deployment_id: flat.deployment_id,
     deployment_name: flat.deployment_name,
     api_key: flat.api_key,
+    mcp_endpoint: flat.mcp_endpoint,
     org_id: flat.org_id,
     space_id: flat.space_id,
   };

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   bindAccountIdentity,
@@ -8,6 +8,7 @@ import {
   type Config,
   clearConfig,
   emptyConfig,
+  getConfigDir,
   getConfigPath,
   isAuthenticated,
   isTokenExpired,
@@ -47,6 +48,57 @@ describe("config", () => {
     const path = getConfigPath();
     expect(path).toBe(join(tempDir, "dosu-cli", "config.json"));
     expect(existsSync(join(tempDir, "dosu-cli"))).toBe(true);
+  });
+
+  it("ignores a relative XDG config root instead of writing secrets below the project cwd", () => {
+    const originalCwd = process.cwd();
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const projectRoot = join(tempDir, "repo");
+    const safeHome = join(tempDir, "safe-home");
+    mkdirSync(projectRoot);
+    try {
+      process.chdir(projectRoot);
+      process.env.XDG_CONFIG_HOME = "repo-relative-config";
+      process.env.HOME = safeHome;
+      delete process.env.USERPROFILE;
+
+      const path = getConfigPath();
+
+      expect(path).toBe(join(safeHome, ".config", "dosu-cli", "config.json"));
+      expect(isAbsolute(path)).toBe(true);
+      expect(existsSync(join(projectRoot, "repo-relative-config"))).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+    }
+  });
+
+  it("uses only an absolute home fallback and otherwise fails closed", () => {
+    expect(
+      getConfigDir({
+        env: {
+          XDG_CONFIG_HOME: "relative-xdg",
+          HOME: "relative-home",
+          USERPROFILE: "also-relative",
+        },
+        homedir: () => join(tempDir, "system-home"),
+      }),
+    ).toBe(join(tempDir, "system-home", ".config", "dosu-cli"));
+
+    expect(() =>
+      getConfigDir({
+        env: {
+          XDG_CONFIG_HOME: "relative-xdg",
+          HOME: "relative-home",
+          USERPROFILE: "also-relative",
+        },
+        homedir: () => "relative-system-home",
+      }),
+    ).toThrow(/absolute user config directory/i);
   });
 
   it("DOSU_DEV=true isolates config into a separate dosu-cli-dev directory", () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,7 +3,8 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { homedir as nodeHomedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 import { migrateLegacyConfig } from "./config-v1-migration";
 import { getAccessTokenUserID } from "./identity";
 import {
@@ -78,13 +79,30 @@ export function updateTarget(cfg: Config, target: AccountTarget): void {
  * Everything that lives under `getConfigDir()` — `config.json`,
  * `update-check.json`, `skill-update-check.json` — is isolated between the two.
  */
-export function getConfigDir(): string {
-  const dirName = process.env.DOSU_DEV === "true" ? "dosu-cli-dev" : "dosu-cli";
+export interface ConfigDirDependencies {
+  /** @internal Test seam for environment/path safety checks. */
+  env?: NodeJS.ProcessEnv;
+  /** @internal Test seam for the operating-system home lookup. */
+  homedir?: () => string;
+}
 
-  const xdgConfig = process.env.XDG_CONFIG_HOME;
-  if (xdgConfig) return join(xdgConfig, dirName);
+export function getConfigDir(deps: ConfigDirDependencies = {}): string {
+  const env = deps.env ?? process.env;
+  const dirName = env.DOSU_DEV === "true" ? "dosu-cli-dev" : "dosu-cli";
 
-  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  // XDG_CONFIG_HOME is defined to be absolute. Treating a relative value as a
+  // pathname would put credentials beneath the caller's current project.
+  const xdgConfig = env.XDG_CONFIG_HOME;
+  if (xdgConfig && isAbsolute(xdgConfig)) return join(xdgConfig, dirName);
+
+  const home = [env.HOME, env.USERPROFILE, (deps.homedir ?? nodeHomedir)()].find(
+    (candidate): candidate is string => Boolean(candidate && isAbsolute(candidate)),
+  );
+  if (!home) {
+    throw new Error(
+      "Dosu could not resolve an absolute user config directory; refusing to store credentials",
+    );
+  }
   return join(home, ".config", dirName);
 }
 
@@ -201,6 +219,7 @@ function normalizeTarget(value: unknown): AccountTarget | undefined {
     deployment_id: stringValue(value.deployment_id),
     deployment_name: stringValue(value.deployment_name),
     api_key: stringValue(value.api_key),
+    mcp_endpoint: stringValue(value.mcp_endpoint),
     org_id: stringValue(value.org_id),
     space_id: stringValue(value.space_id),
   };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -16,6 +16,8 @@ export interface AccountTarget {
   deployment_id?: string;
   deployment_name?: string;
   api_key?: string;
+  /** Trusted runtime endpoint kept in private user config, never in project MCP files. */
+  mcp_endpoint?: string;
   org_id?: string;
   space_id?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,22 @@
  */
 
 import { execute } from "./cli/cli";
+import {
+  CLI_SIGNALS,
+  dispatchCliSignal,
+  installsImmediateSigintHandler,
+} from "./cli/signal-policy";
 
-// Ensure Ctrl+C always exits immediately, even when @clack/prompts
-// intercepts SIGINT and swallows it as a cancel symbol.
-process.on("SIGINT", () => process.exit(0));
+// Ordinary prompt cancellation remains immediate. Short-lived guarded work
+// (currently the project MCP preflight) can delay exit only until its detached
+// process tree has been shut down.
+if (installsImmediateSigintHandler(process.argv)) {
+  for (const signal of CLI_SIGNALS) {
+    process.on(signal, () => {
+      void dispatchCliSignal(signal);
+    });
+  }
+}
 
 execute().catch((err) => {
   console.error(err.message ?? err);

--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -484,8 +484,13 @@ describe("JSON config file operations", () => {
       if (tamper === "hash") {
         writeFileSync(captured, "tampered captured data\n");
       } else {
+        // Allocate the replacement while the captured inode still exists.
+        // Unlink-then-create can immediately reuse the same inode on Linux,
+        // making this mismatch test nondeterministic in CI.
+        const replacement = join(tempDir, "replacement-capture");
+        writeFileSync(replacement, "captured original\n");
         unlinkSync(captured);
-        writeFileSync(captured, "captured original\n");
+        renameSync(replacement, captured);
       }
 
       expect(() => writeProjectFile(path, "new\n", null)).toThrow(/does not match/i);

--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -1,16 +1,35 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   installJSONServer,
+  installProjectJSONServer,
   isJSONKeyConfigured,
+  isProjectJSONServerConfigured,
   loadJSONConfig,
   mcpHeaders,
   mcpURL,
   removeJSONServer,
+  removeProjectFile,
+  removeProjectJSONServer,
   saveJSONConfig,
   stripJSONComments,
+  writeProjectFile,
   writeSecureFile,
 } from "./config-helpers";
 
@@ -118,6 +137,16 @@ describe("JSON config file operations", () => {
       writeFileSync(path, '{\n// comment\n"foo": "bar"\n}');
       expect(loadJSONConfig(path)).toEqual({ foo: "bar" });
     });
+
+    it("returns an empty object for empty or malformed config instead of inventing state", () => {
+      const empty = join(tempDir, "empty.json");
+      const malformed = join(tempDir, "malformed.json");
+      writeFileSync(empty, "  \n");
+      writeFileSync(malformed, '{"mcpServers":');
+
+      expect(loadJSONConfig(empty)).toEqual({});
+      expect(loadJSONConfig(malformed)).toEqual({});
+    });
   });
 
   describe("saveJSONConfig", () => {
@@ -149,6 +178,446 @@ describe("JSON config file operations", () => {
 
       expect(readFileSync(path, "utf-8")).toBe("new secret");
       expect(statSync(path).mode & 0o777).toBe(0o600);
+    });
+  });
+
+  describe("writeProjectFile", () => {
+    it.each([
+      "replace",
+      "remove",
+    ] as const)("leaves an existing target untouched when hard links are unavailable during %s", (operation) => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "original project config\n", { mode: 0o640 });
+      const unavailable = () => {
+        throw Object.assign(new Error("hard links are unsupported"), { code: "ENOTSUP" });
+      };
+
+      expect(() => {
+        if (operation === "replace") {
+          writeProjectFile(path, "Dosu edit\n", "original project config\n", {
+            probeHardLink: unavailable,
+          });
+        } else {
+          removeProjectFile(path, "original project config\n", {
+            probeHardLink: unavailable,
+          });
+        }
+      }).toThrow(/hard links.*unchanged/i);
+
+      expect(readFileSync(path, "utf8")).toBe("original project config\n");
+      expect(statSync(path).mode & 0o777).toBe(0o640);
+      expect(readdirSync(tempDir).some((entry) => entry.includes(".dosu-capture-"))).toBe(false);
+    });
+
+    it.each([
+      "regular file",
+      "symlink",
+      "directory",
+    ] as const)("restores a concurrent %s swapped in after the capture journal", (replacement) => {
+      const path = join(tempDir, "project.json");
+      const displaced = join(tempDir, "displaced-original.json");
+      const outside = join(tempDir, "outside-user-file.txt");
+      writeFileSync(path, "original project config\n");
+      writeFileSync(outside, "outside user data\n");
+
+      expect(() =>
+        writeProjectFile(path, "Dosu edit\n", "original project config\n", {
+          beforeCaptureRename: () => {
+            renameSync(path, displaced);
+            if (replacement === "regular file") writeFileSync(path, "concurrent user file\n");
+            else if (replacement === "symlink") symlinkSync(outside, path);
+            else {
+              mkdirSync(path);
+              writeFileSync(join(path, "nested-user-file.txt"), "nested user data\n");
+            }
+          },
+        }),
+      ).toThrow(/changed during capture.*restored/i);
+
+      expect(readFileSync(displaced, "utf8")).toBe("original project config\n");
+      if (replacement === "regular file") {
+        expect(readFileSync(path, "utf8")).toBe("concurrent user file\n");
+      } else if (replacement === "symlink") {
+        expect(lstatSync(path).isSymbolicLink()).toBe(true);
+        expect(readlinkSync(path)).toBe(outside);
+        expect(readFileSync(outside, "utf8")).toBe("outside user data\n");
+      } else {
+        expect(lstatSync(path).isDirectory()).toBe(true);
+        expect(readFileSync(join(path, "nested-user-file.txt"), "utf8")).toBe("nested user data\n");
+      }
+      expect(readdirSync(tempDir).some((entry) => entry.includes(".dosu-capture-"))).toBe(false);
+    });
+
+    it("does not follow a target or predictable temporary-file symlink", () => {
+      const path = join(tempDir, "project.json");
+      const victim = join(tempDir, "important.txt");
+      writeFileSync(victim, "USER DATA\n");
+      symlinkSync("important.txt", `${path}.${process.pid}.tmp`);
+
+      writeProjectFile(path, "project metadata\n", null);
+
+      expect(readFileSync(victim, "utf8")).toBe("USER DATA\n");
+      expect(lstatSync(path).isFile()).toBe(true);
+
+      const linked = join(tempDir, "linked.json");
+      symlinkSync("important.txt", linked);
+      expect(() => writeProjectFile(linked, "replace\n")).toThrow(/non-regular/i);
+      expect(readFileSync(victim, "utf8")).toBe("USER DATA\n");
+    });
+
+    it.each([
+      "file",
+      "symlink",
+    ] as const)("refuses to create a project file through a parent %s", (kind) => {
+      const parent = join(tempDir, "unsafe-parent");
+      const outside = join(tempDir, "outside-directory");
+      if (kind === "file") writeFileSync(parent, "user data\n");
+      else {
+        mkdirSync(outside);
+        symlinkSync(outside, parent);
+      }
+
+      expect(() => writeProjectFile(join(parent, "config.json"), "Dosu edit\n", null)).toThrow(
+        /project directory/i,
+      );
+      if (kind === "file") expect(readFileSync(parent, "utf8")).toBe("user data\n");
+      else expect(readdirSync(outside)).toEqual([]);
+    });
+
+    it("refuses to remove a project file whose bytes differ from the caller's proof", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "user edit\n");
+
+      expect(() => removeProjectFile(path, "Dosu-owned bytes\n")).toThrow(/changed/i);
+
+      expect(readFileSync(path, "utf8")).toBe("user edit\n");
+    });
+
+    it("refuses to overwrite content that no longer matches the caller's preimage", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "user edit\n");
+
+      expect(() => writeProjectFile(path, "Dosu edit\n", "stale preimage\n")).toThrow(/changed/i);
+      expect(readFileSync(path, "utf8")).toBe("user edit\n");
+    });
+
+    it("preserves a concurrent replacement made before the existing file is captured", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "expected preimage\n");
+
+      expect(() =>
+        writeProjectFile(path, "Dosu edit\n", "expected preimage\n", {
+          beforeCapture: () => writeFileSync(path, "concurrent user edit\n"),
+        }),
+      ).toThrow(/changed/i);
+
+      expect(readFileSync(path, "utf8")).toBe("concurrent user edit\n");
+    });
+
+    it("never overwrites a file created while an absent destination is being published", () => {
+      const path = join(tempDir, "project.json");
+
+      expect(() =>
+        writeProjectFile(path, "Dosu edit\n", null, {
+          beforePublish: () => writeFileSync(path, "concurrent user file\n"),
+        }),
+      ).toThrow();
+
+      expect(readFileSync(path, "utf8")).toBe("concurrent user file\n");
+    });
+
+    it("preserves both a captured preimage and a concurrent replacement", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "expected preimage\n");
+
+      expect(() =>
+        writeProjectFile(path, "Dosu edit\n", "expected preimage\n", {
+          beforePublish: () => writeFileSync(path, "concurrent user edit\n"),
+        }),
+      ).toThrow();
+
+      expect(readFileSync(path, "utf8")).toBe("concurrent user edit\n");
+      const recoveryRoot = readdirSync(tempDir).find((entry) =>
+        entry.startsWith("project.json.dosu-capture-"),
+      );
+      expect(recoveryRoot).toBeDefined();
+      expect(readFileSync(join(tempDir, recoveryRoot as string, "captured"), "utf8")).toBe(
+        "expected preimage\n",
+      );
+    });
+
+    it("removes only the exact file captured for deletion", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "batch output\n");
+
+      removeProjectFile(path, "batch output\n");
+
+      expect(() => lstatSync(path)).toThrow();
+    });
+
+    it("never deletes a concurrent replacement during project-file removal", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "batch output\n");
+
+      expect(() =>
+        removeProjectFile(path, "batch output\n", {
+          beforeCapture: () => writeFileSync(path, "concurrent user edit\n"),
+        }),
+      ).toThrow(/changed/i);
+
+      expect(readFileSync(path, "utf8")).toBe("concurrent user edit\n");
+    });
+
+    it("durably restores a captured file on the next operation after a crash", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "original project config\n", { mode: 0o640 });
+
+      expect(() =>
+        writeProjectFile(path, "interrupted edit\n", "original project config\n", {
+          crashAfterCapture: true,
+        }),
+      ).toThrow(/simulated crash/i);
+      expect(() => lstatSync(path)).toThrow();
+      expect(readdirSync(tempDir).filter((entry) => entry.includes(".dosu-capture-"))).toHaveLength(
+        1,
+      );
+
+      // A real caller may have observed the missing path and supplied null.
+      // Recovery happens first, then the stale CAS fails without changing it.
+      expect(() => writeProjectFile(path, "next edit\n", null)).toThrow(/changed/i);
+      expect(readFileSync(path, "utf8")).toBe("original project config\n");
+      expect(statSync(path).mode & 0o777).toBe(0o640);
+      expect(readdirSync(tempDir).filter((entry) => entry.includes(".dosu-capture-"))).toEqual([]);
+
+      const receipt = writeProjectFile(path, "next edit\n", "original project config\n");
+      expect(receipt.beforeContent).toBe("original project config\n");
+      expect(readFileSync(path, "utf8")).toBe("next edit\n");
+    });
+
+    it("recovers a crashed removal before retrying the exact deletion", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "batch output\n");
+
+      expect(() => removeProjectFile(path, "batch output\n", { crashAfterCapture: true })).toThrow(
+        /simulated crash/i,
+      );
+      expect(() => lstatSync(path)).toThrow();
+
+      removeProjectFile(path, "batch output\n");
+
+      expect(() => lstatSync(path)).toThrow();
+      expect(readdirSync(tempDir).filter((entry) => entry.includes(".dosu-capture-"))).toEqual([]);
+    });
+
+    it("fails closed when the target was recreated beside a pending capture", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "captured original\n");
+      expect(() =>
+        writeProjectFile(path, "interrupted\n", "captured original\n", {
+          crashAfterCapture: true,
+        }),
+      ).toThrow(/simulated crash/i);
+      writeFileSync(path, "user recreated target\n");
+
+      expect(() => writeProjectFile(path, "new\n", "user recreated target\n")).toThrow(
+        /pending recovery stage.*existing target/i,
+      );
+      expect(readFileSync(path, "utf8")).toBe("user recreated target\n");
+      const root = readdirSync(tempDir).find((entry) => entry.includes(".dosu-capture-"));
+      expect(readFileSync(join(tempDir, root as string, "captured"), "utf8")).toBe(
+        "captured original\n",
+      );
+    });
+
+    it("preserves every stage when more than one pending capture is present", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "captured original\n");
+      expect(() =>
+        writeProjectFile(path, "interrupted\n", "captured original\n", {
+          crashAfterCapture: true,
+        }),
+      ).toThrow(/simulated crash/i);
+      const extra = join(tempDir, "project.json.dosu-capture-extra");
+      mkdirSync(extra, { mode: 0o700 });
+
+      expect(() => writeProjectFile(path, "new\n", null)).toThrow(/ambiguous pending/i);
+      expect(() => lstatSync(path)).toThrow();
+      expect(lstatSync(extra).isDirectory()).toBe(true);
+      expect(readdirSync(tempDir).filter((entry) => entry.includes(".dosu-capture-"))).toHaveLength(
+        2,
+      );
+    });
+
+    it("preserves a capture whose journal metadata was tampered with", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "captured original\n");
+      expect(() =>
+        writeProjectFile(path, "interrupted\n", "captured original\n", {
+          crashAfterCapture: true,
+        }),
+      ).toThrow(/simulated crash/i);
+      const root = readdirSync(tempDir).find((entry) => entry.includes(".dosu-capture-"));
+      const journal = join(tempDir, root as string, "journal.json");
+      writeFileSync(journal, "{}\n");
+
+      expect(() => writeProjectFile(path, "new\n", null)).toThrow(/invalid.*journal/i);
+      expect(() => lstatSync(path)).toThrow();
+      expect(readFileSync(journal, "utf8")).toBe("{}\n");
+      expect(readFileSync(join(tempDir, root as string, "captured"), "utf8")).toBe(
+        "captured original\n",
+      );
+    });
+
+    it.each([
+      "hash",
+      "inode",
+    ] as const)("preserves a capture whose %s no longer matches its journal", (tamper) => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "captured original\n");
+      expect(() =>
+        writeProjectFile(path, "interrupted\n", "captured original\n", {
+          crashAfterCapture: true,
+        }),
+      ).toThrow(/simulated crash/i);
+      const root = readdirSync(tempDir).find((entry) => entry.includes(".dosu-capture-"));
+      const captured = join(tempDir, root as string, "captured");
+      if (tamper === "hash") {
+        writeFileSync(captured, "tampered captured data\n");
+      } else {
+        unlinkSync(captured);
+        writeFileSync(captured, "captured original\n");
+      }
+
+      expect(() => writeProjectFile(path, "new\n", null)).toThrow(/does not match/i);
+      expect(() => lstatSync(path)).toThrow();
+      expect(readFileSync(captured, "utf8")).toBe(
+        tamper === "hash" ? "tampered captured data\n" : "captured original\n",
+      );
+    });
+
+    it("does not follow or remove a symlinked recovery journal", () => {
+      const path = join(tempDir, "project.json");
+      const outside = join(tempDir, "outside.txt");
+      writeFileSync(path, "captured original\n");
+      writeFileSync(outside, "outside user data\n");
+      expect(() =>
+        writeProjectFile(path, "interrupted\n", "captured original\n", {
+          crashAfterCapture: true,
+        }),
+      ).toThrow(/simulated crash/i);
+      const root = readdirSync(tempDir).find((entry) => entry.includes(".dosu-capture-"));
+      const journal = join(tempDir, root as string, "journal.json");
+      unlinkSync(journal);
+      symlinkSync(outside, journal);
+
+      expect(() => writeProjectFile(path, "new\n", null)).toThrow(/non-regular/i);
+      expect(readFileSync(outside, "utf8")).toBe("outside user data\n");
+      expect(lstatSync(journal).isSymbolicLink()).toBe(true);
+      expect(readFileSync(join(tempDir, root as string, "captured"), "utf8")).toBe(
+        "captured original\n",
+      );
+    });
+
+    it.each([
+      "invalid JSON",
+      "invalid metadata",
+      "wrong target",
+      "extra stage entry",
+    ] as const)("preserves a pending capture with %s", (tamper) => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, "captured original\n");
+      expect(() =>
+        writeProjectFile(path, "interrupted\n", "captured original\n", {
+          crashAfterCapture: true,
+        }),
+      ).toThrow(/simulated crash/i);
+      const rootName = readdirSync(tempDir).find((entry) => entry.includes(".dosu-capture-"));
+      const root = join(tempDir, rootName as string);
+      const journal = join(root, "journal.json");
+      if (tamper === "invalid JSON") {
+        writeFileSync(journal, "{");
+      } else if (tamper === "extra stage entry") {
+        writeFileSync(join(root, "foreign-user-file"), "keep me\n");
+      } else {
+        const parsed = JSON.parse(readFileSync(journal, "utf8"));
+        if (tamper === "invalid metadata") parsed.captured.mode = "0644";
+        else parsed.target = join(tempDir, "someone-elses-project.json");
+        writeFileSync(journal, `${JSON.stringify(parsed)}\n`);
+      }
+
+      expect(() => writeProjectFile(path, "new\n", null)).toThrow();
+
+      expect(() => lstatSync(path)).toThrow();
+      expect(readFileSync(join(root, "captured"), "utf8")).toBe("captured original\n");
+      if (tamper === "extra stage entry") {
+        expect(readFileSync(join(root, "foreign-user-file"), "utf8")).toBe("keep me\n");
+      }
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "preserves a pending capture whose recovery root became public",
+      () => {
+        const path = join(tempDir, "project.json");
+        writeFileSync(path, "captured original\n");
+        expect(() =>
+          writeProjectFile(path, "interrupted\n", "captured original\n", {
+            crashAfterCapture: true,
+          }),
+        ).toThrow(/simulated crash/i);
+        const rootName = readdirSync(tempDir).find((entry) => entry.includes(".dosu-capture-"));
+        const root = join(tempDir, rootName as string);
+        chmodSync(root, 0o755);
+
+        expect(() => writeProjectFile(path, "new\n", null)).toThrow(/unsafe.*recovery stage/i);
+
+        expect(() => lstatSync(path)).toThrow();
+        expect(readFileSync(join(root, "captured"), "utf8")).toBe("captured original\n");
+      },
+    );
+  });
+
+  describe("project JSON server operations", () => {
+    const owned = (entry: unknown) =>
+      typeof entry === "object" && entry !== null && "command" in entry;
+
+    it.each([
+      "install",
+      "remove",
+    ] as const)("preserves a non-object MCP section during %s", (operation) => {
+      const path = join(tempDir, "project.json");
+      const original = '{"mcpServers":"user-managed"}\n';
+      writeFileSync(path, original);
+
+      expect(() => {
+        if (operation === "install") {
+          installProjectJSONServer(path, "mcpServers", { command: "npx" }, owned);
+        } else {
+          removeProjectJSONServer(path, "mcpServers", owned);
+        }
+      }).toThrow(/not an object/i);
+
+      expect(readFileSync(path, "utf8")).toBe(original);
+    });
+
+    it("treats malformed project JSON as unconfigured without modifying it", () => {
+      const path = join(tempDir, "project.json");
+      writeFileSync(path, '{"mcpServers":');
+
+      expect(isProjectJSONServerConfigured(path, "mcpServers", owned)).toBe(false);
+      expect(readFileSync(path, "utf8")).toBe('{"mcpServers":');
+    });
+
+    it("refuses to follow a project config symlink for install or removal", () => {
+      const outside = join(tempDir, "outside.json");
+      const path = join(tempDir, "project.json");
+      writeFileSync(outside, '{"mcpServers":{}}\n');
+      symlinkSync(outside, path);
+
+      expect(() => installProjectJSONServer(path, "mcpServers", { command: "npx" }, owned)).toThrow(
+        /symbolic link/i,
+      );
+      expect(() => removeProjectJSONServer(path, "mcpServers", owned)).toThrow(/symbolic link/i);
+      expect(readFileSync(outside, "utf8")).toBe('{"mcpServers":{}}\n');
     });
   });
 

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -2,8 +2,36 @@
  * Shared JSON config helpers for MCP provider configuration.
  */
 
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmdirSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+  applyEdits,
+  getNodeValue,
+  type Node as JSONCNode,
+  modify,
+  type ParseError,
+  parseTree,
+} from "jsonc-parser/lib/esm/main.js";
 // Static default import (not `createRequire`) so `bun build --compile`
 // statically detects the dependency and bundles it into the binary.
 // Otherwise the compiled `dosu` looks for `write-file-atomic` on the
@@ -11,6 +39,7 @@ import { dirname } from "node:path";
 // @ts-expect-error — write-file-atomic ships no types; shape is documented inline.
 import writeFileAtomicRaw from "write-file-atomic";
 import { getBackendURL } from "../config/constants";
+import { removeJsonObjectPropertyRaw } from "../migration/planners";
 
 type WriteFileAtomicOptions = {
   mode: number;
@@ -180,6 +209,683 @@ export function writeSecureFile(path: string, content: string): void {
   writeFileAtomic.sync(path, content, { mode: 0o600, chown: false });
 }
 
+type ProjectFileSnapshot =
+  | { kind: "absent" }
+  | { kind: "file"; content: string; dev: number; ino: number; mode: number };
+
+function projectFileSnapshot(path: string): ProjectFileSnapshot {
+  let before: ReturnType<typeof lstatSync>;
+  try {
+    before = lstatSync(path);
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return { kind: "absent" };
+    }
+    throw error;
+  }
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw new Error(`Refusing to modify non-regular project file at ${path}`);
+  }
+  const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(path, constants.O_RDONLY | noFollow);
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error(`Project file changed while it was read: ${path}`);
+    }
+    const content = readFileSync(fd, "utf8");
+    const after = lstatSync(path);
+    if (
+      !after.isFile() ||
+      after.isSymbolicLink() ||
+      after.dev !== opened.dev ||
+      after.ino !== opened.ino
+    ) {
+      throw new Error(`Project file changed while it was read: ${path}`);
+    }
+    return {
+      kind: "file",
+      content,
+      dev: opened.dev,
+      ino: opened.ino,
+      mode: opened.mode & 0o777,
+    };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function sameProjectFileSnapshot(left: ProjectFileSnapshot, right: ProjectFileSnapshot): boolean {
+  if (left.kind !== right.kind) return false;
+  return (
+    left.kind === "absent" ||
+    (right.kind === "file" &&
+      left.dev === right.dev &&
+      left.ino === right.ino &&
+      left.content === right.content)
+  );
+}
+
+function fsyncProjectParent(path: string): void {
+  try {
+    const fd = openSync(dirname(path), "r");
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    // Directory fsync is unavailable on some supported platforms.
+  }
+}
+
+export interface ProjectFileMutationHooks {
+  /** Fault-injection seam for filesystems that cannot publish with hard links. */
+  probeHardLink?: (existingPath: string, newPath: string) => void;
+  /** Fault-injection seam for race regression tests. */
+  beforeCapture?: () => void;
+  /** Fault-injection seam after journaling and immediately before capture rename. */
+  beforeCaptureRename?: () => void;
+  /** Simulates process death after the public path was durably captured. */
+  crashAfterCapture?: boolean;
+  /** Fault-injection seam for race regression tests. */
+  beforePublish?: () => void;
+}
+
+/** Exact file states observed by the atomic writer around one successful mutation. */
+export interface ProjectFileMutationReceipt {
+  path: string;
+  beforeContent: string | null;
+  beforeMode: number | null;
+  afterContent: string;
+  afterMode: number;
+}
+
+interface CapturedProjectFile {
+  path: string;
+  root: string;
+  journalPath: string;
+  journalContent: string;
+}
+
+interface ProjectCaptureJournal {
+  schema: 1;
+  target: string;
+  captured: {
+    dev: string;
+    ino: string;
+    mode: number;
+    bytes: number;
+    sha256: string;
+  };
+}
+
+const CAPTURE_JOURNAL = "journal.json";
+
+function unlinkOwnedProbe(path: string, dev: number, ino: number): void {
+  try {
+    const stat = lstatSync(path);
+    if (stat.isFile() && !stat.isSymbolicLink() && stat.dev === dev && stat.ino === ino) {
+      unlinkSync(path);
+    }
+  } catch {
+    // The random probe path either never existed or no longer belongs to us.
+  }
+}
+
+/**
+ * Existing project files are captured before a no-replace publish. Both safe
+ * publish and safe restore therefore require same-directory hard links. Probe
+ * that capability before moving the user's public path; unsupported filesystems
+ * fail with the original file still exactly where it was.
+ */
+function assertProjectHardLinksAvailable(
+  path: string,
+  probeHardLink: ProjectFileMutationHooks["probeHardLink"] = linkSync,
+): void {
+  const nonce = `${process.pid}-${randomBytes(12).toString("hex")}`;
+  const sourcePath = `${path}.dosu-hardlink-probe-${nonce}`;
+  const linkedPath = `${sourcePath}.link`;
+  let fd: number | undefined;
+  let sourceIdentity: { dev: number; ino: number } | undefined;
+  try {
+    fd = openSync(sourcePath, "wx", 0o600);
+    const source = fstatSync(fd);
+    if (!source.isFile()) throw new Error("probe source is not a regular file");
+    sourceIdentity = { dev: source.dev, ino: source.ino };
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+
+    probeHardLink(sourcePath, linkedPath);
+    const linked = lstatSync(linkedPath);
+    if (
+      !linked.isFile() ||
+      linked.isSymbolicLink() ||
+      linked.dev !== source.dev ||
+      linked.ino !== source.ino
+    ) {
+      throw new Error("probe link did not preserve file identity");
+    }
+  } catch {
+    throw new Error(
+      `Project filesystem does not support the hard links required for a safe update; ${path} was left unchanged`,
+    );
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Continue to identity-checked cleanup below.
+      }
+    }
+    if (sourceIdentity) {
+      unlinkOwnedProbe(linkedPath, sourceIdentity.dev, sourceIdentity.ino);
+      unlinkOwnedProbe(sourcePath, sourceIdentity.dev, sourceIdentity.ino);
+      fsyncProjectParent(path);
+    }
+  }
+}
+
+function contentHash(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function captureRootPrefix(path: string): string {
+  return `${basename(path)}.dosu-capture-`;
+}
+
+function pathEntryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function exactObjectKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function parseCaptureJournal(content: string, path: string): ProjectCaptureJournal {
+  let value: unknown;
+  try {
+    value = JSON.parse(content);
+  } catch {
+    throw new Error(`Invalid project-file recovery journal at ${path}`);
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !exactObjectKeys(value as Record<string, unknown>, ["schema", "target", "captured"])
+  ) {
+    throw new Error(`Invalid project-file recovery journal at ${path}`);
+  }
+  const journal = value as Record<string, unknown>;
+  const captured = journal.captured;
+  if (
+    journal.schema !== 1 ||
+    typeof journal.target !== "string" ||
+    typeof captured !== "object" ||
+    captured === null ||
+    Array.isArray(captured) ||
+    !exactObjectKeys(captured as Record<string, unknown>, ["dev", "ino", "mode", "bytes", "sha256"])
+  ) {
+    throw new Error(`Invalid project-file recovery journal at ${path}`);
+  }
+  const metadata = captured as Record<string, unknown>;
+  if (
+    typeof metadata.dev !== "string" ||
+    typeof metadata.ino !== "string" ||
+    typeof metadata.mode !== "number" ||
+    !Number.isInteger(metadata.mode) ||
+    typeof metadata.bytes !== "number" ||
+    !Number.isSafeInteger(metadata.bytes) ||
+    metadata.bytes < 0 ||
+    typeof metadata.sha256 !== "string" ||
+    !/^[a-f0-9]{64}$/.test(metadata.sha256)
+  ) {
+    throw new Error(`Invalid project-file recovery journal at ${path}`);
+  }
+  return value as ProjectCaptureJournal;
+}
+
+function removeEmptyProjectStagingRoot(root: string): void {
+  try {
+    const stat = lstatSync(root);
+    if (!stat.isDirectory() || stat.isSymbolicLink() || readdirSync(root).length !== 0) return;
+    rmdirSync(root);
+    fsyncProjectParent(root);
+  } catch {
+    // A non-empty root can contain the only recoverable copy of a concurrently
+    // replaced project file. Never remove it recursively.
+  }
+}
+
+function cleanupUnexpectedCaptureMetadata(captured: CapturedProjectFile): void {
+  const journal = projectFileSnapshot(captured.journalPath);
+  if (journal.kind !== "file" || journal.content !== captured.journalContent) {
+    throw new Error(`Project-file recovery journal changed at ${captured.journalPath}`);
+  }
+  unlinkSync(captured.journalPath);
+  removeEmptyProjectStagingRoot(captured.root);
+}
+
+/**
+ * The public entry can change after its regular-file journal is written but
+ * before rename(2). Restore that unexpected object with a no-clobber primitive
+ * instead of hiding it in Dosu's stage. A directory uses an atomically-created
+ * empty placeholder so POSIX rename cannot overwrite a concurrent writer;
+ * platforms that cannot replace the placeholder keep the original stage.
+ */
+function restoreUnexpectedCapturedEntry(captured: CapturedProjectFile, path: string): boolean {
+  try {
+    const root = lstatSync(captured.root);
+    if (!root.isDirectory() || root.isSymbolicLink() || (root.mode & 0o077) !== 0) return false;
+    const entries = readdirSync(captured.root).sort();
+    if (entries.length !== 2 || entries[0] !== "captured" || entries[1] !== CAPTURE_JOURNAL) {
+      return false;
+    }
+    const journal = projectFileSnapshot(captured.journalPath);
+    if (journal.kind !== "file" || journal.content !== captured.journalContent) return false;
+
+    const source = lstatSync(captured.path);
+    if (source.isSymbolicLink()) {
+      const target = readlinkSync(captured.path);
+      symlinkSync(target, path);
+      if (!lstatSync(path).isSymbolicLink() || readlinkSync(path) !== target) return false;
+      unlinkSync(captured.path);
+      cleanupUnexpectedCaptureMetadata(captured);
+      fsyncProjectParent(path);
+      return true;
+    }
+    if (source.isFile()) {
+      linkSync(captured.path, path);
+      const restored = lstatSync(path);
+      if (restored.dev !== source.dev || restored.ino !== source.ino) return false;
+      unlinkSync(captured.path);
+      cleanupUnexpectedCaptureMetadata(captured);
+      fsyncProjectParent(path);
+      return true;
+    }
+    if (!source.isDirectory()) return false;
+
+    mkdirSync(path, { mode: source.mode & 0o777 });
+    const placeholder = lstatSync(path);
+    try {
+      renameSync(captured.path, path);
+      const restored = lstatSync(path);
+      if (!restored.isDirectory() || restored.dev !== source.dev || restored.ino !== source.ino) {
+        return false;
+      }
+      cleanupUnexpectedCaptureMetadata(captured);
+      fsyncProjectParent(path);
+      return true;
+    } catch {
+      try {
+        const current = lstatSync(path);
+        if (
+          current.isDirectory() &&
+          !current.isSymbolicLink() &&
+          current.dev === placeholder.dev &&
+          current.ino === placeholder.ino &&
+          readdirSync(path).length === 0
+        ) {
+          rmdirSync(path);
+        }
+      } catch {
+        // Preserve a concurrently changed placeholder and the captured source.
+      }
+      return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+function captureProjectFile(
+  path: string,
+  hooks?: Pick<ProjectFileMutationHooks, "beforeCaptureRename">,
+): CapturedProjectFile {
+  const parent = dirname(path);
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const root = `${path}.dosu-capture-${process.pid}-${randomBytes(12).toString("hex")}`;
+    let rootCreated = false;
+    let journalCreated = false;
+    let renamed = false;
+    const journalPath = join(root, CAPTURE_JOURNAL);
+    let journalContent = "";
+    try {
+      mkdirSync(root, { mode: 0o700 });
+      rootCreated = true;
+      const stat = lstatSync(root);
+      if (!stat.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) {
+        throw new Error(`Unsafe project-file staging root at ${root}`);
+      }
+      fsyncProjectParent(root);
+      const actual = projectFileSnapshot(path);
+      if (actual.kind !== "file") {
+        throw new Error(`Project file disappeared before capture: ${path}`);
+      }
+      journalContent = `${JSON.stringify({
+        schema: 1,
+        target: resolve(path),
+        captured: {
+          dev: String(actual.dev),
+          ino: String(actual.ino),
+          mode: actual.mode,
+          bytes: Buffer.byteLength(actual.content, "utf8"),
+          sha256: contentHash(actual.content),
+        },
+      } satisfies ProjectCaptureJournal)}\n`;
+      const journalFD = openSync(journalPath, "wx", 0o600);
+      journalCreated = true;
+      try {
+        writeFileSync(journalFD, journalContent, "utf8");
+        fchmodSync(journalFD, 0o600);
+        fsyncSync(journalFD);
+      } finally {
+        closeSync(journalFD);
+      }
+      fsyncProjectParent(journalPath);
+      const captured = join(root, "captured");
+      hooks?.beforeCaptureRename?.();
+      renameSync(path, captured);
+      renamed = true;
+      fsyncProjectParent(path);
+      fsyncProjectParent(captured);
+      const result = { path: captured, root, journalPath, journalContent };
+      try {
+        return verifyCapturedProjectFile(root, path);
+      } catch {
+        if (restoreUnexpectedCapturedEntry(result, path)) {
+          throw new Error(
+            `Project file changed during capture; its concurrent replacement was restored at ${path}`,
+          );
+        }
+        throw new Error(
+          `Project file changed during capture; the captured replacement was retained at ${captured}`,
+        );
+      }
+    } catch (error: unknown) {
+      if (rootCreated && !renamed) {
+        if (journalCreated) {
+          try {
+            const journal = projectFileSnapshot(journalPath);
+            if (journal.kind === "file" && journal.content === journalContent) {
+              unlinkSync(journalPath);
+            }
+          } catch {
+            // Preserve anything that is no longer the exact journal we wrote.
+          }
+        }
+        removeEmptyProjectStagingRoot(root);
+      }
+      if (
+        !rootCreated &&
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "EEXIST"
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error(`Could not allocate project-file staging beside ${parent}`);
+}
+
+function verifyCapturedProjectFile(root: string, path: string): CapturedProjectFile {
+  const rootStat = lstatSync(root);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink() || (rootStat.mode & 0o077) !== 0) {
+    throw new Error(`Unsafe project-file recovery stage at ${root}`);
+  }
+  const entries = readdirSync(root).sort();
+  if (entries.length !== 2 || entries[0] !== "captured" || entries[1] !== CAPTURE_JOURNAL) {
+    throw new Error(`Ambiguous project-file recovery stage at ${root}`);
+  }
+  const journalPath = join(root, CAPTURE_JOURNAL);
+  const journalSnapshot = projectFileSnapshot(journalPath);
+  if (journalSnapshot.kind !== "file" || (journalSnapshot.mode & 0o077) !== 0) {
+    throw new Error(`Unsafe project-file recovery journal at ${journalPath}`);
+  }
+  const journal = parseCaptureJournal(journalSnapshot.content, journalPath);
+  if (journal.target !== resolve(path)) {
+    throw new Error(`Project-file recovery journal targets something else at ${journalPath}`);
+  }
+  const capturedPath = join(root, "captured");
+  const captured = projectFileSnapshot(capturedPath);
+  if (
+    captured.kind !== "file" ||
+    String(captured.dev) !== journal.captured.dev ||
+    String(captured.ino) !== journal.captured.ino ||
+    captured.mode !== journal.captured.mode ||
+    Buffer.byteLength(captured.content, "utf8") !== journal.captured.bytes ||
+    contentHash(captured.content) !== journal.captured.sha256
+  ) {
+    throw new Error(`Captured project file does not match its recovery journal at ${root}`);
+  }
+  return {
+    path: capturedPath,
+    root,
+    journalPath,
+    journalContent: journalSnapshot.content,
+  };
+}
+
+function cleanupVerifiedCapture(captured: CapturedProjectFile, path: string): void {
+  const verified = verifyCapturedProjectFile(captured.root, path);
+  unlinkSync(verified.path);
+  const journal = projectFileSnapshot(verified.journalPath);
+  if (journal.kind !== "file" || journal.content !== verified.journalContent) {
+    throw new Error(`Project-file recovery journal changed at ${verified.journalPath}`);
+  }
+  unlinkSync(verified.journalPath);
+  removeEmptyProjectStagingRoot(verified.root);
+}
+
+function restoreCapturedProjectFile(captured: CapturedProjectFile, path: string): boolean {
+  try {
+    const verified = verifyCapturedProjectFile(captured.root, path);
+    // link(2) is an atomic no-replace publish for regular files. If another
+    // process recreated the project path, preserve both it and the captured
+    // preimage instead of overwriting either one.
+    linkSync(verified.path, path);
+    const source = lstatSync(verified.path);
+    const restored = lstatSync(path);
+    if (source.dev !== restored.dev || source.ino !== restored.ino) return false;
+    cleanupVerifiedCapture(verified, path);
+    fsyncProjectParent(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function recoverPendingProjectCapture(path: string): void {
+  const parent = dirname(path);
+  let pending: string[];
+  try {
+    const prefix = captureRootPrefix(path);
+    pending = readdirSync(parent)
+      .filter((entry) => entry.startsWith(prefix))
+      .map((entry) => join(parent, entry));
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  if (pending.length === 0) return;
+  if (pathEntryExists(path)) {
+    throw new Error(`Project file has a pending recovery stage and an existing target: ${path}`);
+  }
+  if (pending.length !== 1) {
+    throw new Error(`Project file has ambiguous pending recovery stages: ${path}`);
+  }
+  const captured = verifyCapturedProjectFile(pending[0], path);
+  if (!restoreCapturedProjectFile(captured, path)) {
+    throw new Error(`Could not safely restore pending project file: ${path}`);
+  }
+}
+
+/**
+ * Atomically writes non-secret project metadata without following a target or
+ * predictable temporary-file symlink. `expectedContent` is a caller-supplied
+ * compare-and-swap guard; `null` means the destination must still be absent.
+ */
+export function writeProjectFile(
+  path: string,
+  content: string,
+  expectedContent?: string | null,
+  hooks?: ProjectFileMutationHooks,
+): ProjectFileMutationReceipt {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const dirStat = lstatSync(dir);
+  if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+    throw new Error(`Refusing to write through non-regular project directory at ${dir}`);
+  }
+  recoverPendingProjectCapture(path);
+  const initial = projectFileSnapshot(path);
+  if (
+    (expectedContent === null && initial.kind !== "absent") ||
+    (typeof expectedContent === "string" &&
+      (initial.kind !== "file" || initial.content !== expectedContent))
+  ) {
+    throw new Error(`Project file changed before it could be written: ${path}`);
+  }
+  if (initial.kind === "file") {
+    assertProjectHardLinksAvailable(path, hooks?.probeHardLink);
+  }
+  const mode = initial.kind === "file" ? initial.mode : 0o644;
+  const temporary = `${path}.dosu-${process.pid}-${randomBytes(12).toString("hex")}.tmp`;
+  let temporaryExists = false;
+  let captured: CapturedProjectFile | null = null;
+  let preserveCapturedForCrashRecovery = false;
+  try {
+    const fd = openSync(temporary, "wx", mode);
+    temporaryExists = true;
+    try {
+      writeFileSync(fd, content, "utf8");
+      fchmodSync(fd, mode);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    if (initial.kind === "file") {
+      hooks?.beforeCapture?.();
+      captured = captureProjectFile(path, hooks);
+      if (hooks?.crashAfterCapture) {
+        preserveCapturedForCrashRecovery = true;
+        throw new Error(`Simulated crash after project-file capture: ${path}`);
+      }
+      if (!sameProjectFileSnapshot(initial, projectFileSnapshot(captured.path))) {
+        const recoveryPath = captured.path;
+        const restored = restoreCapturedProjectFile(captured, path);
+        if (restored) captured = null;
+        const recovery = restored ? "" : `; captured content retained at ${recoveryPath}`;
+        throw new Error(`Project file changed before it could be written: ${path}${recovery}`);
+      }
+    } else if (projectFileSnapshot(path).kind !== "absent") {
+      throw new Error(`Project file changed before it could be written: ${path}`);
+    }
+
+    hooks?.beforePublish?.();
+    // Publish with no-replace semantics. A concurrent writer wins and is never
+    // overwritten; the captured preimage remains available for recovery.
+    linkSync(temporary, path);
+    const published = projectFileSnapshot(path);
+    if (published.kind !== "file" || published.content !== content) {
+      throw new Error(`Project file changed while it was published: ${path}`);
+    }
+    unlinkSync(temporary);
+    temporaryExists = false;
+    if (captured) {
+      cleanupVerifiedCapture(captured, path);
+      captured = null;
+    }
+    fsyncProjectParent(path);
+  } catch (error) {
+    if (captured && !preserveCapturedForCrashRecovery) {
+      const restored = restoreCapturedProjectFile(captured, path);
+      if (restored) captured = null;
+    }
+    throw error;
+  } finally {
+    if (temporaryExists) {
+      try {
+        unlinkSync(temporary);
+      } catch {
+        // A never-published temporary file contains only non-secret metadata.
+      }
+    }
+  }
+  return {
+    path,
+    beforeContent: initial.kind === "file" ? initial.content : null,
+    beforeMode: initial.kind === "file" ? initial.mode : null,
+    afterContent: content,
+    afterMode: mode,
+  };
+}
+
+/**
+ * Remove one exact regular project file with the same atomic-capture rule used
+ * for replacement. A concurrent replacement is restored or retained in the
+ * staging directory; it is never unlinked through the public project path.
+ */
+export function removeProjectFile(
+  path: string,
+  expectedContent: string,
+  hooks?: Pick<
+    ProjectFileMutationHooks,
+    "probeHardLink" | "beforeCapture" | "beforeCaptureRename" | "crashAfterCapture"
+  >,
+): void {
+  recoverPendingProjectCapture(path);
+  const initial = projectFileSnapshot(path);
+  if (initial.kind !== "file" || initial.content !== expectedContent) {
+    throw new Error(`Project file changed before it could be removed: ${path}`);
+  }
+  assertProjectHardLinksAvailable(path, hooks?.probeHardLink);
+
+  let captured: CapturedProjectFile | null = null;
+  let preserveCapturedForCrashRecovery = false;
+  try {
+    hooks?.beforeCapture?.();
+    captured = captureProjectFile(path, hooks);
+    if (hooks?.crashAfterCapture) {
+      preserveCapturedForCrashRecovery = true;
+      throw new Error(`Simulated crash after project-file capture: ${path}`);
+    }
+    if (!sameProjectFileSnapshot(initial, projectFileSnapshot(captured.path))) {
+      const recoveryPath = captured.path;
+      const restored = restoreCapturedProjectFile(captured, path);
+      if (restored) captured = null;
+      const recovery = restored ? "" : `; captured content retained at ${recoveryPath}`;
+      throw new Error(`Project file changed before it could be removed: ${path}${recovery}`);
+    }
+    cleanupVerifiedCapture(captured, path);
+    captured = null;
+    fsyncProjectParent(path);
+  } catch (error) {
+    if (captured && !preserveCapturedForCrashRecovery) {
+      const restored = restoreCapturedProjectFile(captured, path);
+      if (restored) captured = null;
+    }
+    throw error;
+  }
+}
+
 /**
  * Checks if "dosu" exists under the given top-level key in a JSON config file.
  */
@@ -188,6 +894,152 @@ export function isJSONKeyConfigured(configPath: string, topLevelKey: string): bo
   const section = cfg[topLevelKey];
   if (typeof section !== "object" || section === null) return false;
   return "dosu" in section;
+}
+
+function propertyValueNode(object: JSONCNode, key: string): JSONCNode | undefined {
+  if (object.type !== "object") return undefined;
+  const matches = (object.children ?? []).filter(
+    (property) => property.children?.[0]?.value === key,
+  );
+  if (matches.length > 1) {
+    throw new Error(`Duplicate JSON property "${key}"; refusing to modify the config`);
+  }
+  return matches[0]?.children?.[1];
+}
+
+function parseJSONTreeStrict(path: string, content: string): JSONCNode {
+  const errors: ParseError[] = [];
+  const tree = parseTree(content, errors, { allowTrailingComma: true, disallowComments: false });
+  if (!tree || errors.length > 0 || tree.type !== "object") {
+    throw new Error(`Invalid JSON/JSONC in ${path}; refusing to modify the config`);
+  }
+  assertUniqueProperties(tree, path);
+  return tree;
+}
+
+function assertUniqueProperties(node: JSONCNode, path: string): void {
+  if (node.type === "object") {
+    const keys = new Set<string>();
+    for (const property of node.children ?? []) {
+      const key = property.children?.[0]?.value;
+      if (typeof key === "string") {
+        if (keys.has(key)) {
+          throw new Error(`Duplicate JSON property "${key}"; refusing to modify ${path}`);
+        }
+        keys.add(key);
+      }
+      for (const child of property.children ?? []) assertUniqueProperties(child, path);
+    }
+    return;
+  }
+  for (const child of node.children ?? []) assertUniqueProperties(child, path);
+}
+
+function projectEntry(path: string, topLevelKey: string): unknown {
+  if (!existsSync(path)) return undefined;
+  assertRegularProjectFile(path);
+  const content = readFileSync(path, "utf8");
+  const tree = parseJSONTreeStrict(path, content);
+  const section = propertyValueNode(tree, topLevelKey);
+  if (!section) return undefined;
+  if (section.type !== "object") {
+    throw new Error(`JSON property "${topLevelKey}" is not an object; refusing to modify ${path}`);
+  }
+  const node = propertyValueNode(section, "dosu");
+  return node ? getNodeValue(node) : undefined;
+}
+
+/** Project config symlinks can escape the repository; never replace or follow them silently. */
+export function assertRegularProjectFile(path: string): void {
+  if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+    throw new Error(`Refusing to modify symbolic link at ${path}`);
+  }
+}
+
+function formattingFor(content: string) {
+  const lineEnding = content.includes("\r\n") ? "\r\n" : "\n";
+  const indent = content.match(/\n([ \t]+)\S/)?.[1] ?? "  ";
+  return {
+    insertSpaces: !indent.includes("\t"),
+    tabSize: indent.includes("\t") ? 1 : Math.max(1, indent.length),
+    eol: lineEnding,
+  };
+}
+
+/** Upsert one verified Dosu project entry while preserving JSONC comments and sibling formatting. */
+export function installProjectJSONServer(
+  path: string,
+  topLevelKey: string,
+  server: Record<string, unknown>,
+  isOwned: (entry: unknown) => boolean,
+  validateExisting?: (entry: unknown) => void,
+): ProjectFileMutationReceipt {
+  assertRegularProjectFile(path);
+  if (!existsSync(path)) {
+    return writeProjectFile(
+      path,
+      JSON.stringify({ [topLevelKey]: { dosu: server } }, null, 2),
+      null,
+    );
+  }
+
+  const content = readFileSync(path, "utf8");
+  const tree = parseJSONTreeStrict(path, content);
+  const section = propertyValueNode(tree, topLevelKey);
+  if (section && section.type !== "object") {
+    throw new Error(`JSON property "${topLevelKey}" is not an object; refusing to modify ${path}`);
+  }
+  const currentNode = section ? propertyValueNode(section, "dosu") : undefined;
+  const current = currentNode ? getNodeValue(currentNode) : undefined;
+  if (current !== undefined && !isOwned(current)) {
+    throw new Error(`Found a non-Dosu server named "dosu" in ${path}; refusing to overwrite it`);
+  }
+  if (current !== undefined) validateExisting?.(current);
+
+  const edits = modify(content, [topLevelKey, "dosu"], server, {
+    formattingOptions: formattingFor(content),
+  });
+  return writeProjectFile(path, applyEdits(content, edits), content);
+}
+
+export function isProjectJSONServerConfigured(
+  path: string,
+  topLevelKey: string,
+  isOwned: (entry: unknown) => boolean,
+): boolean {
+  try {
+    const entry = projectEntry(path, topLevelKey);
+    return entry !== undefined && isOwned(entry);
+  } catch {
+    return false;
+  }
+}
+
+/** Remove only a verified Dosu project entry and preserve the containing config file. */
+export function removeProjectJSONServer(
+  path: string,
+  topLevelKey: string,
+  isOwned: (entry: unknown) => boolean,
+): ProjectFileMutationReceipt | undefined {
+  if (!existsSync(path)) return;
+  assertRegularProjectFile(path);
+  const content = readFileSync(path, "utf8");
+  const tree = parseJSONTreeStrict(path, content);
+  const section = propertyValueNode(tree, topLevelKey);
+  if (!section) return;
+  if (section.type !== "object") {
+    throw new Error(`JSON property "${topLevelKey}" is not an object; refusing to modify ${path}`);
+  }
+  const currentNode = propertyValueNode(section, "dosu");
+  if (!currentNode) return;
+  if (!isOwned(getNodeValue(currentNode))) {
+    throw new Error(`Found a non-Dosu server named "dosu" in ${path}; refusing to remove it`);
+  }
+  const next = removeJsonObjectPropertyRaw(content, section, "dosu");
+  if (next === null) {
+    throw new Error(`Could not safely remove "dosu" from ${path}; refusing to modify it`);
+  }
+  return writeProjectFile(path, next, content);
 }
 
 /**

--- a/src/mcp/detect.ts
+++ b/src/mcp/detect.ts
@@ -4,7 +4,7 @@
 
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, join, win32 } from "node:path";
 
 /**
  * Checks if any of the given paths exist on the filesystem.
@@ -48,13 +48,11 @@ export function appSupportDir(): string {
 /* v8 ignore stop */
 
 /**
- * Locates `npx` by absolute path on the current (shell) PATH.
- *
- * GUI hosts that spawn config-file stdio servers (Codex desktop, Claude
- * Desktop) launch them with the minimal launchd PATH that lacks
- * Homebrew/nvm, so entries must reference npx absolutely and carry a PATH
- * under which npx's `#!/usr/bin/env node` shebang resolves. Resolved at
- * install time from the user's shell PATH.
+ * Locates `npx` by absolute path on the current process PATH. Setup uses this
+ * as an install-time availability check; the private proxy runtime uses the
+ * absolute result to give its child a PATH that also resolves Node.js.
+ * Project files deliberately keep the portable command name `npx`, so GUI
+ * clients with a restricted PATH may still need to be restarted from a shell.
  */
 export function findNpx(): string {
   /* v8 ignore next -- platform dispatch, win32 arm not exercised on POSIX CI */
@@ -64,9 +62,7 @@ export function findNpx(): string {
     const candidate = join(dir, bin);
     if (existsSync(candidate)) return candidate;
   }
-  throw new Error(
-    "npx not found on PATH — Node.js is required (the MCP entry runs `npx mcp-remote`).",
-  );
+  throw new Error("npx not found on PATH — Node.js 22+ is required for this MCP configuration.");
 }
 
 /**
@@ -75,5 +71,10 @@ export function findNpx(): string {
  * fallbacks are harmless on Windows.
  */
 export function npxPathEnv(npx: string): string {
-  return [dirname(npx), "/usr/bin", "/bin"].join(delimiter);
+  const windowsStyle = /^[A-Za-z]:[\\/]/.test(npx) || npx.startsWith("\\\\");
+  const parent = windowsStyle ? win32.dirname(npx) : dirname(npx);
+  const separator = windowsStyle ? ";" : delimiter;
+  const inherited = process.env.PATH?.split(separator).filter(Boolean) ?? [];
+  const fallback = windowsStyle ? [] : ["/usr/bin", "/bin"];
+  return [...new Set([parent, ...inherited, ...fallback])].join(separator);
 }

--- a/src/mcp/process-tree.test.ts
+++ b/src/mcp/process-tree.test.ts
@@ -1,0 +1,322 @@
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { terminatePosixProcessTree, terminateWindowsProcessTree } from "./process-tree";
+
+function fakeChild(pid?: number) {
+  return { pid, kill: vi.fn((_signal: NodeJS.Signals) => true) };
+}
+
+function fakeTreeKiller() {
+  const process = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+  process.kill = vi.fn(() => true);
+  return process;
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return predicate();
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return !(
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ESRCH"
+    );
+  }
+}
+
+function readPositivePID(path: string): number | undefined {
+  try {
+    const content = readFileSync(path, "utf8").trim();
+    if (!/^[1-9][0-9]*$/.test(content)) return;
+    const pid = Number.parseInt(content, 10);
+    return Number.isSafeInteger(pid) ? pid : undefined;
+  } catch {
+    return;
+  }
+}
+
+describe("Windows process-tree shutdown", () => {
+  it("runs taskkill against the complete PID tree without a shell", async () => {
+    const child = fakeChild(4321);
+    const treeKiller = fakeTreeKiller();
+    const spawnTreeKiller = vi.fn(() => {
+      queueMicrotask(() => treeKiller.emit("close", 0));
+      return treeKiller;
+    });
+
+    await expect(
+      terminateWindowsProcessTree(child, { spawnTreeKiller: spawnTreeKiller as never }),
+    ).resolves.toBe("terminated");
+
+    expect(spawnTreeKiller).toHaveBeenCalledWith("taskkill", ["/PID", "4321", "/T", "/F"], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "missing pid",
+    "spawn throw",
+    "taskkill error",
+    "taskkill nonzero",
+  ])("falls back to the shell kill for %s", async (scenario) => {
+    const child = fakeChild(scenario === "missing pid" ? undefined : 1234);
+    const treeKiller = fakeTreeKiller();
+    const spawnTreeKiller = vi.fn(() => {
+      if (scenario === "spawn throw") throw new Error("taskkill unavailable");
+      if (scenario === "taskkill error") queueMicrotask(() => treeKiller.emit("error"));
+      if (scenario === "taskkill nonzero") queueMicrotask(() => treeKiller.emit("close", 1));
+      return treeKiller;
+    });
+
+    await expect(
+      terminateWindowsProcessTree(child, { spawnTreeKiller: spawnTreeKiller as never }),
+    ).resolves.toBe("unconfirmed");
+
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(spawnTreeKiller).toHaveBeenCalledTimes(scenario === "missing pid" ? 0 : 1);
+  });
+
+  it("resolves at the hard deadline even when both kill calls throw", async () => {
+    const child = fakeChild(9999);
+    child.kill.mockImplementation(() => {
+      throw new Error("already exited");
+    });
+    const treeKiller = fakeTreeKiller();
+    treeKiller.kill.mockImplementation(() => {
+      throw new Error("already exited");
+    });
+
+    await expect(
+      terminateWindowsProcessTree(child, {
+        spawnTreeKiller: (() => treeKiller) as never,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toBe("unconfirmed");
+    expect(treeKiller.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+});
+
+describe("POSIX process-group shutdown", () => {
+  it.skipIf(process.platform === "win32")(
+    "kills a real SIGTERM-resistant descendant in the detached process group",
+    async () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "dosu-process-tree-"));
+      const descendantPIDPath = join(fixtureRoot, "descendant.pid");
+      const descendantHeartbeatPath = join(fixtureRoot, "descendant.heartbeat");
+      const descendantScript = [
+        'const { writeFileSync } = require("node:fs");',
+        'process.on("SIGTERM", () => {});',
+        "writeFileSync(process.argv[1], String(process.pid));",
+        "let heartbeat = 0;",
+        "setInterval(() => writeFileSync(process.argv[2], String(++heartbeat)), 20);",
+      ].join("");
+      const leaderScript = [
+        'const { spawn } = require("node:child_process");',
+        'process.on("SIGTERM", () => {});',
+        `spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}, process.argv[1], process.argv[2]], { stdio: "ignore" });`,
+        "setInterval(() => {}, 1_000);",
+      ].join("");
+      const leader = spawn(
+        process.execPath,
+        ["-e", leaderScript, descendantPIDPath, descendantHeartbeatPath],
+        {
+          detached: true,
+          stdio: "ignore",
+        },
+      );
+      const leaderClosed = new Promise<void>((resolve) => leader.once("close", () => resolve()));
+      let descendantPID: number | undefined;
+      let testFailure: unknown;
+      let statusChecks = 0;
+      let lastGroupError:
+        | { signal: NodeJS.Signals | 0; code: unknown; message: string }
+        | undefined;
+      const killProcessGroup = (pid: number, signal: NodeJS.Signals | 0) => {
+        if (signal === 0) statusChecks += 1;
+        try {
+          process.kill(pid, signal);
+        } catch (error: unknown) {
+          lastGroupError = {
+            signal,
+            code:
+              typeof error === "object" && error !== null && "code" in error
+                ? error.code
+                : undefined,
+            message: error instanceof Error ? error.message : String(error),
+          };
+          throw error;
+        }
+      };
+
+      try {
+        expect(await waitUntil(() => readPositivePID(descendantPIDPath) !== undefined, 2_000)).toBe(
+          true,
+        );
+        const parsedDescendantPID = readPositivePID(descendantPIDPath);
+        if (parsedDescendantPID === undefined) throw new Error("descendant PID was not published");
+        descendantPID = parsedDescendantPID;
+        expect(processExists(parsedDescendantPID)).toBe(true);
+        expect(
+          await waitUntil(
+            () =>
+              existsSync(descendantHeartbeatPath) &&
+              readFileSync(descendantHeartbeatPath).length > 0,
+            2_000,
+          ),
+        ).toBe(true);
+
+        const shutdownResult = await terminatePosixProcessTree(leader, {
+          killProcessGroup,
+          killGraceMs: 50,
+          // Under the full parallel suite, SIGKILLed grandchildren can remain
+          // visible as zombies or transiently return EPERM from kill(0) until
+          // the OS schedules their reaper.
+          // Keep the production hard deadline unchanged; this E2E gets a
+          // generous confirmation window because it asserts confirmed reaping.
+          shutdownDeadlineMs: 10_000,
+        });
+        expect(
+          shutdownResult,
+          `status checks=${statusChecks}; last group error=${JSON.stringify(lastGroupError)}`,
+        ).toBe("terminated");
+        const stoppedHeartbeat = readFileSync(descendantHeartbeatPath, "utf8");
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(readFileSync(descendantHeartbeatPath, "utf8")).toBe(stoppedHeartbeat);
+      } catch (error: unknown) {
+        testFailure = error;
+      }
+
+      let cleanupFailure: Error | undefined;
+      if (leader.pid) {
+        try {
+          process.kill(-leader.pid, "SIGKILL");
+        } catch {
+          // The helper normally removes the complete group before cleanup.
+        }
+      }
+      const leaderWasReaped = await Promise.race([
+        leaderClosed.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 10_000)),
+      ]);
+      if (!leaderWasReaped) cleanupFailure = new Error("test process-group leader was not reaped");
+      const pidToReap = descendantPID;
+      if (pidToReap !== undefined) {
+        try {
+          process.kill(pidToReap, "SIGKILL");
+        } catch {
+          // The helper normally leaves no executing descendant. A zombie may
+          // remain PID-visible until the platform's orphan reaper schedules it.
+        }
+      }
+      rmSync(fixtureRoot, { recursive: true, force: true });
+      if (cleanupFailure) throw cleanupFailure;
+      if (testFailure) throw testFailure;
+    },
+    30_000,
+  );
+
+  it("signals the negative group PID with TERM then KILL and confirms its exit", async () => {
+    const child = fakeChild(4321);
+    let present = true;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGKILL") present = false;
+      if (signal === 0 && !present) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+
+    await expect(
+      terminatePosixProcessTree(child, {
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toBe("terminated");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4321, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4321, "SIGKILL");
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("falls back to direct TERM/KILL without claiming confirmed cleanup when PID is absent", async () => {
+    const child = fakeChild();
+
+    await expect(
+      terminatePosixProcessTree(child, { killGraceMs: 1, shutdownDeadlineMs: 1 }),
+    ).resolves.toBe("unconfirmed");
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("returns unconfirmed by the hard deadline when a group survives SIGKILL", async () => {
+    const child = fakeChild(2468);
+    const killProcessGroup = vi.fn(() => {});
+
+    await expect(
+      terminatePosixProcessTree(child, {
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toBe("unconfirmed");
+    expect(killProcessGroup).toHaveBeenCalledWith(-2468, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-2468, "SIGKILL");
+  });
+
+  it("continues from transient EPERM probes through KILL until absence is confirmed", async () => {
+    const child = fakeChild(8642);
+    let killed = false;
+    let checksAfterKill = 0;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGKILL") killed = true;
+      if (signal !== 0) return;
+      if (!killed) throw Object.assign(new Error("term reaping"), { code: "EPERM" });
+      checksAfterKill += 1;
+      throw Object.assign(new Error(checksAfterKill === 1 ? "reaping" : "gone"), {
+        code: checksAfterKill === 1 ? "EPERM" : "ESRCH",
+      });
+    });
+
+    await expect(
+      terminatePosixProcessTree(child, {
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 50,
+      }),
+    ).resolves.toBe("terminated");
+    expect(killProcessGroup).toHaveBeenCalledWith(-8642, "SIGKILL");
+    expect(checksAfterKill).toBe(2);
+  });
+
+  it.each(["gone", "forbidden"])("handles a group that is immediately %s", async (scenario) => {
+    const child = fakeChild(777);
+    const killProcessGroup = vi.fn(() => {
+      throw Object.assign(new Error(scenario), { code: scenario === "gone" ? "ESRCH" : "EPERM" });
+    });
+
+    await expect(
+      terminatePosixProcessTree(child, {
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toBe(scenario === "gone" ? "terminated" : "unconfirmed");
+  });
+});

--- a/src/mcp/process-tree.ts
+++ b/src/mcp/process-tree.ts
@@ -1,0 +1,195 @@
+import { spawn as nodeSpawn } from "node:child_process";
+
+export interface KillableProcess {
+  pid?: number;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+interface TreeKillerProcess {
+  once(event: "error", listener: () => void): TreeKillerProcess;
+  once(event: "close", listener: (code: number | null) => void): TreeKillerProcess;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+export type SpawnTreeKiller = (
+  command: string,
+  args: string[],
+  options: {
+    shell: false;
+    stdio: "ignore";
+    windowsHide: true;
+  },
+) => TreeKillerProcess;
+
+export interface WindowsTreeShutdownDependencies {
+  spawnTreeKiller?: SpawnTreeKiller;
+  shutdownDeadlineMs?: number;
+}
+
+export type ProcessTreeShutdownResult = "terminated" | "unconfirmed";
+
+export type KillProcessGroup = (pid: number, signal: NodeJS.Signals | 0) => void;
+
+export interface PosixTreeShutdownDependencies {
+  killProcessGroup?: KillProcessGroup;
+  killGraceMs?: number;
+  shutdownDeadlineMs?: number;
+}
+
+function isPositivePID(pid: number | undefined): pid is number {
+  return Number.isSafeInteger(pid) && (pid ?? 0) > 0;
+}
+
+function codeOf(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(1, ms)));
+}
+
+/**
+ * Terminate a Windows shell and every descendant without putting runtime
+ * secrets on a second command line. The promise always resolves by its hard
+ * deadline, even if taskkill and the original child never emit `close`.
+ */
+export async function terminateWindowsProcessTree(
+  child: KillableProcess,
+  deps: WindowsTreeShutdownDependencies = {},
+): Promise<ProcessTreeShutdownResult> {
+  return await new Promise<ProcessTreeShutdownResult>((resolve) => {
+    let settled = false;
+    let treeKiller: TreeKillerProcess | undefined;
+
+    const settle = (result: ProcessTreeShutdownResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      resolve(result);
+    };
+    const killShellFallback = () => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // The shell may already have exited while taskkill was running.
+      }
+      settle("unconfirmed");
+    };
+    const deadline = setTimeout(
+      () => {
+        try {
+          treeKiller?.kill("SIGKILL");
+        } catch {
+          // A concurrently closed taskkill process needs no cleanup.
+        }
+        killShellFallback();
+      },
+      Math.max(1, deps.shutdownDeadlineMs ?? 1_000),
+    );
+
+    if (!isPositivePID(child.pid)) {
+      killShellFallback();
+      return;
+    }
+
+    try {
+      treeKiller = (deps.spawnTreeKiller ?? (nodeSpawn as unknown as SpawnTreeKiller))(
+        "taskkill",
+        ["/PID", String(child.pid), "/T", "/F"],
+        { shell: false, stdio: "ignore", windowsHide: true },
+      );
+      treeKiller.once("error", killShellFallback);
+      treeKiller.once("close", (code) => {
+        if (code === 0) settle("terminated");
+        else killShellFallback();
+      });
+    } catch {
+      killShellFallback();
+    }
+  });
+}
+
+type GroupStatus = "present" | "absent" | "unknown";
+
+function processGroupStatus(groupID: number, killProcessGroup: KillProcessGroup): GroupStatus {
+  try {
+    killProcessGroup(groupID, 0);
+    return "present";
+  } catch (error: unknown) {
+    return codeOf(error) === "ESRCH" ? "absent" : "unknown";
+  }
+}
+
+function signalProcessGroup(
+  groupID: number,
+  signal: NodeJS.Signals,
+  killProcessGroup: KillProcessGroup,
+): GroupStatus {
+  try {
+    killProcessGroup(groupID, signal);
+    return "present";
+  } catch (error: unknown) {
+    return codeOf(error) === "ESRCH" ? "absent" : "unknown";
+  }
+}
+
+async function waitForGroupExit(
+  groupID: number,
+  timeoutMs: number,
+  killProcessGroup: KillProcessGroup,
+): Promise<GroupStatus> {
+  const deadline = Date.now() + Math.max(1, timeoutMs);
+  while (true) {
+    const status = processGroupStatus(groupID, killProcessGroup);
+    // EPERM can be transient while a killed descendant is being reparented or
+    // reaped (notably under Darwin sandbox/load). It is not proof of cleanup,
+    // but neither should it bypass the remaining TERM/KILL deadline. Only
+    // ESRCH confirms that the group is gone.
+    if (status === "absent") return status;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return status;
+    await delay(Math.min(10, remaining));
+  }
+}
+
+/**
+ * Terminate the dedicated process group created for npx and all descendants.
+ * A missing PID cannot prove tree cleanup, so it deliberately returns
+ * `unconfirmed` after best-effort direct-child TERM/KILL signals.
+ */
+export async function terminatePosixProcessTree(
+  child: KillableProcess,
+  deps: PosixTreeShutdownDependencies = {},
+): Promise<ProcessTreeShutdownResult> {
+  const graceMs = Math.max(1, deps.killGraceMs ?? 250);
+  const deadlineMs = Math.max(1, deps.shutdownDeadlineMs ?? 1_000);
+  if (!isPositivePID(child.pid)) {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // Continue to the forced best-effort signal.
+    }
+    await delay(graceMs);
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Cleanup cannot be confirmed without a process-group ID.
+    }
+    return "unconfirmed";
+  }
+
+  const groupID = -child.pid;
+  const killProcessGroup = deps.killProcessGroup ?? process.kill.bind(process);
+  const termStatus = signalProcessGroup(groupID, "SIGTERM", killProcessGroup);
+  if (termStatus === "absent") return "terminated";
+  if (termStatus === "unknown") return "unconfirmed";
+
+  const afterTerm = await waitForGroupExit(groupID, graceMs, killProcessGroup);
+  if (afterTerm === "absent") return "terminated";
+
+  const killStatus = signalProcessGroup(groupID, "SIGKILL", killProcessGroup);
+  if (killStatus === "absent") return "terminated";
+
+  const afterKill = await waitForGroupExit(groupID, deadlineMs, killProcessGroup);
+  return afterKill === "absent" ? "terminated" : "unconfirmed";
+}

--- a/src/mcp/project-credential-store.test.ts
+++ b/src/mcp/project-credential-store.test.ts
@@ -1,0 +1,492 @@
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearProjectMcpCredentials,
+  getProjectMcpCredentialStorePath,
+  readProjectMcpCredential,
+  saveProjectMcpCredential,
+} from "./project-credential-store";
+
+let directory: string;
+let path: string;
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "dosu-project-credentials-"));
+  path = join(directory, "credentials.json");
+});
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("project MCP credential store", () => {
+  it("derives the default store outside project configuration", () => {
+    expect(getProjectMcpCredentialStorePath()).toMatch(/project-mcp-credentials\.v1$/);
+  });
+
+  it.each([
+    { userID: "", targetKey: "deployment:dep-a" },
+    { userID: "user-a", targetKey: "" },
+  ])("rejects an incomplete credential identity before writing", ({ userID, targetKey }) => {
+    expect(() =>
+      saveProjectMcpCredential({
+        userID,
+        targetKey,
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+        path,
+      }),
+    ).toThrow(/identity is required/i);
+    expect(() => lstatSync(path)).toThrow();
+  });
+
+  it("retains credentials for multiple deployments without exposing them to a project", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-b",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-b", api_key: "key-b" },
+      path,
+    });
+
+    expect(
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toEqual({ endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" });
+    expect(
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-b", path }),
+    ).toEqual({ endpoint: "https://api.test/v1/mcp/deployments/dep-b", api_key: "key-b" });
+    const records = readdirSync(path);
+    expect(records).toHaveLength(2);
+    expect(records.every((record) => (lstatSync(join(path, record)).mode & 0o777) === 0o600)).toBe(
+      true,
+    );
+  });
+
+  it("isolates credentials by authenticated account", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    expect(
+      readProjectMcpCredential({ userID: "user-b", targetKey: "deployment:dep-a", path }),
+    ).toBeUndefined();
+
+    saveProjectMcpCredential({
+      userID: "user-b",
+      targetKey: "deployment:dep-b",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-b", api_key: "key-b" },
+      path,
+    });
+    expect(
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toEqual({ endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" });
+  });
+
+  it.each([
+    ["array record", []],
+    [
+      "extra record field",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+        foreign: true,
+      },
+    ],
+    [
+      "wrong schema",
+      {
+        schema_version: 2,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      },
+    ],
+    [
+      "empty user",
+      {
+        schema_version: 1,
+        user_id: "",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      },
+    ],
+    [
+      "empty target",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      },
+    ],
+    [
+      "non-object credential",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: [],
+      },
+    ],
+    [
+      "extra credential field",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: {
+          endpoint: "https://api.test/v1/mcp",
+          api_key: "key-a",
+          foreign: true,
+        },
+      },
+    ],
+    [
+      "empty endpoint",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "", api_key: "key-a" },
+      },
+    ],
+    [
+      "empty API key",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "" },
+      },
+    ],
+  ])("rejects a syntactically valid but unsafe %s", (_name, unsafeRecord) => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    writeFileSync(record, `${JSON.stringify(unsafeRecord)}\n`);
+
+    expect(() =>
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toThrow(/invalid project MCP credential record/i);
+    expect(readFileSync(record, "utf8")).toBe(`${JSON.stringify(unsafeRecord)}\n`);
+  });
+
+  it("detects a valid record moved under another identity's hashed filename", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const parsed = JSON.parse(readFileSync(record, "utf8"));
+    parsed.user_id = "user-b";
+    writeFileSync(record, `${JSON.stringify(parsed)}\n`);
+
+    expect(() =>
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toThrow(/identity mismatch/i);
+    expect(() =>
+      saveProjectMcpCredential({
+        userID: "user-a",
+        targetKey: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "replacement" },
+        path,
+      }),
+    ).toThrow(/identity mismatch/i);
+    expect(JSON.parse(readFileSync(record, "utf8")).user_id).toBe("user-b");
+  });
+
+  it("fails closed for a malformed file or symlink", () => {
+    writeFileSync(path, "not json");
+    expect(() =>
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toThrow(/invalid project MCP credential store/i);
+
+    rmSync(path);
+    const outside = join(directory, "outside.json");
+    writeFileSync(outside, "{}");
+    symlinkSync(outside, path);
+    expect(() =>
+      saveProjectMcpCredential({
+        userID: "user-a",
+        targetKey: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+        path,
+      }),
+    ).toThrow(/invalid project MCP credential store/i);
+    expect(readFileSync(outside, "utf8")).toBe("{}");
+  });
+
+  it("removes only strictly validated credential records on logout", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    clearProjectMcpCredentials(path);
+    expect(() => lstatSync(path)).toThrow();
+  });
+
+  it("removes a strictly proven 0600 crash temporary on logout", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const crashTemporary = `${record}.4321.abcdef012345.tmp`;
+    writeFileSync(crashTemporary, readFileSync(record), { mode: 0o600 });
+
+    clearProjectMcpCredentials(path);
+
+    expect(() => lstatSync(path)).toThrow();
+  });
+
+  it("accepts libuv's 0666 Windows mode for an otherwise proven crash temporary", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const crashTemporary = `${record}.4321.abcdef012345.tmp`;
+    writeFileSync(crashTemporary, readFileSync(record), { mode: 0o600 });
+    chmodSync(crashTemporary, 0o666);
+
+    clearProjectMcpCredentials(path, { platform: "win32" });
+
+    expect(() => lstatSync(path)).toThrow();
+  });
+
+  it("keeps POSIX mode and owner checks strict for crash temporaries", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const crashTemporary = `${record}.4321.abcdef012345.tmp`;
+    writeFileSync(crashTemporary, readFileSync(record), { mode: 0o600 });
+    chmodSync(crashTemporary, 0o666);
+
+    expect(() => clearProjectMcpCredentials(path, { platform: "darwin" })).toThrow(
+      /invalid project MCP credential temporary/i,
+    );
+    expect(readFileSync(record, "utf8")).toContain('"api_key": "key-a"');
+    expect(readFileSync(crashTemporary, "utf8")).toContain('"api_key": "key-a"');
+
+    chmodSync(crashTemporary, 0o600);
+    const currentUID = lstatSync(crashTemporary).uid;
+    expect(() =>
+      clearProjectMcpCredentials(path, {
+        platform: "linux",
+        getuid: () => currentUID + 1,
+      }),
+    ).toThrow(/invalid project MCP credential temporary/i);
+    expect(readFileSync(record, "utf8")).toContain('"api_key": "key-a"');
+    expect(readFileSync(crashTemporary, "utf8")).toContain('"api_key": "key-a"');
+  });
+
+  it.each([
+    "malformed",
+    "foreign",
+    "symlink",
+  ] as const)("preserves the entire store for a %s crash temporary", (scenario) => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: {
+        endpoint: "https://api.test/v1/mcp/deployments/dep-a",
+        api_key: "key-a",
+      },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const temporaryBase = scenario === "foreign" ? `${"0".repeat(64)}.json` : recordName;
+    const temporary = join(path, `${temporaryBase}.4321.abcdef012345.tmp`);
+    if (scenario === "symlink") {
+      const outside = join(directory, "outside-tmp");
+      writeFileSync(outside, "keep me");
+      symlinkSync(outside, temporary);
+    } else {
+      writeFileSync(temporary, scenario === "malformed" ? "not json" : readFileSync(record), {
+        mode: 0o600,
+      });
+    }
+    const before = readdirSync(path).sort();
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow();
+    expect(() => clearProjectMcpCredentials(path, { platform: "win32" })).toThrow();
+
+    expect(readdirSync(path).sort()).toEqual(before);
+    expect(readFileSync(record, "utf8")).toContain('"api_key": "key-a"');
+    expect(lstatSync(temporary).isSymbolicLink()).toBe(scenario === "symlink");
+  });
+
+  it("preserves the entire store for a crash temporary with public permissions", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const temporary = `${record}.4321.abcdef012345.tmp`;
+    writeFileSync(temporary, readFileSync(record), { mode: 0o600 });
+    chmodSync(temporary, 0o644);
+    const before = readdirSync(path).sort();
+
+    expect(() => clearProjectMcpCredentials(path, { platform: "darwin" })).toThrow(
+      /invalid.*temporary/i,
+    );
+
+    expect(readdirSync(path).sort()).toEqual(before);
+    expect(readFileSync(record, "utf8")).toContain('"api_key": "key-a"');
+  });
+
+  it("preserves every record when a valid record has the wrong hashed filename", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const original = join(path, recordName);
+    const misplaced = join(path, `${"0".repeat(64)}.json`);
+    writeFileSync(misplaced, readFileSync(original), { mode: 0o600 });
+    const before = readdirSync(path).sort();
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow(
+      /invalid project MCP credential record/i,
+    );
+
+    expect(readdirSync(path).sort()).toEqual(before);
+    expect(readFileSync(original, "utf8")).toContain('"api_key": "key-a"');
+  });
+
+  it("preserves every record when the store contains a nested directory", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const nested = join(path, "foreign-directory");
+    mkdirSync(nested);
+    writeFileSync(join(nested, "important.txt"), "user data");
+    const recordsBefore = readdirSync(path).sort();
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow(/unrecognized file/i);
+
+    expect(readdirSync(path).sort()).toEqual(recordsBefore);
+    expect(readFileSync(join(nested, "important.txt"), "utf8")).toBe("user data");
+  });
+
+  it("does not leave a temporary after a successful save", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+
+    expect(readdirSync(path)).toEqual([expect.stringMatching(/^[a-f0-9]{64}\.json$/)]);
+  });
+
+  it("cleans its temporary when publishing a save fails", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    rmSync(join(path, recordName));
+    mkdirSync(join(path, recordName));
+
+    expect(() =>
+      saveProjectMcpCredential({
+        userID: "user-a",
+        targetKey: "deployment:dep-a",
+        credential: {
+          endpoint: "https://api.test/v1/mcp/deployments/dep-a",
+          api_key: "key-b",
+        },
+        path,
+      }),
+    ).toThrow();
+
+    expect(readdirSync(path)).toEqual([recordName]);
+  });
+
+  it("closes and removes its temporary when record serialization fails", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() =>
+      saveProjectMcpCredential({
+        userID: "user-a",
+        targetKey: "deployment:dep-a",
+        credential: circular as unknown as { endpoint: string; api_key: string },
+        path,
+      }),
+    ).toThrow(/circular/i);
+
+    expect(readdirSync(path)).toEqual([]);
+  });
+
+  it("preserves a foreign file instead of recursively deleting the store", () => {
+    mkdirSync(path);
+    const foreign = join(path, "important.txt");
+    writeFileSync(foreign, "keep me");
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow(/unrecognized file/i);
+
+    expect(readFileSync(foreign, "utf8")).toBe("keep me");
+  });
+
+  it("preserves a dangling credential-store symlink on logout", () => {
+    symlinkSync(join(directory, "missing-store"), path);
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow(/invalid project MCP credential store/i);
+
+    expect(lstatSync(path).isSymbolicLink()).toBe(true);
+  });
+});

--- a/src/mcp/project-credential-store.ts
+++ b/src/mcp/project-credential-store.ts
@@ -1,0 +1,249 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { getConfigDir } from "../config/config";
+
+const STORE_VERSION = 1 as const;
+
+function entryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export interface StoredProjectMcpCredential {
+  endpoint: string;
+  api_key: string;
+}
+
+interface ProjectMcpCredentialRecord {
+  schema_version: typeof STORE_VERSION;
+  user_id: string;
+  target_key: string;
+  credential: StoredProjectMcpCredential;
+}
+
+export interface ProjectMcpCredentialCleanupDependencies {
+  platform?: NodeJS.Platform;
+  getuid?: () => number;
+}
+
+export function getProjectMcpCredentialStorePath(): string {
+  return join(getConfigDir(), "project-mcp-credentials.v1");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function credentialFileName(userID: string, targetKey: string): string {
+  return `${createHash("sha256").update(userID).update("\0").update(targetKey).digest("hex")}.json`;
+}
+
+function assertStoreDirectory(path: string): void {
+  if (!entryExists(path)) return;
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Invalid project MCP credential store at ${path}`);
+  }
+}
+
+function recordPath(storePath: string, userID: string, targetKey: string): string {
+  assertStoreDirectory(storePath);
+  return join(storePath, credentialFileName(userID, targetKey));
+}
+
+function parseRecord(path: string): ProjectMcpCredentialRecord | null {
+  if (!entryExists(path)) return null;
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`Invalid project MCP credential record at ${path}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    throw new Error(`Invalid project MCP credential record at ${path}`);
+  }
+  if (
+    !isRecord(parsed) ||
+    !exactKeys(parsed, ["schema_version", "user_id", "target_key", "credential"]) ||
+    parsed.schema_version !== STORE_VERSION ||
+    typeof parsed.user_id !== "string" ||
+    !parsed.user_id ||
+    typeof parsed.target_key !== "string" ||
+    !parsed.target_key ||
+    !isRecord(parsed.credential) ||
+    !exactKeys(parsed.credential, ["endpoint", "api_key"]) ||
+    typeof parsed.credential.endpoint !== "string" ||
+    !parsed.credential.endpoint ||
+    typeof parsed.credential.api_key !== "string" ||
+    !parsed.credential.api_key
+  ) {
+    throw new Error(`Invalid project MCP credential record at ${path}`);
+  }
+  return {
+    schema_version: STORE_VERSION,
+    user_id: parsed.user_id,
+    target_key: parsed.target_key,
+    credential: {
+      endpoint: parsed.credential.endpoint,
+      api_key: parsed.credential.api_key,
+    },
+  };
+}
+
+function assertOwnedCrashTemporary(
+  path: string,
+  expectedRecordName: string,
+  deps: ProjectMcpCredentialCleanupDependencies,
+): ProjectMcpCredentialRecord {
+  const stat = lstatSync(path);
+  const platform = deps.platform ?? process.platform;
+  const permissions = stat.mode & 0o777;
+  // libuv exposes Windows files as 0666 even when Node created them with
+  // mode 0600. Windows therefore relies on the private, non-symlink store plus
+  // the exact random filename, record hash, schema, and identity checks below.
+  const hasExpectedPermissions =
+    platform === "win32" ? permissions === 0o600 || permissions === 0o666 : permissions === 0o600;
+  const getuid =
+    deps.getuid ??
+    (typeof process.getuid === "function" ? process.getuid.bind(process) : undefined);
+  const hasExpectedOwner = platform === "win32" || (getuid !== undefined && stat.uid === getuid());
+  if (!stat.isFile() || stat.isSymbolicLink() || !hasExpectedPermissions || !hasExpectedOwner) {
+    throw new Error(`Invalid project MCP credential temporary at ${path}`);
+  }
+  const parsed = parseRecord(path);
+  if (!parsed || expectedRecordName !== credentialFileName(parsed.user_id, parsed.target_key)) {
+    throw new Error(`Invalid project MCP credential temporary at ${path}`);
+  }
+  return parsed;
+}
+
+export function saveProjectMcpCredential(input: {
+  userID: string;
+  targetKey: string;
+  credential: StoredProjectMcpCredential;
+  path?: string;
+}): void {
+  if (!input.userID || !input.targetKey)
+    throw new Error("Project MCP credential identity is required");
+  const storePath = input.path ?? getProjectMcpCredentialStorePath();
+  assertStoreDirectory(storePath);
+  if (!entryExists(storePath)) mkdirSync(storePath, { recursive: true, mode: 0o700 });
+  chmodSync(storePath, 0o700);
+  const path = recordPath(storePath, input.userID, input.targetKey);
+  const existing = parseRecord(path);
+  if (existing && (existing.user_id !== input.userID || existing.target_key !== input.targetKey)) {
+    throw new Error("Project MCP credential record identity mismatch");
+  }
+  const temporary = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  const record: ProjectMcpCredentialRecord = {
+    schema_version: STORE_VERSION,
+    user_id: input.userID,
+    target_key: input.targetKey,
+    credential: input.credential,
+  };
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(
+      temporary,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+    writeFileSync(descriptor, `${JSON.stringify(record, null, 2)}\n`);
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(temporary, path);
+    chmodSync(path, 0o600);
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        // Continue to remove the exact random temporary created with O_EXCL.
+      }
+    }
+    if (entryExists(temporary)) unlinkSync(temporary);
+  }
+}
+
+export function readProjectMcpCredential(input: {
+  userID: string;
+  targetKey: string;
+  path?: string;
+}): StoredProjectMcpCredential | undefined {
+  const storePath = input.path ?? getProjectMcpCredentialStorePath();
+  const record = parseRecord(recordPath(storePath, input.userID, input.targetKey));
+  if (!record) return undefined;
+  if (record.user_id !== input.userID || record.target_key !== input.targetKey) {
+    throw new Error("Project MCP credential record identity mismatch");
+  }
+  return record.credential;
+}
+
+export function clearProjectMcpCredentials(
+  path: string = getProjectMcpCredentialStorePath(),
+  deps: ProjectMcpCredentialCleanupDependencies = {},
+): void {
+  if (!entryExists(path)) return;
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Invalid project MCP credential store at ${path}`);
+  }
+
+  // Plan the whole cleanup before deleting anything. A dedicated directory is
+  // not sufficient ownership proof: preserve it byte-for-byte if it contains
+  // a foreign file, malformed record, symlink, or nested directory.
+  const ownedRecords = readdirSync(path, { withFileTypes: true }).map((entry) => {
+    const record = join(path, entry.name);
+    if (!entry.isFile()) {
+      throw new Error(`Unrecognized file in project MCP credential store: ${record}`);
+    }
+    if (/^[a-f0-9]{64}\.json$/.test(entry.name)) {
+      const parsed = parseRecord(record);
+      if (!parsed || entry.name !== credentialFileName(parsed.user_id, parsed.target_key)) {
+        throw new Error(`Invalid project MCP credential record at ${record}`);
+      }
+      return record;
+    }
+    const temporary = entry.name.match(
+      /^([a-f0-9]{64}\.json)\.([1-9][0-9]*)\.([a-f0-9]{12})\.tmp$/,
+    );
+    if (!temporary) {
+      throw new Error(`Unrecognized file in project MCP credential store: ${record}`);
+    }
+    assertOwnedCrashTemporary(record, temporary[1], deps);
+    return record;
+  });
+
+  for (const record of ownedRecords) unlinkSync(record);
+  rmdirSync(path);
+}

--- a/src/mcp/project-proxy-preflight.test.ts
+++ b/src/mcp/project-proxy-preflight.test.ts
@@ -1,0 +1,911 @@
+import { spawn as spawnProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliSignalCleanup } from "../cli/signal-policy";
+import { makeTestConfig } from "../config/config.test-utils";
+import { preflightProjectProxy } from "./project-proxy-preflight";
+
+const realProcessKill = process.kill.bind(process);
+
+function config() {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: 1,
+    deployment_id: "dep-a",
+    api_key: "never-in-argv",
+  });
+}
+
+function fakeChild(onWrite?: (value: string, stdout: EventEmitter) => void) {
+  const child = new EventEmitter() as EventEmitter & {
+    pid?: number;
+    stdin: { write(value: string): boolean };
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 2_147_483_647;
+  child.stdin = {
+    write(value: string) {
+      onWrite?.(value, child.stdout);
+      return true;
+    },
+  };
+  child.kill = vi.fn(() => {
+    queueMicrotask(() => child.emit("close"));
+    return true;
+  });
+  return child;
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return predicate();
+}
+
+function processExists(pid: number): boolean {
+  try {
+    realProcessKill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return !(
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ESRCH"
+    );
+  }
+}
+
+function readPositivePID(path: string): number | undefined {
+  try {
+    const content = readFileSync(path, "utf8").trim();
+    if (!/^[1-9][0-9]*$/.test(content)) return;
+    const pid = Number.parseInt(content, 10);
+    return Number.isSafeInteger(pid) ? pid : undefined;
+  } catch {
+    return;
+  }
+}
+
+describe("project proxy preflight", () => {
+  beforeEach(() => {
+    vi.spyOn(process, "kill").mockImplementation((pid) => {
+      if (pid === -2_147_483_647) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      return true;
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("runs the exact project command and requires an MCP initialize response", async () => {
+    const child = fakeChild((value, stdout) => {
+      const message = JSON.parse(value);
+      if (message.method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: {
+                protocolVersion: "2025-03-26",
+                capabilities: {},
+                serverInfo: { name: "dosu", version: "1" },
+              },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    const spawn = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: { cwd: string; shell: boolean; detached: boolean },
+      ) => child as never,
+    );
+
+    await expect(
+      preflightProjectProxy(config(), "/repo", { spawn, timeoutMs: 100 }),
+    ).resolves.toEqual({ ok: true, reason: "initialize_ok" });
+
+    const [command, args, options] = spawn.mock.calls[0];
+    expect(command).toBe("npx");
+    expect(args).toEqual(expect.arrayContaining(["-y", "mcp", "proxy", "--deployment", "dep-a"]));
+    expect(JSON.stringify(args)).not.toContain("never-in-argv");
+    expect(options.cwd).toBe("/repo");
+    expect(options.shell).toBe(false);
+    expect(options.detached).toBe(true);
+    expect(process.kill).toHaveBeenCalledWith(-2_147_483_647, "SIGTERM");
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("launches the checked-in npx command through a shell on Windows", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: {
+                protocolVersion: "2025-03-26",
+                serverInfo: { name: "dosu", version: "1" },
+              },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    const spawn = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: { cwd: string; shell: boolean; detached: boolean },
+      ) => child as never,
+    );
+    child.pid = 4321;
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+    const spawnTreeKiller = vi.fn(() => {
+      queueMicrotask(() => treeKiller.emit("close", 0));
+      return treeKiller;
+    });
+
+    await expect(
+      preflightProjectProxy(config(), "C:\\repo", {
+        spawn,
+        platform: "win32",
+        timeoutMs: 100,
+        spawnTreeKiller: spawnTreeKiller as never,
+      }),
+    ).resolves.toEqual({ ok: true, reason: "initialize_ok" });
+
+    expect(spawn.mock.calls[0][0]).toBe("npx");
+    expect(spawn.mock.calls[0][2]).toMatchObject({
+      cwd: "C:\\repo",
+      shell: true,
+      detached: false,
+    });
+    expect(spawnTreeKiller).toHaveBeenCalledWith("taskkill", ["/PID", "4321", "/T", "/F"], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("resolves by a hard deadline when neither taskkill nor the proxy closes on Windows", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = 9876;
+    child.kill.mockImplementation(() => true);
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+    const spawnTreeKiller = vi.fn(() => treeKiller);
+
+    await expect(
+      preflightProjectProxy(config(), "C:\\repo", {
+        spawn: (() => child) as never,
+        platform: "win32",
+        timeoutMs: 100,
+        shutdownDeadlineMs: 1,
+        spawnTreeKiller: spawnTreeKiller as never,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+
+    expect(spawnTreeKiller).toHaveBeenCalledTimes(1);
+    expect(treeKiller.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("fails closed when the exact proxy cannot initialize before the timeout", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 1,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "timeout" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("waits for a delayed child close before resolving", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+    child.kill.mockImplementation(() => {
+      setTimeout(() => child.emit("close"), 5);
+      return true;
+    });
+    let resolved = false;
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1,
+      killGraceMs: 50,
+    }).then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    expect(resolved).toBe(false);
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "timeout" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("escalates to SIGKILL and reaps a child that ignores SIGTERM", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+    child.kill.mockImplementation((signal: NodeJS.Signals) => {
+      if (signal === "SIGKILL") queueMicrotask(() => child.emit("close"));
+      return true;
+    });
+
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 1,
+        killGraceMs: 1,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "timeout" });
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("reports a synchronous spawn failure without attempting protocol I/O", async () => {
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => {
+          throw new Error("npx unavailable");
+        }) as never,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "spawn_failed" });
+  });
+
+  it("distinguishes child startup errors and early exits", async () => {
+    const failed = fakeChild();
+    const failedResult = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => failed) as never,
+      timeoutMs: 100,
+    });
+    queueMicrotask(() => failed.emit("error", new Error("spawn failed")));
+    await expect(failedResult).resolves.toEqual({ ok: false, reason: "spawn_failed" });
+
+    const exited = fakeChild();
+    const exitedResult = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => exited) as never,
+      timeoutMs: 100,
+    });
+    queueMicrotask(() => exited.emit("close", 1));
+    await expect(exitedResult).resolves.toEqual({ ok: false, reason: "process_exited" });
+  });
+
+  it("terminates and confirms a surviving POSIX group after the leader closes", async () => {
+    const child = fakeChild();
+    child.pid = 4242;
+    let groupPresent = true;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGKILL") groupPresent = false;
+      if (signal === 0 && !groupPresent) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 1,
+      shutdownDeadlineMs: 20,
+      killProcessGroup,
+    });
+
+    child.emit("close", 1);
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "process_exited" });
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, "SIGKILL");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, 0);
+  });
+
+  it("terminates and confirms the POSIX group after a child error", async () => {
+    const child = fakeChild();
+    child.pid = 4243;
+    let groupPresent = true;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") groupPresent = false;
+      if (signal === 0 && !groupPresent) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 20,
+      killProcessGroup,
+    });
+
+    child.emit("error", new Error("leader failed"));
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "spawn_failed" });
+    expect(killProcessGroup).toHaveBeenCalledWith(-4243, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4243, 0);
+  });
+
+  it("uses taskkill to confirm the Windows tree after the shell closes", async () => {
+    const child = fakeChild();
+    child.pid = 4321;
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+    const spawnTreeKiller = vi.fn(() => {
+      queueMicrotask(() => treeKiller.emit("close", 0));
+      return treeKiller;
+    });
+    const preflight = preflightProjectProxy(config(), "C:\\repo", {
+      spawn: (() => child) as never,
+      platform: "win32",
+      timeoutMs: 1_000,
+      spawnTreeKiller: spawnTreeKiller as never,
+    });
+
+    child.emit("close", 1);
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "process_exited" });
+    expect(spawnTreeKiller).toHaveBeenCalledWith("taskkill", ["/PID", "4321", "/T", "/F"], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  });
+
+  it("fails closed when a surviving group cannot be confirmed gone after leader close", async () => {
+    const child = fakeChild();
+    child.pid = 2468;
+    const killProcessGroup = vi.fn(() => {});
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 1,
+      shutdownDeadlineMs: 1,
+      killProcessGroup,
+    });
+
+    child.emit("close", 1);
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+  });
+
+  it("rejects explicit initialize errors and malformed protocol replies", async () => {
+    const cases: Array<[string, unknown]> = [
+      ["initialize_rejected", { jsonrpc: "2.0", id: 1, error: { code: -32_000 } }],
+      ["invalid_response", { jsonrpc: "2.0", id: 1, result: { protocolVersion: 7 } }],
+      [
+        "invalid_response",
+        { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-03-26", serverInfo: [] } },
+      ],
+    ];
+
+    for (const [reason, response] of cases) {
+      const child = fakeChild((value, stdout) => {
+        if (JSON.parse(value).method === "initialize") {
+          queueMicrotask(() => stdout.emit("data", `${JSON.stringify(response)}\n`));
+        }
+      });
+      await expect(
+        preflightProjectProxy(config(), "/repo", {
+          spawn: (() => child) as never,
+          timeoutMs: 100,
+        }),
+      ).resolves.toEqual({ ok: false, reason });
+    }
+  });
+
+  it("handles split lines, ignores unrelated messages, and accepts CRLF", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method !== "initialize") return;
+      queueMicrotask(() => {
+        stdout.emit("data", '{"jsonrpc":"2.0","id":99,"result":{}}\n');
+        stdout.emit("data", '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025');
+        stdout.emit("data", '-03-26","serverInfo":{"name":"dosu"}}}\r\n');
+      });
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: true, reason: "initialize_ok" });
+  });
+
+  it("rejects malformed JSON and caps untrusted protocol output", async () => {
+    const malformed = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() => stdout.emit("data", "not-json\n"));
+      }
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => malformed) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "invalid_response" });
+
+    const noisy = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() => stdout.emit("data", "x".repeat(1024 * 1024 + 1)));
+      }
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => noisy) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "invalid_response" });
+  });
+
+  it("fails closed when the initialize write throws", async () => {
+    const child = fakeChild();
+    child.stdin.write = () => {
+      throw new Error("broken pipe");
+    };
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "spawn_failed" });
+  });
+
+  it("still resolves after signaling races with an already exiting child", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = undefined;
+    child.kill.mockImplementation(() => {
+      setTimeout(() => child.emit("close"), 1);
+      throw new Error("already exited");
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+        killGraceMs: 20,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+  });
+
+  it("ignores blank and non-object messages and makes completion idempotent", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method !== "initialize") return;
+      queueMicrotask(() => {
+        stdout.emit("data", "\nnull\n");
+        stdout.emit(
+          "data",
+          `${JSON.stringify({
+            id: 1,
+            result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+          })}\n`,
+        );
+        stdout.emit("data", "not-json\n");
+      });
+    });
+    child.kill.mockImplementation(() => {
+      setTimeout(() => child.emit("close"), 2);
+      return true;
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: true, reason: "initialize_ok" });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("handles a child that closes synchronously while SIGTERM is sent", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = undefined;
+    child.kill.mockImplementation(() => {
+      child.emit("close");
+      return true;
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+        killGraceMs: 1,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    expect(child.kill).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not authorize cleanup when the direct child closes before its POSIX group is gone", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = 4242;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") queueMicrotask(() => child.emit("close"));
+      // Signal 0 continues to report a surviving descendant after SIGKILL.
+    });
+
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+        killProcessGroup,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, "SIGKILL");
+  });
+
+  it.each([
+    "SIGINT",
+    "SIGTERM",
+    "SIGHUP",
+  ] as const)("turns %s into an interrupted result and waits for the whole group after an early close", async (signal) => {
+    const child = fakeChild();
+    child.pid = 4242;
+    let groupPresent = true;
+    const killProcessGroup = vi.fn((_pid: number, sent: NodeJS.Signals | 0) => {
+      if (sent === "SIGTERM") queueMicrotask(() => child.emit("close"));
+      if (sent === "SIGKILL") groupPresent = false;
+      if (sent === 0 && !groupPresent) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+    let signalCleanup: CliSignalCleanup | undefined;
+    const unregister = vi.fn();
+    const registerSignalCleanup = vi.fn((cleanup) => {
+      signalCleanup = cleanup;
+      return unregister;
+    });
+
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 1,
+      shutdownDeadlineMs: 20,
+      killProcessGroup,
+      registerSignalCleanup,
+    });
+    expect(signalCleanup).toBeTypeOf("function");
+
+    const cleanup = signalCleanup?.(signal);
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "interrupted" });
+    await cleanup;
+
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, "SIGKILL");
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects guarded signal cleanup when tree shutdown cannot be confirmed", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+    let signalCleanup: CliSignalCleanup | undefined;
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 1,
+      registerSignalCleanup: (cleanup) => {
+        signalCleanup = cleanup;
+        return () => {};
+      },
+    });
+
+    const cleanup = Promise.resolve().then(() => signalCleanup?.("SIGINT"));
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+    await expect(cleanup).rejects.toThrow(/could not be confirmed/i);
+  });
+
+  it("does not authorize setup when a signal arrives during successful shutdown", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = 8765;
+    let groupPresent = true;
+    let signalCleanup: CliSignalCleanup | undefined;
+    let cleanup: Promise<void> | undefined;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") {
+        queueMicrotask(() => {
+          cleanup = Promise.resolve().then(() => signalCleanup?.("SIGINT"));
+          groupPresent = false;
+        });
+      }
+      if (signal === 0 && !groupPresent) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 20,
+      killProcessGroup,
+      registerSignalCleanup: (registered) => {
+        signalCleanup = registered;
+        return () => {};
+      },
+    });
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "interrupted" });
+    await cleanup;
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "reaps a real detached descendant when interrupted during preflight",
+    async () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "dosu-preflight-signal-"));
+      const descendantPIDPath = join(fixtureRoot, "descendant.pid");
+      const descendantTerminatedPath = join(fixtureRoot, "descendant-terminated");
+      const descendantScript = [
+        'const { writeFileSync } = require("node:fs");',
+        'process.on("SIGTERM", () => { writeFileSync(process.argv[2], "SIGTERM"); process.exit(0); });',
+        "writeFileSync(process.argv[1], String(process.pid));",
+        "setInterval(() => {}, 1_000);",
+      ].join("");
+      const leaderScript = [
+        'const { spawn } = require("node:child_process");',
+        'process.on("SIGTERM", () => {});',
+        `const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}, process.argv[1], process.argv[2]], { stdio: "ignore" });`,
+        'child.once("exit", () => process.exit(0));',
+        "process.stdin.resume();",
+        "setInterval(() => {}, 1_000);",
+      ].join("");
+      let leaderPID: number | undefined;
+      let descendantPID: number | undefined;
+      let signalCleanup: CliSignalCleanup | undefined;
+      let testFailure: unknown;
+
+      try {
+        const preflight = preflightProjectProxy(config(), fixtureRoot, {
+          spawn: ((
+            _command: string,
+            _args: string[],
+            options: {
+              cwd: string;
+              env: NodeJS.ProcessEnv;
+              stdio: ["pipe", "pipe", "pipe"];
+              shell: boolean;
+              detached: boolean;
+            },
+          ) => {
+            const child = spawnProcess(
+              process.execPath,
+              ["-e", leaderScript, descendantPIDPath, descendantTerminatedPath],
+              options,
+            );
+            leaderPID = child.pid;
+            return child as never;
+          }) as never,
+          timeoutMs: 10_000,
+          killGraceMs: 50,
+          shutdownDeadlineMs: 10_000,
+          killProcessGroup: realProcessKill,
+          registerSignalCleanup: (cleanup) => {
+            signalCleanup = cleanup;
+            return () => {
+              signalCleanup = undefined;
+            };
+          },
+        });
+
+        expect(await waitUntil(() => readPositivePID(descendantPIDPath) !== undefined, 2_000)).toBe(
+          true,
+        );
+        descendantPID = readPositivePID(descendantPIDPath);
+        if (descendantPID === undefined) throw new Error("descendant PID was not published");
+        expect(processExists(descendantPID)).toBe(true);
+        expect(signalCleanup).toBeTypeOf("function");
+
+        const cleanup = signalCleanup?.("SIGTERM");
+        await expect(preflight).resolves.toEqual({ ok: false, reason: "interrupted" });
+        await cleanup;
+        expect(await waitUntil(() => existsSync(descendantTerminatedPath), 2_000)).toBe(true);
+        expect(processExists(-(leaderPID as number))).toBe(false);
+      } catch (error: unknown) {
+        testFailure = error;
+      }
+
+      if (leaderPID) {
+        try {
+          realProcessKill(-leaderPID, "SIGKILL");
+        } catch {
+          // The guarded shutdown normally removes the complete group.
+        }
+      }
+      rmSync(fixtureRoot, { recursive: true, force: true });
+      if (testFailure) throw testFailure;
+    },
+    30_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "reaps a real surviving descendant after its detached leader exits early",
+    async () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "dosu-preflight-early-exit-"));
+      const descendantPIDPath = join(fixtureRoot, "descendant.pid");
+      const descendantTerminatedPath = join(fixtureRoot, "descendant-terminated");
+      const descendantScript = [
+        'const { writeFileSync } = require("node:fs");',
+        'process.on("SIGTERM", () => { writeFileSync(process.argv[2], "SIGTERM"); process.exit(0); });',
+        "writeFileSync(process.argv[1], String(process.pid));",
+        "setInterval(() => {}, 1_000);",
+      ].join("");
+      const leaderScript = [
+        'const { spawn } = require("node:child_process");',
+        `spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}, process.argv[1], process.argv[2]], { stdio: "ignore" });`,
+        "setTimeout(() => process.exit(7), 100);",
+      ].join("");
+      let leaderPID: number | undefined;
+      let descendantPID: number | undefined;
+      let testFailure: unknown;
+
+      try {
+        const preflight = preflightProjectProxy(config(), fixtureRoot, {
+          spawn: ((
+            _command: string,
+            _args: string[],
+            options: {
+              cwd: string;
+              env: NodeJS.ProcessEnv;
+              stdio: ["pipe", "pipe", "pipe"];
+              shell: boolean;
+              detached: boolean;
+            },
+          ) => {
+            const child = spawnProcess(
+              process.execPath,
+              ["-e", leaderScript, descendantPIDPath, descendantTerminatedPath],
+              options,
+            );
+            leaderPID = child.pid;
+            return child as never;
+          }) as never,
+          timeoutMs: 2_000,
+          killGraceMs: 250,
+          shutdownDeadlineMs: 10_000,
+          killProcessGroup: realProcessKill,
+        });
+
+        expect(await waitUntil(() => readPositivePID(descendantPIDPath) !== undefined, 2_000)).toBe(
+          true,
+        );
+        descendantPID = readPositivePID(descendantPIDPath);
+        if (descendantPID === undefined) throw new Error("descendant PID was not published");
+        expect(processExists(descendantPID)).toBe(true);
+        await expect(preflight).resolves.toEqual({ ok: false, reason: "process_exited" });
+        expect(await waitUntil(() => existsSync(descendantTerminatedPath), 2_000)).toBe(true);
+        // An orphaned, already-dead descendant can remain visible as a zombie
+        // until the host's PID 1 reaps it. The process-group probe is the
+        // production contract: ESRCH proves no member remains signalable.
+        expect(processExists(-(leaderPID as number))).toBe(false);
+      } catch (error: unknown) {
+        testFailure = error;
+      }
+
+      if (leaderPID) {
+        try {
+          realProcessKill(-leaderPID, "SIGKILL");
+        } catch {
+          // The guarded shutdown normally removes the complete group.
+        }
+      }
+      rmSync(fixtureRoot, { recursive: true, force: true });
+      if (testFailure) throw testFailure;
+    },
+    30_000,
+  );
+
+  it("resolves a protocol result received after an early close without double-settling", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method !== "initialize") return;
+      child.emit("close");
+      stdout.emit(
+        "data",
+        `${JSON.stringify({
+          id: 1,
+          result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+        })}\n`,
+      );
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "process_exited" });
+  });
+
+  it("survives a SIGKILL race after an ignored SIGTERM", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+    child.kill.mockImplementation((signal: NodeJS.Signals) => {
+      if (signal === "SIGKILL") {
+        setTimeout(() => child.emit("close"), 1);
+        throw new Error("already exited");
+      }
+      return true;
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 1,
+        killGraceMs: 1,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "timeout" });
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+});

--- a/src/mcp/project-proxy-preflight.ts
+++ b/src/mcp/project-proxy-preflight.ts
@@ -1,0 +1,245 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { type CliSignalCleanup, registerCliSignalCleanup } from "../cli/signal-policy";
+import type { Config } from "../config/config";
+import { VERSION } from "../version/version";
+import {
+  type KillProcessGroup,
+  type SpawnTreeKiller,
+  terminatePosixProcessTree,
+  terminateWindowsProcessTree,
+} from "./process-tree";
+import { buildProjectProxyCommand } from "./project-proxy";
+
+export type ProjectProxyPreflightReason =
+  | "initialize_ok"
+  | "spawn_failed"
+  | "initialize_rejected"
+  | "invalid_response"
+  | "interrupted"
+  | "process_exited"
+  | "shutdown_unconfirmed"
+  | "timeout";
+
+export type ProjectProxyPreflightResult =
+  | { ok: true; reason: "initialize_ok" }
+  | { ok: false; reason: Exclude<ProjectProxyPreflightReason, "initialize_ok"> };
+
+interface PreflightInput {
+  write(value: string): boolean;
+}
+
+interface PreflightOutput {
+  on(event: "data", listener: (chunk: Uint8Array | string) => void): PreflightOutput;
+}
+
+interface PreflightChild {
+  pid?: number;
+  stdin: PreflightInput;
+  stdout: PreflightOutput;
+  stderr: PreflightOutput;
+  once(event: "error", listener: () => void): PreflightChild;
+  once(event: "close", listener: () => void): PreflightChild;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+type SpawnPreflight = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    stdio: ["pipe", "pipe", "pipe"];
+    shell: boolean;
+    detached: boolean;
+  },
+) => PreflightChild;
+
+export interface ProjectProxyPreflightDependencies {
+  spawn?: SpawnPreflight;
+  timeoutMs?: number;
+  killGraceMs?: number;
+  shutdownDeadlineMs?: number;
+  platform?: NodeJS.Platform;
+  spawnTreeKiller?: SpawnTreeKiller;
+  killProcessGroup?: KillProcessGroup;
+  registerSignalCleanup?: (cleanup: CliSignalCleanup) => () => void;
+}
+
+const INITIALIZE_ID = 1;
+const MAX_PROTOCOL_OUTPUT = 1024 * 1024;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Start the exact checked-in stdio command and complete an MCP initialize round-trip.
+ * Legacy globals are preserved unless this succeeds.
+ */
+export async function preflightProjectProxy(
+  cfg: Config,
+  projectRoot: string,
+  deps: ProjectProxyPreflightDependencies = {},
+): Promise<ProjectProxyPreflightResult> {
+  const command = buildProjectProxyCommand(cfg);
+  const platform = deps.platform ?? process.platform;
+  let child: PreflightChild;
+  try {
+    child = (deps.spawn ?? (nodeSpawn as unknown as SpawnPreflight))(
+      command.command,
+      command.args,
+      {
+        cwd: projectRoot,
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"],
+        // The exact project command is `npx`; on Windows it resolves to
+        // npx.cmd, which Node can execute only through a shell.
+        shell: platform === "win32",
+        // npm exec launches the requested binary through a child shell even
+        // on POSIX. A dedicated group lets shutdown reach every descendant.
+        detached: platform !== "win32",
+      },
+    );
+  } catch {
+    return { ok: false, reason: "spawn_failed" };
+  }
+
+  return await new Promise<ProjectProxyPreflightResult>((resolve) => {
+    let finalResult: ProjectProxyPreflightResult | undefined;
+    let shutdownStarted = false;
+    let shutdownMustBeConfirmed = false;
+    let interrupted = false;
+    let shutdownComplete: Promise<void> | undefined;
+    let shutdownStatus: "terminated" | "unconfirmed" | undefined;
+    let unregisterSignalCleanup = () => {};
+    let stdout = "";
+    // Codex currently allows roughly ten seconds for stdio startup. Passing a
+    // slower check would authorize cleanup for a project entry Codex still times out on.
+    const timeout = setTimeout(
+      () => finish({ ok: false, reason: "timeout" }),
+      deps.timeoutMs ?? 8_000,
+    );
+
+    function resolveClosed(result: ProjectProxyPreflightResult): void {
+      clearTimeout(timeout);
+      unregisterSignalCleanup();
+      resolve(result);
+    }
+
+    function resolveAfterShutdown(
+      result: ProjectProxyPreflightResult,
+      status: "terminated" | "unconfirmed",
+    ): void {
+      const effectiveResult: ProjectProxyPreflightResult = interrupted
+        ? { ok: false, reason: "interrupted" }
+        : result;
+      resolveClosed(
+        status !== "terminated" &&
+          (shutdownMustBeConfirmed ||
+            effectiveResult.ok ||
+            effectiveResult.reason === "interrupted")
+          ? { ok: false, reason: "shutdown_unconfirmed" }
+          : effectiveResult,
+      );
+    }
+
+    function finish(result: ProjectProxyPreflightResult, requireConfirmedShutdown = false): void {
+      if (requireConfirmedShutdown) shutdownMustBeConfirmed = true;
+      if (finalResult) return;
+      finalResult = result;
+      clearTimeout(timeout);
+      shutdownStarted = true;
+      if (platform === "win32") {
+        shutdownComplete = terminateWindowsProcessTree(child, {
+          spawnTreeKiller: deps.spawnTreeKiller,
+          shutdownDeadlineMs: deps.shutdownDeadlineMs,
+        }).then((status) => {
+          shutdownStatus = status;
+          resolveAfterShutdown(result, status);
+        });
+        return;
+      }
+      shutdownComplete = terminatePosixProcessTree(child, {
+        killProcessGroup: deps.killProcessGroup,
+        killGraceMs: deps.killGraceMs,
+        shutdownDeadlineMs: deps.shutdownDeadlineMs,
+      }).then((status) => {
+        shutdownStatus = status;
+        resolveAfterShutdown(result, status);
+      });
+    }
+
+    unregisterSignalCleanup = (deps.registerSignalCleanup ?? registerCliSignalCleanup)(async () => {
+      interrupted = true;
+      finish({ ok: false, reason: "interrupted" }, true);
+      await shutdownComplete;
+      if (shutdownStatus !== "terminated") {
+        throw new Error("Project MCP preflight shutdown could not be confirmed");
+      }
+    });
+
+    child.once("error", () => {
+      if (shutdownStarted) return;
+      finish({ ok: false, reason: "spawn_failed" }, true);
+    });
+    child.once("close", () => {
+      if (shutdownStarted) return;
+      finish({ ok: false, reason: "process_exited" }, true);
+    });
+    child.stderr.on("data", () => {
+      // Drain diagnostics so a noisy package runner cannot block. Never echo it:
+      // nested process errors can contain private paths or endpoint details.
+    });
+    child.stdout.on("data", (chunk) => {
+      stdout += Buffer.from(chunk).toString("utf8");
+      if (stdout.length > MAX_PROTOCOL_OUTPUT) {
+        finish({ ok: false, reason: "invalid_response" });
+        return;
+      }
+      const lines = stdout.split(/\r?\n/);
+      stdout = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let message: unknown;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          finish({ ok: false, reason: "invalid_response" });
+          return;
+        }
+        if (!isRecord(message) || message.id !== INITIALIZE_ID) continue;
+        if (isRecord(message.error)) {
+          finish({ ok: false, reason: "initialize_rejected" });
+          return;
+        }
+        const result = isRecord(message.result) ? message.result : undefined;
+        if (!result || typeof result.protocolVersion !== "string" || !isRecord(result.serverInfo)) {
+          finish({ ok: false, reason: "invalid_response" });
+          return;
+        }
+        child.stdin.write(
+          `${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`,
+        );
+        finish({ ok: true, reason: "initialize_ok" });
+        return;
+      }
+    });
+
+    try {
+      child.stdin.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: INITIALIZE_ID,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "dosu-cli-project-preflight", version: VERSION },
+          },
+        })}\n`,
+      );
+    } catch {
+      finish({ ok: false, reason: "spawn_failed" });
+    }
+  });
+}

--- a/src/mcp/project-proxy.test.ts
+++ b/src/mcp/project-proxy.test.ts
@@ -1,0 +1,653 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../config/config";
+import { makeTestConfig } from "../config/config.test-utils";
+import {
+  buildProjectProxyCommand,
+  isDosuMcpEntry,
+  isDosuMcpEntryForProvider,
+  isProjectProxyEntry,
+  isProjectProxyEntryForProvider,
+  isSafeProjectDeploymentID,
+  ownedProjectProxyOptionsForProvider,
+  ownedProjectProxyOptionsFromEntry,
+  projectProxyOptionsFromEntry,
+  recordProjectProxyEndpoint,
+  resolveProjectProxyRuntime,
+  runProjectProxy,
+  sameProjectProxyTarget,
+} from "./project-proxy";
+
+const API_KEY = "dosu-secret-never-write-to-project";
+
+function cloudConfig(overrides: Record<string, unknown> = {}): Config {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 60_000,
+    deployment_id: "dep-123",
+    deployment_name: "Knowledge",
+    api_key: API_KEY,
+    mcp_endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+    ...overrides,
+  });
+}
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-project-proxy-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("buildProjectProxyCommand", () => {
+  it("writes only a non-secret deployment reference into project config", () => {
+    const command = buildProjectProxyCommand(cloudConfig());
+    const serialized = JSON.stringify(command);
+
+    expect(command.command).toBe("npx");
+    expect(command.args).toContain("mcp");
+    expect(command.args).toContain("proxy");
+    expect(command.args).toContain("dep-123");
+    expect(serialized).not.toContain(API_KEY);
+    expect(serialized).not.toContain("X-Dosu-API-Key");
+    expect(serialized).not.toContain("api.dosu.dev");
+  });
+
+  it("marks OSS project entries without inventing a deployment", () => {
+    const command = buildProjectProxyCommand(
+      cloudConfig({ mode: "oss", deployment_id: undefined }),
+    );
+
+    expect(command.args).toContain("--oss");
+    expect(command.args).not.toContain("--deployment");
+  });
+
+  it("rejects deployment IDs that could become Windows shell syntax", () => {
+    expect(() =>
+      buildProjectProxyCommand(cloudConfig({ deployment_id: "dep-a & calc.exe" })),
+    ).toThrow(/invalid project deployment ID/i);
+  });
+
+  it("accepts only bounded identifiers with no shell metacharacters", () => {
+    expect(isSafeProjectDeploymentID("dep-A_1.2:prod")).toBe(true);
+    expect(isSafeProjectDeploymentID("x".repeat(256))).toBe(true);
+    expect(isSafeProjectDeploymentID("x".repeat(257))).toBe(false);
+    expect(isSafeProjectDeploymentID("-starts-with-dash")).toBe(false);
+    expect(isSafeProjectDeploymentID(123)).toBe(false);
+  });
+});
+
+describe("project proxy ownership", () => {
+  it("recognizes only the exact checked-in command shape", () => {
+    const command = buildProjectProxyCommand(cloudConfig());
+
+    expect(isProjectProxyEntry(command)).toBe(true);
+    expect(projectProxyOptionsFromEntry(command)).toEqual({ deploymentID: "dep-123" });
+    expect(
+      isProjectProxyEntry({
+        type: "local",
+        command: [command.command, ...command.args],
+        enabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a lookalike command, extra args, and secret-bearing entries", () => {
+    const command = buildProjectProxyCommand(cloudConfig());
+
+    expect(isProjectProxyEntry({ command: "npx", args: ["dosu", "mcp", "proxy"] })).toBe(false);
+    expect(isProjectProxyEntry({ ...command, args: [...command.args, "--unexpected"] })).toBe(
+      false,
+    );
+    expect(
+      isProjectProxyEntry({
+        ...command,
+        headers: { "X-Dosu-API-Key": API_KEY },
+      }),
+    ).toBe(false);
+    expect(isDosuMcpEntry({ command: "wrapper", args: ["dosu", "mcp", "proxy", "--oss"] })).toBe(
+      false,
+    );
+    expect(
+      isDosuMcpEntry({
+        command: "npx",
+        args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", "dep-a & calc.exe"],
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes an exact proxy emitted by an older released CLI for safe replacement", () => {
+    expect(
+      isDosuMcpEntry({
+        command: "npx",
+        args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", "dep-old"],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not claim ownership of edited proxy or HTTP shapes with extra fields", () => {
+    const command = buildProjectProxyCommand(cloudConfig());
+    expect(isDosuMcpEntry({ ...command, userSetting: true })).toBe(false);
+    expect(
+      isDosuMcpEntry({
+        type: "http",
+        url: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+        headers: { "X-Dosu-API-Key": API_KEY },
+        userSetting: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat another provider's released shape as ownership", () => {
+    const standardDeployment = {
+      type: "http",
+      url: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+      headers: { "X-Dosu-API-Key": API_KEY },
+    };
+    expect(isDosuMcpEntryForProvider("cursor", standardDeployment)).toBe(false);
+    expect(isDosuMcpEntryForProvider("opencode", standardDeployment)).toBe(false);
+    expect(isDosuMcpEntryForProvider("copilot", standardDeployment)).toBe(false);
+
+    const ossStandard = { ...standardDeployment, url: "https://api.dosu.dev/v1/mcp" };
+    expect(isDosuMcpEntryForProvider("cursor", ossStandard)).toBe(true);
+    expect(isDosuMcpEntryForProvider("opencode", ossStandard)).toBe(true);
+    expect(isDosuMcpEntryForProvider("copilot", ossStandard)).toBe(false);
+  });
+
+  it("parses every exact provider-specific proxy shape and rejects cross-provider shapes", () => {
+    const args = ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", "dep-old"];
+    const entries: Record<string, unknown> = {
+      claude: { type: "stdio", command: "npx", args },
+      gemini: { command: "npx", args },
+      zed: { command: "npx", args, env: {} },
+      opencode: { type: "local", command: ["npx", ...args], enabled: true },
+    };
+
+    for (const [provider, entry] of Object.entries(entries)) {
+      expect(ownedProjectProxyOptionsForProvider(provider, entry)).toEqual({
+        deploymentID: "dep-old",
+      });
+    }
+    expect(ownedProjectProxyOptionsForProvider("zed", entries.gemini)).toBeNull();
+    expect(ownedProjectProxyOptionsForProvider("opencode", entries.claude)).toBeNull();
+    const current = buildProjectProxyCommand(cloudConfig());
+    expect(isProjectProxyEntryForProvider("claude", { type: "stdio", ...current })).toBe(true);
+    expect(isProjectProxyEntryForProvider("claude", null)).toBe(false);
+  });
+
+  it("rejects malformed command arrays, args, versions, and target tails", () => {
+    const cases: unknown[] = [
+      null,
+      [],
+      { command: ["npx", 7], type: "local", enabled: true },
+      { command: 7, args: [] },
+      { command: "npx", args: [7] },
+      { command: "npx", args: ["-y", "@dosu/cli@latest", "mcp", "proxy", "--oss"] },
+      { command: "npx", args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy"] },
+      {
+        command: "npx",
+        args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", "bad value"],
+      },
+      { command: "npx", args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--oss"], env: [] },
+    ];
+    for (const entry of cases) expect(ownedProjectProxyOptionsFromEntry(entry)).toBeNull();
+  });
+
+  it("recognizes each released HTTP provider shape but rejects unsafe URLs", () => {
+    const headers = { "X-Dosu-API-Key": API_KEY };
+    const deploymentURL = "https://api.dosu.dev/v1/mcp/deployments/dep-123";
+    const shapes: Array<[string, Record<string, unknown>]> = [
+      ["claude", { type: "http", url: deploymentURL, headers }],
+      ["cursor", { url: deploymentURL, headers }],
+      ["opencode", { type: "remote", enabled: true, url: deploymentURL, headers }],
+      ["zed", { source: "custom", type: "http", url: deploymentURL, headers }],
+      ["antigravity", { serverUrl: deploymentURL, headers }],
+      ["copilot", { type: "http", url: deploymentURL, tools: ["*"], headers }],
+    ];
+    for (const [provider, entry] of shapes) {
+      expect(isDosuMcpEntry(entry)).toBe(true);
+      expect(isDosuMcpEntryForProvider(provider, entry)).toBe(true);
+    }
+    for (const url of [
+      "file:///v1/mcp",
+      "not a URL",
+      `${deploymentURL}?leak=true`,
+      `${deploymentURL}#fragment`,
+      "https://api.dosu.dev/v1/mcp/deployments/a/b",
+    ]) {
+      expect(isDosuMcpEntry({ type: "http", url, headers })).toBe(false);
+    }
+    expect(
+      isDosuMcpEntry({ type: "streamableHttp", disabled: true, url: deploymentURL, headers }),
+    ).toBe(false);
+    expect(isDosuMcpEntryForProvider("unknown", shapes[0][1])).toBe(false);
+  });
+
+  it("never claims a same-shaped MCP server on a foreign origin", () => {
+    const headers = { "X-Dosu-API-Key": API_KEY };
+    const url = "https://foreign.example/v1/mcp/deployments/dep-123";
+    const shapes: Array<[string, Record<string, unknown>]> = [
+      ["claude", { type: "http", url, headers }],
+      ["cursor", { url, headers }],
+      ["vscode", { type: "http", url, headers }],
+      ["gemini", { type: "http", url, headers }],
+      ["zed", { source: "custom", type: "http", url, headers }],
+      ["copilot", { type: "http", url, tools: ["*"], headers }],
+      ["opencode", { type: "remote", enabled: true, url, headers }],
+      ["antigravity", { serverUrl: url, headers }],
+      ["mcporter", { type: "http", url, headers }],
+      ["factory", { type: "http", url, headers }],
+    ];
+
+    for (const [provider, entry] of shapes) {
+      expect(isDosuMcpEntry(entry)).toBe(false);
+      expect(isDosuMcpEntryForProvider(provider, entry)).toBe(false);
+    }
+  });
+
+  it("compares OSS and deployment targets without conflating them", () => {
+    expect(sameProjectProxyTarget({ oss: true }, { oss: true })).toBe(true);
+    expect(sameProjectProxyTarget({ oss: true }, { deploymentID: "dep-a" })).toBe(false);
+    expect(sameProjectProxyTarget({ deploymentID: "dep-a" }, { deploymentID: "dep-a" })).toBe(true);
+    expect(sameProjectProxyTarget({ deploymentID: "dep-a" }, { deploymentID: "dep-b" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("recordProjectProxyEndpoint", () => {
+  it("stores the trusted endpoint in private user config state", () => {
+    const cfg = cloudConfig({ mcp_endpoint: undefined });
+    const saveCredential = vi.fn();
+    recordProjectProxyEndpoint(cfg, { saveCredential });
+
+    expect(cfg.active_account?.target?.mcp_endpoint).toContain("/v1/mcp/deployments/dep-123");
+    expect(saveCredential).toHaveBeenCalledWith({
+      userID: "test-user-id",
+      targetKey: "deployment:dep-123",
+      credential: {
+        endpoint: expect.stringContaining("/v1/mcp/deployments/dep-123"),
+        api_key: API_KEY,
+      },
+    });
+  });
+
+  it("records an OSS endpoint and rejects incomplete cloud credentials", () => {
+    const saveCredential = vi.fn();
+    const oss = cloudConfig({ mode: "oss", deployment_id: undefined, mcp_endpoint: undefined });
+    recordProjectProxyEndpoint(oss, { saveCredential });
+    expect(saveCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetKey: "oss",
+        credential: expect.objectContaining({ endpoint: expect.stringMatching(/\/v1\/mcp$/) }),
+      }),
+    );
+
+    expect(() => recordProjectProxyEndpoint(cloudConfig({ deployment_id: undefined }))).toThrow(
+      /deployment ID/i,
+    );
+    expect(() => recordProjectProxyEndpoint(cloudConfig({ api_key: undefined }))).toThrow(
+      /API key/i,
+    );
+  });
+});
+
+describe("resolveProjectProxyRuntime", () => {
+  it("loads the endpoint and key only from the matching user-level target", () => {
+    expect(resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep-123" })).toEqual({
+      endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+      apiKey: API_KEY,
+    });
+  });
+
+  it("fails closed after the user switches to a different deployment", () => {
+    expect(() => resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep-other" })).toThrow(
+      /re-run.*setup/i,
+    );
+  });
+
+  it("keeps different projects usable after the active deployment changes", () => {
+    const cfg = cloudConfig({
+      deployment_id: "dep-456",
+      api_key: "key-for-dep-456",
+      mcp_endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-456",
+    });
+    const credentials = {
+      "deployment:dep-123": {
+        endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+        api_key: API_KEY,
+      },
+      "deployment:dep-456": {
+        endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-456",
+        api_key: "key-for-dep-456",
+      },
+    };
+    const readCredential = ({ targetKey }: { targetKey: string }) =>
+      credentials[targetKey as keyof typeof credentials];
+
+    expect(resolveProjectProxyRuntime(cfg, { deploymentID: "dep-123" }, readCredential)).toEqual({
+      endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+      apiKey: API_KEY,
+    });
+    expect(
+      resolveProjectProxyRuntime(cfg, { deploymentID: "dep-456" }, readCredential).apiKey,
+    ).toBe("key-for-dep-456");
+  });
+
+  it("refuses a stored endpoint that is not a Dosu MCP path", () => {
+    expect(() =>
+      resolveProjectProxyRuntime(cloudConfig({ mcp_endpoint: "https://evil.test/collect" }), {
+        deploymentID: "dep-123",
+      }),
+    ).toThrow(/invalid MCP endpoint/i);
+  });
+
+  it("fails closed when the user-level API key is missing", () => {
+    expect(() =>
+      resolveProjectProxyRuntime(cloudConfig({ api_key: undefined }), {
+        deploymentID: "dep-123",
+      }),
+    ).toThrow(/API key/i);
+  });
+
+  it("resolves OSS credentials and rejects missing or contradictory targets", () => {
+    const oss = cloudConfig({
+      mode: "oss",
+      deployment_id: undefined,
+      mcp_endpoint: "https://api.dosu.dev/v1/mcp",
+    });
+    expect(resolveProjectProxyRuntime(oss, { oss: true })).toEqual({
+      endpoint: "https://api.dosu.dev/v1/mcp",
+      apiKey: API_KEY,
+    });
+    expect(() => resolveProjectProxyRuntime(oss, {})).toThrow(/exactly one project MCP target/i);
+    expect(() => resolveProjectProxyRuntime(oss, { oss: true, deploymentID: "dep-a" })).toThrow(
+      /exactly one project MCP target/i,
+    );
+  });
+
+  it.each([
+    ["invalid URL", "not a URL"],
+    ["unsupported scheme", "file:///v1/mcp/deployments/dep-123"],
+    ["wrong path", "https://api.dosu.dev/v1/mcp/deployments/other"],
+    ["query", "https://api.dosu.dev/v1/mcp/deployments/dep-123?token=x"],
+    ["fragment", "https://api.dosu.dev/v1/mcp/deployments/dep-123#x"],
+    [
+      "Windows shell metacharacters in userinfo",
+      "https://user&whoami@api.dosu.dev/v1/mcp/deployments/dep-123",
+    ],
+    ["percent expansion syntax", "https://%25PATH%25@api.dosu.dev/v1/mcp/deployments/dep-123"],
+  ])("rejects a stored endpoint with %s", (_name, endpoint) => {
+    expect(() =>
+      resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep-123" }, () => ({
+        endpoint,
+        api_key: API_KEY,
+      })),
+    ).toThrow(/invalid MCP endpoint/i);
+  });
+
+  it("does not fall back to the active API key when a stored record omits its key", () => {
+    expect(() =>
+      resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep-123" }, () => ({
+        endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+        api_key: "",
+      })),
+    ).toThrow(/API key/i);
+  });
+});
+
+describe("runProjectProxy", () => {
+  it("passes the key through child env, never argv", async () => {
+    const spawn = vi.fn().mockReturnValue({
+      once(event: string, listener: (value: number) => void) {
+        if (event === "close") listener(0);
+        return this;
+      },
+    });
+
+    await expect(
+      runProjectProxy(
+        { deploymentID: "dep-123" },
+        {
+          loadConfig: () => cloudConfig(),
+          spawn: spawn as never,
+          readCredential: () => undefined,
+        },
+      ),
+    ).resolves.toBe(0);
+
+    const [_command, args, options] = spawn.mock.calls[0];
+    expect(JSON.stringify(args)).not.toContain(API_KEY);
+    expect(options.env.X_DOSU_API_KEY).toBe(API_KEY);
+    expect(options.stdio).toBe("inherit");
+    expect(options.shell).toBe(false);
+    expect(options.detached).toBe(true);
+  });
+
+  it("launches npx.cmd through a shell on Windows without putting the key in argv", async () => {
+    const spawn = vi.fn().mockReturnValue({
+      once(event: string, listener: (value: number) => void) {
+        if (event === "close") listener(0);
+        return this;
+      },
+    });
+
+    await expect(
+      runProjectProxy(
+        { deploymentID: "dep-123" },
+        {
+          loadConfig: () => cloudConfig(),
+          spawn: spawn as never,
+          readCredential: () => undefined,
+          platform: "win32",
+          findNpx: () => "C:\\Program Files\\nodejs\\npx.cmd",
+        },
+      ),
+    ).resolves.toBe(0);
+
+    const [command, args, options] = spawn.mock.calls[0];
+    expect(command).toBe("npx.cmd");
+    expect(options.shell).toBe(true);
+    expect(options.detached).toBe(false);
+    expect(options.env.PATH).toMatch(/^C:\\Program Files\\nodejs;/);
+    expect(JSON.stringify(args)).not.toContain(API_KEY);
+  });
+
+  it("forwards shutdown signals to the bridge and removes its listeners", async () => {
+    const signals = new EventEmitter();
+    const kill = vi.fn(() => true);
+    const spawn = vi.fn().mockReturnValue({
+      pid: 4321,
+      once(_event: string, _listener: (value: number | null) => void) {
+        return this;
+      },
+      kill,
+    });
+    let present = true;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") present = false;
+      if (signal === 0 && !present) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+
+    const result = runProjectProxy(
+      { deploymentID: "dep-123" },
+      {
+        loadConfig: () => cloudConfig(),
+        spawn: spawn as never,
+        signalSource: signals,
+        readCredential: () => undefined,
+        killProcessGroup,
+      },
+    );
+    signals.emit("SIGTERM");
+
+    await expect(result).resolves.toBe(0);
+    expect(killProcessGroup).toHaveBeenCalledWith(-4321, "SIGTERM");
+    expect(kill).not.toHaveBeenCalled();
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+    expect(signals.listenerCount("SIGHUP")).toBe(0);
+  });
+
+  it("does not let an early leader close hide a surviving POSIX descendant", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.pid = 9753;
+    child.kill = vi.fn(() => true);
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") queueMicrotask(() => child.emit("close", 0));
+      // Signal 0 continues to report a surviving descendant after SIGKILL.
+    });
+
+    const result = runProjectProxy(
+      { deploymentID: "dep-123" },
+      {
+        loadConfig: () => cloudConfig(),
+        spawn: (() => child) as never,
+        signalSource: signals,
+        readCredential: () => undefined,
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      },
+    );
+    signals.emit("SIGTERM");
+
+    await expect(result).resolves.toBe(1);
+    expect(killProcessGroup).toHaveBeenCalledWith(-9753, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-9753, "SIGKILL");
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(signals.eventNames()).toEqual([]);
+  });
+
+  it("terminates the full Windows proxy tree and settles even without a child close event", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.pid = 2468;
+    child.kill = vi.fn(() => true);
+    const spawn = vi.fn(() => child);
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+    const spawnTreeKiller = vi.fn(() => {
+      queueMicrotask(() => treeKiller.emit("close", 0));
+      return treeKiller;
+    });
+
+    const result = runProjectProxy(
+      { deploymentID: "dep-123" },
+      {
+        loadConfig: () => cloudConfig(),
+        spawn: spawn as never,
+        signalSource: signals,
+        readCredential: () => undefined,
+        platform: "win32",
+        findNpx: () => "C:\\Program Files\\nodejs\\npx.cmd",
+        spawnTreeKiller: spawnTreeKiller as never,
+      },
+    );
+    signals.emit("SIGTERM");
+
+    await expect(result).resolves.toBe(0);
+    expect(spawnTreeKiller).toHaveBeenCalledWith("taskkill", ["/PID", "2468", "/T", "/F"], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(signals.eventNames()).toEqual([]);
+  });
+
+  it("ignores an early Windows proxy close until taskkill reaches its hard deadline", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.pid = 1357;
+    child.kill = vi.fn(() => true);
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+
+    const result = runProjectProxy(
+      { deploymentID: "dep-123" },
+      {
+        loadConfig: () => cloudConfig(),
+        spawn: (() => child) as never,
+        signalSource: signals,
+        readCredential: () => undefined,
+        platform: "win32",
+        findNpx: () => "C:\\node\\npx.cmd",
+        spawnTreeKiller: (() => treeKiller) as never,
+        shutdownDeadlineMs: 1,
+      },
+    );
+    signals.emit("SIGHUP");
+    queueMicrotask(() => child.emit("close", 0));
+
+    await expect(result).resolves.toBe(1);
+    expect(treeKiller.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(signals.eventNames()).toEqual([]);
+  });
+
+  it("returns one for a signal-like null exit and removes listeners", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    child.kill = vi.fn(() => true);
+    const spawn = vi.fn(() => {
+      queueMicrotask(() => child.emit("close", null));
+      return child;
+    });
+    await expect(
+      runProjectProxy(
+        { deploymentID: "dep-123" },
+        {
+          loadConfig: () => cloudConfig(),
+          spawn: spawn as never,
+          signalSource: signals,
+          readCredential: () => undefined,
+        },
+      ),
+    ).resolves.toBe(1);
+    expect(signals.eventNames()).toEqual([]);
+  });
+
+  it("rejects bridge spawn errors and removes all signal listeners", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    child.kill = vi.fn(() => true);
+    const failure = new Error("bridge failed");
+    const spawn = vi.fn(() => {
+      queueMicrotask(() => child.emit("error", failure));
+      return child;
+    });
+    await expect(
+      runProjectProxy(
+        { deploymentID: "dep-123" },
+        {
+          loadConfig: () => cloudConfig(),
+          spawn: spawn as never,
+          signalSource: signals,
+          readCredential: () => undefined,
+        },
+      ),
+    ).rejects.toThrow("bridge failed");
+    expect(signals.eventNames()).toEqual([]);
+  });
+});

--- a/src/mcp/project-proxy.ts
+++ b/src/mcp/project-proxy.ts
@@ -1,0 +1,600 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { win32 } from "node:path";
+import type { Config } from "../config/config";
+import { getConfigUserID, loadConfig, MODE_OSS, updateTarget } from "../config/config";
+import { VERSION } from "../version/version";
+import { mcpBaseURL, mcpRemoteServer, mcpURL } from "./config-helpers";
+import { findNpx, npxPathEnv } from "./detect";
+import {
+  type KillProcessGroup,
+  type SpawnTreeKiller,
+  terminatePosixProcessTree,
+  terminateWindowsProcessTree,
+} from "./process-tree";
+import {
+  readProjectMcpCredential,
+  type StoredProjectMcpCredential,
+  saveProjectMcpCredential,
+} from "./project-credential-store";
+
+export interface ProjectProxyCommand {
+  command: string;
+  args: string[];
+}
+
+export interface ProjectProxyOptions {
+  deploymentID?: string;
+  oss?: boolean;
+}
+
+export interface ProjectProxyRuntime {
+  endpoint: string;
+  apiKey: string;
+}
+
+function credentialKey(opts: ProjectProxyOptions): string {
+  if (Boolean(opts.deploymentID) === Boolean(opts.oss)) {
+    throw new Error("Exactly one project MCP target is required. Re-run `dosu setup`.");
+  }
+  return opts.oss ? "oss" : `deployment:${requireSafeProjectDeploymentID(opts.deploymentID)}`;
+}
+
+interface SpawnedProcess {
+  pid?: number;
+  once(event: "error", listener: (error: Error) => void): SpawnedProcess;
+  once(event: "close", listener: (code: number | null) => void): SpawnedProcess;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+type ProxySignal = "SIGINT" | "SIGTERM" | "SIGHUP";
+
+interface SignalSource {
+  once(event: ProxySignal, listener: () => void): unknown;
+  removeListener(event: ProxySignal, listener: () => void): unknown;
+}
+
+type SpawnProxy = (
+  command: string,
+  args: string[],
+  options: { stdio: "inherit"; env: NodeJS.ProcessEnv; shell: boolean; detached: boolean },
+) => SpawnedProcess;
+
+export interface ProjectProxyDependencies {
+  loadConfig?: () => Config;
+  spawn?: SpawnProxy;
+  signalSource?: SignalSource;
+  platform?: NodeJS.Platform;
+  findNpx?: () => string;
+  spawnTreeKiller?: SpawnTreeKiller;
+  killProcessGroup?: KillProcessGroup;
+  killGraceMs?: number;
+  shutdownDeadlineMs?: number;
+  readCredential?: (input: {
+    userID: string;
+    targetKey: string;
+  }) => StoredProjectMcpCredential | undefined;
+}
+
+export interface ProjectProxyRecordDependencies {
+  saveCredential?: typeof saveProjectMcpCredential;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function containsProjectSecretField(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsProjectSecretField);
+  if (!isRecord(value)) return false;
+  return Object.entries(value).some(([key, child]) => {
+    const normalized = key.toLowerCase().replace(/_/g, "-");
+    return normalized === "x-dosu-api-key" || containsProjectSecretField(child);
+  });
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function hasExactProjectProxyShape(value: Record<string, unknown>): boolean {
+  if (Array.isArray(value.command)) {
+    return (
+      hasExactKeys(value, ["type", "command", "enabled"]) &&
+      value.type === "local" &&
+      value.enabled === true
+    );
+  }
+  if (hasExactKeys(value, ["command", "args"])) return true;
+  if (hasExactKeys(value, ["type", "command", "args"])) return value.type === "stdio";
+  if (hasExactKeys(value, ["command", "args", "env"])) {
+    return isRecord(value.env) && Object.keys(value.env).length === 0;
+  }
+  return false;
+}
+
+function projectProxyParts(value: Record<string, unknown>): string[] | null {
+  if (Array.isArray(value.command)) {
+    if (value.command.some((part) => typeof part !== "string")) return null;
+    return value.command as string[];
+  }
+  if (typeof value.command !== "string") return null;
+  if (!Array.isArray(value.args) || value.args.some((part) => typeof part !== "string")) {
+    return null;
+  }
+  return [value.command, ...(value.args as string[])];
+}
+
+function optionsFromParts(
+  parts: readonly string[],
+  packageSpec: string | RegExp,
+): ProjectProxyOptions | null {
+  const expectedPackage = parts[2];
+  const packageMatches =
+    typeof packageSpec === "string"
+      ? expectedPackage === packageSpec
+      : typeof expectedPackage === "string" && packageSpec.test(expectedPackage);
+  const prefixMatches =
+    parts[0] === "npx" &&
+    parts[1] === "-y" &&
+    packageMatches &&
+    parts[3] === "mcp" &&
+    parts[4] === "proxy";
+  if (!prefixMatches) return null;
+  const tail = parts.slice(5);
+  if (tail.length === 1 && tail[0] === "--oss") return { oss: true };
+  if (tail.length === 2 && tail[0] === "--deployment" && isSafeProjectDeploymentID(tail[1])) {
+    return { deploymentID: tail[1] };
+  }
+  return null;
+}
+
+// Project deployment IDs cross a shell boundary on Windows because Node cannot
+// execute npx.cmd directly. Keep the accepted syntax deliberately narrower
+// than cmd.exe's metacharacter set before an ID can enter a checked-in command.
+const SAFE_PROJECT_DEPLOYMENT_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+
+export function isSafeProjectDeploymentID(value: unknown): value is string {
+  return typeof value === "string" && SAFE_PROJECT_DEPLOYMENT_ID.test(value);
+}
+
+function requireSafeProjectDeploymentID(value: unknown): string {
+  if (!isSafeProjectDeploymentID(value)) {
+    throw new Error("Invalid project deployment ID. Re-run `dosu setup`.");
+  }
+  return value;
+}
+
+/** Parse only the exact, current, secretless command emitted into project files. */
+export function projectProxyOptionsFromEntry(value: unknown): ProjectProxyOptions | null {
+  if (!isRecord(value) || !hasExactProjectProxyShape(value) || containsProjectSecretField(value)) {
+    return null;
+  }
+  const parts = projectProxyParts(value);
+  if (!parts) return null;
+  return optionsFromParts(parts, `@dosu/cli@${VERSION}`);
+}
+
+/** Parse an exact secretless project proxy emitted by any released Dosu CLI version. */
+export function ownedProjectProxyOptionsFromEntry(value: unknown): ProjectProxyOptions | null {
+  if (!isRecord(value) || !hasExactProjectProxyShape(value) || containsProjectSecretField(value)) {
+    return null;
+  }
+  const parts = projectProxyParts(value);
+  if (!parts) return null;
+  return optionsFromParts(parts, /^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+}
+
+export function isProjectProxyEntry(value: unknown): boolean {
+  return projectProxyOptionsFromEntry(value) !== null;
+}
+
+function hasProviderProjectShape(providerID: string, value: Record<string, unknown>): boolean {
+  switch (providerID) {
+    case "gemini":
+    case "antigravity":
+    case "mcporter":
+    case "codex":
+      return hasExactKeys(value, ["command", "args"]);
+    case "zed":
+      return (
+        hasExactKeys(value, ["command", "args", "env"]) &&
+        isRecord(value.env) &&
+        Object.keys(value.env).length === 0
+      );
+    case "opencode":
+      return (
+        hasExactKeys(value, ["type", "command", "enabled"]) &&
+        value.type === "local" &&
+        value.enabled === true
+      );
+    default:
+      return hasExactKeys(value, ["type", "command", "args"]) && value.type === "stdio";
+  }
+}
+
+export function isProjectProxyEntryForProvider(providerID: string, value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasProviderProjectShape(providerID, value) &&
+    projectProxyOptionsFromEntry(value) !== null
+  );
+}
+
+export function ownedProjectProxyOptionsForProvider(
+  providerID: string,
+  value: unknown,
+): ProjectProxyOptions | null {
+  return isRecord(value) && hasProviderProjectShape(providerID, value)
+    ? ownedProjectProxyOptionsFromEntry(value)
+    : null;
+}
+
+export function sameProjectProxyTarget(
+  left: ProjectProxyOptions,
+  right: ProjectProxyOptions,
+): boolean {
+  return left.oss === true
+    ? right.oss === true
+    : right.oss !== true && left.deploymentID === right.deploymentID;
+}
+
+// Only released production URLs prove that a historical HTTP entry belongs to
+// Dosu. A matching path/header on localhost, staging, or a third-party origin
+// is user-owned and must never be removed automatically.
+const RELEASED_DOSU_MCP_ORIGIN = "https://api.dosu.dev";
+
+function hasDosuMcpPath(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.origin === RELEASED_DOSU_MCP_ORIGIN &&
+      !parsed.username &&
+      !parsed.password &&
+      !parsed.search &&
+      !parsed.hash &&
+      (/^\/v1\/mcp$/.test(parsed.pathname) ||
+        /^\/v1\/mcp\/deployments\/[^/]+$/.test(parsed.pathname))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasBaseDosuMcpPath(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.origin === RELEASED_DOSU_MCP_ORIGIN &&
+      !parsed.username &&
+      !parsed.password &&
+      !parsed.search &&
+      !parsed.hash &&
+      parsed.pathname === "/v1/mcp"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasExactDosuHeaders(value: Record<string, unknown>): boolean {
+  const headers = isRecord(value.headers) ? value.headers : undefined;
+  return Boolean(
+    headers &&
+      hasExactKeys(headers, ["X-Dosu-API-Key"]) &&
+      typeof headers["X-Dosu-API-Key"] === "string" &&
+      headers["X-Dosu-API-Key"].length > 0,
+  );
+}
+
+function isStandardHttpEntry(value: Record<string, unknown>, baseOnly = false): boolean {
+  return (
+    hasExactKeys(value, ["type", "url", "headers"]) &&
+    value.type === "http" &&
+    hasExactDosuHeaders(value) &&
+    (baseOnly ? hasBaseDosuMcpPath(value.url) : hasDosuMcpPath(value.url))
+  );
+}
+
+/** Recognize entries written by released Dosu CLIs or by this project proxy. */
+export function isDosuMcpEntry(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (isProjectProxyEntry(value)) return true;
+  const parts = projectProxyParts(value);
+  if (
+    hasExactProjectProxyShape(value) &&
+    !containsProjectSecretField(value) &&
+    parts &&
+    optionsFromParts(parts, /^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+  ) {
+    return true;
+  }
+
+  const headers = isRecord(value.headers) ? value.headers : undefined;
+  if (
+    !headers ||
+    !hasExactKeys(headers, ["X-Dosu-API-Key"]) ||
+    typeof headers["X-Dosu-API-Key"] !== "string" ||
+    headers["X-Dosu-API-Key"].length === 0
+  ) {
+    return false;
+  }
+  if (hasExactKeys(value, ["type", "url", "headers"])) {
+    return value.type === "http" && hasDosuMcpPath(value.url);
+  }
+  if (hasExactKeys(value, ["url", "headers"])) return hasDosuMcpPath(value.url);
+  if (hasExactKeys(value, ["type", "disabled", "url", "headers"])) {
+    return value.type === "streamableHttp" && value.disabled === false && hasDosuMcpPath(value.url);
+  }
+  if (hasExactKeys(value, ["type", "enabled", "url", "headers"])) {
+    return value.type === "remote" && value.enabled === true && hasDosuMcpPath(value.url);
+  }
+  if (hasExactKeys(value, ["source", "type", "url", "headers"])) {
+    return value.source === "custom" && value.type === "http" && hasDosuMcpPath(value.url);
+  }
+  if (hasExactKeys(value, ["serverUrl", "headers"])) return hasDosuMcpPath(value.serverUrl);
+  if (hasExactKeys(value, ["type", "url", "tools", "headers"])) {
+    return (
+      value.type === "http" &&
+      hasDosuMcpPath(value.url) &&
+      Array.isArray(value.tools) &&
+      value.tools.length === 1 &&
+      value.tools[0] === "*"
+    );
+  }
+  return false;
+}
+
+/** Provider-specific ownership used before replacing or removing a project entry. */
+export function isDosuMcpEntryForProvider(providerID: string, value: unknown): boolean {
+  if (!isRecord(value)) return false;
+
+  const parts = projectProxyParts(value);
+  if (
+    hasProviderProjectShape(providerID, value) &&
+    !containsProjectSecretField(value) &&
+    parts &&
+    optionsFromParts(parts, /^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+  ) {
+    return true;
+  }
+
+  switch (providerID) {
+    case "claude":
+    case "vscode":
+    case "gemini":
+    case "factory":
+    case "mcporter":
+      return isStandardHttpEntry(value);
+    case "cursor":
+      return (
+        (hasExactKeys(value, ["url", "headers"]) &&
+          hasExactDosuHeaders(value) &&
+          hasDosuMcpPath(value.url)) ||
+        isStandardHttpEntry(value, true)
+      );
+    case "opencode":
+      return (
+        (hasExactKeys(value, ["type", "enabled", "url", "headers"]) &&
+          value.type === "remote" &&
+          value.enabled === true &&
+          hasExactDosuHeaders(value) &&
+          hasDosuMcpPath(value.url)) ||
+        isStandardHttpEntry(value, true)
+      );
+    case "zed":
+      return (
+        (hasExactKeys(value, ["source", "type", "url", "headers"]) &&
+          value.source === "custom" &&
+          value.type === "http" &&
+          hasExactDosuHeaders(value) &&
+          hasDosuMcpPath(value.url)) ||
+        isStandardHttpEntry(value, true)
+      );
+    case "antigravity":
+      return (
+        (hasExactKeys(value, ["serverUrl", "headers"]) &&
+          hasExactDosuHeaders(value) &&
+          hasDosuMcpPath(value.serverUrl)) ||
+        isStandardHttpEntry(value, true)
+      );
+    case "copilot":
+      return (
+        hasExactKeys(value, ["type", "url", "tools", "headers"]) &&
+        value.type === "http" &&
+        hasExactDosuHeaders(value) &&
+        hasDosuMcpPath(value.url) &&
+        Array.isArray(value.tools) &&
+        value.tools.length === 1 &&
+        value.tools[0] === "*"
+      );
+    default:
+      return false;
+  }
+}
+
+/**
+ * Build the checked-in command. It contains a deployment identifier, but no endpoint or secret;
+ * both are resolved from the user's private Dosu config when the agent starts the MCP server.
+ */
+export function buildProjectProxyCommand(cfg: Config): ProjectProxyCommand {
+  // Fail during setup, before writing a config that cannot start.
+  findNpx();
+  const args = ["-y", `@dosu/cli@${VERSION}`, "mcp", "proxy"];
+  if (cfg.mode === MODE_OSS) {
+    args.push("--oss");
+  } else {
+    const deploymentID = requireSafeProjectDeploymentID(cfg.active_account?.target?.deployment_id);
+    args.push("--deployment", deploymentID);
+  }
+  return { command: "npx", args };
+}
+
+/** Persist the endpoint beside the API key in the private user config before project files refer to it. */
+export function recordProjectProxyEndpoint(
+  cfg: Config,
+  deps: ProjectProxyRecordDependencies = {},
+): void {
+  const deploymentID = cfg.active_account?.target?.deployment_id;
+  if (cfg.mode !== MODE_OSS && !deploymentID) throw new Error("deployment ID is required");
+  const apiKey = cfg.active_account?.target?.api_key;
+  if (!apiKey) throw new Error("API key is required");
+  const key = credentialKey(
+    cfg.mode === MODE_OSS ? { oss: true } : { deploymentID: deploymentID as string },
+  );
+  const endpoint = cfg.mode === MODE_OSS ? mcpBaseURL() : mcpURL(deploymentID as string);
+  updateTarget(cfg, {
+    mcp_endpoint: endpoint,
+  });
+  const userID = getConfigUserID(cfg);
+  if (!userID) throw new Error("authenticated account identity is required");
+  (deps.saveCredential ?? saveProjectMcpCredential)({
+    userID,
+    targetKey: key,
+    credential: { endpoint, api_key: apiKey },
+  });
+}
+
+function validateStoredEndpoint(endpoint: string, deploymentID?: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    throw new Error("Invalid MCP endpoint in Dosu user config. Re-run `dosu setup`.");
+  }
+
+  const expectedPath = deploymentID
+    ? `/v1/mcp/deployments/${encodeURIComponent(deploymentID)}`
+    : "/v1/mcp";
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("Invalid MCP endpoint in Dosu user config. Re-run `dosu setup`.");
+  }
+  if (
+    parsed.username ||
+    parsed.password ||
+    /[\s"&|<>()^%!]/.test(endpoint) ||
+    parsed.pathname !== expectedPath ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error("Invalid MCP endpoint in Dosu user config. Re-run `dosu setup`.");
+  }
+}
+
+/** Resolve secret runtime state without trusting any endpoint supplied by a project file. */
+export function resolveProjectProxyRuntime(
+  cfg: Config,
+  opts: ProjectProxyOptions,
+  readCredential: ProjectProxyDependencies["readCredential"] = readProjectMcpCredential,
+): ProjectProxyRuntime {
+  const key = credentialKey(opts);
+  const target = cfg.active_account?.target;
+  const userID = getConfigUserID(cfg);
+  const stored = userID ? readCredential?.({ userID, targetKey: key }) : undefined;
+  const canUseActiveTarget = opts.oss
+    ? cfg.mode === MODE_OSS
+    : Boolean(opts.deploymentID && target?.deployment_id === opts.deploymentID);
+  const endpoint = stored?.endpoint ?? (canUseActiveTarget ? target?.mcp_endpoint : undefined);
+  if (!endpoint) {
+    throw new Error(
+      "This project's Dosu credentials are missing. Re-run `dosu setup` in the project.",
+    );
+  }
+  validateStoredEndpoint(endpoint, opts.oss ? undefined : opts.deploymentID);
+
+  const apiKey = stored?.api_key ?? (canUseActiveTarget ? target?.api_key : undefined);
+  if (!apiKey) throw new Error("Dosu API key is missing. Re-run `dosu setup` in the project.");
+  return { endpoint, apiKey };
+}
+
+/** Run the pinned HTTP-to-stdio bridge used by project configuration entries. */
+export async function runProjectProxy(
+  opts: ProjectProxyOptions,
+  deps: ProjectProxyDependencies = {},
+): Promise<number> {
+  const runtime = resolveProjectProxyRuntime(
+    (deps.loadConfig ?? loadConfig)(),
+    opts,
+    deps.readCredential,
+  );
+  const npx = (deps.findNpx ?? findNpx)();
+  const platform = deps.platform ?? process.platform;
+  const remote = mcpRemoteServer(runtime.endpoint, runtime.apiKey);
+  // Node's shell mode concatenates the executable and arguments without
+  // quoting the executable. Use the basename on Windows and prepend the
+  // already-verified directory to PATH so `C:\\Program Files\\...` works.
+  const executable = platform === "win32" ? win32.basename(npx) : npx;
+  const child = (deps.spawn ?? (nodeSpawn as unknown as SpawnProxy))(executable, remote.args, {
+    stdio: "inherit",
+    // On Windows npm exposes npx as npx.cmd. Node documents that .cmd files
+    // cannot be launched directly; they must run through a shell.
+    shell: platform === "win32",
+    detached: platform !== "win32",
+    env: {
+      ...process.env,
+      PATH: npxPathEnv(npx),
+      ...remote.env,
+    },
+  });
+
+  return await new Promise<number>((resolve, reject) => {
+    const signalSource = deps.signalSource ?? (process as SignalSource);
+    const signals: readonly ProxySignal[] = ["SIGINT", "SIGTERM", "SIGHUP"];
+    const forwarders = new Map<ProxySignal, () => void>();
+    let settled = false;
+    let shuttingDown = false;
+    const cleanup = () => {
+      for (const [signal, listener] of forwarders) {
+        signalSource.removeListener(signal, listener);
+      }
+      forwarders.clear();
+    };
+    const settleResolve = (code: number) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(code);
+    };
+    const settleReject = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    for (const signal of signals) {
+      const forward = () => {
+        if (platform !== "win32") {
+          if (shuttingDown) return;
+          shuttingDown = true;
+          void terminatePosixProcessTree(child, {
+            killProcessGroup: deps.killProcessGroup,
+            killGraceMs: deps.killGraceMs,
+            shutdownDeadlineMs: deps.shutdownDeadlineMs,
+          }).then((status) => settleResolve(status === "terminated" ? 0 : 1));
+          return;
+        }
+        if (shuttingDown) return;
+        shuttingDown = true;
+        void terminateWindowsProcessTree(child, {
+          spawnTreeKiller: deps.spawnTreeKiller,
+          shutdownDeadlineMs: deps.shutdownDeadlineMs,
+        }).then((status) => settleResolve(status === "terminated" ? 0 : 1));
+      };
+      forwarders.set(signal, forward);
+      signalSource.once(signal, forward);
+    }
+
+    child.once("error", (error) => {
+      if (shuttingDown) return;
+      settleReject(error);
+    });
+    child.once("close", (code) => {
+      if (shuttingDown) return;
+      settleResolve(code ?? 1);
+    });
+  });
+}

--- a/src/mcp/providers.test.ts
+++ b/src/mcp/providers.test.ts
@@ -61,7 +61,7 @@ describe("provider registry", () => {
       { id: "cline-cli", name: "Cline CLI", local: false },
       { id: "copilot", name: "GitHub Copilot CLI", local: true },
       { id: "opencode", name: "OpenCode", local: true },
-      { id: "antigravity", name: "Antigravity", local: false },
+      { id: "antigravity", name: "Antigravity", local: true },
       { id: "mcporter", name: "MCPorter", local: true },
       { id: "manual", name: "Manual Configuration", local: false },
     ];

--- a/src/mcp/providers.ts
+++ b/src/mcp/providers.ts
@@ -3,20 +3,29 @@
  */
 
 import type { Config } from "../config/config";
+import type { ProjectFileMutationReceipt } from "./config-helpers";
 
 /**
  * Provider is the base interface for MCP tool providers.
  */
 export interface ProviderInstallOptions {
   showSecret?: boolean;
+  /** Canonical Git worktree root for project-scoped configuration. */
+  projectRoot?: string;
+  /** Explicit user authorization to replace an owned project entry with a different target. */
+  allowProjectRetarget?: boolean;
 }
 
 export interface Provider {
   name(): string;
   id(): string;
   supportsLocal(): boolean;
-  install(cfg: Config, global: boolean, opts?: ProviderInstallOptions): void;
-  remove(global: boolean): void;
+  install(
+    cfg: Config,
+    global: boolean,
+    opts?: ProviderInstallOptions,
+  ): ProjectFileMutationReceipt | undefined;
+  remove(global: boolean, opts?: ProviderInstallOptions): ProjectFileMutationReceipt | undefined;
 }
 
 /**
@@ -27,6 +36,8 @@ export interface SetupProvider extends Provider {
   isInstalled(): boolean;
   isConfigured(): boolean;
   globalConfigPath(): string;
+  projectConfigPath(projectRoot: string): string | null;
+  isProjectConfigured(projectRoot: string): boolean;
   priority(): number;
 }
 

--- a/src/mcp/providers/antigravity.ts
+++ b/src/mcp/providers/antigravity.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { mcpHeaders, mcpURL } from "../config-helpers";
 import { createJSONProvider } from "./base";
 
@@ -5,10 +6,11 @@ export const AntigravityProvider = () =>
   createJSONProvider({
     providerName: "Antigravity",
     providerID: "antigravity",
-    local: false,
+    local: true,
     priorityValue: 15,
     paths: ["~/.gemini"],
-    globalPath: "~/.gemini/antigravity/mcp_config.json",
+    globalPath: "~/.gemini/config/mcp_config.json",
+    configuredGlobalPaths: ["~/.gemini/antigravity/mcp_config.json"],
     topKey: "mcpServers",
     buildServer: (cfg) => ({
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
@@ -16,4 +18,6 @@ export const AntigravityProvider = () =>
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
+    buildProjectServer: (command) => ({ command: command.command, args: command.args }),
+    localConfigPath: (cwd) => join(cwd, ".agents", "mcp_config.json"),
   });

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -4,15 +4,24 @@
  */
 
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-path";
 import {
   installJSONServer,
-  isJSONKeyConfigured,
+  installProjectJSONServer,
+  isProjectJSONServerConfigured,
   mcpBaseURL,
   mcpHeaders,
   mcpURL,
   removeJSONServer,
+  removeProjectJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import {
+  buildProjectProxyCommand,
+  isDosuMcpEntryForProvider,
+  ownedProjectProxyOptionsForProvider,
+  sameProjectProxyTarget,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 export interface BaseProviderConfig {
@@ -22,10 +31,16 @@ export interface BaseProviderConfig {
   priorityValue: number;
   paths: string[];
   globalPath: string;
+  /** Historical global paths used only for detection, never for new writes. */
+  configuredGlobalPaths?: string[];
   topKey: string;
   /** Override the server entry shape if needed */
   // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
   buildServer?: (cfg: Config) => Record<string, any>;
+  /** Exact provider-specific stdio shape for a secretless project entry. */
+  buildProjectServer?: (
+    command: ReturnType<typeof buildProjectProxyCommand>,
+  ) => Record<string, unknown>;
   /** For providers that use a different local config path pattern */
   localConfigPath?: (cwd: string) => string;
 }
@@ -47,6 +62,26 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
   });
 
   const buildServer = opts.buildServer ?? defaultBuildServer;
+  const buildProjectServer =
+    opts.buildProjectServer ??
+    ((command: ReturnType<typeof buildProjectProxyCommand>) => ({
+      type: "stdio",
+      command: command.command,
+      args: command.args,
+    }));
+
+  const projectConfigPath = (projectRoot: string): string | null =>
+    opts.localConfigPath ? opts.localConfigPath(projectRoot) : null;
+  const isOwned = (entry: unknown): boolean => isDosuMcpEntryForProvider(opts.providerID, entry);
+  const isCurrentProjectEntry = (entry: unknown): boolean =>
+    ownedProjectProxyOptionsForProvider(opts.providerID, entry) !== null;
+
+  const requireProjectRoot = (projectRoot: string | undefined): string => {
+    if (!projectRoot) {
+      throw new Error(`${opts.providerName} project installation requires a verified project root`);
+    }
+    return projectRoot;
+  };
 
   return {
     name: () => opts.providerName,
@@ -56,33 +91,71 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     detectPaths: () => opts.paths,
     isInstalled: () => isInstalled(opts.paths),
     globalConfigPath: () => expandHome(opts.globalPath),
-    isConfigured: () => isJSONKeyConfigured(expandHome(opts.globalPath), opts.topKey),
+    isConfigured: () =>
+      [opts.globalPath, ...(opts.configuredGlobalPaths ?? [])].some((path) =>
+        isProjectJSONServerConfigured(expandHome(path), opts.topKey, isOwned),
+      ),
+    projectConfigPath,
+    isProjectConfigured: (projectRoot: string) => {
+      const path = projectConfigPath(projectRoot);
+      return path ? isProjectJSONServerConfigured(path, opts.topKey, isCurrentProjectEntry) : false;
+    },
 
-    install(cfg: Config, global: boolean): void {
+    install(cfg: Config, global: boolean, installOpts = {}) {
       if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
         throw new Error("deployment ID is required");
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
       } else if (opts.localConfigPath) {
-        configPath = opts.localConfigPath(process.cwd());
+        const projectRoot = requireProjectRoot(installOpts.projectRoot);
+        configPath = opts.localConfigPath(projectRoot);
+        assertSafeProjectPath(projectRoot, configPath);
       } else {
-        throw new Error(`${opts.providerName} does not support local installation`);
+        throw new Error(`${opts.providerName} does not support project installation`);
       }
-      const serverBuilder = cfg.mode === MODE_OSS ? defaultBuildOSSServer : buildServer;
-      installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
+      if (global) {
+        const serverBuilder = cfg.mode === MODE_OSS ? defaultBuildOSSServer : buildServer;
+        installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
+      } else {
+        const desiredTarget =
+          cfg.mode === MODE_OSS
+            ? ({ oss: true } as const)
+            : { deploymentID: cfg.active_account?.target?.deployment_id as string };
+        return installProjectJSONServer(
+          configPath,
+          opts.topKey,
+          buildProjectServer(buildProjectProxyCommand(cfg)),
+          isOwned,
+          (current) => {
+            const currentTarget = ownedProjectProxyOptionsForProvider(opts.providerID, current);
+            if (
+              !installOpts.allowProjectRetarget &&
+              (!currentTarget || !sameProjectProxyTarget(currentTarget, desiredTarget))
+            ) {
+              throw new Error(
+                `Existing ${opts.providerName} project MCP targets something else; refusing to retarget. ` +
+                  "pass an explicit deployment to retarget it",
+              );
+            }
+          },
+        );
+      }
     },
 
-    remove(global: boolean): void {
+    remove(global: boolean, removeOpts = {}) {
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
       } else if (opts.localConfigPath) {
-        configPath = opts.localConfigPath(process.cwd());
+        const projectRoot = requireProjectRoot(removeOpts.projectRoot);
+        configPath = opts.localConfigPath(projectRoot);
+        assertSafeProjectPath(projectRoot, configPath);
       } else {
-        throw new Error(`${opts.providerName} does not support local removal`);
+        throw new Error(`${opts.providerName} does not support project removal`);
       }
-      removeJSONServer(configPath, opts.topKey);
+      if (global) removeJSONServer(configPath, opts.topKey);
+      else return removeProjectJSONServer(configPath, opts.topKey, isOwned);
     },
   };
 }

--- a/src/mcp/providers/claude-desktop.ts
+++ b/src/mcp/providers/claude-desktop.ts
@@ -24,9 +24,11 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
   isInstalled: () => isInstalled([join(appSupportDir(), "Claude")]),
   globalConfigPath: () => configPath(),
   isConfigured: () => isJSONKeyConfigured(configPath(), "mcpServers"),
+  projectConfigPath: () => null,
+  isProjectConfigured: () => false,
 
-  install(cfg: Config, global: boolean): void {
-    if (!global) throw new Error("Claude Desktop does not support local installation");
+  install(cfg: Config, global: boolean) {
+    if (!global) throw new Error("Claude Desktop does not support project installation");
     if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
       throw new Error("deployment ID is required");
     const url =
@@ -48,10 +50,12 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
       args: remote.args,
       env: { PATH: npxPathEnv(npx), ...remote.env },
     });
+    return undefined;
   },
 
-  remove(global: boolean): void {
-    if (!global) throw new Error("Claude Desktop does not support local removal");
+  remove(global: boolean) {
+    if (!global) throw new Error("Claude Desktop does not support project removal");
     removeJSONServer(configPath(), "mcpServers");
+    return undefined;
   },
 });

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -6,18 +6,39 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { parse as parseToml } from "smol-toml";
 import { type Config, MODE_OSS } from "../../config/config";
-import { mcpBaseURL, mcpRemoteServer, mcpURL, writeSecureFile } from "../config-helpers";
+import {
+  isExactProjectCodexProxy,
+  type ProjectProxyExpectation,
+  planCodexDosuMcp,
+} from "../../migration/planners";
+import { assertSafeProjectPath } from "../../setup/project-path";
+import { VERSION } from "../../version/version";
+import {
+  mcpBaseURL,
+  mcpRemoteServer,
+  mcpURL,
+  type ProjectFileMutationReceipt,
+  writeProjectFile,
+  writeSecureFile,
+} from "../config-helpers";
 import { expandHome, findNpx, isInstalled, npxPathEnv } from "../detect";
+import {
+  buildProjectProxyCommand,
+  ownedProjectProxyOptionsFromEntry,
+  sameProjectProxyTarget,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function codexHome(): string {
   return process.env.CODEX_HOME ?? expandHome("~/.codex");
 }
 
-function getConfigPath(global: boolean): string {
+function getConfigPath(global: boolean, projectRoot?: string): string {
   if (global) return join(codexHome(), "config.toml");
-  return join(process.cwd(), ".codex", "config.toml");
+  if (!projectRoot) throw new Error("Codex project installation requires a verified project root");
+  return join(projectRoot, ".codex", "config.toml");
 }
 
 /**
@@ -29,8 +50,14 @@ function readTOML(path: string): string {
   return readFileSync(path, "utf-8");
 }
 
-function writeTOML(path: string, content: string): void {
-  writeSecureFile(path, content);
+function writeTOML(
+  path: string,
+  content: string,
+  global: boolean,
+  expectedProjectContent?: string | null,
+): ProjectFileMutationReceipt | undefined {
+  if (global) writeSecureFile(path, content);
+  else return writeProjectFile(path, content, expectedProjectContent);
 }
 
 function mcpEndpoint(cfg: Config): string {
@@ -43,11 +70,75 @@ function tomlString(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function installDosuToTOML(path: string, cfg: Config): void {
+function projectExpectation(cfg: Config): ProjectProxyExpectation {
+  if (cfg.mode === MODE_OSS) return { packageVersion: VERSION, oss: true };
+  const deploymentID = cfg.active_account?.target?.deployment_id;
+  if (!deploymentID) throw new Error("deployment ID is required");
+  return { packageVersion: VERSION, deploymentID };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function existingProjectTarget(content: string): {
+  present: boolean;
+  target: ReturnType<typeof ownedProjectProxyOptionsFromEntry>;
+} {
+  if (!content.trim()) return { present: false, target: null };
+  try {
+    const parsed: unknown = parseToml(content);
+    if (!isRecord(parsed) || !isRecord(parsed.mcp_servers)) {
+      return { present: false, target: null };
+    }
+    if (!Object.hasOwn(parsed.mcp_servers, "dosu")) return { present: false, target: null };
+    return {
+      present: true,
+      target: ownedProjectProxyOptionsFromEntry(parsed.mcp_servers.dosu),
+    };
+  } catch {
+    return { present: true, target: null };
+  }
+}
+
+function removeOwnedDosuFromTOML(content: string): string {
+  const plan = planCodexDosuMcp(content, {
+    projectProxy: "any",
+    allowLegacyGlobal: true,
+  });
+  if (plan.disposition === "preserved_ambiguous") {
+    throw new Error("Found a non-Dosu or ambiguous Codex server named dosu; refusing to modify it");
+  }
+  return plan.disposition === "remove" ? (plan.nextContent ?? content) : content;
+}
+
+function installDosuToTOML(
+  path: string,
+  cfg: Config,
+  global: boolean,
+  allowProjectRetarget = false,
+): ProjectFileMutationReceipt | undefined {
+  const projectFileExisted = !global && existsSync(path);
   let content = readTOML(path);
-  // Remove existing [mcp_servers.dosu] section if present (including the
-  // legacy [mcp_servers.dosu.http_headers] subtable from the remote-HTTP form)
-  content = removeDosuFromTOML(content);
+  const originalContent = content;
+  if (!global) {
+    const current = existingProjectTarget(content);
+    const expectation = projectExpectation(cfg);
+    const desired = expectation.oss
+      ? ({ oss: true } as const)
+      : { deploymentID: expectation.deploymentID };
+    if (
+      current.present &&
+      !allowProjectRetarget &&
+      (!current.target || !sameProjectProxyTarget(current.target, desired))
+    ) {
+      throw new Error(
+        "Existing Codex project MCP targets something else; refusing to retarget. " +
+          "Pass an explicit deployment to retarget it",
+      );
+    }
+  }
+  content = removeOwnedDosuFromTOML(content);
   // Codex desktop only renders MCP Apps (the Session Knowledge card) for
   // locally spawned stdio servers — a remote-HTTP entry serves tools fine
   // but never shows the card — so proxy the endpoint through `npx
@@ -58,40 +149,29 @@ function installDosuToTOML(path: string, cfg: Config): void {
   // with an explicit PATH because this config is shared with Codex desktop,
   // which launches from the Dock with the minimal launchd PATH — the same
   // pitfall as Claude Desktop.
-  const npx = findNpx();
-  const remote = mcpRemoteServer(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
-  const env: Record<string, string> = { PATH: npxPathEnv(npx), ...remote.env };
-  const envEntries = Object.entries(env)
-    .map(([key, value]) => `${key} = ${tomlString(value)}`)
-    .join("\n");
-  const args = remote.args.map(tomlString).join(", ");
-  const section =
-    `\n[mcp_servers.dosu]\ncommand = ${tomlString(npx)}\nargs = [${args}]\n` +
-    `\n[mcp_servers.dosu.env]\n${envEntries}\n`;
-  content += section;
-  writeTOML(path, content);
-}
-
-function removeDosuFromTOML(content: string): string {
-  // Remove [mcp_servers.dosu] and [mcp_servers.dosu.*] sections
-  const lines = content.split("\n");
-  const result: string[] = [];
-  let inDosuSection = false;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed.match(/^\[mcp_servers\.dosu(\..*)?]$/)) {
-      inDosuSection = true;
-      continue;
-    }
-    if (inDosuSection && trimmed.startsWith("[")) {
-      inDosuSection = false;
-    }
-    if (!inDosuSection) {
-      result.push(line);
+  let section: string;
+  if (global) {
+    const npx = findNpx();
+    const remote = mcpRemoteServer(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
+    const env: Record<string, string> = { PATH: npxPathEnv(npx), ...remote.env };
+    const envEntries = Object.entries(env)
+      .map(([key, value]) => `${key} = ${tomlString(value)}`)
+      .join("\n");
+    const args = remote.args.map(tomlString).join(", ");
+    section =
+      `\n[mcp_servers.dosu]\ncommand = ${tomlString(npx)}\nargs = [${args}]\n` +
+      `\n[mcp_servers.dosu.env]\n${envEntries}\n`;
+  } else {
+    const expectation = projectExpectation(cfg);
+    const command = buildProjectProxyCommand(cfg);
+    const args = command.args.map(tomlString).join(", ");
+    section = `\n[mcp_servers.dosu]\ncommand = ${tomlString(command.command)}\nargs = [${args}]\n`;
+    if (command.args[1] !== `@dosu/cli@${expectation.packageVersion}`) {
+      throw new Error("Project proxy version mismatch");
     }
   }
-  return result.join("\n");
+  content += section;
+  return writeTOML(path, content, global, projectFileExisted ? originalContent : null);
 }
 
 export const CodexProvider = (): SetupProvider => ({
@@ -104,16 +184,24 @@ export const CodexProvider = (): SetupProvider => ({
   globalConfigPath: () => join(codexHome(), "config.toml"),
   isConfigured: () => {
     const content = readTOML(join(codexHome(), "config.toml"));
-    return content.includes("[mcp_servers.dosu]");
+    return planCodexDosuMcp(content).disposition === "remove";
   },
-  install(cfg: Config, global: boolean): void {
+  projectConfigPath: (projectRoot) => join(projectRoot, ".codex", "config.toml"),
+  isProjectConfigured: (projectRoot) => {
+    const content = readTOML(join(projectRoot, ".codex", "config.toml"));
+    return isExactProjectCodexProxy(content);
+  },
+  install(cfg: Config, global: boolean, opts = {}) {
     if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
       throw new Error("deployment ID is required");
-    installDosuToTOML(getConfigPath(global), cfg);
+    const path = getConfigPath(global, opts.projectRoot);
+    if (!global) assertSafeProjectPath(opts.projectRoot as string, path);
+    return installDosuToTOML(path, cfg, global, opts.allowProjectRetarget);
   },
-  remove(global: boolean): void {
-    const path = getConfigPath(global);
+  remove(global: boolean, opts = {}) {
+    const path = getConfigPath(global, opts.projectRoot);
+    if (!global) assertSafeProjectPath(opts.projectRoot as string, path);
     const content = readTOML(path);
-    if (content) writeTOML(path, removeDosuFromTOML(content));
+    if (content) return writeTOML(path, removeOwnedDosuFromTOML(content), global, content);
   },
 });

--- a/src/mcp/providers/copilot.ts
+++ b/src/mcp/providers/copilot.ts
@@ -1,14 +1,23 @@
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-path";
 import {
   installJSONServer,
-  isJSONKeyConfigured,
+  installProjectJSONServer,
+  isProjectJSONServerConfigured,
   mcpBaseURL,
   mcpHeaders,
   mcpURL,
   removeJSONServer,
+  removeProjectJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import {
+  buildProjectProxyCommand,
+  isDosuMcpEntryForProvider,
+  ownedProjectProxyOptionsForProvider,
+  sameProjectProxyTarget,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function globalPath(): string {
@@ -24,6 +33,12 @@ function mcpEndpoint(cfg: Config): string {
   return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
+function requireProjectRoot(projectRoot: string | undefined): string {
+  if (!projectRoot)
+    throw new Error("Copilot project installation requires a verified project root");
+  return projectRoot;
+}
+
 export const CopilotProvider = (): SetupProvider => ({
   name: () => "GitHub Copilot CLI",
   id: () => "copilot",
@@ -32,9 +47,17 @@ export const CopilotProvider = (): SetupProvider => ({
   detectPaths: () => [expandHome("~/.copilot")],
   isInstalled: () => isInstalled([expandHome("~/.copilot")]),
   globalConfigPath: () => globalPath(),
-  isConfigured: () => isJSONKeyConfigured(globalPath(), "mcpServers"),
+  isConfigured: () =>
+    isProjectJSONServerConfigured(globalPath(), "mcpServers", (entry) =>
+      isDosuMcpEntryForProvider("copilot", entry),
+    ),
+  projectConfigPath: (projectRoot) => join(projectRoot, ".mcp.json"),
+  isProjectConfigured: (projectRoot) =>
+    isProjectJSONServerConfigured(join(projectRoot, ".mcp.json"), "mcpServers", (entry) =>
+      Boolean(ownedProjectProxyOptionsForProvider("copilot", entry)),
+    ),
 
-  install(cfg: Config, global: boolean): void {
+  install(cfg: Config, global: boolean, opts = {}) {
     const url = mcpEndpoint(cfg);
 
     if (global) {
@@ -47,23 +70,50 @@ export const CopilotProvider = (): SetupProvider => ({
       };
       installJSONServer(globalPath(), "mcpServers", server);
     } else {
-      const configPath = join(process.cwd(), ".vscode", "mcp.json");
+      const projectRoot = requireProjectRoot(opts.projectRoot);
+      const configPath = join(projectRoot, ".mcp.json");
+      assertSafeProjectPath(projectRoot, configPath);
+      const command = buildProjectProxyCommand(cfg);
+      const desiredTarget =
+        cfg.mode === MODE_OSS
+          ? ({ oss: true } as const)
+          : { deploymentID: cfg.active_account?.target?.deployment_id as string };
       const server = {
-        type: "http",
-        url,
-        // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-        headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+        type: "stdio",
+        command: command.command,
+        args: command.args,
       };
-      installJSONServer(configPath, "servers", server);
+      return installProjectJSONServer(
+        configPath,
+        "mcpServers",
+        server,
+        (entry) => isDosuMcpEntryForProvider("copilot", entry),
+        (current) => {
+          const currentTarget = ownedProjectProxyOptionsForProvider("copilot", current);
+          if (
+            !opts.allowProjectRetarget &&
+            (!currentTarget || !sameProjectProxyTarget(currentTarget, desiredTarget))
+          ) {
+            throw new Error(
+              "Existing GitHub Copilot CLI project MCP targets something else; refusing to retarget. " +
+                "Pass an explicit deployment to retarget it",
+            );
+          }
+        },
+      );
     }
   },
 
-  remove(global: boolean): void {
+  remove(global: boolean, opts = {}) {
     if (global) {
       removeJSONServer(globalPath(), "mcpServers");
     } else {
-      const configPath = join(process.cwd(), ".vscode", "mcp.json");
-      removeJSONServer(configPath, "servers");
+      const projectRoot = requireProjectRoot(opts.projectRoot);
+      const configPath = join(projectRoot, ".mcp.json");
+      assertSafeProjectPath(projectRoot, configPath);
+      return removeProjectJSONServer(configPath, "mcpServers", (entry) =>
+        isDosuMcpEntryForProvider("copilot", entry),
+      );
     }
   },
 });

--- a/src/mcp/providers/gemini.ts
+++ b/src/mcp/providers/gemini.ts
@@ -10,5 +10,6 @@ export const GeminiProvider = () =>
     paths: ["~/.gemini"],
     globalPath: "~/.gemini/settings.json",
     topKey: "mcpServers",
+    buildProjectServer: (command) => ({ command: command.command, args: command.args }),
     localConfigPath: (cwd) => join(cwd, ".gemini", "settings.json"),
   });

--- a/src/mcp/providers/manual.ts
+++ b/src/mcp/providers/manual.ts
@@ -19,7 +19,7 @@ export const ManualProvider = (): Provider => ({
   id: () => "manual",
   supportsLocal: () => false,
 
-  install(cfg: Config, _global: boolean, opts: ProviderInstallOptions = {}): void {
+  install(cfg: Config, _global: boolean, opts: ProviderInstallOptions = {}) {
     const url = mcpEndpoint(cfg);
     const apiKey = mcpHeaders(cfg.active_account?.target?.api_key)["X-Dosu-API-Key"];
     const headerValue = opts.showSecret ? apiKey : maskSecret(apiKey);
@@ -33,11 +33,13 @@ export const ManualProvider = (): Provider => ({
       console.log("  Secret hidden. Re-run with --show-secret to print the full API key.");
     }
     console.log();
+    return undefined;
   },
 
-  remove(): void {
+  remove() {
     console.log(
       "\nTo remove the Dosu MCP server, manually delete the configuration from your client.",
     );
+    return undefined;
   },
 });

--- a/src/mcp/providers/mcporter.ts
+++ b/src/mcp/providers/mcporter.ts
@@ -1,15 +1,24 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-path";
 import {
   installJSONServer,
-  isJSONKeyConfigured,
+  installProjectJSONServer,
+  isProjectJSONServerConfigured,
   mcpBaseURL,
   mcpHeaders,
   mcpURL,
   removeJSONServer,
+  removeProjectJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import {
+  buildProjectProxyCommand,
+  isDosuMcpEntryForProvider,
+  ownedProjectProxyOptionsForProvider,
+  sameProjectProxyTarget,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function resolveGlobalConfigPath(): string {
@@ -26,6 +35,12 @@ function mcpEndpoint(cfg: Config): string {
   return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
+function requireProjectRoot(projectRoot: string | undefined): string {
+  if (!projectRoot)
+    throw new Error("MCPorter project installation requires a verified project root");
+  return projectRoot;
+}
+
 export const MCPorterProvider = (): SetupProvider => ({
   name: () => "MCPorter",
   id: () => "mcporter",
@@ -34,25 +49,69 @@ export const MCPorterProvider = (): SetupProvider => ({
   detectPaths: () => ["~/.mcporter"],
   isInstalled: () => isInstalled(["~/.mcporter"]),
   globalConfigPath: () => resolveGlobalConfigPath(),
-  isConfigured: () => isJSONKeyConfigured(resolveGlobalConfigPath(), "mcpServers"),
+  isConfigured: () =>
+    isProjectJSONServerConfigured(resolveGlobalConfigPath(), "mcpServers", (entry) =>
+      isDosuMcpEntryForProvider("mcporter", entry),
+    ),
+  projectConfigPath: (projectRoot) => join(projectRoot, "config", "mcporter.json"),
+  isProjectConfigured: (projectRoot) =>
+    isProjectJSONServerConfigured(
+      join(projectRoot, "config", "mcporter.json"),
+      "mcpServers",
+      (entry) => Boolean(ownedProjectProxyOptionsForProvider("mcporter", entry)),
+    ),
 
-  install(cfg: Config, global: boolean): void {
+  install(cfg: Config, global: boolean, opts = {}) {
+    const projectRoot = global ? undefined : requireProjectRoot(opts.projectRoot);
     const configPath = global
       ? resolveGlobalConfigPath()
-      : join(process.cwd(), "config", "mcporter.json");
-    const server = {
-      type: "http",
-      url: mcpEndpoint(cfg),
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
-    };
-    installJSONServer(configPath, "mcpServers", server);
+      : join(projectRoot as string, "config", "mcporter.json");
+    if (projectRoot) assertSafeProjectPath(projectRoot, configPath);
+    if (global) {
+      const server = {
+        type: "http",
+        url: mcpEndpoint(cfg),
+        // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
+        headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+      };
+      installJSONServer(configPath, "mcpServers", server);
+    } else {
+      const command = buildProjectProxyCommand(cfg);
+      const desiredTarget =
+        cfg.mode === MODE_OSS
+          ? ({ oss: true } as const)
+          : { deploymentID: cfg.active_account?.target?.deployment_id as string };
+      return installProjectJSONServer(
+        configPath,
+        "mcpServers",
+        { command: command.command, args: command.args },
+        (entry) => isDosuMcpEntryForProvider("mcporter", entry),
+        (current) => {
+          const currentTarget = ownedProjectProxyOptionsForProvider("mcporter", current);
+          if (
+            !opts.allowProjectRetarget &&
+            (!currentTarget || !sameProjectProxyTarget(currentTarget, desiredTarget))
+          ) {
+            throw new Error(
+              "Existing MCPorter project MCP targets something else; refusing to retarget. " +
+                "Pass an explicit deployment to retarget it",
+            );
+          }
+        },
+      );
+    }
   },
 
-  remove(global: boolean): void {
+  remove(global: boolean, opts = {}) {
+    const projectRoot = global ? undefined : requireProjectRoot(opts.projectRoot);
     const configPath = global
       ? resolveGlobalConfigPath()
-      : join(process.cwd(), "config", "mcporter.json");
-    removeJSONServer(configPath, "mcpServers");
+      : join(projectRoot as string, "config", "mcporter.json");
+    if (projectRoot) assertSafeProjectPath(projectRoot, configPath);
+    if (global) removeJSONServer(configPath, "mcpServers");
+    else
+      return removeProjectJSONServer(configPath, "mcpServers", (entry) =>
+        isDosuMcpEntryForProvider("mcporter", entry),
+      );
   },
 });

--- a/src/mcp/providers/opencode.ts
+++ b/src/mcp/providers/opencode.ts
@@ -19,5 +19,10 @@ export const OpenCodeProvider = () =>
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
+    buildProjectServer: (command) => ({
+      type: "local",
+      command: [command.command, ...command.args],
+      enabled: true,
+    }),
     localConfigPath: (cwd) => join(cwd, "opencode.json"),
   });

--- a/src/mcp/providers/project-install.test.ts
+++ b/src/mcp/providers/project-install.test.ts
@@ -1,0 +1,325 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Config } from "../../config/config";
+import { makeTestConfig } from "../../config/config.test-utils";
+import { loadJSONConfig } from "../config-helpers";
+import { allSetupProviders } from "../providers";
+
+const SECRET = "project-config-must-not-contain-this-key";
+
+function config(): Config {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 60_000,
+    deployment_id: "dep-project",
+    deployment_name: "Project brain",
+    api_key: SECRET,
+    mcp_endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-project",
+  });
+}
+
+interface JSONExpectation {
+  provider: string;
+  relativePath: string;
+  topKey: string;
+  type?: string;
+  commandArray?: boolean;
+}
+
+const JSON_PROJECT_PROVIDERS: JSONExpectation[] = [
+  { provider: "claude", relativePath: ".mcp.json", topKey: "mcpServers", type: "stdio" },
+  { provider: "cursor", relativePath: ".cursor/mcp.json", topKey: "mcpServers", type: "stdio" },
+  { provider: "vscode", relativePath: ".vscode/mcp.json", topKey: "servers", type: "stdio" },
+  { provider: "gemini", relativePath: ".gemini/settings.json", topKey: "mcpServers" },
+  { provider: "zed", relativePath: ".zed/settings.json", topKey: "context_servers" },
+  // Claude and Copilot intentionally share the cross-client .mcp.json contract.
+  { provider: "copilot", relativePath: ".mcp.json", topKey: "mcpServers", type: "stdio" },
+  {
+    provider: "opencode",
+    relativePath: "opencode.json",
+    topKey: "mcp",
+    type: "local",
+    commandArray: true,
+  },
+  { provider: "antigravity", relativePath: ".agents/mcp_config.json", topKey: "mcpServers" },
+  { provider: "mcporter", relativePath: "config/mcporter.json", topKey: "mcpServers" },
+  { provider: "factory", relativePath: ".factory/mcp.json", topKey: "mcpServers", type: "stdio" },
+];
+
+let tempDir: string;
+let projectRoot: string;
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-project-providers-"));
+  projectRoot = join(tempDir, "repo");
+  mkdirSync(projectRoot, { recursive: true });
+  originalEnv = { ...process.env };
+  process.env.HOME = join(tempDir, "home");
+  process.env.XDG_CONFIG_HOME = join(tempDir, "xdg");
+  process.env.APPDATA = join(tempDir, "appdata");
+  process.env.CODEX_HOME = join(tempDir, "codex-home");
+  const binDir = join(tempDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(binDir, process.platform === "win32" ? "npx.cmd" : "npx"), "", {
+    mode: 0o755,
+  });
+  process.env.PATH = binDir;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("project-scoped MCP provider entries", () => {
+  it("never falls back to an arbitrary current working directory", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false)).toThrow(/verified project root/i);
+  });
+
+  it.each(
+    JSON_PROJECT_PROVIDERS,
+  )("$provider writes the official project schema without credentials", ({
+    provider: id,
+    relativePath,
+    topKey,
+    type,
+    commandArray,
+  }) => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === id);
+    expect(provider).toBeDefined();
+
+    const receipt = provider?.install(config(), false, { projectRoot });
+
+    const path = join(projectRoot, relativePath);
+    expect(provider?.projectConfigPath(projectRoot)).toBe(path);
+    const entry = loadJSONConfig(path)[topKey].dosu;
+    if (type) expect(entry.type).toBe(type);
+    if (commandArray) {
+      expect(entry.command).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-project"]));
+    } else {
+      expect(entry.command).toBe("npx");
+      expect(entry.args).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-project"]));
+    }
+    const raw = readFileSync(path, "utf8");
+    expect(receipt).toMatchObject({
+      path,
+      beforeContent: null,
+      beforeMode: null,
+      afterContent: raw,
+      afterMode: 0o644,
+    });
+    expect(statSync(path).mode & 0o777).toBe(0o644);
+    expect(raw).not.toContain(SECRET);
+    expect(raw).not.toContain("X-Dosu-API-Key");
+    expect(raw).not.toContain("api.dosu.dev");
+    expect(provider?.isProjectConfigured(projectRoot)).toBe(true);
+  });
+
+  it("Codex writes a secretless project TOML entry", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "codex");
+    const receipt = provider?.install(config(), false, { projectRoot });
+
+    const path = join(projectRoot, ".codex", "config.toml");
+    const raw = readFileSync(path, "utf8");
+    expect(receipt).toMatchObject({
+      path,
+      beforeContent: null,
+      beforeMode: null,
+      afterContent: raw,
+      afterMode: 0o644,
+    });
+    expect(statSync(path).mode & 0o777).toBe(0o644);
+    expect(raw).toContain("[mcp_servers.dosu]");
+    expect(raw).toContain('command = "npx"');
+    expect(raw).toContain('"mcp", "proxy"');
+    expect(raw).not.toContain(SECRET);
+    expect(raw).not.toContain("X-Dosu-API-Key");
+    expect(raw).not.toContain("api.dosu.dev");
+    expect(provider?.projectConfigPath(projectRoot)).toBe(path);
+    expect(provider?.isProjectConfigured(projectRoot)).toBe(true);
+  });
+
+  it("Codex refuses to overwrite or remove a foreign server named dosu", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "codex");
+    const path = join(projectRoot, ".codex", "config.toml");
+    mkdirSync(join(projectRoot, ".codex"), { recursive: true });
+    const foreign = '[mcp_servers.dosu]\ncommand = "my-company-server"\nargs = []\n';
+    writeFileSync(path, foreign);
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/refusing/i);
+    expect(() => provider?.remove(false, { projectRoot })).toThrow(/refusing/i);
+    expect(readFileSync(path, "utf8")).toBe(foreign);
+  });
+
+  it("Codex refuses an invalid TOML document even when it contains an exact proxy table", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "codex");
+    provider?.install(config(), false, { projectRoot });
+    const path = join(projectRoot, ".codex", "config.toml");
+    const invalid = `not valid toml !!!\n${readFileSync(path, "utf8")}`;
+    writeFileSync(path, invalid);
+
+    expect(provider?.isProjectConfigured(projectRoot)).toBe(false);
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/refusing/i);
+    expect(readFileSync(path, "utf8")).toBe(invalid);
+  });
+
+  it("uses the explicit Git root instead of process.cwd()", () => {
+    const nested = join(projectRoot, "packages", "api");
+    mkdirSync(nested, { recursive: true });
+    const originalCwd = process.cwd();
+    process.chdir(nested);
+    try {
+      const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+      provider?.install(config(), false, { projectRoot });
+      expect(existsSync(join(projectRoot, ".cursor", "mcp.json"))).toBe(true);
+      expect(existsSync(join(nested, ".cursor", "mcp.json"))).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it.each([
+    "claude-desktop",
+    "windsurf",
+    "cline",
+    "cline-cli",
+  ])("%s remains unsupported instead of silently falling back to global", (id) => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === id);
+    expect(provider?.supportsLocal()).toBe(false);
+    expect(provider?.projectConfigPath(projectRoot)).toBeNull();
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(
+      /does not support project/i,
+    );
+  });
+
+  it("refuses to overwrite a non-Dosu server that happens to use the dosu name", () => {
+    const path = join(projectRoot, ".cursor", "mcp.json");
+    mkdirSync(join(projectRoot, ".cursor"), { recursive: true });
+    writeFileSync(path, JSON.stringify({ mcpServers: { dosu: { command: "my-company-server" } } }));
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(
+      /non-Dosu server named "dosu"/i,
+    );
+    expect(readFileSync(path, "utf8")).toContain("my-company-server");
+  });
+
+  it.each(
+    JSON_PROJECT_PROVIDERS,
+  )("$provider preserves a same-shaped server on a foreign origin during removal", ({
+    provider: id,
+    relativePath,
+    topKey,
+  }) => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === id);
+    const path = join(projectRoot, relativePath);
+    mkdirSync(join(path, ".."), { recursive: true });
+    const url = "https://foreign.example/v1/mcp/deployments/dep-project";
+    const headers = { "X-Dosu-API-Key": "foreign-key" };
+    const entry =
+      id === "cursor"
+        ? { url, headers }
+        : id === "opencode"
+          ? { type: "remote", enabled: true, url, headers }
+          : id === "zed"
+            ? { source: "custom", type: "http", url, headers }
+            : id === "antigravity"
+              ? { serverUrl: url, headers }
+              : id === "copilot"
+                ? { type: "http", url, tools: ["*"], headers }
+                : { type: "http", url, headers };
+    const original = JSON.stringify({ [topKey]: { dosu: entry, user: { command: "keep" } } });
+    writeFileSync(path, original);
+
+    expect(() => provider?.remove(false, { projectRoot })).toThrow(/refusing/i);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it("Codex preserves a same-shaped HTTP server on a foreign origin during removal", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "codex");
+    const path = join(projectRoot, ".codex", "config.toml");
+    mkdirSync(join(projectRoot, ".codex"), { recursive: true });
+    const original = `[mcp_servers.dosu]\ntype = "http"\nurl = "https://foreign.example/v1/mcp/deployments/dep-project"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "foreign-key"\n`;
+    writeFileSync(path, original);
+
+    expect(() => provider?.remove(false, { projectRoot })).toThrow(/refusing/i);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it("refuses a project MCP config symlink that could escape the repository", () => {
+    const outside = join(tempDir, "outside.json");
+    writeFileSync(outside, JSON.stringify({ mcpServers: {} }));
+    mkdirSync(join(projectRoot, ".cursor"), { recursive: true });
+    symlinkSync(outside, join(projectRoot, ".cursor", "mcp.json"));
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/symbolic link/i);
+    expect(readFileSync(outside, "utf8")).toBe(JSON.stringify({ mcpServers: {} }));
+  });
+
+  it("refuses a symlinked project config directory", () => {
+    const outside = join(tempDir, "outside-dir");
+    mkdirSync(outside);
+    symlinkSync(outside, join(projectRoot, ".cursor"));
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/symbolic link/i);
+    expect(existsSync(join(outside, "mcp.json"))).toBe(false);
+  });
+
+  it("refuses duplicate JSON properties instead of guessing which value owns the file", () => {
+    const path = join(projectRoot, ".cursor", "mcp.json");
+    mkdirSync(join(projectRoot, ".cursor"), { recursive: true });
+    writeFileSync(
+      path,
+      '{"mcpServers":{"dosu":{"command":"foreign"},"dosu":{"command":"foreign-2"}}}',
+    );
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/duplicate/i);
+  });
+
+  it("removes a project entry without rewriting sibling JSONC bytes", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+    provider?.install(config(), false, { projectRoot });
+    const path = join(projectRoot, ".cursor", "mcp.json");
+    const owned = loadJSONConfig(path).mcpServers.dosu;
+    const before = `{
+  // keep this root comment
+  "mcpServers": {
+    "user": {"url":"x"}, // keep this user comment
+    "dosu": ${JSON.stringify(owned)}
+  },
+  "other": [1,2,3]
+}
+`;
+    writeFileSync(path, before);
+
+    provider?.remove(false, { projectRoot });
+
+    expect(readFileSync(path, "utf8")).toBe(`{
+  // keep this root comment
+  "mcpServers": {
+    "user": {"url":"x"} // keep this user comment
+${"    "}
+  },
+  "other": [1,2,3]
+}
+`);
+  });
+});

--- a/src/mcp/providers/project-retarget.test.ts
+++ b/src/mcp/providers/project-retarget.test.ts
@@ -1,0 +1,222 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { parse as parseJSONC } from "jsonc-parser/lib/esm/main.js";
+import { parse as parseToml } from "smol-toml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Config } from "../../config/config";
+import { makeTestConfig } from "../../config/config.test-utils";
+import { VERSION } from "../../version/version";
+import { ownedProjectProxyOptionsFromEntry, type ProjectProxyOptions } from "../project-proxy";
+import type { SetupProvider } from "../providers";
+import { CodexProvider } from "./codex";
+import { CopilotProvider } from "./copilot";
+import { CursorProvider } from "./cursor";
+import { MCPorterProvider } from "./mcporter";
+
+const HISTORICAL_VERSION = "0.42.0";
+
+type ProjectProviderCase = {
+  id: "cursor" | "codex" | "copilot" | "mcporter";
+  create: () => SetupProvider;
+  relativePath: string;
+};
+
+const PROJECT_PROVIDERS: ProjectProviderCase[] = [
+  { id: "cursor", create: CursorProvider, relativePath: ".cursor/mcp.json" },
+  { id: "codex", create: CodexProvider, relativePath: ".codex/config.toml" },
+  { id: "copilot", create: CopilotProvider, relativePath: ".mcp.json" },
+  { id: "mcporter", create: MCPorterProvider, relativePath: "config/mcporter.json" },
+];
+
+function cloudConfig(deploymentID: string): Config {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 60_000,
+    deployment_id: deploymentID,
+    deployment_name: deploymentID,
+    api_key: `key-for-${deploymentID}`,
+    mcp_endpoint: `https://api.dosu.dev/v1/mcp/deployments/${deploymentID}`,
+  });
+}
+
+function ossConfig(): Config {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 60_000,
+    mode: "oss",
+    api_key: "key-for-oss",
+    mcp_endpoint: "https://api.dosu.dev/v1/mcp",
+  });
+}
+
+function proxyArgs(target: ProjectProxyOptions, packageVersion = HISTORICAL_VERSION): string[] {
+  const prefix = ["-y", `@dosu/cli@${packageVersion}`, "mcp", "proxy"];
+  return target.oss
+    ? [...prefix, "--oss"]
+    : [...prefix, "--deployment", target.deploymentID as string];
+}
+
+function historicalFixture(id: ProjectProviderCase["id"], target: ProjectProxyOptions): string {
+  const args = proxyArgs(target);
+  if (id !== "codex") {
+    const entry = {
+      ...(id === "cursor" || id === "copilot" ? { type: "stdio" } : {}),
+      command: "npx",
+      args,
+    };
+    return `{
+  // unrelated project setting: preserve this comment
+  "mcpServers": {
+    "other": { "command": "other-server", "args": [] },
+    "dosu": ${JSON.stringify(entry)}
+  },
+  "userSetting": "preserve-me"
+}
+`;
+  }
+
+  return `# unrelated project setting: preserve this comment
+model = "preserve-me"
+
+[mcp_servers.other]
+command = "other-server"
+args = []
+
+[mcp_servers.dosu]
+command = "npx"
+args = ${JSON.stringify(args)}
+`;
+}
+
+function writeHistoricalFixture(
+  providerCase: ProjectProviderCase,
+  projectRoot: string,
+  target: ProjectProxyOptions,
+): string {
+  const path = join(projectRoot, providerCase.relativePath);
+  mkdirSync(dirname(path), { recursive: true });
+  const content = historicalFixture(providerCase.id, target);
+  writeFileSync(path, content);
+  return content;
+}
+
+function readEntry(providerCase: ProjectProviderCase, projectRoot: string): unknown {
+  const path = join(projectRoot, providerCase.relativePath);
+  if (providerCase.id !== "codex") {
+    const parsed = parseJSONC(readFileSync(path, "utf8")) as {
+      mcpServers?: { dosu?: unknown };
+    };
+    return parsed.mcpServers?.dosu;
+  }
+  const parsed = parseToml(readFileSync(path, "utf8")) as {
+    mcp_servers?: { dosu?: unknown };
+  };
+  return parsed.mcp_servers?.dosu;
+}
+
+function expectCurrentTarget(
+  providerCase: ProjectProviderCase,
+  projectRoot: string,
+  expected: ProjectProxyOptions,
+): void {
+  const path = join(projectRoot, providerCase.relativePath);
+  const raw = readFileSync(path, "utf8");
+  expect(raw).toContain(`@dosu/cli@${VERSION}`);
+  expect(raw).toContain("unrelated project setting: preserve this comment");
+  expect(raw).toContain("preserve-me");
+  expect(ownedProjectProxyOptionsFromEntry(readEntry(providerCase, projectRoot))).toEqual(expected);
+}
+
+let tempDir: string;
+let projectRoot: string;
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-project-retarget-"));
+  projectRoot = join(tempDir, "repo");
+  mkdirSync(projectRoot, { recursive: true });
+  originalEnv = { ...process.env };
+  process.env.HOME = join(tempDir, "home");
+  process.env.XDG_CONFIG_HOME = join(tempDir, "xdg");
+  process.env.CODEX_HOME = join(tempDir, "codex-home");
+  const binDir = join(tempDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(binDir, process.platform === "win32" ? "npx.cmd" : "npx"), "", {
+    mode: 0o755,
+  });
+  process.env.PATH = binDir;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe.each(PROJECT_PROVIDERS)("$id project target safety", (providerCase) => {
+  it("recognizes an exact project proxy emitted by a historical CLI version", () => {
+    const provider = providerCase.create();
+    writeHistoricalFixture(providerCase, projectRoot, { deploymentID: "deployment-a" });
+
+    expect(provider.isProjectConfigured(projectRoot)).toBe(true);
+  });
+
+  it("refreshes a historical proxy for the same deployment without retarget permission", () => {
+    const provider = providerCase.create();
+    writeHistoricalFixture(providerCase, projectRoot, { deploymentID: "deployment-a" });
+
+    provider.install(cloudConfig("deployment-a"), false, { projectRoot });
+
+    expectCurrentTarget(providerCase, projectRoot, { deploymentID: "deployment-a" });
+  });
+
+  it("preserves every byte when a different deployment is not explicitly authorized", () => {
+    const provider = providerCase.create();
+    const original = writeHistoricalFixture(providerCase, projectRoot, {
+      deploymentID: "deployment-a",
+    });
+    const path = join(projectRoot, providerCase.relativePath);
+
+    expect(() => provider.install(cloudConfig("deployment-b"), false, { projectRoot })).toThrow(
+      /retarget/i,
+    );
+    expect(readFileSync(path, "utf8")).toBe(original);
+
+    provider.install(cloudConfig("deployment-b"), false, {
+      projectRoot,
+      allowProjectRetarget: true,
+    });
+    expectCurrentTarget(providerCase, projectRoot, { deploymentID: "deployment-b" });
+  });
+
+  it.each([
+    {
+      label: "cloud to OSS",
+      existing: { deploymentID: "deployment-a" } as ProjectProxyOptions,
+      desiredConfig: ossConfig,
+      expected: { oss: true } as ProjectProxyOptions,
+    },
+    {
+      label: "OSS to cloud",
+      existing: { oss: true } as ProjectProxyOptions,
+      desiredConfig: () => cloudConfig("deployment-a"),
+      expected: { deploymentID: "deployment-a" } as ProjectProxyOptions,
+    },
+  ])("requires explicit retarget permission for $label", ({
+    existing,
+    desiredConfig,
+    expected,
+  }) => {
+    const provider = providerCase.create();
+    const original = writeHistoricalFixture(providerCase, projectRoot, existing);
+    const path = join(projectRoot, providerCase.relativePath);
+
+    expect(() => provider.install(desiredConfig(), false, { projectRoot })).toThrow(/retarget/i);
+    expect(readFileSync(path, "utf8")).toBe(original);
+
+    provider.install(desiredConfig(), false, { projectRoot, allowProjectRetarget: true });
+    expectCurrentTarget(providerCase, projectRoot, expected);
+  });
+});

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -124,7 +124,9 @@ describe("createJSONProvider (base)", () => {
       topKey: "mcpServers",
     });
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support project installation",
+    );
   });
 
   it("local install writes to localConfigPath when provided", async () => {
@@ -141,11 +143,13 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: () => localPath,
     });
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const cfg = loadJSONConfig(localPath);
     expect(cfg.mcpServers.dosu).toBeDefined();
-    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.args).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-123"]));
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
   it("global remove deletes dosu entry from JSON config", async () => {
@@ -187,15 +191,12 @@ describe("createJSONProvider (base)", () => {
       topKey: "mcpServers",
     });
 
-    expect(() => provider.remove(false)).toThrow("does not support local removal");
+    expect(() => provider.remove(false)).toThrow("does not support project removal");
   });
 
   it("local remove deletes dosu entry when localConfigPath is provided", async () => {
     const { createJSONProvider } = await import("./base");
     const localPath = join(tempDir, "local-rm", "mcp.json");
-    mkdirSync(join(tempDir, "local-rm"), { recursive: true });
-    writeFileSync(localPath, JSON.stringify({ mcpServers: { dosu: { url: "x" } } }));
-
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
@@ -207,7 +208,8 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: () => localPath,
     });
 
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const cfg = loadJSONConfig(localPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
@@ -246,6 +248,7 @@ describe("CodexProvider", () => {
   let origCodexHome: string | undefined;
   let origCwd: string;
   let origPath: string | undefined;
+  let origBackendOverride: string | undefined;
   let npxPath: string;
 
   beforeEach(() => {
@@ -255,6 +258,8 @@ describe("CodexProvider", () => {
     origCwd = process.cwd();
     process.chdir(tempDir);
     origPath = process.env.PATH;
+    origBackendOverride = process.env.DOSU_BACKEND_URL_OVERRIDE;
+    process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api.dosu.dev";
     const binDir = join(tempDir, "fake-bin");
     mkdirSync(binDir, { recursive: true });
     npxPath = join(binDir, "npx");
@@ -270,6 +275,8 @@ describe("CodexProvider", () => {
       delete process.env.CODEX_HOME;
     }
     process.env.PATH = origPath;
+    if (origBackendOverride === undefined) delete process.env.DOSU_BACKEND_URL_OVERRIDE;
+    else process.env.DOSU_BACKEND_URL_OVERRIDE = origBackendOverride;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -303,11 +310,11 @@ describe("CodexProvider", () => {
     expect(content).not.toContain("http_headers");
   });
 
-  it("local install writes TOML config to .codex/config.toml in cwd", async () => {
+  it("project install writes TOML config to the explicit project root", async () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".codex", "config.toml");
     expect(existsSync(configPath)).toBe(true);
@@ -372,7 +379,7 @@ describe("CodexProvider", () => {
     mkdirSync(join(tempDir, "codex-home"), { recursive: true });
     writeFileSync(
       configPath,
-      '[mcp_servers.dosu]\ntype = "http"\nurl = "https://old.example"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "old-key"\n',
+      '[mcp_servers.dosu]\ntype = "http"\nurl = "https://api.dosu.dev/v1/mcp/deployments/old-dep"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "old-key"\n',
     );
 
     provider.install(makeCfg(), true);
@@ -399,6 +406,20 @@ describe("CodexProvider", () => {
     expect(content).toContain("[other_section]");
     expect(content).toContain('key = "value"');
     expect(content).toContain("[mcp_servers.dosu]");
+  });
+
+  it("refuses to install over or remove a semantically equivalent quoted Dosu table", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+    const configPath = join(tempDir, "codex-home", "config.toml");
+    const original = '[mcp_servers."dosu"]\ncommand = "foreign"\nargs = []\n';
+    mkdirSync(join(tempDir, "codex-home"), { recursive: true });
+    writeFileSync(configPath, original);
+
+    expect(() => provider.install(makeCfg(), true)).toThrow(/ambiguous|refus/i);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(() => provider.remove(true)).toThrow(/ambiguous|refus/i);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
   });
 
   it("global install replaces loose-permission TOML config with owner-only permissions", async () => {
@@ -431,8 +452,8 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".codex", "config.toml");
     const content = readFileSync(configPath, "utf-8");
@@ -515,37 +536,38 @@ describe("CopilotProvider", () => {
     expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
-  it("local install writes to cwd/.vscode/mcp.json with servers key", async () => {
+  it("project install writes the shared .mcp.json Copilot CLI schema", async () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
-    const configPath = join(tempDir, ".vscode", "mcp.json");
+    const configPath = join(tempDir, ".mcp.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.servers).toBeDefined();
-    expect(cfg.servers.dosu).toBeDefined();
-    expect(cfg.servers.dosu.type).toBe("http");
-    expect(cfg.servers.dosu.url).toContain("dep-123");
-    // local config should not have tools key
-    expect(cfg.servers.dosu.tools).toBeUndefined();
+    expect(cfg.mcpServers).toBeDefined();
+    expect(cfg.mcpServers.dosu.type).toBe("stdio");
+    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.args).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-123"]));
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
-  it("OSS mode install writes base MCP URL for global and local Copilot configs", async () => {
+  it("OSS mode keeps the global URL but writes a secretless project proxy", async () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
     provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), false);
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), false, {
+      projectRoot: tempDir,
+    });
 
     const globalCfg = loadJSONConfig(join(tempDir, "xdg-config", "mcp-config.json"));
     expect(globalCfg.mcpServers.dosu.url).toContain("/v1/mcp");
     expect(globalCfg.mcpServers.dosu.url).not.toContain("/deployments/");
 
-    const localCfg = loadJSONConfig(join(tempDir, ".vscode", "mcp.json"));
-    expect(localCfg.servers.dosu.url).toContain("/v1/mcp");
-    expect(localCfg.servers.dosu.url).not.toContain("/deployments/");
+    const localCfg = loadJSONConfig(join(tempDir, ".mcp.json"));
+    expect(localCfg.mcpServers.dosu.args).toContain("--oss");
+    expect(localCfg.mcpServers.dosu.url).toBeUndefined();
   });
 
   it("install throws when deployment_id is missing", async () => {
@@ -569,16 +591,16 @@ describe("CopilotProvider", () => {
     expect(cfg.mcpServers.dosu).toBeUndefined();
   });
 
-  it("local remove deletes dosu entry from servers", async () => {
+  it("project remove deletes the owned dosu entry", async () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
-    const configPath = join(tempDir, ".vscode", "mcp.json");
+    const configPath = join(tempDir, ".mcp.json");
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.servers.dosu).toBeUndefined();
+    expect(cfg.mcpServers.dosu).toBeUndefined();
   });
 
   it("install preserves existing entries", async () => {
@@ -665,11 +687,11 @@ describe("MCPorterProvider", () => {
     expect(cfg.mcpServers.dosu).toBeDefined();
   });
 
-  it("local install writes to cwd/config/mcporter.json", async () => {
+  it("project install writes to the explicit project config/mcporter.json", async () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "config", "mcporter.json");
     expect(existsSync(configPath)).toBe(true);
@@ -714,8 +736,8 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "config", "mcporter.json");
     const cfg = loadJSONConfig(configPath);
@@ -915,7 +937,9 @@ describe("ClaudeDesktopProvider", () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support project installation",
+    );
   });
 
   it("remove deletes the dosu entry", async () => {
@@ -933,7 +957,7 @@ describe("ClaudeDesktopProvider", () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.remove(false)).toThrow("does not support local removal");
+    expect(() => provider.remove(false)).toThrow("does not support project removal");
   });
 
   it("install skips empty PATH segments when resolving npx", async () => {
@@ -999,11 +1023,11 @@ describe("CursorProvider", () => {
     expect(cfg.mcpServers.dosu.type).toBeUndefined();
   });
 
-  it("local install writes to cwd/.cursor/mcp.json", async () => {
+  it("project install writes to the explicit project .cursor/mcp.json", async () => {
     const { CursorProvider } = await import("./cursor");
     const provider = CursorProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".cursor", "mcp.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1058,11 +1082,11 @@ describe("OpenCodeProvider", () => {
     expect(cfg.mcp.dosu.url).toContain("dep-123");
   });
 
-  it("local install writes to cwd/opencode.json", async () => {
+  it("project install writes to the explicit project opencode.json", async () => {
     const { OpenCodeProvider } = await import("./opencode");
     const provider = OpenCodeProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "opencode.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1142,7 +1166,9 @@ describe("ClineCliProvider", () => {
     const { ClineCliProvider } = await import("./cline-cli");
     const provider = ClineCliProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support project installation",
+    );
   });
 });
 
@@ -1161,13 +1187,13 @@ describe("AntigravityProvider", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("global install writes to ~/.gemini/antigravity/mcp_config.json with mcpServers key", async () => {
+  it("global install writes to ~/.gemini/config/mcp_config.json with mcpServers key", async () => {
     const { AntigravityProvider } = await import("./antigravity");
     const provider = AntigravityProvider();
 
     provider.install(makeCfg(), true);
 
-    const configPath = join(tempDir, ".gemini", "antigravity", "mcp_config.json");
+    const configPath = join(tempDir, ".gemini", "config", "mcp_config.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
     expect(cfg.mcpServers.dosu).toBeDefined();
@@ -1176,11 +1202,17 @@ describe("AntigravityProvider", () => {
     expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
-  it("local install throws because Antigravity does not support local", async () => {
+  it("project install writes .agents/mcp_config.json without a secret", async () => {
     const { AntigravityProvider } = await import("./antigravity");
     const provider = AntigravityProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+
+    const configPath = join(tempDir, ".agents", "mcp_config.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.args).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-123"]));
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
   it("remove deletes dosu entry", async () => {
@@ -1190,7 +1222,7 @@ describe("AntigravityProvider", () => {
     provider.install(makeCfg(), true);
     provider.remove(true);
 
-    const configPath = join(tempDir, ".gemini", "antigravity", "mcp_config.json");
+    const configPath = join(tempDir, ".gemini", "config", "mcp_config.json");
     const cfg = loadJSONConfig(configPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
   });
@@ -1230,11 +1262,11 @@ describe("ZedProvider", () => {
     expect(cfg.context_servers.dosu.url).toContain("dep-123");
   });
 
-  it("local install writes to cwd/.zed/settings.json", async () => {
+  it("project install writes to the explicit project .zed/settings.json", async () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".zed", "settings.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1258,8 +1290,8 @@ describe("ZedProvider", () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".zed", "settings.json");
     const cfg = loadJSONConfig(configPath);

--- a/src/mcp/providers/zed.ts
+++ b/src/mcp/providers/zed.ts
@@ -29,5 +29,10 @@ export const ZedProvider = () =>
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
+    buildProjectServer: (command) => ({
+      command: command.command,
+      args: command.args,
+      env: {},
+    }),
     localConfigPath: (cwd) => join(cwd, ".zed", "settings.json"),
   });

--- a/src/migration/global-intent.test.ts
+++ b/src/migration/global-intent.test.ts
@@ -1,0 +1,272 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  finalizeGlobalMcpIntent,
+  globalMcpIntentMarkerPath,
+  inspectGlobalMcpIntent,
+  prepareGlobalMcpIntent,
+  releaseGlobalMcpIntent,
+} from "./global-intent";
+import { acquireTargetOperationLock, releaseTargetOperationLock } from "./orchestrator";
+
+let tempDir: string;
+let intentRoot: string;
+let targetPath: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-global-intent-"));
+  intentRoot = join(tempDir, "private", "migrations", "global-mcp-intent-v1");
+  targetPath = join(tempDir, "home", ".cursor", "mcp.json");
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("explicit global MCP intent", () => {
+  it("rejects invalid identities, relative paths, and a non-file marker before writing", () => {
+    expect(() => globalMcpIntentMarkerPath({ provider: "Cursor", targetPath, intentRoot })).toThrow(
+      "Invalid global MCP provider ID",
+    );
+    expect(() =>
+      globalMcpIntentMarkerPath({ provider: "cursor", targetPath: "relative", intentRoot }),
+    ).toThrow("Global MCP target path must be absolute");
+    expect(() =>
+      globalMcpIntentMarkerPath({ provider: "cursor", targetPath, intentRoot: "relative" }),
+    ).toThrow("Global MCP intent root must be absolute");
+
+    mkdirSync(intentRoot, { recursive: true });
+    const markerPath = globalMcpIntentMarkerPath({ provider: "cursor", targetPath, intentRoot });
+    mkdirSync(markerPath);
+
+    expect(() => prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toThrow(
+      "Unsafe global MCP intent marker",
+    );
+    expect(lstatSync(markerPath).isDirectory()).toBe(true);
+  });
+
+  it("durably records pending intent before the target changes, then binds installed content", () => {
+    const pending = prepareGlobalMcpIntent({
+      provider: "cursor",
+      targetPath,
+      intentRoot,
+    });
+    const pendingMarker = JSON.parse(readFileSync(pending.markerPath, "utf8"));
+    expect(pendingMarker).toMatchObject({
+      version: 1,
+      state: "pending",
+      provider: "cursor",
+      targetPath,
+    });
+    expect(existsSync(`${targetPath}.dosu-migration.lock`)).toBe(true);
+
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    finalizeGlobalMcpIntent(pending);
+
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "explicit_global_intent",
+    });
+    expect(existsSync(`${targetPath}.dosu-migration.lock`)).toBe(false);
+  });
+
+  it("shares target exclusion with migration and releases it while retaining failed intent", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    const migrationLock = acquireTargetOperationLock(targetPath, join(tempDir, "receipts"));
+    expect(() => prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toThrow(
+      "Global MCP target is locked",
+    );
+    expect(
+      existsSync(globalMcpIntentMarkerPath({ provider: "cursor", targetPath, intentRoot })),
+    ).toBe(false);
+    releaseTargetOperationLock(migrationLock);
+
+    const pending = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    expect(existsSync(pending.operationLock.path)).toBe(true);
+    releaseGlobalMcpIntent(pending);
+    expect(existsSync(pending.operationLock.path)).toBe(false);
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "global_intent_pending",
+    });
+  });
+
+  it("updates the content binding on an explicit reinstall", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    const first = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    finalizeGlobalMcpIntent(first);
+    const markerPath = globalMcpIntentMarkerPath({ provider: "cursor", targetPath, intentRoot });
+    const firstHash = JSON.parse(readFileSync(markerPath, "utf8")).contentHash;
+
+    const second = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"two"}}}\n');
+    finalizeGlobalMcpIntent(second);
+    const secondHash = JSON.parse(readFileSync(markerPath, "utf8")).contentHash;
+
+    expect(secondHash).not.toBe(firstHash);
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "explicit_global_intent",
+    });
+  });
+
+  it("prefers an exact marker and recognizes canonical intent shared across providers", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"shared"}}}\n');
+    for (const provider of ["claude", "copilot", "cursor"]) {
+      const pending = prepareGlobalMcpIntent({ provider, targetPath, intentRoot });
+      finalizeGlobalMcpIntent(pending);
+    }
+
+    for (const provider of ["claude", "copilot", "cursor", "gemini"]) {
+      expect(inspectGlobalMcpIntent({ provider, targetPath, intentRoot })).toEqual({
+        status: "preserve",
+        reason: "explicit_global_intent",
+      });
+    }
+  });
+
+  it("refuses to finalize a marker or target that changed after prepare", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    const changedMarker = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    const marker = JSON.parse(readFileSync(changedMarker.markerPath, "utf8"));
+    writeFileSync(changedMarker.markerPath, `${JSON.stringify({ ...marker, unexpected: true })}\n`);
+
+    expect(() => finalizeGlobalMcpIntent(changedMarker)).toThrow(
+      "Global MCP intent marker changed during install",
+    );
+    expect(readFileSync(targetPath, "utf8")).toContain('"url":"one"');
+
+    const directoryTarget = join(tempDir, "home", ".claude", "config.json");
+    const nonRegularTarget = prepareGlobalMcpIntent({
+      provider: "claude",
+      targetPath: directoryTarget,
+      intentRoot,
+    });
+    mkdirSync(directoryTarget, { recursive: true });
+
+    expect(() => finalizeGlobalMcpIntent(nonRegularTarget)).toThrow(
+      "Global MCP install target is not a regular file",
+    );
+    expect(lstatSync(directoryTarget).isDirectory()).toBe(true);
+  });
+
+  it("fails closed for invalid inputs, unsafe roots, and an empty marker inventory", () => {
+    expect(inspectGlobalMcpIntent({ provider: "Cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "global_intent_unsafe",
+    });
+
+    const unsafeRoot = join(tempDir, "intent-root-file");
+    writeFileSync(unsafeRoot, "do not replace");
+    expect(
+      inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot: unsafeRoot }),
+    ).toEqual({ status: "preserve", reason: "global_intent_unsafe" });
+    expect(readFileSync(unsafeRoot, "utf8")).toBe("do not replace");
+
+    mkdirSync(intentRoot, { recursive: true });
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "absent",
+    });
+  });
+
+  it("fails closed for invalid installed markers and missing or non-regular targets", () => {
+    mkdirSync(intentRoot, { recursive: true });
+    const hash = "0".repeat(64);
+    const writeInstalledMarker = (
+      provider: string,
+      target: string,
+      extra: Record<string, unknown> = {},
+    ) => {
+      const markerPath = globalMcpIntentMarkerPath({ provider, targetPath: target, intentRoot });
+      writeFileSync(
+        markerPath,
+        `${JSON.stringify({
+          version: 1,
+          state: "installed",
+          provider,
+          targetPath: target,
+          contentHash: hash,
+          ...extra,
+        })}\n`,
+      );
+    };
+
+    const invalidTarget = join(tempDir, "invalid-target.json");
+    writeInstalledMarker("cursor", invalidTarget, { unexpected: true });
+    expect(
+      inspectGlobalMcpIntent({ provider: "cursor", targetPath: invalidTarget, intentRoot }),
+    ).toEqual({ status: "preserve", reason: "global_intent_invalid" });
+
+    const directoryTarget = join(tempDir, "directory-target");
+    mkdirSync(directoryTarget);
+    writeInstalledMarker("claude", directoryTarget);
+    expect(
+      inspectGlobalMcpIntent({ provider: "claude", targetPath: directoryTarget, intentRoot }),
+    ).toEqual({ status: "preserve", reason: "global_intent_content_changed" });
+
+    const missingTarget = join(tempDir, "missing-target.json");
+    writeInstalledMarker("gemini", missingTarget);
+    expect(
+      inspectGlobalMcpIntent({ provider: "gemini", targetPath: missingTarget, intentRoot }),
+    ).toEqual({ status: "preserve", reason: "global_intent_content_changed" });
+  });
+
+  it("rejects a marker replaced by a symlink between prepare and finalize", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    const pending = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    const pendingContent = readFileSync(pending.markerPath, "utf8");
+    const foreignMarker = join(tempDir, "foreign-pending-marker");
+    writeFileSync(foreignMarker, pendingContent);
+    rmSync(pending.markerPath);
+    symlinkSync(foreignMarker, pending.markerPath);
+
+    expect(() => finalizeGlobalMcpIntent(pending)).toThrow(/regular|unsafe/i);
+    expect(readFileSync(foreignMarker, "utf8")).toBe(pendingContent);
+  });
+
+  it("fails closed for pending, damaged, symlinked, and content-mismatched markers", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    const pending = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toMatchObject({
+      status: "preserve",
+    });
+
+    writeFileSync(pending.markerPath, "not-json");
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toMatchObject({
+      status: "preserve",
+    });
+
+    rmSync(pending.markerPath);
+    symlinkSync(join(tempDir, "foreign-marker"), pending.markerPath);
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toMatchObject({
+      status: "preserve",
+    });
+
+    rmSync(pending.markerPath);
+    releaseGlobalMcpIntent(pending);
+    const installed = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    finalizeGlobalMcpIntent(installed);
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"changed"}}}\n');
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "global_intent_content_changed",
+    });
+  });
+});

--- a/src/migration/global-intent.ts
+++ b/src/migration/global-intent.ts
@@ -1,0 +1,367 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import {
+  getNodeValue,
+  type Node as JsonNode,
+  type ParseError,
+  parseTree,
+} from "jsonc-parser/lib/esm/main.js";
+import { getConfigDir } from "../config/config";
+import {
+  acquireTargetOperationLock,
+  releaseTargetOperationLock,
+  type TargetOperationLock,
+} from "./orchestrator";
+
+const VERSION = 1;
+const DIRECTORY_NAME = "global-mcp-intent-v1";
+
+export interface GlobalMcpIntentInput {
+  provider: string;
+  targetPath: string;
+  /** Test override. Production intent lives under Dosu's private config directory. */
+  intentRoot?: string;
+}
+
+export interface PendingGlobalMcpIntent {
+  provider: string;
+  targetPath: string;
+  intentRoot: string;
+  markerPath: string;
+  nonce: string;
+  operationLock: TargetOperationLock;
+}
+
+export type GlobalMcpIntentInspection =
+  | { status: "absent" }
+  | {
+      status: "preserve";
+      reason:
+        | "explicit_global_intent"
+        | "global_intent_pending"
+        | "global_intent_invalid"
+        | "global_intent_unsafe"
+        | "global_intent_content_changed";
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function duplicateJsonKey(node: JsonNode): boolean {
+  if (node.type === "object") {
+    const seen = new Set<string>();
+    for (const property of node.children ?? []) {
+      const keyNode = property.children?.[0];
+      const key = keyNode ? getNodeValue(keyNode) : undefined;
+      if (typeof key !== "string") continue;
+      if (seen.has(key)) return true;
+      seen.add(key);
+    }
+  }
+  return (node.children ?? []).some(duplicateJsonKey);
+}
+
+function parseStrictObject(content: string): Record<string, unknown> | null {
+  const errors: ParseError[] = [];
+  const root = parseTree(content, errors, { allowTrailingComma: false, disallowComments: true });
+  if (root?.type !== "object" || errors.length > 0 || duplicateJsonKey(root)) return null;
+  const value: unknown = getNodeValue(root);
+  return isRecord(value) ? value : null;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+}
+
+function canonicalInput(input: GlobalMcpIntentInput): {
+  provider: string;
+  targetPath: string;
+  intentRoot: string;
+} {
+  if (!/^[a-z0-9-]+$/.test(input.provider)) throw new Error("Invalid global MCP provider ID");
+  if (!isAbsolute(input.targetPath)) throw new Error("Global MCP target path must be absolute");
+  const intentRoot = input.intentRoot ?? join(getConfigDir(), "migrations", DIRECTORY_NAME);
+  if (!isAbsolute(intentRoot)) throw new Error("Global MCP intent root must be absolute");
+  return {
+    provider: input.provider,
+    targetPath: resolve(input.targetPath),
+    intentRoot: resolve(intentRoot),
+  };
+}
+
+export function globalMcpIntentMarkerPath(input: GlobalMcpIntentInput): string {
+  const canonical = canonicalInput(input);
+  const pathHash = targetPathHash(canonical.targetPath);
+  return join(canonical.intentRoot, `${canonical.provider}-${pathHash}.json`);
+}
+
+function targetPathHash(path: string): string {
+  return createHash("sha256").update(path).digest("hex").slice(0, 24);
+}
+
+function contentHash(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function fsyncParent(path: string): void {
+  try {
+    const fd = openSync(dirname(path), "r");
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    // Some supported platforms do not expose directory fsync.
+  }
+}
+
+function atomicWrite(path: string, content: string): void {
+  const temporary = `${path}.candidate-${process.pid}-${randomBytes(6).toString("hex")}`;
+  let exists = false;
+  try {
+    const fd = openSync(temporary, "wx", 0o600);
+    exists = true;
+    try {
+      writeFileSync(fd, content, "utf8");
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(temporary, path);
+    chmodSync(path, 0o600);
+    fsyncParent(path);
+    exists = false;
+  } finally {
+    if (exists) {
+      try {
+        unlinkSync(temporary);
+      } catch {
+        // A never-published candidate is not authoritative.
+      }
+    }
+  }
+}
+
+function prepareRoot(path: string): void {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error("Unsafe global MCP intent root");
+    }
+  } catch (error: unknown) {
+    const code = isRecord(error) && "code" in error ? error.code : undefined;
+    if (code !== "ENOENT") throw error;
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+  }
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe global MCP intent root");
+  }
+  chmodSync(path, 0o700);
+}
+
+function assertReplaceableMarker(path: string): void {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error("Unsafe global MCP intent marker");
+    }
+  } catch (error: unknown) {
+    const code = isRecord(error) && "code" in error ? error.code : undefined;
+    if (code !== "ENOENT") throw error;
+  }
+}
+
+/** Persist a fail-closed pending marker before any global provider file is changed. */
+export function prepareGlobalMcpIntent(input: GlobalMcpIntentInput): PendingGlobalMcpIntent {
+  const canonical = canonicalInput(input);
+  prepareRoot(canonical.intentRoot);
+  mkdirSync(dirname(canonical.targetPath), { recursive: true, mode: 0o700 });
+  const targetParent = lstatSync(dirname(canonical.targetPath));
+  if (!targetParent.isDirectory() || targetParent.isSymbolicLink()) {
+    throw new Error("Unsafe global MCP target directory");
+  }
+  const operationLock = acquireTargetOperationLock(canonical.targetPath, canonical.intentRoot);
+  try {
+    const markerPath = globalMcpIntentMarkerPath(canonical);
+    assertReplaceableMarker(markerPath);
+    const nonce = randomBytes(16).toString("hex");
+    atomicWrite(
+      markerPath,
+      `${JSON.stringify({
+        version: VERSION,
+        state: "pending",
+        provider: canonical.provider,
+        targetPath: canonical.targetPath,
+        nonce,
+      })}\n`,
+    );
+    return { ...canonical, markerPath, nonce, operationLock };
+  } catch (error) {
+    releaseTargetOperationLock(operationLock);
+    throw error;
+  }
+}
+
+/** Bind the marker to the exact complete config contents produced by install. */
+export function finalizeGlobalMcpIntent(pending: PendingGlobalMcpIntent): void {
+  try {
+    const markerStat = lstatSync(pending.markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
+      throw new Error("Global MCP intent marker is not a regular file");
+    }
+    const marker = parseStrictObject(readFileSync(pending.markerPath, "utf8"));
+    if (
+      !marker ||
+      !exactKeys(marker, ["version", "state", "provider", "targetPath", "nonce"]) ||
+      marker.version !== VERSION ||
+      marker.state !== "pending" ||
+      marker.provider !== pending.provider ||
+      marker.targetPath !== pending.targetPath ||
+      marker.nonce !== pending.nonce
+    ) {
+      throw new Error("Global MCP intent marker changed during install");
+    }
+    const targetStat = lstatSync(pending.targetPath);
+    if (!targetStat.isFile() || targetStat.isSymbolicLink()) {
+      throw new Error("Global MCP install target is not a regular file");
+    }
+    const installedHash = contentHash(pending.targetPath);
+    atomicWrite(
+      pending.markerPath,
+      `${JSON.stringify({
+        version: VERSION,
+        state: "installed",
+        provider: pending.provider,
+        targetPath: pending.targetPath,
+        contentHash: installedHash,
+      })}\n`,
+    );
+  } finally {
+    releaseTargetOperationLock(pending.operationLock);
+  }
+}
+
+/** Keep the pending marker as fail-closed evidence, but release the operation lock after failure. */
+export function releaseGlobalMcpIntent(pending: PendingGlobalMcpIntent): void {
+  releaseTargetOperationLock(pending.operationLock);
+}
+
+/** Read-only migration guard. Every non-absent unknown state preserves config. */
+export function inspectGlobalMcpIntent(input: GlobalMcpIntentInput): GlobalMcpIntentInspection {
+  let canonical: ReturnType<typeof canonicalInput>;
+  try {
+    canonical = canonicalInput(input);
+  } catch {
+    return { status: "preserve", reason: "global_intent_unsafe" };
+  }
+
+  try {
+    const rootStat = lstatSync(canonical.intentRoot);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+      return { status: "preserve", reason: "global_intent_unsafe" };
+    }
+  } catch (error: unknown) {
+    const code = isRecord(error) && "code" in error ? error.code : undefined;
+    return code === "ENOENT"
+      ? { status: "absent" }
+      : { status: "preserve", reason: "global_intent_unsafe" };
+  }
+
+  const exactMarkerPath = globalMcpIntentMarkerPath(canonical);
+  let candidatePaths: string[];
+  try {
+    const hash = targetPathHash(canonical.targetPath);
+    const pattern = new RegExp(`^.+-${hash}\\.json$`);
+    candidatePaths = readdirSync(canonical.intentRoot)
+      .filter((name) => pattern.test(name))
+      .map((name) => join(canonical.intentRoot, name))
+      .sort((left, right) => {
+        if (left === exactMarkerPath) return -1;
+        if (right === exactMarkerPath) return 1;
+        return left.localeCompare(right);
+      });
+  } catch {
+    return { status: "preserve", reason: "global_intent_unsafe" };
+  }
+  if (candidatePaths.length === 0) return { status: "absent" };
+  const markerPath = candidatePaths[0];
+  let markerContent: string;
+  try {
+    const markerStat = lstatSync(markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
+      return { status: "preserve", reason: "global_intent_unsafe" };
+    }
+    markerContent = readFileSync(markerPath, "utf8");
+  } catch {
+    return { status: "preserve", reason: "global_intent_unsafe" };
+  }
+
+  const marker = parseStrictObject(markerContent);
+  if (!marker) return { status: "preserve", reason: "global_intent_invalid" };
+  if (
+    exactKeys(marker, ["version", "state", "provider", "targetPath", "nonce"]) &&
+    marker.version === VERSION &&
+    marker.state === "pending" &&
+    typeof marker.provider === "string" &&
+    /^[a-z0-9-]+$/.test(marker.provider) &&
+    marker.targetPath === canonical.targetPath &&
+    typeof marker.nonce === "string" &&
+    /^[a-f0-9]{32}$/.test(marker.nonce) &&
+    markerPath ===
+      globalMcpIntentMarkerPath({
+        provider: marker.provider,
+        targetPath: canonical.targetPath,
+        intentRoot: canonical.intentRoot,
+      })
+  ) {
+    return { status: "preserve", reason: "global_intent_pending" };
+  }
+  if (
+    !exactKeys(marker, ["version", "state", "provider", "targetPath", "contentHash"]) ||
+    marker.version !== VERSION ||
+    marker.state !== "installed" ||
+    typeof marker.provider !== "string" ||
+    !/^[a-z0-9-]+$/.test(marker.provider) ||
+    marker.targetPath !== canonical.targetPath ||
+    typeof marker.contentHash !== "string" ||
+    !/^[a-f0-9]{64}$/.test(marker.contentHash) ||
+    markerPath !==
+      globalMcpIntentMarkerPath({
+        provider: marker.provider,
+        targetPath: canonical.targetPath,
+        intentRoot: canonical.intentRoot,
+      })
+  ) {
+    return { status: "preserve", reason: "global_intent_invalid" };
+  }
+
+  try {
+    const targetStat = lstatSync(canonical.targetPath);
+    if (!targetStat.isFile() || targetStat.isSymbolicLink()) {
+      return { status: "preserve", reason: "global_intent_content_changed" };
+    }
+    return contentHash(canonical.targetPath) === marker.contentHash
+      ? { status: "preserve", reason: "explicit_global_intent" }
+      : { status: "preserve", reason: "global_intent_content_changed" };
+  } catch {
+    return { status: "preserve", reason: "global_intent_content_changed" };
+  }
+}

--- a/src/migration/index.ts
+++ b/src/migration/index.ts
@@ -1,0 +1,45 @@
+export {
+  applyContentPlan,
+  inspectLegacyTarget,
+  type LegacyTargetInspection,
+  legacyTargetsNeedCleanup,
+  type MigrationOutcome,
+  type MigrationReceipt,
+  migrateLegacyTargets,
+} from "./orchestrator";
+export {
+  type ContentPlan,
+  isExactProjectCodexProxy,
+  isExactProjectJsonProxy,
+  type ProjectProxyExpectation,
+  planCodexDosuMcp,
+  planLegacyCodexMcp,
+  planLegacyJsonMcp,
+  planLegacyRuleSection,
+  planLegacyStandaloneRule,
+  planProjectCodexMcp,
+  removeJsonObjectPropertyRaw,
+} from "./planners";
+export {
+  assertProjectBundleProof,
+  type ProjectBundleFailureReason,
+  type ProjectBundleProof,
+  type ProjectBundleStatus,
+  type ProjectBundleVerification,
+  projectBundleStatus,
+  verifyProjectBundle,
+} from "./project-bundle";
+export {
+  type ProjectFacts,
+  type ProjectProof,
+  type ProjectProofResult,
+  proveProjectScope,
+  resolveProjectProof,
+} from "./project-proof";
+export {
+  type LegacyTarget,
+  type LegacyTargetEnvironment,
+  type LegacyTargetResolution,
+  type ProviderId,
+  resolveLegacyTargets,
+} from "./targets";

--- a/src/migration/orchestrator.test.ts
+++ b/src/migration/orchestrator.test.ts
@@ -1,0 +1,2050 @@
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyContentPlan,
+  ensureBackup,
+  inspectLegacyTarget,
+  legacyTargetsNeedCleanup,
+  type MigrationReceipt,
+  migrateLegacyTargets,
+} from "./orchestrator";
+import { hashContent, planLegacyJsonMcp, planLegacyStandaloneRule } from "./planners";
+import { type ProjectBundleProof, verifyProjectBundle } from "./project-bundle";
+import { proveProjectScope } from "./project-proof";
+import type { LegacyTarget } from "./targets";
+
+let tempDir: string;
+let backupRoot: string;
+const RELEASED_RULE = readFileSync(join(process.cwd(), "rules", "dosu.md"), "utf8");
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-legacy-migration-"));
+  backupRoot = join(tempDir, "backups");
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function proof(): ProjectBundleProof {
+  const root = join(tempDir, "project");
+  mkdirSync(join(root, ".agents", "skills", "dosu"), { recursive: true });
+  mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+  const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  writeFileSync(join(root, ".agents", "skills", "dosu", "SKILL.md"), skill);
+  const skillHash = createHash("sha256").update("SKILL.md").update(skill).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash: skillHash,
+        },
+      },
+    }),
+  );
+  const claudeSkill = join(root, ".claude", "skills", "dosu");
+  mkdirSync(claudeSkill, { recursive: true });
+  writeFileSync(join(claudeSkill, "SKILL.md"), skill);
+  writeFileSync(
+    join(root, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"],
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, "AGENTS.md"),
+    "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+  );
+  writeFileSync(
+    join(root, "CLAUDE.md"),
+    "<!-- dosu:project-instructions:start v1 -->\n@AGENTS.md\n<!-- dosu:project-instructions:end -->\n",
+  );
+  const result = proveProjectScope({
+    cwd: root,
+    gitTopLevel: root,
+    insideWorkTree: true,
+    bareRepository: false,
+  });
+  if (!result.ok) throw new Error(result.reason);
+  const bundle = verifyProjectBundle({
+    project: result.proof,
+    providerIDs: ["claude"],
+    proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+    instructionContent: "Use Dosu.",
+  });
+  if (!bundle.ok) throw new Error(bundle.reason);
+  return bundle.proof;
+}
+
+function jsonTarget(path: string): LegacyTarget {
+  return {
+    id: "claude:mcp",
+    provider: "claude",
+    kind: "json_mcp",
+    path,
+    topKey: "mcpServers",
+  };
+}
+
+function crashedWriteCapture(name: string): {
+  path: string;
+  original: string;
+  plan: ReturnType<typeof planLegacyJsonMcp>;
+  pending: MigrationReceipt;
+} {
+  const path = join(tempDir, `${name}.json`);
+  const original = JSON.stringify({
+    mcpServers: {
+      dosu: {
+        type: "http",
+        url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+        headers: { "X-Dosu-API-Key": "legacy-secret" },
+      },
+      user: { url: "https://example.com" },
+    },
+  });
+  writeFileSync(path, original);
+  const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+  expect(
+    applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: () => {
+          throw new Error("simulated crash");
+        },
+      },
+    }),
+  ).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+  const receiptName = readdirSync(backupRoot).find((entry) => entry.endsWith(".receipt.json"));
+  if (!receiptName) throw new Error("expected pending receipt");
+  const pending = JSON.parse(readFileSync(join(backupRoot, receiptName), "utf8"));
+  return { path, original, plan, pending };
+}
+
+describe("backup, receipt, concurrent hash, and idempotence orchestration", () => {
+  it("rejects and removes a newly copied backup whose bytes do not match the preimage", () => {
+    const source = join(tempDir, "source.json");
+    const backup = join(tempDir, "corrupted.bak");
+    const content = '{"secret":"original"}';
+    writeFileSync(source, content);
+    const expectedHash = createHash("sha256").update(content).digest("hex");
+
+    expect(() =>
+      ensureBackup(source, backup, expectedHash, (from, to, flags) => {
+        copyFileSync(from, to, flags);
+        writeFileSync(to, "corrupted during copy");
+      }),
+    ).toThrow("New migration backup does not match the planned content");
+    expect(existsSync(backup)).toBe(false);
+  });
+
+  it("rejects an existing backup symlink even when it resolves to the exact preimage", () => {
+    const source = join(tempDir, "source.json");
+    const backup = join(tempDir, "linked.bak");
+    const content = '{"secret":"original"}';
+    writeFileSync(source, content);
+    symlinkSync(source, backup);
+
+    expect(() => ensureBackup(source, backup, hashContent(content))).toThrow(
+      "Existing migration backup is not a regular file",
+    );
+    expect(readFileSync(source, "utf8")).toBe(content);
+    expect(lstatSync(backup).isSymbolicLink()).toBe(true);
+  });
+
+  it("inspects strict current plans without mutating and requests runtime verification only for removal", () => {
+    const owned = join(tempDir, "owned.json");
+    const foreign = join(tempDir, "foreign-inspection.json");
+    writeFileSync(
+      owned,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": "secret" },
+          },
+        },
+      }),
+    );
+    writeFileSync(foreign, '{"mcpServers":{"dosu":{"url":"https://example.com"}}}');
+
+    expect(legacyTargetsNeedCleanup([jsonTarget(owned)])).toBe(true);
+    expect(legacyTargetsNeedCleanup([jsonTarget(foreign)])).toBe(false);
+    expect(inspectLegacyTarget(jsonTarget(owned))).toMatchObject({ disposition: "remove" });
+    expect(inspectLegacyTarget(jsonTarget(foreign))).toMatchObject({
+      disposition: "ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+    expect(inspectLegacyTarget(jsonTarget(join(tempDir, "absent.json")))).toEqual({
+      disposition: "not_found",
+      reason: "target_absent",
+    });
+    expect(existsSync(backupRoot)).toBe(false);
+  });
+
+  it("inspects every historical target kind and deduplicates repeated paths", () => {
+    const codexPath = join(tempDir, "config.toml");
+    writeFileSync(
+      codexPath,
+      '[mcp_servers.dosu]\ntype = "http"\nurl = "https://api.dosu.dev/v1/mcp/deployments/dep"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "secret"\n',
+    );
+    const claudeRule = join(tempDir, "dosu.md");
+    writeFileSync(claudeRule, RELEASED_RULE);
+    const cursorRule = join(tempDir, "dosu.mdc");
+    writeFileSync(cursorRule, `---\nalwaysApply: true\n---\n\n${RELEASED_RULE}`);
+    const targets: LegacyTarget[] = [
+      { id: "codex:mcp", provider: "codex", kind: "codex_toml", path: codexPath },
+      {
+        id: "claude:rule",
+        provider: "claude",
+        kind: "rule_file",
+        path: claudeRule,
+        ruleKind: "claude",
+      },
+      {
+        id: "cursor:rule",
+        provider: "cursor",
+        kind: "rule_file",
+        path: cursorRule,
+        ruleKind: "cursor",
+      },
+    ];
+    for (const target of targets) {
+      expect(inspectLegacyTarget(target)).toMatchObject({ disposition: "remove" });
+    }
+    expect(legacyTargetsNeedCleanup([targets[0], targets[0]])).toBe(true);
+  });
+
+  it("treats directories and symlinks as ambiguous without following them", () => {
+    const directory = join(tempDir, "directory-target");
+    const linked = join(tempDir, "linked-target.json");
+    const foreign = join(tempDir, "foreign.json");
+    mkdirSync(directory);
+    writeFileSync(foreign, '{"mcpServers":{}}');
+    symlinkSync(foreign, linked);
+
+    expect(inspectLegacyTarget(jsonTarget(directory))).toEqual({
+      disposition: "ambiguous",
+      reason: "non_regular_target",
+    });
+    expect(inspectLegacyTarget(jsonTarget(linked))).toEqual({
+      disposition: "ambiguous",
+      reason: "non_regular_target",
+    });
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [jsonTarget(directory), jsonTarget(linked)],
+        backupRoot,
+        allowRemoval: true,
+      }).map((receipt) => receipt.reason),
+    ).toEqual(["non_regular_target", "non_regular_target"]);
+    expect(lstatSync(linked).isSymbolicLink()).toBe(true);
+  });
+
+  it("fails closed when even a not-found receipt cannot be written", () => {
+    const unsafeBackupRoot = join(tempDir, "backup-file");
+    writeFileSync(unsafeBackupRoot, "not a directory");
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [jsonTarget(join(tempDir, "missing.json"))],
+        backupRoot: unsafeBackupRoot,
+        allowRemoval: true,
+      }),
+    ).toEqual([expect.objectContaining({ outcome: "failed", reason: "receipt_write_failed" })]);
+  });
+
+  it("does not mutate or tombstone a removable target without runtime verification", () => {
+    const path = join(tempDir, "runtime-gated.json");
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    writeFileSync(path, content);
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: false,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "runtime_not_verified",
+    });
+    expect(readFileSync(path, "utf8")).toBe(content);
+    expect(existsSync(backupRoot)).toBe(false);
+  });
+
+  it("backs up before mutation, writes a secret-free receipt, and is idempotent", () => {
+    const path = join(tempDir, "home", ".claude.json");
+    mkdirSync(join(tempDir, "home"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": "super-secret" },
+          },
+          user: { url: "https://example.com" },
+        },
+      }),
+      { mode: 0o600 },
+    );
+
+    const first = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(first).toHaveLength(1);
+    expect(first[0]).toMatchObject({ outcome: "removed", targetId: "claude:mcp" });
+    expect(readFileSync(path, "utf8")).toContain("https://example.com");
+    expect(readFileSync(path, "utf8")).not.toContain("super-secret");
+    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+
+    const backupFiles = readdirSync(backupRoot).filter((name) => name.endsWith(".bak"));
+    const receiptFiles = readdirSync(backupRoot).filter((name) => name.endsWith(".receipt.json"));
+    expect(backupFiles).toHaveLength(1);
+    expect(receiptFiles).toHaveLength(1);
+    expect(readFileSync(join(backupRoot, backupFiles[0]), "utf8")).toContain("super-secret");
+    const receiptText = readFileSync(join(backupRoot, receiptFiles[0]), "utf8");
+    expect(receiptText).not.toContain("super-secret");
+    expect(JSON.parse(receiptText)).toMatchObject({ outcome: "removed" });
+    expect(JSON.parse(receiptText)).toMatchObject({
+      plannedMutation: "write",
+      plannedAfterHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+
+    const second = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(second[0]).toMatchObject({ outcome: "not_found" });
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".bak"))).toHaveLength(1);
+  });
+
+  it("refuses to apply a stale plan after a concurrent content change", async () => {
+    const path = join(tempDir, "config.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    writeFileSync(path, original);
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    writeFileSync(path, `${original}\n// concurrent edit\n`);
+
+    const { applyContentPlan } = await import("./orchestrator");
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+    });
+
+    expect(receipt).toMatchObject({ outcome: "concurrent_conflict" });
+    expect(readFileSync(path, "utf8")).toContain("concurrent edit");
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".receipt.json"))).toHaveLength(
+      1,
+    );
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".bak"))).toHaveLength(0);
+  });
+
+  it("rechecks the source and project bundle at every pre-capture boundary", () => {
+    const phases = [
+      "afterLockAcquired",
+      "afterBackupCreated",
+      "beforeFinalBundleCheck",
+      "beforeFinalSourceCheck",
+    ] as const;
+
+    for (const phase of phases) {
+      const phaseBackupRoot = join(backupRoot, phase);
+      const path = join(tempDir, `${phase}.json`);
+      const original = JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": "legacy-secret" },
+          },
+          user: { url: "https://example.com" },
+        },
+      });
+      writeFileSync(path, original);
+      const bundle = proof();
+      const mutate = () => {
+        if (phase === "beforeFinalBundleCheck") {
+          writeFileSync(join(bundle.root, ".mcp.json"), '{"mcpServers":{}}');
+        } else {
+          writeFileSync(path, `${original}\nuser concurrent edit`);
+        }
+      };
+      const testHooks =
+        phase === "afterLockAcquired"
+          ? { afterLockAcquired: mutate }
+          : phase === "afterBackupCreated"
+            ? { afterBackupCreated: mutate }
+            : phase === "beforeFinalBundleCheck"
+              ? { beforeFinalBundleCheck: mutate }
+              : { beforeFinalSourceCheck: mutate };
+
+      const receipt = applyContentPlan({
+        bundle,
+        target: jsonTarget(path),
+        plan: planLegacyJsonMcp({
+          content: original,
+          provider: "claude",
+          topKey: "mcpServers",
+        }),
+        backupRoot: phaseBackupRoot,
+        allowRemoval: true,
+        _testHooks: testHooks,
+      });
+
+      expect(receipt).toMatchObject({
+        outcome: phase === "beforeFinalBundleCheck" ? "preserved_ambiguous" : "concurrent_conflict",
+        reason:
+          phase === "beforeFinalBundleCheck" ? "project_bundle_changed" : "content_hash_changed",
+      });
+    }
+  });
+
+  it("applies authorization and not-found plans without touching the target", () => {
+    const path = join(tempDir, "direct-not-found.json");
+    const content = '{"mcpServers":{"user":{"url":"https://example.com"}}}';
+    writeFileSync(path, content);
+    const plan = planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" });
+    expect(plan.disposition).toBe("not_found");
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: jsonTarget(path),
+        plan,
+        backupRoot: join(backupRoot, "not-found"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "not_found" });
+
+    const unauthorized: LegacyTarget = {
+      ...jsonTarget(path),
+      id: "shared:mcp",
+      requiredProviders: ["claude", "gemini"],
+    };
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: unauthorized,
+        plan,
+        backupRoot: join(backupRoot, "unauthorized"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "shared_target_not_fully_authorized",
+    });
+    expect(readFileSync(path, "utf8")).toBe(content);
+  });
+
+  it("restores a replacement captured after the final delete check instead of deleting it", () => {
+    const path = join(tempDir, "delete-capture-race.md");
+    const displaced = join(tempDir, "delete-capture-race.displaced.md");
+    const original = RELEASED_RULE;
+    const replacement = "# User-owned replacement\n";
+    writeFileSync(path, original);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+    const plan = planLegacyStandaloneRule(original, "claude");
+    expect(plan.mutation).toBe("delete");
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeCapture: () => {
+          renameSync(path, displaced);
+          writeFileSync(path, replacement);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "captured_source_mismatch",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+    expect(readFileSync(displaced, "utf8")).toBe(original);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("restores a symlink captured after the final delete check without following it", () => {
+    const path = join(tempDir, "delete-capture-symlink-race.md");
+    const displaced = join(tempDir, "delete-capture-symlink-race.displaced.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeCapture: () => {
+          renameSync(path, displaced);
+          symlinkSync(displaced, path);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "captured_source_mismatch",
+    });
+    expect(lstatSync(path).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(path)).toBe(displaced);
+    expect(readFileSync(displaced, "utf8")).toBe(RELEASED_RULE);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("keeps a captured directory in a durable pending journal and reports it again on recovery", () => {
+    const path = join(tempDir, "delete-capture-directory-race.md");
+    const displaced = join(tempDir, "delete-capture-directory-race.displaced.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeCapture: () => {
+          renameSync(path, displaced);
+          mkdirSync(path);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "pending", reason: "captured_source_mismatch" });
+    const receiptName = readdirSync(backupRoot).find((name) => name.endsWith(".receipt.json"));
+    if (!receiptName) throw new Error("expected pending receipt");
+    const persisted = JSON.parse(readFileSync(join(backupRoot, receiptName), "utf8"));
+    expect(persisted).toMatchObject({ outcome: "pending", reason: "mutation_prepared" });
+    expect(lstatSync(persisted.capturePath).isDirectory()).toBe(true);
+    expect(existsSync(path)).toBe(false);
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [target],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(retried).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_capture_invalid",
+    });
+    expect(JSON.parse(readFileSync(join(backupRoot, receiptName), "utf8"))).toMatchObject({
+      outcome: "pending",
+    });
+    expect(lstatSync(persisted.capturePath).isDirectory()).toBe(true);
+  });
+
+  it("never overwrites a target created after an exact source was captured for a write", () => {
+    const path = join(tempDir, "write-publish-race.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const replacement = '{"userOwned":"created after capture"}';
+    writeFileSync(path, original);
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    expect(plan.mutation).toBe("write");
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: () => writeFileSync(path, replacement),
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "target_recreated_during_migration",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("retries a pending write after a crash immediately after atomic capture", () => {
+    const path = join(tempDir, "write-capture-crash.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: jsonTarget(path),
+        plan,
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterCapture: () => {
+            throw new Error("simulated crash");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(existsSync(path)).toBe(false);
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(retried.outcome).toBe("removed");
+    expect(readFileSync(path, "utf8")).toBe(plan.nextContent);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("finalizes a pending delete without leaking the exact captured legacy file", () => {
+    const path = join(tempDir, "delete-capture-crash.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+    const plan = planLegacyStandaloneRule(RELEASED_RULE, "claude");
+
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target,
+        plan,
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterCapture: () => {
+            throw new Error("simulated crash");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(existsSync(path)).toBe(false);
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [target],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(retried).toMatchObject({ outcome: "removed", reason: "recovered_pending_mutation" });
+    expect(existsSync(path)).toBe(false);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("does not delete a target recreated after an exact delete capture", () => {
+    const path = join(tempDir, "delete-target-recreated.md");
+    const replacement = "# New user rule\n";
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: { afterCapture: () => writeFileSync(path, replacement) },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "target_recreated_during_migration",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+  });
+
+  it("does not overwrite a target replacement installed immediately after publish", () => {
+    const path = join(tempDir, "write-after-publish-race.json");
+    const publishedAside = join(tempDir, "write-after-publish-race.published.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const replacement = '{"userOwned":"after publish"}';
+    writeFileSync(path, original);
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({
+        content: original,
+        provider: "claude",
+        topKey: "mcpServers",
+      }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterPublish: () => {
+          renameSync(path, publishedAside);
+          writeFileSync(path, replacement);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "target_changed_after_publish",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+    expect(readFileSync(publishedAside, "utf8")).toContain("https://example.com");
+  });
+
+  it("cleans an unjournaled private stage when preparation fails", () => {
+    const path = join(tempDir, "stage-preparation-failure.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: jsonTarget(path),
+        plan: planLegacyJsonMcp({
+          content: original,
+          provider: "claude",
+          topKey: "mcpServers",
+        }),
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterStagePrepared: () => {
+            throw new Error("simulated preparation failure");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(readFileSync(path, "utf8")).toBe(original);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("fails closed when staged write bytes change after capture", () => {
+    const path = join(tempDir, "changed-staged-write.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: (stage) => writeFileSync(stage.nextPath as string, "tampered next bytes"),
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("keeps a recreated delete target when an unknown stage artifact blocks cleanup", () => {
+    const path = join(tempDir, "delete-cleanup-failure.md");
+    const replacement = "# User rule created during migration\n";
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: (stage) => {
+          writeFileSync(path, replacement);
+          writeFileSync(join(stage.capturePath, "..", "unknown"), "do not remove blindly");
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+  });
+
+  it("keeps a recreated write target when an unknown stage artifact blocks conflict cleanup", () => {
+    const path = join(tempDir, "write-cleanup-failure.json");
+    const replacement = '{"userOwned":"publish conflict"}';
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: (stage) => {
+          writeFileSync(path, replacement);
+          writeFileSync(join(stage.capturePath, "..", "unknown"), "do not remove blindly");
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+  });
+
+  it("leaves a valid published target when an unknown stage artifact blocks final cleanup", () => {
+    const path = join(tempDir, "write-final-cleanup-failure.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, original);
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterPublish: (stage) =>
+          writeFileSync(join(stage.capturePath, "..", "unknown"), "do not remove blindly"),
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(readFileSync(path, "utf8")).toBe(plan.nextContent);
+  });
+
+  it("preserves a pending capture when an unknown artifact prevents recovery cleanup", () => {
+    const path = join(tempDir, "pending-cleanup-failure.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target,
+        plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterCapture: (stage) => {
+            writeFileSync(join(stage.capturePath, "..", "unknown"), "do not remove blindly");
+            throw new Error("simulated crash");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed" });
+
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [target],
+        backupRoot,
+        allowRemoval: true,
+      })[0],
+    ).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_capture_cleanup_failed",
+    });
+  });
+
+  it.each([
+    [
+      "outside path",
+      (receipt: MigrationReceipt) => ({
+        ...receipt,
+        capturePath: join(tempDir, "outside", "captured"),
+      }),
+    ],
+    ["non-number device", (receipt: MigrationReceipt) => ({ ...receipt, sourceDev: "x" })],
+    ["negative device", (receipt: MigrationReceipt) => ({ ...receipt, sourceDev: -1 })],
+    ["non-number inode", (receipt: MigrationReceipt) => ({ ...receipt, sourceIno: "x" })],
+    ["negative inode", (receipt: MigrationReceipt) => ({ ...receipt, sourceIno: -1 })],
+  ])("preserves a pending capture with invalid %s authority", (_variant, mutate) => {
+    const { path, pending } = crashedWriteCapture(`invalid-capture-${_variant}`);
+    writeFileSync(pending.receiptPath as string, JSON.stringify(mutate(pending)));
+
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      })[0],
+    ).toMatchObject({ outcome: "preserved_ambiguous", reason: "invalid_pending_receipt" });
+  });
+
+  it("keeps a changed captured object and its pending recovery journal", () => {
+    const { path, pending } = crashedWriteCapture("changed-pending-capture");
+    writeFileSync(pending.capturePath as string, "changed captured object");
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_capture_invalid",
+    });
+    expect(readFileSync(pending.receiptPath as string, "utf8")).toContain('"outcome": "pending"');
+  });
+
+  it("keeps an exact capture when a conflicting target appears during recovery", () => {
+    const { path, pending } = crashedWriteCapture("conflicted-pending-capture");
+    const replacement = '{"userOwned":"during recovery"}';
+    writeFileSync(path, replacement);
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_recovery_conflict",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+    expect(readFileSync(pending.capturePath as string, "utf8")).toContain("legacy-secret");
+  });
+
+  it("preserves a captured delete when its recovery backup changed", () => {
+    const path = join(tempDir, "invalid-pending-backup.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target,
+        plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterCapture: () => {
+            throw new Error("simulated crash");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed" });
+    const receiptName = readdirSync(backupRoot).find((entry) => entry.endsWith(".receipt.json"));
+    if (!receiptName) throw new Error("expected pending receipt");
+    const pending: MigrationReceipt = JSON.parse(
+      readFileSync(join(backupRoot, receiptName), "utf8"),
+    );
+    writeFileSync(pending.backupPath as string, "changed backup");
+
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [target],
+        backupRoot,
+        allowRemoval: true,
+      })[0],
+    ).toMatchObject({ outcome: "preserved_ambiguous", reason: "pending_backup_invalid" });
+  });
+
+  it("retries a pre-mutation conflict after the exact source preimage returns", () => {
+    const path = join(tempDir, "retry-conflict.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    writeFileSync(path, `${original}\nchanged concurrently`);
+
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: jsonTarget(path),
+        plan,
+        backupRoot,
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "concurrent_conflict" });
+
+    writeFileSync(path, original);
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+
+    expect(retried.outcome).toBe("removed");
+    expect(JSON.parse(readFileSync(path, "utf8")).mcpServers.dosu).toBeUndefined();
+  });
+
+  it("retries a terminal pre-mutation I/O failure from the exact source preimage", () => {
+    const path = join(tempDir, "retry-io-failure.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    writeFileSync(
+      receiptPath,
+      JSON.stringify({
+        targetId: "claude:mcp",
+        provider: "claude",
+        path,
+        targetPathHash: targetHash,
+        outcome: "failed",
+        reason: "migration_io_failed",
+        beforeHash: hashContent(original),
+        plannedMutation: "delete",
+        receiptPath,
+      }),
+    );
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+
+    expect(retried.outcome).toBe("removed");
+    expect(JSON.parse(readFileSync(path, "utf8")).mcpServers.dosu).toBeUndefined();
+  });
+
+  it("never mutates ambiguous content and records the reason", () => {
+    const path = join(tempDir, "foreign.json");
+    const content = JSON.stringify({ mcpServers: { dosu: { url: "https://example.com" } } });
+    writeFileSync(path, content);
+    const receipts = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(receipts[0]).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+    expect(readFileSync(path, "utf8")).toBe(content);
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".receipt.json"))).toHaveLength(
+      1,
+    );
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".bak"))).toHaveLength(0);
+  });
+
+  it("deduplicates a shared target and returns one per-target receipt", () => {
+    const path = join(tempDir, "GEMINI.md");
+    writeFileSync(
+      path,
+      `<!-- dosu:rules:start v1 -->\n${RELEASED_RULE.trimEnd()}\n<!-- dosu:rules:end -->\n`,
+    );
+    const shared: LegacyTarget = {
+      id: "claude:rule-alias-a",
+      provider: "claude",
+      kind: "rule_section",
+      path,
+    };
+    const duplicate: LegacyTarget = { ...shared, id: "claude:rule-alias-b" };
+    const receipts: MigrationReceipt[] = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [shared, duplicate],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].outcome).toBe("removed");
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("preserves a shared target unless every historical consumer has a project proof", () => {
+    const path = join(tempDir, "shared-rule.md");
+    const content = `<!-- dosu:rules:start v1 -->\n${RELEASED_RULE.trimEnd()}\n<!-- dosu:rules:end -->\n`;
+    writeFileSync(path, content);
+    const target: LegacyTarget = {
+      id: "claude:shared-rule",
+      provider: "claude",
+      requiredProviders: ["claude", "gemini"],
+      kind: "rule_section",
+      path,
+    };
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [target],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "shared_target_not_fully_authorized",
+    });
+    expect(readFileSync(path, "utf8")).toBe(content);
+  });
+
+  it("treats a terminal receipt as a tombstone and never deletes a later global re-creation", () => {
+    const path = join(tempDir, "recreated.json");
+    const globalEntry = (key: string) =>
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": key },
+          },
+        },
+      });
+    writeFileSync(path, globalEntry("old-secret"));
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      })[0].outcome,
+    ).toBe("removed");
+
+    writeFileSync(path, globalEntry("explicit-new-secret"));
+    const second = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(second[0]).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "already_migrated",
+    });
+    expect(readFileSync(path, "utf8")).toContain("explicit-new-secret");
+  });
+
+  it("persists an absent target tombstone so a later user-created global entry is preserved", () => {
+    const path = join(tempDir, "absent-then-created.json");
+    const first = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(first[0]).toMatchObject({ outcome: "not_found", reason: "target_absent" });
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".receipt.json"))).toHaveLength(
+      1,
+    );
+
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/new",
+            headers: { "X-Dosu-API-Key": "new-user-choice" },
+          },
+        },
+      }),
+    );
+    const second = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(second[0]).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "already_migrated",
+    });
+    expect(readFileSync(path, "utf8")).toContain("new-user-choice");
+  });
+
+  it("recovers a pending journal when mutation already reached the planned after-state", () => {
+    const path = join(tempDir, "pending-after.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        other: { url: "https://example.com" },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, plan.nextContent);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const backupPath = join(backupRoot, "pending.bak");
+    writeFileSync(backupPath, original);
+    writeFileSync(
+      receiptPath,
+      JSON.stringify({
+        targetId: "claude:mcp",
+        provider: "claude",
+        path,
+        targetPathHash: targetHash,
+        outcome: "pending",
+        reason: "mutation_prepared",
+        beforeHash: plan.expectedHash,
+        plannedMutation: "write",
+        plannedAfterHash: createHash("sha256").update(plan.nextContent).digest("hex"),
+        backupPath,
+        receiptPath,
+      }),
+    );
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({ outcome: "removed", reason: "recovered_pending_mutation" });
+    expect(JSON.parse(readFileSync(receiptPath, "utf8"))).toMatchObject({ outcome: "removed" });
+  });
+
+  it("retries a pending journal from the exact before-state and terminalizes conflicts", () => {
+    const path = join(tempDir, "pending-before.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const backupPath = join(backupRoot, "pending-before.bak");
+    writeFileSync(backupPath, original);
+    const pending = {
+      targetId: "claude:mcp",
+      provider: "claude",
+      path,
+      targetPathHash: targetHash,
+      outcome: "pending",
+      reason: "mutation_prepared",
+      beforeHash: plan.expectedHash,
+      plannedMutation: "write",
+      plannedAfterHash: createHash("sha256").update(plan.nextContent).digest("hex"),
+      backupPath,
+      receiptPath,
+    };
+    writeFileSync(receiptPath, JSON.stringify(pending));
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(retried.outcome).toBe("removed");
+
+    const conflictPath = join(tempDir, "pending-conflict.json");
+    writeFileSync(conflictPath, `${original}\n// user changed it`);
+    const conflictHash = createHash("sha256").update(conflictPath).digest("hex").slice(0, 12);
+    const conflictReceiptPath = join(backupRoot, `target-${conflictHash}.receipt.json`);
+    const conflictBackupPath = join(backupRoot, "pending-conflict.bak");
+    writeFileSync(conflictBackupPath, original);
+    writeFileSync(
+      conflictReceiptPath,
+      JSON.stringify({
+        ...pending,
+        path: conflictPath,
+        targetPathHash: conflictHash,
+        receiptPath: conflictReceiptPath,
+        backupPath: conflictBackupPath,
+      }),
+    );
+    const conflict = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(conflictPath)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(conflict).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_recovery_conflict",
+    });
+    expect(JSON.parse(readFileSync(conflictReceiptPath, "utf8"))).toMatchObject({
+      outcome: "preserved_ambiguous",
+    });
+  });
+
+  it("recovers an old lock owned by a process that is definitely gone", () => {
+    const path = join(tempDir, "stale-lock.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const pendingBackup = join(backupRoot, "stale-lock-pending.bak");
+    writeFileSync(pendingBackup, original);
+    writeFileSync(
+      receiptPath,
+      JSON.stringify({
+        targetId: "claude:mcp",
+        provider: "claude",
+        path,
+        targetPathHash: targetHash,
+        outcome: "pending",
+        reason: "mutation_prepared",
+        beforeHash: plan.expectedHash,
+        plannedMutation: "write",
+        plannedAfterHash: hashContent(plan.nextContent),
+        backupPath: pendingBackup,
+        receiptPath,
+      }),
+    );
+    const lockPath = `${path}.dosu-migration.lock`;
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        version: 1,
+        pid: 2_147_483_647,
+        createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+        targetPath: path,
+        backupRoot,
+        nonce: "a".repeat(32),
+      })}\n`,
+    );
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({ outcome: "removed" });
+    expect(readFileSync(path, "utf8")).toContain("https://example.com");
+    expect(existsSync(lockPath)).toBe(false);
+    expect(JSON.parse(readFileSync(receiptPath, "utf8"))).toMatchObject({ outcome: "removed" });
+  });
+
+  it("never unlinks a replacement raced into a stale lock path", () => {
+    const path = join(tempDir, "stale-lock-race.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const lockPath = `${path}.dosu-migration.lock`;
+    const displaced = `${lockPath}.displaced`;
+    const replacement = "user-owned lock replacement\n";
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        version: 1,
+        pid: 2_147_483_647,
+        createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+        targetPath: path,
+        backupRoot,
+        nonce: "c".repeat(32),
+      })}\n`,
+    );
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeLockCapture: (kind) => {
+          if (kind !== "stale") return;
+          renameSync(lockPath, displaced);
+          writeFileSync(lockPath, replacement);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "preserved_ambiguous", reason: "target_locked" });
+    expect(readFileSync(path, "utf8")).toBe(original);
+    expect(readFileSync(lockPath, "utf8")).toBe(replacement);
+    expect(readFileSync(displaced, "utf8")).toContain('"version":1');
+  });
+
+  it.each([
+    "symlink",
+    "directory",
+  ] as const)("restores or durably reports a %s raced into a stale lock capture", (replacementKind) => {
+    const path = join(tempDir, `stale-lock-${replacementKind}.json`);
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const lockPath = `${path}.dosu-migration.lock`;
+    const displaced = `${lockPath}.displaced`;
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        version: 1,
+        pid: 2_147_483_647,
+        createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+        targetPath: path,
+        backupRoot,
+        nonce: "d".repeat(32),
+      })}\n`,
+    );
+
+    const first = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeLockCapture: (kind) => {
+          if (kind !== "stale") return;
+          renameSync(lockPath, displaced);
+          if (replacementKind === "symlink") symlinkSync(displaced, lockPath);
+          else mkdirSync(lockPath);
+        },
+      },
+    });
+
+    expect(first).toMatchObject({ outcome: "preserved_ambiguous", reason: "target_locked" });
+    expect(readFileSync(path, "utf8")).toBe(original);
+    if (replacementKind === "symlink") {
+      expect(lstatSync(lockPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(lockPath)).toBe(displaced);
+    } else {
+      expect(existsSync(lockPath)).toBe(false);
+      expect(
+        readdirSync(tempDir).filter((name) => name.startsWith(".dosu-public-capture-")),
+      ).toHaveLength(1);
+    }
+
+    const retried = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(retried).toMatchObject(
+      replacementKind === "directory"
+        ? { outcome: "preserved_ambiguous", reason: "pending_lock_capture_recovery" }
+        : { outcome: "preserved_ambiguous", reason: "invalid_target_lock" },
+    );
+    if (replacementKind === "directory") {
+      expect(
+        readdirSync(tempDir).filter((name) => name.startsWith(".dosu-public-capture-")),
+      ).toHaveLength(1);
+    }
+  });
+
+  it("never unlinks a replacement raced into the acquired lock during release", () => {
+    const path = join(tempDir, "release-lock-race.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const lockPath = `${path}.dosu-migration.lock`;
+    const displaced = `${lockPath}.displaced`;
+    const replacement = "user-owned release replacement\n";
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeLockCapture: (kind) => {
+          if (kind !== "release") return;
+          renameSync(lockPath, displaced);
+          writeFileSync(lockPath, replacement);
+        },
+      },
+    });
+
+    expect(receipt.outcome).toBe("removed");
+    expect(readFileSync(path, "utf8")).toContain("https://example.com");
+    expect(readFileSync(lockPath, "utf8")).toBe(replacement);
+    expect(readFileSync(displaced, "utf8")).toContain('"version":1');
+  });
+
+  it.each([
+    "symlink",
+    "directory",
+  ] as const)("restores or durably reports a %s raced into an acquired lock during release", (replacementKind) => {
+    const path = join(tempDir, `release-lock-${replacementKind}.json`);
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const lockPath = `${path}.dosu-migration.lock`;
+    const displaced = `${lockPath}.displaced`;
+    const plan = planLegacyJsonMcp({
+      content: original,
+      provider: "claude",
+      topKey: "mcpServers",
+    });
+
+    const first = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeLockCapture: (kind) => {
+          if (kind !== "release") return;
+          renameSync(lockPath, displaced);
+          if (replacementKind === "symlink") symlinkSync(displaced, lockPath);
+          else mkdirSync(lockPath);
+        },
+      },
+    });
+
+    expect(first.outcome).toBe("removed");
+    expect(readFileSync(path, "utf8")).toContain("https://example.com");
+    if (replacementKind === "symlink") {
+      expect(lstatSync(lockPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(lockPath)).toBe(displaced);
+    } else {
+      expect(existsSync(lockPath)).toBe(false);
+      expect(
+        readdirSync(tempDir).filter((name) => name.startsWith(".dosu-public-capture-")),
+      ).toHaveLength(1);
+    }
+
+    const retried = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(retried).toMatchObject(
+      replacementKind === "directory"
+        ? { outcome: "preserved_ambiguous", reason: "pending_lock_capture_recovery" }
+        : { outcome: "not_found", reason: "terminal_receipt_unchanged" },
+    );
+    if (replacementKind === "directory") {
+      expect(
+        readdirSync(tempDir).filter((name) => name.startsWith(".dosu-public-capture-")),
+      ).toHaveLength(1);
+    }
+  });
+
+  it("does not overwrite a pending journal while a recognized active lock exists", () => {
+    const path = join(tempDir, "active-lock.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const pendingText = `${JSON.stringify({
+      targetId: "claude:mcp",
+      provider: "claude",
+      path,
+      targetPathHash: targetHash,
+      outcome: "pending",
+      reason: "mutation_prepared",
+      beforeHash: plan.expectedHash,
+      plannedMutation: "write",
+      plannedAfterHash: hashContent(plan.nextContent),
+      backupPath: join(backupRoot, "active-lock-pending.bak"),
+      receiptPath,
+    })}\n`;
+    writeFileSync(receiptPath, pendingText);
+    const lockPath = `${path}.dosu-migration.lock`;
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        version: 1,
+        pid: process.pid,
+        createdAt: new Date().toISOString(),
+        targetPath: path,
+        backupRoot,
+        nonce: "b".repeat(32),
+      })}\n`,
+    );
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({ outcome: "preserved_ambiguous", reason: "target_locked" });
+    expect(readFileSync(receiptPath, "utf8")).toBe(pendingText);
+    expect(readFileSync(path, "utf8")).toBe(original);
+    expect(existsSync(lockPath)).toBe(true);
+  });
+
+  it("preserves a pending journal and target behind an unrecognized lock", () => {
+    const path = join(tempDir, "invalid-lock.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const pendingText = `${JSON.stringify({
+      targetId: "claude:mcp",
+      provider: "claude",
+      path,
+      targetPathHash: targetHash,
+      outcome: "pending",
+      reason: "mutation_prepared",
+      beforeHash: plan.expectedHash,
+      plannedMutation: plan.mutation,
+      backupPath: join(backupRoot, "invalid-lock-pending.bak"),
+      receiptPath,
+    })}\n`;
+    writeFileSync(receiptPath, pendingText);
+    writeFileSync(`${path}.dosu-migration.lock`, "user data");
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "invalid_target_lock",
+    });
+    expect(readFileSync(receiptPath, "utf8")).toBe(pendingText);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it.each([
+    "directory",
+    "array",
+    "wrong target",
+    "malformed JSON",
+  ])("preserves the target behind a tampered %s receipt", (variant) => {
+    const path = join(tempDir, `receipt-${variant.replaceAll(" ", "-")}.json`);
+    const bundle = proof();
+    const first = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    if (!first.receiptPath) throw new Error("expected receipt path");
+    rmSync(first.receiptPath);
+    if (variant === "directory") mkdirSync(first.receiptPath);
+    if (variant === "array") writeFileSync(first.receiptPath, "[]");
+    if (variant === "wrong target") {
+      writeFileSync(
+        first.receiptPath,
+        JSON.stringify({
+          path: "/other",
+          targetPathHash: "wrong",
+          outcome: "removed",
+          reason: "x",
+        }),
+      );
+    }
+    if (variant === "malformed JSON") writeFileSync(first.receiptPath, "{");
+
+    expect(
+      migrateLegacyTargets({
+        bundle,
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        outcome: "preserved_ambiguous",
+        reason: "invalid_migration_receipt",
+      }),
+    ]);
+  });
+
+  it("returns an unchanged terminal ambiguity without reinterpreting edited content", () => {
+    const path = join(tempDir, "foreign-repeat.json");
+    writeFileSync(path, '{"mcpServers":{"dosu":{"url":"https://example.com/user"}}}');
+    const bundle = proof();
+    const first = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(first).toMatchObject({ outcome: "preserved_ambiguous", reason: "foreign_dosu_entry" });
+    const second = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(second).toMatchObject({ outcome: "preserved_ambiguous", reason: "foreign_dosu_entry" });
+  });
+
+  it("rejects a pending receipt missing its recovery authority", () => {
+    const path = join(tempDir, "invalid-pending.json");
+    const bundle = proof();
+    const first = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    if (!first.receiptPath) throw new Error("expected receipt path");
+    writeFileSync(
+      first.receiptPath,
+      JSON.stringify({ ...first, outcome: "pending", reason: "mutation_prepared" }),
+    );
+    expect(
+      migrateLegacyTargets({
+        bundle,
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        outcome: "preserved_ambiguous",
+        reason: "invalid_pending_receipt",
+      }),
+    ]);
+  });
+
+  it("does not finalize a pending after-state when its immutable backup is gone", () => {
+    const path = join(tempDir, "pending-missing-backup.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const bundle = proof();
+    const removed = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    if (!removed.receiptPath || !removed.backupPath) throw new Error("expected recovery journal");
+    writeFileSync(
+      removed.receiptPath,
+      JSON.stringify({ ...removed, outcome: "pending", reason: "mutation_prepared" }),
+    );
+    rmSync(removed.backupPath);
+
+    expect(
+      migrateLegacyTargets({
+        bundle,
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        outcome: "preserved_ambiguous",
+        reason: "pending_backup_invalid",
+      }),
+    ]);
+  });
+
+  it("rejects invalid plans and source replacement before creating a backup", () => {
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    const bundle = proof();
+
+    const invalidPath = join(tempDir, "invalid-plan.json");
+    writeFileSync(invalidPath, original);
+    expect(
+      applyContentPlan({
+        bundle,
+        target: jsonTarget(invalidPath),
+        plan: { ...plan, mutation: "write", nextContent: undefined },
+        backupRoot: join(tempDir, "invalid-plan-backups"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "preserved_ambiguous", reason: "invalid_migration_plan" });
+
+    const directoryPath = join(tempDir, "replaced-by-directory.json");
+    writeFileSync(directoryPath, original);
+    rmSync(directoryPath);
+    mkdirSync(directoryPath);
+    expect(
+      applyContentPlan({
+        bundle,
+        target: jsonTarget(directoryPath),
+        plan,
+        backupRoot: join(tempDir, "directory-backups"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "concurrent_conflict", reason: "non_regular_target" });
+
+    const missingPath = join(tempDir, "removed-before-apply.json");
+    expect(
+      applyContentPlan({
+        bundle,
+        target: jsonTarget(missingPath),
+        plan,
+        backupRoot: join(tempDir, "missing-backups"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "concurrent_conflict", reason: "target_changed_or_missing" });
+  });
+});

--- a/src/migration/orchestrator.ts
+++ b/src/migration/orchestrator.ts
@@ -1,0 +1,2009 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmdirSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+  type ContentPlan,
+  hashContent,
+  planLegacyCodexMcp,
+  planLegacyJsonMcp,
+  planLegacyRuleSection,
+  planLegacyStandaloneRule,
+} from "./planners";
+import {
+  assertProjectBundleProof,
+  type ProjectBundleProof,
+  projectBundleStatus,
+} from "./project-bundle";
+import type { LegacyTarget } from "./targets";
+
+export type MigrationOutcome =
+  | "pending"
+  | "removed"
+  | "not_found"
+  | "preserved_ambiguous"
+  | "concurrent_conflict"
+  | "failed";
+
+export interface MigrationReceipt {
+  targetId: string;
+  provider: LegacyTarget["provider"];
+  path: string;
+  outcome: MigrationOutcome;
+  reason: string;
+  beforeHash?: string;
+  afterHash?: string;
+  backupPath?: string;
+  receiptPath?: string;
+  targetPathHash?: string;
+  plannedMutation?: ContentPlan["mutation"];
+  plannedAfterHash?: string;
+  capturePath?: string;
+  sourceDev?: number;
+  sourceIno?: number;
+}
+
+export type LegacyTargetInspection =
+  | { disposition: "remove"; reason: string }
+  | { disposition: "not_found"; reason: string }
+  | { disposition: "ambiguous"; reason: string };
+
+function pathHash(path: string): string {
+  return createHash("sha256").update(resolve(path)).digest("hex").slice(0, 12);
+}
+
+function safeId(id: string): string {
+  return id.replace(/[^A-Za-z0-9_.-]+/g, "_");
+}
+
+function baseReceipt(
+  target: LegacyTarget,
+  outcome: MigrationOutcome,
+  reason: string,
+): MigrationReceipt {
+  return { targetId: target.id, provider: target.provider, path: target.path, outcome, reason };
+}
+
+function planForTarget(target: LegacyTarget, content: string): ContentPlan {
+  switch (target.kind) {
+    case "json_mcp":
+      return planLegacyJsonMcp({
+        content,
+        provider: target.provider,
+        topKey: target.topKey,
+      });
+    case "codex_toml":
+      return planLegacyCodexMcp(content);
+    case "rule_file":
+      return planLegacyStandaloneRule(content, target.ruleKind);
+    case "rule_section":
+      return planLegacyRuleSection(content);
+  }
+}
+
+/** Strict read-only ownership inspection; it never creates receipts, locks, or backups. */
+export function inspectLegacyTarget(target: LegacyTarget): LegacyTargetInspection {
+  try {
+    const stat = lstatSync(target.path);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return { disposition: "ambiguous", reason: "non_regular_target" };
+    }
+    const plan = planForTarget(target, readFileSync(target.path, "utf8"));
+    if (plan.disposition === "remove") {
+      return { disposition: "remove", reason: plan.reason };
+    }
+    if (plan.disposition === "not_found") {
+      return { disposition: "not_found", reason: plan.reason };
+    }
+    return { disposition: "ambiguous", reason: plan.reason };
+  } catch (error: unknown) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+    return code === "ENOENT"
+      ? { disposition: "not_found", reason: "target_absent" }
+      : { disposition: "ambiguous", reason: "target_read_failed" };
+  }
+}
+
+/** Read-only strict inspection used to decide whether runtime verification is necessary. */
+export function legacyTargetsNeedCleanup(targets: readonly LegacyTarget[]): boolean {
+  const seenPaths = new Set<string>();
+  for (const target of targets) {
+    const key = resolve(target.path);
+    if (seenPaths.has(key)) continue;
+    seenPaths.add(key);
+    if (inspectLegacyTarget(target).disposition === "remove") return true;
+  }
+  return false;
+}
+
+function prepareBackupRoot(backupRoot: string): void {
+  mkdirSync(backupRoot, { recursive: true, mode: 0o700 });
+  const stat = lstatSync(backupRoot);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe migration backup root");
+  }
+  chmodSync(backupRoot, 0o700);
+}
+
+function fsyncPath(path: string): void {
+  const fd = openSync(path, "r");
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function fsyncParent(path: string): void {
+  try {
+    fsyncPath(dirname(path));
+  } catch {
+    // Directory fsync is unavailable on some supported platforms.
+  }
+}
+
+function atomicWrite(path: string, content: string, mode: number): void {
+  const temporary = `${path}.dosu-migration-${process.pid}-${randomBytes(6).toString("hex")}.tmp`;
+  let created = false;
+  try {
+    const file = openSync(temporary, "wx", mode);
+    created = true;
+    try {
+      writeFileSync(file, content, "utf8");
+      fsyncSync(file);
+    } finally {
+      closeSync(file);
+    }
+    renameSync(temporary, path);
+    chmodSync(path, mode);
+    fsyncParent(path);
+    created = false;
+  } finally {
+    if (created) {
+      try {
+        unlinkSync(temporary);
+      } catch {
+        // Best effort cleanup of a never-published temporary file.
+      }
+    }
+  }
+}
+
+function writePersistedReceipt(path: string, receipt: MigrationReceipt): void {
+  atomicWrite(path, `${JSON.stringify(receipt, null, 2)}\n`, 0o600);
+}
+
+function backupPathFor(target: LegacyTarget, expectedHash: string, backupRoot: string): string {
+  return join(
+    backupRoot,
+    `${safeId(target.id)}-${pathHash(target.path)}-${expectedHash.slice(0, 12)}.bak`,
+  );
+}
+
+function receiptPathFor(target: LegacyTarget, backupRoot: string): string {
+  return join(backupRoot, `target-${pathHash(target.path)}.receipt.json`);
+}
+
+type BackupCopy = (source: string, destination: string, mode: number) => void;
+
+export function ensureBackup(
+  targetPath: string,
+  backupPath: string,
+  expectedHash: string,
+  copy: BackupCopy = copyFileSync,
+): void {
+  if (existsSync(backupPath)) {
+    secureBackup(backupPath, expectedHash, "Existing");
+    return;
+  }
+  let created = false;
+  try {
+    copy(targetPath, backupPath, constants.COPYFILE_EXCL);
+    created = true;
+    secureBackup(backupPath, expectedHash, "New");
+  } catch (error) {
+    if (created) {
+      try {
+        unlinkSync(backupPath);
+      } catch {
+        // A corrupt backup is never trusted; a failed cleanup still aborts mutation.
+      }
+    }
+    throw error;
+  }
+}
+
+function secureBackup(path: string, expectedHash: string, label = "Migration"): void {
+  const before = lstatSync(path);
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw new Error(`${label} migration backup is not a regular file`);
+  }
+  const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(path, constants.O_RDONLY | noFollow);
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error(`${label} migration backup changed while it was verified`);
+    }
+    if (hashContent(readFileSync(fd, "utf8")) !== expectedHash) {
+      throw new Error(`${label} migration backup does not match the planned content`);
+    }
+    fchmodSync(fd, 0o600);
+    fsyncSync(fd);
+    const after = lstatSync(path);
+    if (
+      !after.isFile() ||
+      after.isSymbolicLink() ||
+      after.dev !== opened.dev ||
+      after.ino !== opened.ino
+    ) {
+      throw new Error(`${label} migration backup changed while it was verified`);
+    }
+  } finally {
+    closeSync(fd);
+  }
+}
+
+const STALE_LOCK_MINIMUM_AGE_MS = 5 * 60 * 1000;
+
+type MigrationLockResult =
+  | { ok: true; content: string; dev: number; ino: number }
+  | { ok: false; reason: "target_locked" | "invalid_target_lock" };
+
+interface MigrationTestHooks {
+  afterStagePrepared?: (stage: { capturePath: string; nextPath?: string }) => void;
+  beforeCapture?: (target: LegacyTarget) => void;
+  afterCapture?: (stage: { capturePath: string; nextPath?: string }) => void;
+  afterPublish?: (stage: { capturePath: string; nextPath?: string }) => void;
+  beforeLockCapture?: (kind: "stale" | "release", path: string) => void;
+  afterLockAcquired?: () => void;
+  afterBackupCreated?: () => void;
+  beforeFinalBundleCheck?: () => void;
+  beforeFinalSourceCheck?: () => void;
+  beforeFinalMutationAuthorization?: () => void;
+}
+
+type FinalMutationAuthorization = (target: LegacyTarget) => string | null;
+
+function mutationAuthorizationFailure(
+  authorize: FinalMutationAuthorization | undefined,
+  target: LegacyTarget,
+): string | null {
+  try {
+    return authorize?.(target) ?? null;
+  } catch {
+    return "mutation_authorization_failed";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(record: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(record).sort();
+  const sortedExpected = [...expected].sort();
+  return (
+    actual.length === sortedExpected.length &&
+    actual.every((key, index) => key === sortedExpected[index])
+  );
+}
+
+function validIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+}
+
+function migrationLockContent(targetPath: string, backupRoot: string): string {
+  return `${JSON.stringify({
+    version: 1,
+    pid: process.pid,
+    createdAt: new Date().toISOString(),
+    targetPath: resolve(targetPath),
+    backupRoot: resolve(backupRoot),
+    nonce: randomBytes(16).toString("hex"),
+  })}\n`;
+}
+
+function publishMigrationLock(path: string, content: string): { dev: number; ino: number } {
+  const candidate = `${path}.candidate-${process.pid}-${randomBytes(6).toString("hex")}`;
+  let candidateExists = false;
+  try {
+    const fd = openSync(candidate, "wx", 0o600);
+    candidateExists = true;
+    let identity: { dev: number; ino: number };
+    try {
+      writeFileSync(fd, content, "utf8");
+      fsyncSync(fd);
+      const stat = fstatSync(fd);
+      identity = { dev: stat.dev, ino: stat.ino };
+    } finally {
+      closeSync(fd);
+    }
+    // Publishing a fully-written inode avoids crash-created empty lock files.
+    linkSync(candidate, path);
+    fsyncParent(path);
+    return identity;
+  } finally {
+    if (candidateExists) {
+      try {
+        unlinkSync(candidate);
+      } catch {
+        // The fixed path, when present, is the only authoritative lock.
+      }
+    }
+  }
+}
+
+function processIsDefinitelyGone(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error: unknown) {
+    return isRecord(error) && error.code === "ESRCH";
+  }
+}
+
+function recognizedLock(
+  parsed: unknown,
+  targetPath: string,
+  backupRoot: string,
+): parsed is Record<string, unknown> {
+  return (
+    isRecord(parsed) &&
+    exactKeys(parsed, ["version", "pid", "createdAt", "targetPath", "backupRoot", "nonce"]) &&
+    parsed.version === 1 &&
+    typeof parsed.pid === "number" &&
+    Number.isSafeInteger(parsed.pid) &&
+    parsed.pid > 0 &&
+    validIsoTimestamp(parsed.createdAt) &&
+    parsed.targetPath === resolve(targetPath) &&
+    parsed.backupRoot === resolve(backupRoot) &&
+    typeof parsed.nonce === "string" &&
+    /^[a-f0-9]{32}$/.test(parsed.nonce)
+  );
+}
+
+function staleMigrationLockContent(
+  path: string,
+  targetPath: string,
+  backupRoot: string,
+): { content: string; dev: number; ino: number } | null {
+  try {
+    const snapshot = readStableRegularFile(path);
+    if (!snapshot.ok) return null;
+    const content = snapshot.file.content;
+    const parsed: unknown = JSON.parse(content);
+    if (
+      !recognizedLock(parsed, targetPath, backupRoot) ||
+      Date.now() - new Date(parsed.createdAt as string).getTime() < STALE_LOCK_MINIMUM_AGE_MS ||
+      !processIsDefinitelyGone(parsed.pid as number)
+    ) {
+      return null;
+    }
+    return { content, dev: snapshot.file.dev, ino: snapshot.file.ino };
+  } catch {
+    return null;
+  }
+}
+
+function acquireMigrationLock(
+  path: string,
+  targetPath: string,
+  backupRoot: string,
+  testHooks?: MigrationTestHooks,
+): MigrationLockResult {
+  if (!recoverPublicCaptures(path)) {
+    return { ok: false, reason: "invalid_target_lock" };
+  }
+  const content = migrationLockContent(targetPath, backupRoot);
+  try {
+    const identity = publishMigrationLock(path, content);
+    return { ok: true, content, ...identity };
+  } catch (error: unknown) {
+    if (!isRecord(error) || error.code !== "EEXIST") {
+      return { ok: false, reason: "invalid_target_lock" };
+    }
+  }
+
+  const stale = staleMigrationLockContent(path, targetPath, backupRoot);
+  if (!stale) {
+    try {
+      const stat = lstatSync(path);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        return { ok: false, reason: "invalid_target_lock" };
+      }
+      const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+      return {
+        ok: false,
+        reason: recognizedLock(parsed, targetPath, backupRoot)
+          ? "target_locked"
+          : "invalid_target_lock",
+      };
+    } catch {
+      return { ok: false, reason: "invalid_target_lock" };
+    }
+  }
+
+  try {
+    if (
+      !atomicCaptureAndRemovePublicFile(
+        path,
+        stale.content,
+        { dev: stale.dev, ino: stale.ino },
+        () => testHooks?.beforeLockCapture?.("stale", path),
+      )
+    ) {
+      return { ok: false, reason: "target_locked" };
+    }
+    const identity = publishMigrationLock(path, content);
+    return { ok: true, content, ...identity };
+  } catch {
+    return { ok: false, reason: "target_locked" };
+  }
+}
+
+function releaseMigrationLock(
+  path: string,
+  expectedContent: string,
+  expectedIdentity: { dev: number; ino: number },
+  testHooks?: MigrationTestHooks,
+): void {
+  atomicCaptureAndRemovePublicFile(path, expectedContent, expectedIdentity, () =>
+    testHooks?.beforeLockCapture?.("release", path),
+  );
+}
+
+export interface TargetOperationLock {
+  path: string;
+  content: string;
+  dev: number;
+  ino: number;
+}
+
+/**
+ * Acquire the same atomic exclusion used by migration before another command
+ * starts a target-wide operation. Sharing this lock removes authorization
+ * TOCTOU windows between explicit global installs and legacy cleanup.
+ */
+export function acquireTargetOperationLock(
+  targetPath: string,
+  authorityRoot: string,
+): TargetOperationLock {
+  const path = `${resolve(targetPath)}.dosu-migration.lock`;
+  const acquired = acquireMigrationLock(path, targetPath, authorityRoot);
+  if (!acquired.ok) throw new Error(`Global MCP target is locked (${acquired.reason})`);
+  return { path, content: acquired.content, dev: acquired.dev, ino: acquired.ino };
+}
+
+/** Release only the exact lock inode/content acquired by this operation. */
+export function releaseTargetOperationLock(lock: TargetOperationLock): void {
+  releaseMigrationLock(lock.path, lock.content, { dev: lock.dev, ino: lock.ino });
+}
+
+function bundleFailure(bundle: ProjectBundleProof, target: LegacyTarget): string | null {
+  const required = target.requiredProviders ?? [target.provider];
+  for (const provider of required) {
+    const status = projectBundleStatus(bundle, provider);
+    if (status === "changed") return "project_bundle_changed";
+    if (status === "unauthorized_provider") {
+      return target.requiredProviders
+        ? "shared_target_not_fully_authorized"
+        : "project_bundle_not_authorized";
+    }
+  }
+  return null;
+}
+
+type PriorReceiptRead =
+  | { status: "absent" }
+  | { status: "invalid" }
+  | { status: "valid"; receipt: MigrationReceipt };
+
+function readPriorReceipt(target: LegacyTarget, receiptPath: string): PriorReceiptRead {
+  if (!existsSync(receiptPath)) return { status: "absent" };
+  try {
+    const stat = lstatSync(receiptPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) return { status: "invalid" };
+    const parsed: unknown = JSON.parse(readFileSync(receiptPath, "utf8"));
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return { status: "invalid" };
+    }
+    const receipt = parsed as Record<string, unknown>;
+    if (
+      receipt.path !== target.path ||
+      receipt.targetPathHash !== pathHash(target.path) ||
+      typeof receipt.outcome !== "string" ||
+      typeof receipt.reason !== "string"
+    ) {
+      return { status: "invalid" };
+    }
+    return { status: "valid", receipt: receipt as unknown as MigrationReceipt };
+  } catch {
+    return { status: "invalid" };
+  }
+}
+
+function receiptWithJournalFields(
+  target: LegacyTarget,
+  outcome: MigrationOutcome,
+  reason: string,
+  beforeHash: string,
+  backupPath: string,
+  receiptPath: string,
+  afterHash?: string,
+  plannedMutation?: ContentPlan["mutation"],
+  plannedAfterHash?: string,
+  capture?: CaptureAuthority,
+): MigrationReceipt {
+  return {
+    ...baseReceipt(target, outcome, reason),
+    beforeHash,
+    ...(afterHash ? { afterHash } : {}),
+    backupPath,
+    receiptPath,
+    targetPathHash: pathHash(target.path),
+    ...(plannedMutation ? { plannedMutation } : {}),
+    ...(plannedAfterHash ? { plannedAfterHash } : {}),
+    ...(capture
+      ? {
+          capturePath: capture.capturePath,
+          sourceDev: capture.sourceDev,
+          sourceIno: capture.sourceIno,
+        }
+      : {}),
+  };
+}
+
+function persistTerminal(
+  target: LegacyTarget,
+  backupRoot: string,
+  outcome: Exclude<MigrationOutcome, "pending">,
+  reason: string,
+  options: {
+    beforeHash?: string;
+    afterHash?: string;
+    backupPath?: string;
+    plannedMutation?: ContentPlan["mutation"];
+    plannedAfterHash?: string;
+  } = {},
+): MigrationReceipt {
+  try {
+    prepareBackupRoot(backupRoot);
+    const receiptPath = receiptPathFor(target, backupRoot);
+    const receipt: MigrationReceipt = {
+      ...baseReceipt(target, outcome, reason),
+      ...(options.beforeHash ? { beforeHash: options.beforeHash } : {}),
+      ...(options.afterHash ? { afterHash: options.afterHash } : {}),
+      ...(options.backupPath ? { backupPath: options.backupPath } : {}),
+      ...(options.plannedMutation ? { plannedMutation: options.plannedMutation } : {}),
+      ...(options.plannedAfterHash ? { plannedAfterHash: options.plannedAfterHash } : {}),
+      receiptPath,
+      targetPathHash: pathHash(target.path),
+    };
+    writePersistedReceipt(receiptPath, receipt);
+    return receipt;
+  } catch {
+    return baseReceipt(target, "failed", "receipt_write_failed");
+  }
+}
+
+type TargetState = { kind: "absent" } | { kind: "file"; hash: string } | { kind: "unsafe" };
+
+function targetState(path: string): TargetState {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) return { kind: "unsafe" };
+    return { kind: "file", hash: hashContent(readFileSync(path, "utf8")) };
+  } catch (error: unknown) {
+    const code = typeof error === "object" && error !== null && "code" in error ? error.code : null;
+    return code === "ENOENT" ? { kind: "absent" } : { kind: "unsafe" };
+  }
+}
+
+type PriorReceiptDecision =
+  | { action: "continue" }
+  | { action: "return"; receipt: MigrationReceipt };
+
+function decidePriorReceipt(target: LegacyTarget, backupRoot: string): PriorReceiptDecision {
+  if (!recoverPublicCaptures(`${target.path}.dosu-migration.lock`)) {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "pending_lock_capture_recovery"),
+    };
+  }
+  const receiptPath = receiptPathFor(target, backupRoot);
+  const prior = readPriorReceipt(target, receiptPath);
+  if (prior.status === "absent") return { action: "continue" };
+  if (prior.status === "invalid") {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "invalid_migration_receipt"),
+    };
+  }
+
+  const receipt = prior.receipt;
+  const state = targetState(target.path);
+  if (receipt.outcome !== "pending") {
+    // A terminal pre-mutation failure is not a tombstone when the exact
+    // planned preimage is present again. Retrying from that byte-for-byte
+    // state is safe; any changed or unknown state remains preserved.
+    const retryablePreMutationFailure =
+      (receipt.outcome === "failed" || receipt.outcome === "concurrent_conflict") &&
+      state.kind === "file" &&
+      typeof receipt.beforeHash === "string" &&
+      state.hash === receipt.beforeHash;
+    if (retryablePreMutationFailure) return { action: "continue" };
+
+    const unchangedAfterWrite =
+      receipt.outcome === "removed" &&
+      receipt.plannedMutation === "write" &&
+      state.kind === "file" &&
+      typeof receipt.afterHash === "string" &&
+      state.hash === receipt.afterHash;
+    const unchangedAfterDelete =
+      receipt.outcome === "removed" &&
+      receipt.plannedMutation === "delete" &&
+      state.kind === "absent";
+    const stillAbsent = receipt.outcome === "not_found" && state.kind === "absent";
+    if (unchangedAfterWrite || unchangedAfterDelete || stillAbsent) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "not_found", "terminal_receipt_unchanged"),
+      };
+    }
+    if (
+      receipt.outcome === "preserved_ambiguous" &&
+      state.kind === "file" &&
+      receipt.beforeHash === state.hash
+    ) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "preserved_ambiguous", receipt.reason),
+      };
+    }
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "already_migrated"),
+    };
+  }
+
+  if (
+    typeof receipt.beforeHash !== "string" ||
+    (receipt.plannedMutation !== "write" && receipt.plannedMutation !== "delete") ||
+    typeof receipt.backupPath !== "string"
+  ) {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "invalid_pending_receipt"),
+    };
+  }
+
+  const capturedPendingDecision = decideCapturedPendingReceipt(target, backupRoot, receipt, state);
+  if (capturedPendingDecision) return capturedPendingDecision;
+
+  if (state.kind === "file" && state.hash === receipt.beforeHash) {
+    return { action: "continue" };
+  }
+
+  const reachedAfter =
+    (receipt.plannedMutation === "delete" && state.kind === "absent") ||
+    (receipt.plannedMutation === "write" &&
+      state.kind === "file" &&
+      typeof receipt.plannedAfterHash === "string" &&
+      state.hash === receipt.plannedAfterHash);
+  if (reachedAfter) {
+    try {
+      const backupStat = lstatSync(receipt.backupPath);
+      if (
+        !backupStat.isFile() ||
+        backupStat.isSymbolicLink() ||
+        hashContent(readFileSync(receipt.backupPath, "utf8")) !== receipt.beforeHash
+      ) {
+        throw new Error("invalid backup");
+      }
+    } catch {
+      return {
+        action: "return",
+        receipt: persistTerminal(
+          target,
+          backupRoot,
+          "preserved_ambiguous",
+          "pending_backup_invalid",
+          { beforeHash: receipt.beforeHash },
+        ),
+      };
+    }
+    return {
+      action: "return",
+      receipt: persistTerminal(target, backupRoot, "removed", "recovered_pending_mutation", {
+        beforeHash: receipt.beforeHash,
+        afterHash: receipt.plannedAfterHash,
+        backupPath: receipt.backupPath,
+        plannedMutation: receipt.plannedMutation,
+        plannedAfterHash: receipt.plannedAfterHash,
+      }),
+    };
+  }
+
+  return {
+    action: "return",
+    receipt: persistTerminal(
+      target,
+      backupRoot,
+      "preserved_ambiguous",
+      "pending_recovery_conflict",
+      { beforeHash: receipt.beforeHash, backupPath: receipt.backupPath },
+    ),
+  };
+}
+
+type StableRegularFile = {
+  mode: number;
+  dev: number;
+  ino: number;
+  hash: string;
+  content: string;
+};
+
+type StableRegularFileResult =
+  | { ok: true; file: StableRegularFile }
+  | { ok: false; reason: "non_regular_target" | "target_changed_or_missing" };
+
+function readStableRegularFile(path: string): StableRegularFileResult {
+  try {
+    const before = lstatSync(path);
+    if (!before.isFile() || before.isSymbolicLink()) {
+      return { ok: false, reason: "non_regular_target" };
+    }
+    const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+    const fd = openSync(path, constants.O_RDONLY | noFollow);
+    try {
+      const opened = fstatSync(fd);
+      if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+        return { ok: false, reason: "target_changed_or_missing" };
+      }
+      const content = readFileSync(fd, "utf8");
+      const hash = hashContent(content);
+      const after = lstatSync(path);
+      if (
+        !after.isFile() ||
+        after.isSymbolicLink() ||
+        after.dev !== opened.dev ||
+        after.ino !== opened.ino
+      ) {
+        return { ok: false, reason: "target_changed_or_missing" };
+      }
+      return {
+        ok: true,
+        file: {
+          mode: opened.mode & 0o777,
+          dev: opened.dev,
+          ino: opened.ino,
+          hash,
+          content,
+        },
+      };
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return { ok: false, reason: "target_changed_or_missing" };
+  }
+}
+
+function recheckSource(
+  target: LegacyTarget,
+  expectedHash: string,
+): { ok: true; mode: number; dev: number; ino: number } | { ok: false; reason: string } {
+  const snapshot = readStableRegularFile(target.path);
+  if (!snapshot.ok) return snapshot;
+  if (snapshot.file.hash !== expectedHash) {
+    return { ok: false, reason: "content_hash_changed" };
+  }
+  return {
+    ok: true,
+    mode: snapshot.file.mode,
+    dev: snapshot.file.dev,
+    ino: snapshot.file.ino,
+  };
+}
+
+interface CaptureAuthority {
+  capturePath: string;
+  sourceDev: number;
+  sourceIno: number;
+}
+
+interface CaptureStage extends CaptureAuthority {
+  directory: string;
+  nextPath?: string;
+}
+
+function createCaptureStage(
+  targetPath: string,
+  source: { mode: number; dev: number; ino: number },
+  nextContent?: string,
+): CaptureStage {
+  const directory = mkdtempSync(join(dirname(resolve(targetPath)), ".dosu-migration-capture-"));
+  chmodSync(directory, 0o700);
+  const directoryStat = lstatSync(directory);
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+    throw new Error("Unsafe migration capture directory");
+  }
+  const capturePath = join(directory, "captured");
+  let nextPath: string | undefined;
+  try {
+    if (nextContent !== undefined) {
+      nextPath = join(directory, "next");
+      const fd = openSync(nextPath, "wx", 0o600);
+      try {
+        writeFileSync(fd, nextContent, "utf8");
+        fchmodSync(fd, source.mode);
+        fsyncSync(fd);
+      } finally {
+        closeSync(fd);
+      }
+    }
+    try {
+      fsyncPath(directory);
+    } catch {
+      // Directory fsync is unavailable on some supported platforms.
+    }
+    return {
+      directory,
+      capturePath,
+      sourceDev: source.dev,
+      sourceIno: source.ino,
+      ...(nextPath ? { nextPath } : {}),
+    };
+  } catch (error) {
+    if (nextPath) {
+      try {
+        unlinkSync(nextPath);
+      } catch {
+        // Best effort cleanup before this private stage is journaled.
+      }
+    }
+    try {
+      rmdirSync(directory);
+    } catch {
+      // Best effort cleanup before this private stage is journaled.
+    }
+    throw error;
+  }
+}
+
+function captureDirectoryFor(targetPath: string, capturePath: string): string | null {
+  const resolvedCapture = resolve(capturePath);
+  const directory = dirname(resolvedCapture);
+  if (
+    basename(resolvedCapture) !== "captured" ||
+    dirname(directory) !== dirname(resolve(targetPath)) ||
+    !basename(directory).startsWith(".dosu-migration-capture-")
+  ) {
+    return null;
+  }
+  return directory;
+}
+
+// This helper is deliberately restricted to files inside a random 0700
+// capture directory. Public target and lock paths are always renamed into a
+// private capture first and are never passed here directly.
+function removeExactPrivateStageFile(
+  path: string,
+  expectedHash: string,
+  expectedIdentity?: { dev: number; ino: number },
+): boolean {
+  try {
+    const snapshot = readStableRegularFile(path);
+    if (
+      !snapshot.ok ||
+      snapshot.file.hash !== expectedHash ||
+      (expectedIdentity !== undefined &&
+        (snapshot.file.dev !== expectedIdentity.dev || snapshot.file.ino !== expectedIdentity.ino))
+    ) {
+      return false;
+    }
+    unlinkSync(path);
+    fsyncParent(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathIsAbsent(path: string): boolean {
+  try {
+    lstatSync(path);
+    return false;
+  } catch (error: unknown) {
+    return isRecord(error) && error.code === "ENOENT";
+  }
+}
+
+function removeStageDirectoryIfEmpty(targetPath: string, capturePath: string): boolean {
+  const directory = captureDirectoryFor(targetPath, capturePath);
+  if (!directory) return false;
+  if (pathIsAbsent(directory)) return true;
+  try {
+    rmdirSync(directory);
+    fsyncParent(directory);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function cleanupStagedNext(
+  targetPath: string,
+  capturePath: string,
+  plannedAfterHash: string | undefined,
+): boolean {
+  const directory = captureDirectoryFor(targetPath, capturePath);
+  if (!directory) return false;
+  const nextPath = join(directory, "next");
+  if (pathIsAbsent(nextPath)) return true;
+  return plannedAfterHash !== undefined && removeExactPrivateStageFile(nextPath, plannedAfterHash);
+}
+
+function exactCapturedSource(capture: CaptureAuthority, expectedHash: string): boolean {
+  const snapshot = readStableRegularFile(capture.capturePath);
+  return (
+    snapshot.ok &&
+    snapshot.file.hash === expectedHash &&
+    snapshot.file.dev === capture.sourceDev &&
+    snapshot.file.ino === capture.sourceIno
+  );
+}
+
+function cleanupVerifiedCapture(
+  targetPath: string,
+  capture: CaptureAuthority,
+  expectedHash: string,
+  plannedAfterHash: string | undefined,
+): boolean {
+  if (
+    !cleanupStagedNext(targetPath, capture.capturePath, plannedAfterHash) ||
+    !removeExactPrivateStageFile(capture.capturePath, expectedHash, {
+      dev: capture.sourceDev,
+      ino: capture.sourceIno,
+    })
+  ) {
+    return false;
+  }
+  return removeStageDirectoryIfEmpty(targetPath, capture.capturePath);
+}
+
+function restoreCapturedReplacement(
+  targetPath: string,
+  capturePath: string,
+  plannedAfterHash: string | undefined,
+): boolean {
+  try {
+    const capturedStat = lstatSync(capturePath);
+    if (capturedStat.isSymbolicLink()) {
+      const linkTarget = readlinkSync(capturePath);
+      // symlinkSync is no-clobber: a concurrently recreated public path makes
+      // restoration fail and leaves the private capture untouched.
+      symlinkSync(linkTarget, targetPath);
+      fsyncParent(targetPath);
+      const restored = lstatSync(targetPath);
+      if (!restored.isSymbolicLink() || readlinkSync(targetPath) !== linkTarget) return false;
+      unlinkSync(capturePath);
+      fsyncParent(capturePath);
+      cleanupStagedNext(targetPath, capturePath, plannedAfterHash);
+      removeStageDirectoryIfEmpty(targetPath, capturePath);
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  const captured = readStableRegularFile(capturePath);
+  if (!captured.ok) return false;
+  try {
+    linkSync(capturePath, targetPath);
+    fsyncParent(targetPath);
+  } catch {
+    return false;
+  }
+
+  const restored = readStableRegularFile(targetPath);
+  if (
+    !restored.ok ||
+    restored.file.dev !== captured.file.dev ||
+    restored.file.ino !== captured.file.ino ||
+    restored.file.hash !== captured.file.hash
+  ) {
+    return false;
+  }
+
+  // The user object is now back at its original path. Only unlink the private
+  // duplicate after proving it is still the same inode we restored.
+  if (
+    !removeExactPrivateStageFile(capturePath, captured.file.hash, {
+      dev: captured.file.dev,
+      ino: captured.file.ino,
+    })
+  ) {
+    return true;
+  }
+  cleanupStagedNext(targetPath, capturePath, plannedAfterHash);
+  removeStageDirectoryIfEmpty(targetPath, capturePath);
+  return true;
+}
+
+type CapturedPublicNode =
+  | { kind: "regular"; dev: number; ino: number; hash: string }
+  | { kind: "symlink"; dev: number; ino: number; linkTarget: string }
+  | { kind: "directory"; dev: number; ino: number };
+
+type PublicCaptureJournal = {
+  version: 1;
+  state: "prepared" | "captured";
+  publicPath: string;
+  capturePath: string;
+  expectedHash: string;
+  expectedDev: number;
+  expectedIno: number;
+  captured?: CapturedPublicNode;
+};
+
+interface PublicCaptureStage {
+  directory: string;
+  capturePath: string;
+  journalPath: string;
+  journalContent: string;
+  journal: PublicCaptureJournal;
+}
+
+function publicCapturePrefix(publicPath: string): string {
+  return `.dosu-public-capture-${pathHash(publicPath)}-`;
+}
+
+function capturedPublicNode(path: string): CapturedPublicNode | null {
+  try {
+    const before = lstatSync(path);
+    if (before.isFile() && !before.isSymbolicLink()) {
+      const snapshot = readStableRegularFile(path);
+      return snapshot.ok
+        ? {
+            kind: "regular",
+            dev: snapshot.file.dev,
+            ino: snapshot.file.ino,
+            hash: snapshot.file.hash,
+          }
+        : null;
+    }
+    if (before.isSymbolicLink()) {
+      const linkTarget = readlinkSync(path);
+      const after = lstatSync(path);
+      return after.isSymbolicLink() && after.dev === before.dev && after.ino === before.ino
+        ? { kind: "symlink", dev: before.dev, ino: before.ino, linkTarget }
+        : null;
+    }
+    if (before.isDirectory()) {
+      const after = lstatSync(path);
+      return after.isDirectory() &&
+        !after.isSymbolicLink() &&
+        after.dev === before.dev &&
+        after.ino === before.ino
+        ? { kind: "directory", dev: before.dev, ino: before.ino }
+        : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function sameCapturedPublicNode(left: CapturedPublicNode, right: CapturedPublicNode): boolean {
+  if (left.kind !== right.kind || left.dev !== right.dev || left.ino !== right.ino) return false;
+  if (left.kind === "regular" && right.kind === "regular") return left.hash === right.hash;
+  if (left.kind === "symlink" && right.kind === "symlink") {
+    return left.linkTarget === right.linkTarget;
+  }
+  return left.kind === "directory" && right.kind === "directory";
+}
+
+function serializePublicCaptureJournal(journal: PublicCaptureJournal): string {
+  return `${JSON.stringify(journal)}\n`;
+}
+
+function writePublicCaptureJournal(
+  stage: PublicCaptureStage,
+  journal: PublicCaptureJournal,
+): PublicCaptureStage {
+  const content = serializePublicCaptureJournal(journal);
+  atomicWrite(stage.journalPath, content, 0o600);
+  return { ...stage, journal, journalContent: content };
+}
+
+function createPublicCaptureStage(
+  publicPath: string,
+  source: StableRegularFile,
+): PublicCaptureStage {
+  const canonicalPath = resolve(publicPath);
+  const directory = mkdtempSync(join(dirname(canonicalPath), publicCapturePrefix(canonicalPath)));
+  chmodSync(directory, 0o700);
+  const directoryStat = lstatSync(directory);
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+    throw new Error("Unsafe public capture directory");
+  }
+  const stage: PublicCaptureStage = {
+    directory,
+    capturePath: join(directory, "captured"),
+    journalPath: join(directory, "journal.json"),
+    journalContent: "",
+    journal: {
+      version: 1,
+      state: "prepared",
+      publicPath: canonicalPath,
+      capturePath: join(directory, "captured"),
+      expectedHash: source.hash,
+      expectedDev: source.dev,
+      expectedIno: source.ino,
+    },
+  };
+  try {
+    return writePublicCaptureJournal(stage, stage.journal);
+  } catch (error) {
+    try {
+      rmdirSync(directory);
+    } catch {
+      // A failed journal publication leaves no authority to mutate publicPath.
+    }
+    throw error;
+  }
+}
+
+function validPublicCaptureJournal(
+  value: unknown,
+  publicPath: string,
+  directory: string,
+): value is PublicCaptureJournal {
+  if (!isRecord(value)) return false;
+  const preparedKeys = [
+    "version",
+    "state",
+    "publicPath",
+    "capturePath",
+    "expectedHash",
+    "expectedDev",
+    "expectedIno",
+  ];
+  const capturedKeys = [...preparedKeys, "captured"];
+  if (!exactKeys(value, value.state === "captured" ? capturedKeys : preparedKeys)) return false;
+  if (
+    value.version !== 1 ||
+    (value.state !== "prepared" && value.state !== "captured") ||
+    value.publicPath !== resolve(publicPath) ||
+    value.capturePath !== join(directory, "captured") ||
+    typeof value.expectedHash !== "string" ||
+    !/^[a-f0-9]{64}$/.test(value.expectedHash) ||
+    typeof value.expectedDev !== "number" ||
+    !Number.isSafeInteger(value.expectedDev) ||
+    value.expectedDev < 0 ||
+    typeof value.expectedIno !== "number" ||
+    !Number.isSafeInteger(value.expectedIno) ||
+    value.expectedIno < 0
+  ) {
+    return false;
+  }
+  if (value.state === "prepared") return true;
+  if (!isRecord(value.captured)) return false;
+  const captured = value.captured;
+  const commonValid =
+    typeof captured.kind === "string" &&
+    typeof captured.dev === "number" &&
+    Number.isSafeInteger(captured.dev) &&
+    captured.dev >= 0 &&
+    typeof captured.ino === "number" &&
+    Number.isSafeInteger(captured.ino) &&
+    captured.ino >= 0;
+  if (!commonValid) return false;
+  if (captured.kind === "regular") {
+    return (
+      exactKeys(captured, ["kind", "dev", "ino", "hash"]) &&
+      typeof captured.hash === "string" &&
+      /^[a-f0-9]{64}$/.test(captured.hash)
+    );
+  }
+  if (captured.kind === "symlink") {
+    return (
+      exactKeys(captured, ["kind", "dev", "ino", "linkTarget"]) &&
+      typeof captured.linkTarget === "string"
+    );
+  }
+  return captured.kind === "directory" && exactKeys(captured, ["kind", "dev", "ino"]);
+}
+
+function readPublicCaptureStage(publicPath: string, directory: string): PublicCaptureStage | null {
+  try {
+    const directoryStat = lstatSync(directory);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) return null;
+    const journalPath = join(directory, "journal.json");
+    const snapshot = readStableRegularFile(journalPath);
+    if (!snapshot.ok) return null;
+    const parsed: unknown = JSON.parse(snapshot.file.content);
+    if (!validPublicCaptureJournal(parsed, publicPath, directory)) return null;
+    return {
+      directory,
+      capturePath: join(directory, "captured"),
+      journalPath,
+      journalContent: snapshot.file.content,
+      journal: parsed,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function removeExactPublicCaptureJournal(stage: PublicCaptureStage): boolean {
+  const snapshot = readStableRegularFile(stage.journalPath);
+  if (!snapshot.ok || snapshot.file.content !== stage.journalContent) return false;
+  try {
+    unlinkSync(stage.journalPath);
+    fsyncParent(stage.journalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function finishPublicCaptureStage(stage: PublicCaptureStage): boolean {
+  if (!pathIsAbsent(stage.capturePath)) return false;
+  if (!removeExactPublicCaptureJournal(stage)) return false;
+  try {
+    rmdirSync(stage.directory);
+    fsyncParent(stage.directory);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removeExactCapturedPublicNode(
+  stage: PublicCaptureStage,
+  expected: CapturedPublicNode,
+): boolean {
+  const current = capturedPublicNode(stage.capturePath);
+  if (!current || !sameCapturedPublicNode(current, expected)) return false;
+  if (current.kind === "directory") return false;
+  try {
+    unlinkSync(stage.capturePath);
+    fsyncParent(stage.capturePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function restoreCapturedPublicNode(
+  stage: PublicCaptureStage,
+  captured: CapturedPublicNode,
+): boolean {
+  if (captured.kind === "directory" || !pathIsAbsent(stage.journal.publicPath)) return false;
+  try {
+    if (captured.kind === "regular") {
+      linkSync(stage.capturePath, stage.journal.publicPath);
+      fsyncParent(stage.journal.publicPath);
+      const restored = capturedPublicNode(stage.journal.publicPath);
+      if (!restored || !sameCapturedPublicNode(restored, captured)) return false;
+    } else {
+      symlinkSync(captured.linkTarget, stage.journal.publicPath);
+      fsyncParent(stage.journal.publicPath);
+      const restored = capturedPublicNode(stage.journal.publicPath);
+      if (restored?.kind !== "symlink" || restored.linkTarget !== captured.linkTarget) {
+        return false;
+      }
+    }
+    return removeExactCapturedPublicNode(stage, captured);
+  } catch {
+    return false;
+  }
+}
+
+function recoverPublicCaptureStage(stage: PublicCaptureStage): boolean {
+  const captured = capturedPublicNode(stage.capturePath);
+  if (!captured) {
+    return pathIsAbsent(stage.capturePath) && finishPublicCaptureStage(stage);
+  }
+
+  const expected: CapturedPublicNode = {
+    kind: "regular",
+    dev: stage.journal.expectedDev,
+    ino: stage.journal.expectedIno,
+    hash: stage.journal.expectedHash,
+  };
+  if (sameCapturedPublicNode(captured, expected)) {
+    return removeExactCapturedPublicNode(stage, expected) && finishPublicCaptureStage(stage);
+  }
+
+  if (
+    stage.journal.state !== "captured" ||
+    !stage.journal.captured ||
+    !sameCapturedPublicNode(captured, stage.journal.captured)
+  ) {
+    return false;
+  }
+
+  if (pathIsAbsent(stage.journal.publicPath)) {
+    return restoreCapturedPublicNode(stage, captured) && finishPublicCaptureStage(stage);
+  }
+
+  const publicNode = capturedPublicNode(stage.journal.publicPath);
+  if (
+    captured.kind === "regular" &&
+    publicNode?.kind === "regular" &&
+    sameCapturedPublicNode(publicNode, captured)
+  ) {
+    return removeExactCapturedPublicNode(stage, captured) && finishPublicCaptureStage(stage);
+  }
+  return false;
+}
+
+/** Recover or explicitly retain every durable sidecar capture for one lock path. */
+function recoverPublicCaptures(publicPath: string): boolean {
+  const canonicalPath = resolve(publicPath);
+  const prefix = publicCapturePrefix(canonicalPath);
+  let names: string[];
+  try {
+    names = readdirSync(dirname(canonicalPath))
+      .filter((name) => name.startsWith(prefix))
+      .sort();
+  } catch (error: unknown) {
+    return isRecord(error) && error.code === "ENOENT";
+  }
+  for (const name of names) {
+    const directory = join(dirname(canonicalPath), name);
+    const stage = readPublicCaptureStage(canonicalPath, directory);
+    if (!stage || !recoverPublicCaptureStage(stage)) return false;
+  }
+  return true;
+}
+
+function atomicCaptureAndRemovePublicFile(
+  path: string,
+  expectedContent: string,
+  expectedIdentity: { dev: number; ino: number },
+  beforeCapture?: () => void,
+): boolean {
+  const snapshot = readStableRegularFile(path);
+  if (
+    !snapshot.ok ||
+    snapshot.file.content !== expectedContent ||
+    snapshot.file.dev !== expectedIdentity.dev ||
+    snapshot.file.ino !== expectedIdentity.ino
+  ) {
+    return false;
+  }
+
+  let stage: PublicCaptureStage | undefined;
+  try {
+    stage = createPublicCaptureStage(path, snapshot.file);
+    beforeCapture?.();
+    renameSync(path, stage.capturePath);
+    fsyncParent(path);
+    const captured = capturedPublicNode(stage.capturePath);
+    if (!captured) return false;
+    const expected: CapturedPublicNode = {
+      kind: "regular",
+      dev: snapshot.file.dev,
+      ino: snapshot.file.ino,
+      hash: snapshot.file.hash,
+    };
+    if (!sameCapturedPublicNode(captured, expected)) {
+      stage = writePublicCaptureJournal(stage, {
+        ...stage.journal,
+        state: "captured",
+        captured,
+      });
+      if (
+        (captured.kind === "regular" || captured.kind === "symlink") &&
+        restoreCapturedPublicNode(stage, captured)
+      ) {
+        finishPublicCaptureStage(stage);
+      }
+      return false;
+    }
+    if (!removeExactCapturedPublicNode(stage, expected)) return false;
+    return finishPublicCaptureStage(stage);
+  } catch {
+    // The prepared/captured journal remains authoritative. The next migration
+    // pass either completes a proven cleanup/restoration or reports it.
+    return false;
+  }
+}
+
+function pendingCaptureAuthority(
+  target: LegacyTarget,
+  receipt: MigrationReceipt,
+): CaptureAuthority | "invalid" | null {
+  const fields = [receipt.capturePath, receipt.sourceDev, receipt.sourceIno];
+  if (fields.every((value) => value === undefined)) return null;
+  if (
+    typeof receipt.capturePath !== "string" ||
+    typeof receipt.sourceDev !== "number" ||
+    !Number.isSafeInteger(receipt.sourceDev) ||
+    receipt.sourceDev < 0 ||
+    typeof receipt.sourceIno !== "number" ||
+    !Number.isSafeInteger(receipt.sourceIno) ||
+    receipt.sourceIno < 0 ||
+    !captureDirectoryFor(target.path, receipt.capturePath)
+  ) {
+    return "invalid";
+  }
+  return {
+    capturePath: receipt.capturePath,
+    sourceDev: receipt.sourceDev,
+    sourceIno: receipt.sourceIno,
+  };
+}
+
+function cleanupPendingStageWithoutCapture(
+  targetPath: string,
+  capturePath: string,
+  plannedAfterHash: string | undefined,
+): boolean {
+  return (
+    cleanupStagedNext(targetPath, capturePath, plannedAfterHash) &&
+    removeStageDirectoryIfEmpty(targetPath, capturePath)
+  );
+}
+
+function pendingBackupIsValid(receipt: MigrationReceipt): boolean {
+  if (typeof receipt.backupPath !== "string" || typeof receipt.beforeHash !== "string") {
+    return false;
+  }
+  try {
+    secureBackup(receipt.backupPath, receipt.beforeHash);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Recover journals written by the atomic-capture implementation. `null`
+ * delegates to the pre-capture recovery path for old receipts.
+ */
+function decideCapturedPendingReceipt(
+  target: LegacyTarget,
+  backupRoot: string,
+  receipt: MigrationReceipt,
+  state: TargetState,
+): PriorReceiptDecision | null {
+  const capture = pendingCaptureAuthority(target, receipt);
+  if (capture === null) return null;
+  if (capture === "invalid") {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "invalid_pending_receipt"),
+    };
+  }
+  if (typeof receipt.beforeHash !== "string") {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "invalid_pending_receipt"),
+    };
+  }
+
+  const captureAbsent = pathIsAbsent(capture.capturePath);
+  const captureExact = !captureAbsent && exactCapturedSource(capture, receipt.beforeHash);
+  if (!captureAbsent && !captureExact) {
+    // Keep the pending journal and unexpected object as recovery evidence.
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "pending_capture_invalid"),
+    };
+  }
+
+  const cleanupCapture = (): boolean =>
+    captureExact
+      ? cleanupVerifiedCapture(
+          target.path,
+          capture,
+          receipt.beforeHash as string,
+          receipt.plannedAfterHash,
+        )
+      : cleanupPendingStageWithoutCapture(
+          target.path,
+          capture.capturePath,
+          receipt.plannedAfterHash,
+        );
+
+  if (state.kind === "file" && state.hash === receipt.beforeHash) {
+    if (!cleanupCapture()) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "preserved_ambiguous", "pending_capture_cleanup_failed"),
+      };
+    }
+    return { action: "continue" };
+  }
+
+  const reachedAfter =
+    (receipt.plannedMutation === "delete" && state.kind === "absent") ||
+    (receipt.plannedMutation === "write" &&
+      state.kind === "file" &&
+      typeof receipt.plannedAfterHash === "string" &&
+      state.hash === receipt.plannedAfterHash);
+  if (reachedAfter) {
+    if (!pendingBackupIsValid(receipt)) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "preserved_ambiguous", "pending_backup_invalid"),
+      };
+    }
+    if (!cleanupCapture()) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "preserved_ambiguous", "pending_capture_cleanup_failed"),
+      };
+    }
+    return {
+      action: "return",
+      receipt: persistTerminal(target, backupRoot, "removed", "recovered_pending_mutation", {
+        beforeHash: receipt.beforeHash,
+        afterHash: receipt.plannedAfterHash,
+        backupPath: receipt.backupPath,
+        plannedMutation: receipt.plannedMutation,
+        plannedAfterHash: receipt.plannedAfterHash,
+      }),
+    };
+  }
+
+  if (
+    receipt.plannedMutation === "write" &&
+    state.kind === "absent" &&
+    captureExact &&
+    restoreCapturedReplacement(target.path, capture.capturePath, receipt.plannedAfterHash)
+  ) {
+    return { action: "continue" };
+  }
+
+  // Leave both the pending journal and capture untouched when another object
+  // now owns the target path or recovery cannot be proven.
+  return {
+    action: "return",
+    receipt: baseReceipt(target, "preserved_ambiguous", "pending_recovery_conflict"),
+  };
+}
+
+export function applyContentPlan(input: {
+  bundle: ProjectBundleProof;
+  target: LegacyTarget;
+  plan: ContentPlan;
+  backupRoot: string;
+  allowRemoval: boolean;
+  /**
+   * Final fail-closed authorization evaluated under the per-target lock both
+   * immediately before and immediately after capture. A non-null reason keeps
+   * the public target intact (or restores its exact captured preimage).
+   */
+  finalMutationAuthorization?: FinalMutationAuthorization;
+  /** @internal Deterministic fault injection for filesystem race tests only. */
+  _testHooks?: MigrationTestHooks;
+}): MigrationReceipt {
+  assertProjectBundleProof(input.bundle);
+  const { target, plan, backupRoot } = input;
+  const authorizationFailure = bundleFailure(input.bundle, target);
+  if (authorizationFailure) {
+    return baseReceipt(target, "preserved_ambiguous", authorizationFailure);
+  }
+  if (plan.disposition === "remove" && !input.allowRemoval) {
+    return baseReceipt(target, "preserved_ambiguous", "runtime_not_verified");
+  }
+  const priorDecision = decidePriorReceipt(target, backupRoot);
+  if (priorDecision.action === "return") return priorDecision.receipt;
+  if (plan.disposition === "not_found") {
+    return persistTerminal(target, backupRoot, "not_found", plan.reason, {
+      beforeHash: plan.expectedHash,
+    });
+  }
+  if (plan.disposition === "preserved_ambiguous") {
+    return persistTerminal(target, backupRoot, "preserved_ambiguous", plan.reason, {
+      beforeHash: plan.expectedHash,
+    });
+  }
+  if (!plan.mutation || (plan.mutation === "write" && plan.nextContent === undefined)) {
+    return persistTerminal(target, backupRoot, "preserved_ambiguous", "invalid_migration_plan", {
+      beforeHash: plan.expectedHash,
+    });
+  }
+
+  // This early guard gives a newly published intent a descriptive preserve
+  // result before lock acquisition. The shared target lock and the two final
+  // checks below remain the actual race-free mutation authorization.
+  const earlyAuthorizationFailure = mutationAuthorizationFailure(
+    input.finalMutationAuthorization,
+    target,
+  );
+  if (earlyAuthorizationFailure) {
+    return baseReceipt(target, "preserved_ambiguous", earlyAuthorizationFailure);
+  }
+
+  const firstCheck = recheckSource(target, plan.expectedHash);
+  if (!firstCheck.ok) {
+    return persistTerminal(target, backupRoot, "concurrent_conflict", firstCheck.reason, {
+      beforeHash: plan.expectedHash,
+    });
+  }
+
+  const receiptPath = receiptPathFor(target, backupRoot);
+  const lockPath = `${target.path}.dosu-migration.lock`;
+  const lock = acquireMigrationLock(lockPath, target.path, backupRoot, input._testHooks);
+  if (!lock.ok) {
+    // Do not overwrite a pending journal: another process (or an untrusted
+    // sidecar) may be the only evidence needed for safe crash recovery.
+    return baseReceipt(target, "preserved_ambiguous", lock.reason);
+  }
+
+  let journalWritten = false;
+  let stage: CaptureStage | undefined;
+  const plannedAfterHash =
+    plan.mutation === "write" ? hashContent(plan.nextContent ?? "") : undefined;
+  try {
+    input._testHooks?.afterLockAcquired?.();
+    const lockedCheck = recheckSource(target, plan.expectedHash);
+    if (!lockedCheck.ok) {
+      return persistTerminal(target, backupRoot, "concurrent_conflict", lockedCheck.reason, {
+        beforeHash: plan.expectedHash,
+      });
+    }
+    prepareBackupRoot(backupRoot);
+    const backupPath = backupPathFor(target, plan.expectedHash, backupRoot);
+    ensureBackup(target.path, backupPath, plan.expectedHash);
+
+    input._testHooks?.afterBackupCreated?.();
+    const afterBackupCheck = recheckSource(target, plan.expectedHash);
+    if (!afterBackupCheck.ok) {
+      return persistTerminal(target, backupRoot, "concurrent_conflict", afterBackupCheck.reason, {
+        beforeHash: plan.expectedHash,
+        backupPath,
+      });
+    }
+
+    input._testHooks?.beforeFinalBundleCheck?.();
+    const finalBundleFailure = bundleFailure(input.bundle, target);
+    if (finalBundleFailure) {
+      const receipt = receiptWithJournalFields(
+        target,
+        "preserved_ambiguous",
+        finalBundleFailure,
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+
+    input._testHooks?.beforeFinalSourceCheck?.();
+    const finalCheck = recheckSource(target, plan.expectedHash);
+    if (!finalCheck.ok) {
+      const receipt = receiptWithJournalFields(
+        target,
+        "concurrent_conflict",
+        finalCheck.reason,
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+    input._testHooks?.beforeFinalMutationAuthorization?.();
+    const finalAuthorizationFailure = mutationAuthorizationFailure(
+      input.finalMutationAuthorization,
+      target,
+    );
+    if (finalAuthorizationFailure) {
+      const receipt = receiptWithJournalFields(
+        target,
+        "preserved_ambiguous",
+        finalAuthorizationFailure,
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+    // Re-prove the immutable preimage backup before preparing a durable
+    // capture journal. A replaced symlink is never trusted.
+    secureBackup(backupPath, plan.expectedHash);
+
+    stage = createCaptureStage(
+      target.path,
+      finalCheck,
+      plan.mutation === "write" ? (plan.nextContent ?? "") : undefined,
+    );
+    input._testHooks?.afterStagePrepared?.(stage);
+    const pending = receiptWithJournalFields(
+      target,
+      "pending",
+      "mutation_prepared",
+      plan.expectedHash,
+      backupPath,
+      receiptPath,
+      undefined,
+      plan.mutation,
+      plannedAfterHash,
+      stage,
+    );
+    writePersistedReceipt(receiptPath, pending);
+    journalWritten = true;
+
+    input._testHooks?.beforeCapture?.(target);
+    renameSync(target.path, stage.capturePath);
+    fsyncParent(target.path);
+    input._testHooks?.afterCapture?.(stage);
+
+    if (!exactCapturedSource(stage, plan.expectedHash)) {
+      const restored = restoreCapturedReplacement(target.path, stage.capturePath, plannedAfterHash);
+      if (!restored || !pathIsAbsent(stage.capturePath)) {
+        // The durable pending journal is the recovery authority for a captured
+        // directory or any object that cannot be restored without clobbering.
+        // Never replace it with a terminal tombstone while capturePath exists.
+        return baseReceipt(target, "pending", "captured_source_mismatch");
+      }
+      const receipt = receiptWithJournalFields(
+        target,
+        "concurrent_conflict",
+        "captured_source_mismatch",
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+        undefined,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+
+    // A concurrent explicit-global install publishes its intent marker before
+    // it touches the provider file. Rechecking after capture closes the final
+    // authorization-to-rename window. If authorization changed, restore the
+    // exact legacy preimage with no-clobber semantics; when another writer has
+    // already recreated the target, retain the durable pending journal and
+    // capture for the next recovery pass.
+    const capturedAuthorizationFailure = mutationAuthorizationFailure(
+      input.finalMutationAuthorization,
+      target,
+    );
+    if (capturedAuthorizationFailure) {
+      if (
+        !restoreCapturedReplacement(target.path, stage.capturePath, plannedAfterHash) ||
+        !pathIsAbsent(stage.capturePath)
+      ) {
+        return baseReceipt(target, "pending", capturedAuthorizationFailure);
+      }
+      const receipt = receiptWithJournalFields(
+        target,
+        "preserved_ambiguous",
+        capturedAuthorizationFailure,
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+
+    if (plan.mutation === "delete") {
+      if (!pathIsAbsent(target.path)) {
+        if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+          throw new Error("Could not safely clean the captured legacy source");
+        }
+        const receipt = receiptWithJournalFields(
+          target,
+          "concurrent_conflict",
+          "target_recreated_during_migration",
+          plan.expectedHash,
+          backupPath,
+          receiptPath,
+          undefined,
+          plan.mutation,
+          plannedAfterHash,
+        );
+        writePersistedReceipt(receiptPath, receipt);
+        return receipt;
+      }
+      if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+        throw new Error("Could not safely remove the captured legacy source");
+      }
+    } else {
+      if (!stage.nextPath || plannedAfterHash === undefined) {
+        throw new Error("Missing staged migration content");
+      }
+      const stagedWrite = readStableRegularFile(stage.nextPath);
+      if (!stagedWrite.ok || stagedWrite.file.hash !== plannedAfterHash) {
+        throw new Error("Staged migration content changed");
+      }
+      try {
+        // A hard link is an atomic no-replace publish on the same filesystem.
+        // Unlike rename(), it fails when any process has recreated target.path.
+        linkSync(stage.nextPath, target.path);
+        fsyncParent(target.path);
+      } catch (error: unknown) {
+        if (!isRecord(error) || error.code !== "EEXIST") throw error;
+        if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+          throw new Error("Could not safely clean a conflicted capture");
+        }
+        const receipt = receiptWithJournalFields(
+          target,
+          "concurrent_conflict",
+          "target_recreated_during_migration",
+          plan.expectedHash,
+          backupPath,
+          receiptPath,
+          undefined,
+          plan.mutation,
+          plannedAfterHash,
+        );
+        writePersistedReceipt(receiptPath, receipt);
+        return receipt;
+      }
+      input._testHooks?.afterPublish?.(stage);
+
+      const published = readStableRegularFile(target.path);
+      if (
+        !published.ok ||
+        published.file.hash !== plannedAfterHash ||
+        published.file.dev !== stagedWrite.file.dev ||
+        published.file.ino !== stagedWrite.file.ino
+      ) {
+        if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+          throw new Error("Could not safely clean a raced publish");
+        }
+        const receipt = receiptWithJournalFields(
+          target,
+          "concurrent_conflict",
+          "target_changed_after_publish",
+          plan.expectedHash,
+          backupPath,
+          receiptPath,
+          undefined,
+          plan.mutation,
+          plannedAfterHash,
+        );
+        writePersistedReceipt(receiptPath, receipt);
+        return receipt;
+      }
+      if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+        throw new Error("Could not safely finalize the captured legacy source");
+      }
+    }
+    const afterHash = plan.mutation === "delete" ? undefined : hashContent(plan.nextContent ?? "");
+    const receipt = receiptWithJournalFields(
+      target,
+      "removed",
+      plan.reason,
+      plan.expectedHash,
+      backupPath,
+      receiptPath,
+      afterHash,
+      plan.mutation,
+      plannedAfterHash,
+    );
+    writePersistedReceipt(receiptPath, receipt);
+    return receipt;
+  } catch {
+    // Once pending is durable, leave it intact. The next run can distinguish
+    // before/after/conflict and recover safely instead of guessing here.
+    if (journalWritten) return baseReceipt(target, "failed", "migration_io_failed");
+    if (stage) {
+      cleanupStagedNext(target.path, stage.capturePath, plannedAfterHash);
+      removeStageDirectoryIfEmpty(target.path, stage.capturePath);
+    }
+    return persistTerminal(target, backupRoot, "failed", "migration_io_failed", {
+      beforeHash: plan.expectedHash,
+      plannedMutation: plan.mutation,
+      plannedAfterHash,
+    });
+  } finally {
+    releaseMigrationLock(
+      lockPath,
+      lock.content,
+      { dev: lock.dev, ino: lock.ino },
+      input._testHooks,
+    );
+  }
+}
+
+export function migrateLegacyTargets(input: {
+  bundle: ProjectBundleProof;
+  targets: readonly LegacyTarget[];
+  backupRoot: string;
+  allowRemoval: boolean;
+  finalMutationAuthorization?: FinalMutationAuthorization;
+  /** @internal Deterministic fault injection for filesystem race tests only. */
+  _testHooks?: MigrationTestHooks;
+}): MigrationReceipt[] {
+  assertProjectBundleProof(input.bundle);
+  const receipts: MigrationReceipt[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const target of input.targets) {
+    const key = resolve(target.path);
+    if (seenPaths.has(key)) continue;
+    seenPaths.add(key);
+
+    const authorizationFailure = bundleFailure(input.bundle, target);
+    if (authorizationFailure) {
+      receipts.push(baseReceipt(target, "preserved_ambiguous", authorizationFailure));
+      continue;
+    }
+
+    const priorDecision = decidePriorReceipt(target, input.backupRoot);
+    if (priorDecision.action === "return") {
+      receipts.push(priorDecision.receipt);
+      continue;
+    }
+
+    let content: string;
+    try {
+      const stat = lstatSync(target.path);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        receipts.push(
+          persistTerminal(target, input.backupRoot, "preserved_ambiguous", "non_regular_target"),
+        );
+        continue;
+      }
+      content = readFileSync(target.path, "utf8");
+    } catch (error: unknown) {
+      const code =
+        typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+      receipts.push(
+        code === "ENOENT"
+          ? persistTerminal(target, input.backupRoot, "not_found", "target_absent")
+          : baseReceipt(target, "failed", "target_read_failed"),
+      );
+      continue;
+    }
+
+    const plan = planForTarget(target, content);
+    receipts.push(applyContentPlan({ ...input, target, plan }));
+  }
+  return receipts;
+}

--- a/src/migration/planners.test.ts
+++ b/src/migration/planners.test.ts
@@ -1,0 +1,948 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { type ParseError, parse as parseJsonc, parseTree } from "jsonc-parser/lib/esm/main.js";
+import { describe, expect, it } from "vitest";
+import {
+  isExactProjectCodexProxy,
+  isExactProjectJsonProxy,
+  planCodexDosuMcp,
+  planLegacyCodexMcp,
+  planLegacyJsonMcp,
+  planLegacyRuleSection,
+  planLegacyStandaloneRule,
+  planProjectCodexMcp,
+  removeJsonObjectPropertyRaw,
+} from "./planners";
+
+const API_KEY = "dosu_test_key";
+const DEPLOYMENT_URL = "https://api.dosu.dev/v1/mcp/deployments/dep-123";
+const BASE_URL = "https://api.dosu.dev/v1/mcp";
+const RELEASED_RULE = readFileSync(join(process.cwd(), "rules", "dosu.md"), "utf8");
+
+describe("legacy JSON/JSONC MCP planner", () => {
+  const cases: Array<{
+    name: string;
+    provider: Parameters<typeof planLegacyJsonMcp>[0]["provider"];
+    topKey: string;
+    entry: Record<string, unknown>;
+  }> = [
+    {
+      name: "standard HTTP",
+      provider: "claude",
+      topKey: "mcpServers",
+      entry: {
+        type: "http",
+        url: DEPLOYMENT_URL,
+        headers: { "X-Dosu-API-Key": API_KEY },
+      },
+    },
+    {
+      name: "Cursor cloud",
+      provider: "cursor",
+      topKey: "mcpServers",
+      entry: { url: DEPLOYMENT_URL, headers: { "X-Dosu-API-Key": API_KEY } },
+    },
+    {
+      name: "Cline cloud",
+      provider: "cline",
+      topKey: "mcpServers",
+      entry: {
+        type: "streamableHttp",
+        disabled: false,
+        url: DEPLOYMENT_URL,
+        headers: { "X-Dosu-API-Key": API_KEY },
+      },
+    },
+    {
+      name: "OpenCode cloud",
+      provider: "opencode",
+      topKey: "mcp",
+      entry: {
+        type: "remote",
+        enabled: true,
+        url: DEPLOYMENT_URL,
+        headers: { "X-Dosu-API-Key": API_KEY },
+      },
+    },
+    {
+      name: "Zed cloud",
+      provider: "zed",
+      topKey: "context_servers",
+      entry: {
+        source: "custom",
+        type: "http",
+        url: DEPLOYMENT_URL,
+        headers: { "X-Dosu-API-Key": API_KEY },
+      },
+    },
+    {
+      name: "Antigravity cloud",
+      provider: "antigravity",
+      topKey: "mcpServers",
+      entry: {
+        serverUrl: DEPLOYMENT_URL,
+        headers: { "X-Dosu-API-Key": API_KEY },
+      },
+    },
+    {
+      name: "Copilot cloud",
+      provider: "copilot",
+      topKey: "mcpServers",
+      entry: {
+        type: "http",
+        url: DEPLOYMENT_URL,
+        tools: ["*"],
+        headers: { "X-Dosu-API-Key": API_KEY },
+      },
+    },
+    {
+      // Custom-shape providers used the common standard builder in OSS mode.
+      name: "custom provider OSS fallback",
+      provider: "opencode",
+      topKey: "mcp",
+      entry: {
+        type: "http",
+        url: BASE_URL,
+        headers: { "X-Dosu-API-Key": API_KEY },
+      },
+    },
+    {
+      name: "Claude Desktop mcp-remote",
+      provider: "claude-desktop",
+      topKey: "mcpServers",
+      entry: {
+        command: "/opt/homebrew/bin/npx",
+        args: [
+          "-y",
+          "mcp-remote@0.1.38",
+          DEPLOYMENT_URL,
+          "--header",
+          "X-Dosu-API-Key:$" + "{X_DOSU_API_KEY}",
+          "--transport",
+          "http-only",
+        ],
+        env: { PATH: "/opt/homebrew/bin:/usr/bin:/bin", X_DOSU_API_KEY: API_KEY },
+      },
+    },
+  ];
+
+  for (const fixture of cases) {
+    it(`removes the released ${fixture.name} shape and preserves JSONC siblings`, () => {
+      const content = `{
+  // keep this user comment
+  "${fixture.topKey}": {
+    "other": { "url": "https://example.com" },
+    "dosu": ${JSON.stringify(fixture.entry)}
+  },
+  "userSetting": true
+}\n`;
+
+      const plan = planLegacyJsonMcp({
+        content,
+        provider: fixture.provider,
+        topKey: fixture.topKey,
+      });
+
+      expect(plan.disposition).toBe("remove");
+      expect(plan.mutation).toBe("write");
+      expect(plan.nextContent).toContain("keep this user comment");
+      expect(plan.nextContent).toContain('"other"');
+      expect(plan.nextContent).toContain('"userSetting"');
+      expect(plan.nextContent).not.toContain('"dosu"');
+      expect(plan.nextContent).not.toContain(API_KEY);
+    });
+  }
+
+  it("refuses duplicate keys instead of trusting JSON.parse last-write-wins", () => {
+    const content = `{
+      "mcpServers": {
+        "dosu": {"type":"http","url":"${DEPLOYMENT_URL}","headers":{"X-Dosu-API-Key":"a"}},
+        "dosu": {"type":"http","url":"${DEPLOYMENT_URL}","headers":{"X-Dosu-API-Key":"b"}}
+      }
+    }`;
+    const plan = planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" });
+    expect(plan).toMatchObject({ disposition: "preserved_ambiguous", reason: "duplicate_key" });
+  });
+
+  it("refuses malformed JSONC", () => {
+    const plan = planLegacyJsonMcp({
+      content: '{"mcpServers":{"dosu":',
+      provider: "claude",
+      topKey: "mcpServers",
+    });
+    expect(plan).toMatchObject({ disposition: "preserved_ambiguous", reason: "parse_error" });
+  });
+
+  it("refuses a foreign server that happens to be named dosu", () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://example.com/mcp",
+          headers: { Authorization: "Bearer user-owned" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" });
+    expect(plan).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+  });
+
+  it("does not treat a Dosu-shaped entry on a foreign origin as released", () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://example.invalid/v1/mcp/deployments/dep-123",
+          headers: { "X-Dosu-API-Key": API_KEY },
+        },
+      },
+    });
+
+    expect(planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" })).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+  });
+
+  it("preserves a Dosu-shaped URL containing userinfo", () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://user:pass@api.dosu.dev/v1/mcp/deployments/dep-123",
+          headers: { "X-Dosu-API-Key": API_KEY },
+        },
+      },
+    });
+
+    expect(planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" })).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+  });
+
+  it("refuses unknown fields even on an otherwise matching Dosu entry", () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: DEPLOYMENT_URL,
+          headers: { "X-Dosu-API-Key": API_KEY },
+          userAdded: true,
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" });
+    expect(plan).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "unknown_dosu_shape",
+    });
+  });
+
+  it("accepts the standard fallback for custom providers only at the OSS base URL", () => {
+    const standard = (url: string) =>
+      JSON.stringify({
+        mcp: {
+          dosu: { type: "http", url, headers: { "X-Dosu-API-Key": API_KEY } },
+        },
+      });
+    expect(
+      planLegacyJsonMcp({ content: standard(BASE_URL), provider: "opencode", topKey: "mcp" }),
+    ).toMatchObject({ disposition: "remove" });
+    expect(
+      planLegacyJsonMcp({
+        content: standard(DEPLOYMENT_URL),
+        provider: "opencode",
+        topKey: "mcp",
+      }),
+    ).toMatchObject({ disposition: "preserved_ambiguous", reason: "unknown_dosu_shape" });
+  });
+
+  it("never accepts a common standard fallback for Copilot", () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: { type: "http", url: BASE_URL, headers: { "X-Dosu-API-Key": API_KEY } },
+      },
+    });
+    expect(planLegacyJsonMcp({ content, provider: "copilot", topKey: "mcpServers" })).toMatchObject(
+      { disposition: "preserved_ambiguous", reason: "unknown_dosu_shape" },
+    );
+  });
+
+  it("preserves every unrelated JSONC byte while deleting only Dosu and its separator", () => {
+    const entry = JSON.stringify({
+      type: "http",
+      url: DEPLOYMENT_URL,
+      headers: { "X-Dosu-API-Key": API_KEY },
+    });
+    const content = `{
+  "mcpServers": {
+    "first" : { "url": "https://one.example" }, /* keep comma, spacing */
+    "dosu": ${entry}, // keep this user comment byte-for-byte
+    "last": {"url":"https://last.example"}
+  }
+}\n`;
+    const expected = `{
+  "mcpServers": {
+    "first" : { "url": "https://one.example" }, /* keep comma, spacing */
+     // keep this user comment byte-for-byte
+    "last": {"url":"https://last.example"}
+  }
+}\n`;
+    const plan = planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" });
+    expect(plan).toMatchObject({ disposition: "remove", nextContent: expected });
+  });
+
+  it("keeps a one-child JSONC object valid when Dosu has a trailing comma", () => {
+    const content = `{
+  "mcpServers": {
+    "dosu": {"type":"http","url":"${DEPLOYMENT_URL}","headers":{"X-Dosu-API-Key":"${API_KEY}"}},
+  },
+}
+`;
+    const plan = planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" });
+    expect(plan).toMatchObject({ disposition: "remove" });
+    const errors: ParseError[] = [];
+    expect(parseJsonc(plan.nextContent ?? "", errors, { allowTrailingComma: true })).toEqual({
+      mcpServers: {},
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects relative PATH entries in the released Claude Desktop shape", () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "stdio",
+          command: "/usr/local/bin/npx",
+          args: [
+            "-y",
+            "mcp-remote@0.1.38",
+            DEPLOYMENT_URL,
+            "--header",
+            "X-Dosu-API-Key:$" + "{X_DOSU_API_KEY}",
+            "--transport",
+            "http-only",
+          ],
+          env: { PATH: "relative/bin:/usr/bin", X_DOSU_API_KEY: API_KEY },
+        },
+      },
+    });
+    expect(
+      planLegacyJsonMcp({ content, provider: "claude-desktop", topKey: "mcpServers" }),
+    ).toMatchObject({ disposition: "preserved_ambiguous", reason: "unknown_dosu_shape" });
+  });
+
+  it("does not silently own endpoint paths with a trailing slash", () => {
+    for (const url of [
+      "https://api.dosu.dev/v1/mcp/",
+      "https://api.dosu.dev/v1/mcp/deployments/dep-123/",
+    ]) {
+      const content = JSON.stringify({
+        mcpServers: {
+          dosu: { type: "http", url, headers: { "X-Dosu-API-Key": API_KEY } },
+        },
+      });
+      expect(
+        planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" }),
+      ).toMatchObject({ disposition: "preserved_ambiguous", reason: "foreign_dosu_entry" });
+    }
+  });
+
+  it("is idempotent when no Dosu child exists", () => {
+    const content = '{"mcpServers":{"other":{"url":"https://example.com"}}}';
+    const plan = planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" });
+    expect(plan).toMatchObject({ disposition: "not_found", reason: "dosu_entry_absent" });
+    expect(plan.nextContent).toBeUndefined();
+  });
+
+  it.each([
+    ["[]", "root_not_object"],
+    ['{"mcpServers":true}', "top_key_not_object"],
+    ['{"mcpServers":{"dosu":"user-owned"}}', "foreign_dosu_entry"],
+    ['{"other":{}}', "dosu_entry_absent"],
+  ])("fails closed for structural JSON edge case %#", (content, reason) => {
+    expect(planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" })).toMatchObject({
+      reason,
+    });
+  });
+
+  it.each([
+    42,
+    "not a URL",
+    "ftp://api.dosu.dev/v1/mcp",
+    "https://api.dosu.dev/v1/mcp?mine=true",
+    "https://api.dosu.dev/v1/mcp#mine",
+  ])("preserves a same-named entry with an unowned endpoint %#", (url) => {
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: { type: "http", url, headers: { "X-Dosu-API-Key": API_KEY } },
+      },
+    });
+    expect(planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" })).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+  });
+
+  it.each([
+    null,
+    {},
+    { "X-Dosu-API-Key": "" },
+    { "X-Dosu-API-Key": API_KEY, Authorization: "mine" },
+  ])("preserves standard entries whose header proof is not exact %#", (headers) => {
+    const content = JSON.stringify({
+      mcpServers: { dosu: { type: "http", url: DEPLOYMENT_URL, headers } },
+    });
+    expect(planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" })).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "unknown_dosu_shape",
+    });
+  });
+
+  it("accepts the released Windows Claude Desktop command and PATH shape", () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          command: "C:\\Program Files\\nodejs\\npx.cmd",
+          args: [
+            "-y",
+            "mcp-remote@0.1.38",
+            DEPLOYMENT_URL,
+            "--header",
+            "X-Dosu-API-Key:$" + "{X_DOSU_API_KEY}",
+            "--transport",
+            "http-only",
+          ],
+          env: {
+            PATH: "C:\\Program Files\\nodejs;C:\\Windows\\System32",
+            X_DOSU_API_KEY: API_KEY,
+          },
+        },
+      },
+    });
+    expect(
+      planLegacyJsonMcp({ content, provider: "claude-desktop", topKey: "mcpServers" }),
+    ).toMatchObject({ disposition: "remove" });
+  });
+
+  it.each([
+    { command: 1 },
+    { command: "npx" },
+    { command: "/usr/bin/node" },
+    { args: "not-an-array" },
+    { args: ["-y"] },
+    { env: null },
+    { env: { PATH: "/usr/bin", X_DOSU_API_KEY: API_KEY, USER_VALUE: "mine" } },
+  ])("preserves mutated Claude Desktop ownership evidence %#", (replacement) => {
+    const entry = {
+      command: "/usr/bin/npx",
+      args: [
+        "-y",
+        "mcp-remote@0.1.38",
+        DEPLOYMENT_URL,
+        "--header",
+        "X-Dosu-API-Key:$" + "{X_DOSU_API_KEY}",
+        "--transport",
+        "http-only",
+      ],
+      env: { PATH: "/usr/bin:/bin", X_DOSU_API_KEY: API_KEY },
+      ...replacement,
+    };
+    const content = JSON.stringify({ mcpServers: { dosu: entry } });
+    expect(
+      planLegacyJsonMcp({ content, provider: "claude-desktop", topKey: "mcpServers" }),
+    ).toMatchObject({ disposition: "preserved_ambiguous" });
+  });
+
+  it("validates every provider-specific project proxy envelope", () => {
+    const expectation = { packageVersion: "0.43.0", deploymentID: "dep-project" } as const;
+    const args = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"];
+    const cases = [
+      ["claude", "mcpServers", { type: "stdio", command: "npx", args }],
+      ["gemini", "mcpServers", { command: "npx", args }],
+      ["zed", "context_servers", { command: "npx", args, env: {} }],
+      ["opencode", "mcp", { type: "local", command: ["npx", ...args], enabled: true }],
+    ] as const;
+    for (const [provider, topKey, entry] of cases) {
+      expect(
+        isExactProjectJsonProxy({
+          content: JSON.stringify({ [topKey]: { dosu: entry } }),
+          provider,
+          topKey,
+          expectation,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects malformed project proxy documents and envelopes", () => {
+    const expectation = { packageVersion: "0.43.0", oss: true } as const;
+    for (const content of ["{", "[]", '{"mcpServers":{"dosu":{},"dosu":{}}}']) {
+      expect(
+        isExactProjectJsonProxy({ content, provider: "claude", topKey: "mcpServers", expectation }),
+      ).toBe(false);
+    }
+    expect(
+      isExactProjectJsonProxy({
+        content: JSON.stringify({
+          context_servers: { dosu: { command: "npx", args: [], env: { MINE: "1" } } },
+        }),
+        provider: "zed",
+        topKey: "context_servers",
+        expectation,
+      }),
+    ).toBe(false);
+  });
+
+  it("raw JSONC removal refuses non-objects, absent keys, and inconsistent separators", () => {
+    const content = '{"dosu":1,"other":2}';
+    const root = parseTree(content);
+    const valueNode = root?.children?.[0]?.children?.[1];
+    if (!root || !valueNode) throw new Error("expected parsed object fixture");
+    expect(removeJsonObjectPropertyRaw(content, valueNode, "dosu")).toBe(null);
+    expect(removeJsonObjectPropertyRaw(content, root, "missing")).toBe(null);
+    expect(removeJsonObjectPropertyRaw(content.replace(",", ":"), root, "dosu")).toBe(null);
+  });
+});
+
+describe("legacy Codex TOML planner", () => {
+  it("removes the pre-v0.42 HTTP form and keeps unrelated TOML byte content", () => {
+    const content = `model = "gpt-5"
+
+[mcp_servers.other]
+url = "https://example.com"
+
+[mcp_servers.dosu]
+type = "http"
+url = "${DEPLOYMENT_URL}"
+
+[mcp_servers.dosu.http_headers]
+X-Dosu-API-Key = "${API_KEY}"
+
+[projects."/tmp/example"]
+trust_level = "trusted"
+`;
+    const plan = planLegacyCodexMcp(content);
+    expect(plan.disposition).toBe("remove");
+    expect(plan.nextContent).toContain('model = "gpt-5"');
+    expect(plan.nextContent).toContain("[mcp_servers.other]");
+    expect(plan.nextContent).toContain('[projects."/tmp/example"]');
+    expect(plan.nextContent).not.toContain("mcp_servers.dosu");
+    expect(plan.nextContent).not.toContain(API_KEY);
+  });
+
+  it("removes the current stdio mcp-remote form", () => {
+    const content = `[mcp_servers.dosu]
+command = "/opt/homebrew/bin/npx"
+args = ["-y", "mcp-remote@0.1.38", "${DEPLOYMENT_URL}", "--header", "X-Dosu-API-Key:\${X_DOSU_API_KEY}", "--transport", "http-only"]
+
+[mcp_servers.dosu.env]
+PATH = "/opt/homebrew/bin:/usr/bin:/bin"
+X_DOSU_API_KEY = "${API_KEY}"
+`;
+    const plan = planLegacyCodexMcp(content);
+    expect(plan.disposition).toBe("remove");
+    expect(plan.nextContent).not.toContain("mcp_servers.dosu");
+    expect(plan.nextContent).not.toContain(API_KEY);
+  });
+
+  it("preserves trailing user comments byte-for-byte after the last legacy assignment", () => {
+    const kept = `# KEEP USER COMMENT
+
+[mcp_servers.other]
+url = "https://example.com"
+`;
+    const content = `[mcp_servers.dosu]
+type = "http"
+url = "${DEPLOYMENT_URL}"
+
+[mcp_servers.dosu.http_headers]
+X-Dosu-API-Key = "${API_KEY}"
+${kept}`;
+    const plan = planLegacyCodexMcp(content);
+    expect(plan).toMatchObject({ disposition: "remove", nextContent: `\n${kept}` });
+  });
+
+  it("refuses duplicate Dosu sections", () => {
+    const content = `[mcp_servers.dosu]
+type = "http"
+url = "${DEPLOYMENT_URL}"
+[mcp_servers.dosu]
+type = "http"
+url = "${DEPLOYMENT_URL}"
+`;
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "parse_error",
+    });
+  });
+
+  it("refuses foreign and unknown shapes", () => {
+    const foreign = `[mcp_servers.dosu]\ntype = "http"\nurl = "https://example.com/mcp"\n`;
+    expect(planLegacyCodexMcp(foreign)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+
+    const unknown = `[mcp_servers.dosu]\ntype = "http"\nurl = "${DEPLOYMENT_URL}"\nuser_key = true\n`;
+    expect(planLegacyCodexMcp(unknown)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "unknown_dosu_shape",
+    });
+  });
+
+  it("preserves a complete Codex-shaped entry on a foreign origin", () => {
+    const content = `[mcp_servers.dosu]
+type = "http"
+url = "https://example.invalid/v1/mcp/deployments/dep-123"
+
+[mcp_servers.dosu.http_headers]
+X-Dosu-API-Key = "${API_KEY}"
+`;
+
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+  });
+
+  it("preserves a complete Codex-shaped URL containing userinfo", () => {
+    const content = `[mcp_servers.dosu]
+type = "http"
+url = "https://user:pass@api.dosu.dev/v1/mcp/deployments/dep-123"
+
+[mcp_servers.dosu.http_headers]
+X-Dosu-API-Key = "${API_KEY}"
+`;
+
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+  });
+
+  it("refuses an orphan nested Dosu section", () => {
+    const content = `[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "${API_KEY}"\n`;
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "incomplete_dosu_shape",
+    });
+  });
+
+  it("never treats table-like text inside TOML multiline strings as a section", () => {
+    const content = `message = """
+[mcp_servers.dosu]
+type = "http"
+url = "${DEPLOYMENT_URL}"
+[mcp_servers.dosu.http_headers]
+X-Dosu-API-Key = "${API_KEY}"
+"""
+
+[mcp_servers.other]
+url = "https://example.com"
+`;
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "not_found",
+      reason: "dosu_entry_absent",
+    });
+  });
+
+  it("preserves malformed TOML with an unterminated multiline string", () => {
+    const content = `message = """
+[mcp_servers.dosu]
+type = "http"
+url = "${DEPLOYMENT_URL}"
+`;
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "parse_error",
+    });
+  });
+
+  it("also ignores table-like text inside multiline literal strings", () => {
+    const content = `message = '''
+[mcp_servers.dosu]
+type = "http"
+url = "${DEPLOYMENT_URL}"
+'''
+`;
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "not_found",
+      reason: "dosu_entry_absent",
+    });
+  });
+
+  it("requires the entire document to be valid TOML before removing a legacy table", () => {
+    const content = `invalid = = =
+
+[mcp_servers.dosu]
+type = "http"
+url = "${DEPLOYMENT_URL}"
+
+[mcp_servers.dosu.http_headers]
+X-Dosu-API-Key = "${API_KEY}"
+`;
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "parse_error",
+    });
+  });
+
+  it("rejects a relative PATH in the released stdio form", () => {
+    const content = `[mcp_servers.dosu]
+command = "/usr/local/bin/npx"
+args = ["-y", "mcp-remote@0.1.38", "${DEPLOYMENT_URL}", "--header", "X-Dosu-API-Key:\${X_DOSU_API_KEY}", "--transport", "http-only"]
+
+[mcp_servers.dosu.env]
+PATH = "relative/bin:/usr/bin"
+X_DOSU_API_KEY = "${API_KEY}"
+`;
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "unknown_dosu_shape",
+    });
+  });
+
+  it.each([
+    [`[mcp_servers.dosu]\n\ntype = "http"\nurl = "${DEPLOYMENT_URL}"\n`, "unknown_dosu_shape"],
+    [
+      `[mcp_servers.dosu]\ntype = "http" # comment\nurl = "${DEPLOYMENT_URL}"\n`,
+      "unknown_dosu_shape",
+    ],
+    [`[mcp_servers.dosu]\ntype = 1\nurl = "${DEPLOYMENT_URL}"\n`, "unknown_dosu_shape"],
+    [
+      `[mcp_servers.dosu]\ntype = "http"\ntype = "http"\nurl = "${DEPLOYMENT_URL}"\n`,
+      "parse_error",
+    ],
+    [
+      `[mcp_servers.dosu]\ntype = "http"\nurl = "${DEPLOYMENT_URL}"\n\n[mcp_servers.other]\nurl = "https://example.com"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "${API_KEY}"\n`,
+      "noncontiguous_dosu_sections",
+    ],
+  ])("preserves strict TOML ownership edge case %#", (content, reason) => {
+    expect(planLegacyCodexMcp(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason,
+    });
+  });
+
+  it("recognizes the released Codex shape with CRLF and a Windows absolute PATH", () => {
+    const content = [
+      "[mcp_servers.dosu]",
+      'command = "C:\\\\Program Files\\\\nodejs\\\\npx.cmd"',
+      `args = ["-y", "mcp-remote@0.1.38", "${DEPLOYMENT_URL}", "--header", "X-Dosu-API-Key:\${X_DOSU_API_KEY}", "--transport", "http-only"]`,
+      "[mcp_servers.dosu.env]",
+      'PATH = "C:\\\\Program Files\\\\nodejs;C:\\\\Windows\\\\System32"',
+      `X_DOSU_API_KEY = "${API_KEY}"`,
+      "",
+    ].join("\r\n");
+    expect(planLegacyCodexMcp(content)).toMatchObject({ disposition: "remove" });
+  });
+});
+
+describe("project Codex TOML planner", () => {
+  const expected = { packageVersion: "0.43.0", deploymentID: "dep-project" } as const;
+  const projectSection = `[mcp_servers.dosu]\ncommand = "npx"\nargs = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"]\n`;
+
+  it("recognizes and range-removes only the exact current secretless proxy", () => {
+    const content = `model = "gpt-5"\n\n${projectSection}\n[projects."/repo"]\ntrust_level = "trusted"\n`;
+    expect(isExactProjectCodexProxy(content, expected)).toBe(true);
+    const plan = planProjectCodexMcp(content, expected);
+    expect(plan).toMatchObject({ disposition: "remove", mutation: "write" });
+    expect(plan.nextContent).toContain('model = "gpt-5"');
+    expect(plan.nextContent).toContain('[projects."/repo"]');
+    expect(plan.nextContent).not.toContain("mcp_servers.dosu");
+  });
+
+  it("preserves trailing user comments byte-for-byte after the project proxy assignment", () => {
+    const kept = `# KEEP USER COMMENT
+
+[projects."/repo"]
+trust_level = "trusted"
+`;
+    const plan = planProjectCodexMcp(`${projectSection}${kept}`, expected);
+    expect(plan).toMatchObject({ disposition: "remove", nextContent: kept });
+  });
+
+  it("rejects a wrong deployment, raw-key field, duplicate section, and unknown field", () => {
+    expect(
+      isExactProjectCodexProxy(projectSection.replace("dep-project", "other-deployment"), expected),
+    ).toBe(false);
+    expect(
+      planProjectCodexMcp(`${projectSection}X_DOSU_API_KEY = "secret"\n`, expected),
+    ).toMatchObject({ disposition: "preserved_ambiguous", reason: "unknown_dosu_shape" });
+    expect(planProjectCodexMcp(`${projectSection}${projectSection}`, expected)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "parse_error",
+    });
+    expect(
+      planProjectCodexMcp(projectSection.replace("\n", '\nuser_key = "mine"\n'), expected),
+    ).toMatchObject({ disposition: "preserved_ambiguous", reason: "unknown_dosu_shape" });
+  });
+
+  it("recognizes the exact OSS proxy independently from global paths", () => {
+    const content = `[mcp_servers.dosu]\ncommand = "npx"\nargs = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss"]\n`;
+    expect(isExactProjectCodexProxy(content, { packageVersion: "0.43.0", oss: true })).toBe(true);
+  });
+
+  it("accepts any exact pinned project proxy for safe provider upgrades", () => {
+    const old = projectSection.replace("@dosu/cli@0.43.0", "@dosu/cli@0.42.1");
+    expect(isExactProjectCodexProxy(old)).toBe(true);
+    expect(planProjectCodexMcp(old)).toMatchObject({ disposition: "remove" });
+  });
+
+  it("requires the entire document to be valid TOML before proving a project proxy", () => {
+    const content = `invalid = = =\n\n${projectSection}`;
+    expect(isExactProjectCodexProxy(content, expected)).toBe(false);
+    expect(planProjectCodexMcp(content, expected)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "parse_error",
+    });
+  });
+
+  it.each([
+    `[mcp_servers.dosu]\ncommand = "other"\nargs = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss"]\n`,
+    `[mcp_servers.dosu]\ncommand = "npx"\nargs = ["-y", "@dosu/cli@latest", "mcp", "proxy", "--oss"]\n`,
+    `[mcp_servers.dosu]\ncommand = "npx"\nargs = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", ""]\n`,
+    `[mcp_servers.dosu]\ncommand = "npx"\nargs = [1]\n`,
+  ])("does not own a mutated historical project pin %#", (content) => {
+    expect(planProjectCodexMcp(content)).toMatchObject({ disposition: "preserved_ambiguous" });
+  });
+
+  it("covers explicit shared planner policy switches", () => {
+    expect(planCodexDosuMcp('model = "gpt-5"\n', { allowLegacyGlobal: false })).toMatchObject({
+      disposition: "not_found",
+    });
+    expect(planCodexDosuMcp(projectSection, { projectProxy: undefined })).toMatchObject({
+      disposition: "preserved_ambiguous",
+    });
+  });
+});
+
+describe("shared Codex semantic ownership guard", () => {
+  it("refuses quoted or dotted semantic Dosu tables that raw range removal cannot own", () => {
+    for (const header of ['[mcp_servers."dosu"]', '["mcp_servers".dosu]']) {
+      const content = `${header}\ncommand = "npx"\nargs = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss"]\n`;
+      expect(planCodexDosuMcp(content)).toMatchObject({
+        disposition: "preserved_ambiguous",
+        reason: "semantic_dosu_table_unowned",
+      });
+    }
+  });
+
+  it("does not mistake quoted table text inside a multiline string for semantic config", () => {
+    const content = `message = """
+[mcp_servers."dosu"]
+command = "npx"
+"""
+`;
+    expect(planCodexDosuMcp(content)).toMatchObject({
+      disposition: "not_found",
+      reason: "dosu_entry_absent",
+    });
+  });
+});
+
+describe("legacy rules planners", () => {
+  it("removes one complete marker block and preserves user instructions", () => {
+    const content = `# User instructions
+
+<!-- dosu:rules:start v1 -->
+${RELEASED_RULE.trimEnd()}
+<!-- dosu:rules:end -->
+
+Keep this.
+`;
+    const plan = planLegacyRuleSection(content);
+    expect(plan).toMatchObject({ disposition: "remove", mutation: "write" });
+    expect(plan.nextContent).toContain("# User instructions");
+    expect(plan.nextContent).toContain("Keep this.");
+    expect(plan.nextContent).not.toContain("dosu:rules:start");
+  });
+
+  it("does not normalize blank lines outside the owned marker block", () => {
+    const content = `First line
+
+
+
+Second line
+
+<!-- dosu:rules:start v1 -->
+${RELEASED_RULE.trimEnd()}
+<!-- dosu:rules:end -->
+
+Last line
+`;
+    const plan = planLegacyRuleSection(content);
+    expect(plan).toMatchObject({ disposition: "remove", mutation: "write" });
+    expect(plan.nextContent).toBe(`First line
+
+
+
+Second line
+
+
+Last line
+`);
+  });
+
+  it("plans file deletion when the marker block is the whole file", () => {
+    const content = `<!-- dosu:rules:start v1 -->\n${RELEASED_RULE.trimEnd()}\n<!-- dosu:rules:end -->\n`;
+    expect(planLegacyRuleSection(content)).toMatchObject({
+      disposition: "remove",
+      mutation: "delete",
+    });
+  });
+
+  it("handles CRLF marker blocks and the completely absent case", () => {
+    expect(planLegacyRuleSection("user text\r\n")).toMatchObject({
+      disposition: "not_found",
+      reason: "dosu_rule_absent",
+    });
+    expect(
+      planLegacyRuleSection(
+        `before\r\n<!-- dosu:rules:start v1 -->\r\n${RELEASED_RULE.trimEnd().replace(/\n/g, "\r\n")}\r\n<!-- dosu:rules:end -->\r\nafter\r\n`,
+      ),
+    ).toMatchObject({ disposition: "remove", mutation: "write" });
+  });
+
+  it("preserves a marker block whose body was edited by the user", () => {
+    const content =
+      "<!-- dosu:rules:start v1 -->\nUSER CUSTOM: never delete\n<!-- dosu:rules:end -->\n";
+    expect(planLegacyRuleSection(content)).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "modified_rule_section",
+    });
+  });
+
+  it("refuses duplicate or incomplete markers", () => {
+    expect(
+      planLegacyRuleSection(
+        "<!-- dosu:rules:start v1 -->a<!-- dosu:rules:end -->\n<!-- dosu:rules:start v1 -->b<!-- dosu:rules:end -->",
+      ),
+    ).toMatchObject({ disposition: "preserved_ambiguous", reason: "duplicate_marker" });
+    expect(planLegacyRuleSection("<!-- dosu:rules:start v1 -->\nmissing end")).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "incomplete_marker",
+    });
+  });
+
+  it("deletes only exact released standalone Claude/Cursor rules", () => {
+    expect(planLegacyStandaloneRule(RELEASED_RULE, "claude")).toMatchObject({
+      disposition: "remove",
+      mutation: "delete",
+    });
+    const cursorRule = `---\nalwaysApply: true\n---\n\n${RELEASED_RULE}`;
+    expect(planLegacyStandaloneRule(cursorRule, "cursor")).toMatchObject({
+      disposition: "remove",
+      mutation: "delete",
+    });
+    expect(planLegacyStandaloneRule(`${RELEASED_RULE}\n# user edit\n`, "claude")).toMatchObject({
+      disposition: "preserved_ambiguous",
+      reason: "modified_standalone_rule",
+    });
+  });
+});

--- a/src/migration/planners.ts
+++ b/src/migration/planners.ts
@@ -1,0 +1,1094 @@
+import { createHash } from "node:crypto";
+import { isAbsolute } from "node:path";
+import {
+  getNodeValue,
+  type Node as JsonNode,
+  type ParseError,
+  parseTree,
+} from "jsonc-parser/lib/esm/main.js";
+import { parse as parseToml } from "smol-toml";
+import type { ProviderId } from "./targets";
+
+export type ContentPlan = {
+  disposition: "remove" | "not_found" | "preserved_ambiguous";
+  reason: string;
+  expectedHash: string;
+  mutation?: "write" | "delete";
+  nextContent?: string;
+};
+
+export type ProjectProxyExpectation =
+  | { packageVersion: string; deploymentID: string; oss?: false }
+  | { packageVersion: string; oss: true; deploymentID?: never };
+
+const DOSU_RULE_START = "<!-- dosu:rules:start v1 -->";
+const DOSU_RULE_END = "<!-- dosu:rules:end -->";
+const MCP_REMOTE_VERSION = "mcp-remote@0.1.38";
+const API_KEY_HEADER = "X-Dosu-API-Key";
+const API_KEY_PLACEHOLDER = "X-Dosu-API-Key:$" + "{X_DOSU_API_KEY}";
+// Every released production CLI embeds this origin. Runtime backend overrides
+// are deliberately not migration ownership proof: preserving an internal/dev
+// entry is safer than deleting a same-shaped user server on an arbitrary host.
+const RELEASED_DOSU_MCP_ORIGIN = "https://api.dosu.dev";
+
+const RELEASED_STANDALONE_RULE_HASHES: Readonly<Record<"claude" | "cursor", ReadonlySet<string>>> =
+  {
+    claude: new Set([
+      "82771652853dcf8b4bf7256fbbe039d24b49a7b17604d691deb512464cb74c84",
+      "159e7d77db73739c2f06a9859d03cadcf9c3d3d9a412471595cc995aab298330",
+    ]),
+    cursor: new Set([
+      "c1e507aa52dad2c211246aa17fa5bcabc6bf135c31d59046d93c4b64a11cb561",
+      "98337c715e5df540d50f5366ec1f88906b3ef038985fcf612b3a451d7f4a911e",
+    ]),
+  };
+
+// Marker-based rules contain the same normalized body as the released Claude
+// standalone rule. Markers identify the range; this hash proves the user did
+// not edit that range before migration removes it.
+const RELEASED_RULE_BODY_HASHES = RELEASED_STANDALONE_RULE_HASHES.claude;
+
+export function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function result(
+  content: string,
+  disposition: ContentPlan["disposition"],
+  reason: string,
+  mutation?: ContentPlan["mutation"],
+  nextContent?: string,
+): ContentPlan {
+  return {
+    disposition,
+    reason,
+    expectedHash: hashContent(content),
+    ...(mutation ? { mutation } : {}),
+    ...(nextContent !== undefined ? { nextContent } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isDosuMcpUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    if (url.origin !== RELEASED_DOSU_MCP_ORIGIN) return false;
+    if (url.username || url.password) return false;
+    if (url.search || url.hash) return false;
+    return url.pathname === "/v1/mcp" || /^\/v1\/mcp\/deployments\/[^/]+$/.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function isDosuBaseMcpUrl(value: unknown): value is string {
+  if (!isDosuMcpUrl(value)) return false;
+  const url = new URL(value);
+  return url.pathname === "/v1/mcp";
+}
+
+function isExactHeaders(value: unknown): boolean {
+  return (
+    isRecord(value) && exactKeys(value, [API_KEY_HEADER]) && isNonEmptyString(value[API_KEY_HEADER])
+  );
+}
+
+function isStandardHttpEntry(entry: Record<string, unknown>): boolean {
+  return (
+    exactKeys(entry, ["type", "url", "headers"]) &&
+    entry.type === "http" &&
+    isDosuMcpUrl(entry.url) &&
+    isExactHeaders(entry.headers)
+  );
+}
+
+function isCursorEntry(entry: Record<string, unknown>): boolean {
+  return (
+    exactKeys(entry, ["url", "headers"]) && isDosuMcpUrl(entry.url) && isExactHeaders(entry.headers)
+  );
+}
+
+function isClineEntry(entry: Record<string, unknown>): boolean {
+  return (
+    exactKeys(entry, ["type", "disabled", "url", "headers"]) &&
+    entry.type === "streamableHttp" &&
+    entry.disabled === false &&
+    isDosuMcpUrl(entry.url) &&
+    isExactHeaders(entry.headers)
+  );
+}
+
+function isOpenCodeEntry(entry: Record<string, unknown>): boolean {
+  return (
+    exactKeys(entry, ["type", "enabled", "url", "headers"]) &&
+    entry.type === "remote" &&
+    entry.enabled === true &&
+    isDosuMcpUrl(entry.url) &&
+    isExactHeaders(entry.headers)
+  );
+}
+
+function isZedEntry(entry: Record<string, unknown>): boolean {
+  return (
+    exactKeys(entry, ["source", "type", "url", "headers"]) &&
+    entry.source === "custom" &&
+    entry.type === "http" &&
+    isDosuMcpUrl(entry.url) &&
+    isExactHeaders(entry.headers)
+  );
+}
+
+function isAntigravityEntry(entry: Record<string, unknown>): boolean {
+  return (
+    exactKeys(entry, ["serverUrl", "headers"]) &&
+    isDosuMcpUrl(entry.serverUrl) &&
+    isExactHeaders(entry.headers)
+  );
+}
+
+function isCopilotEntry(entry: Record<string, unknown>): boolean {
+  return (
+    exactKeys(entry, ["type", "url", "tools", "headers"]) &&
+    entry.type === "http" &&
+    isDosuMcpUrl(entry.url) &&
+    Array.isArray(entry.tools) &&
+    entry.tools.length === 1 &&
+    entry.tools[0] === "*" &&
+    isExactHeaders(entry.headers)
+  );
+}
+
+function isAbsoluteNpx(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const absolute = isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value);
+  return absolute && /(?:^|[\\/])npx(?:\.cmd)?$/i.test(value);
+}
+
+function isAbsolutePathList(value: unknown): value is string {
+  if (!isNonEmptyString(value)) return false;
+  const windowsParts = value.includes(";");
+  const parts = windowsParts
+    ? value.split(";")
+    : /^[A-Za-z]:[\\/]/.test(value)
+      ? [value]
+      : value.split(":");
+  return parts.every(
+    (part) => part.length > 0 && (isAbsolute(part) || /^[A-Za-z]:[\\/]/.test(part)),
+  );
+}
+
+function isMcpRemoteArgs(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length === 7 &&
+    value[0] === "-y" &&
+    value[1] === MCP_REMOTE_VERSION &&
+    isDosuMcpUrl(value[2]) &&
+    value[3] === "--header" &&
+    value[4] === API_KEY_PLACEHOLDER &&
+    value[5] === "--transport" &&
+    value[6] === "http-only"
+  );
+}
+
+function isMcpRemoteEnv(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    exactKeys(value, ["PATH", "X_DOSU_API_KEY"]) &&
+    isAbsolutePathList(value.PATH) &&
+    isNonEmptyString(value.X_DOSU_API_KEY)
+  );
+}
+
+function isClaudeDesktopEntry(entry: Record<string, unknown>): boolean {
+  return (
+    exactKeys(entry, ["command", "args", "env"]) &&
+    isAbsoluteNpx(entry.command) &&
+    isMcpRemoteArgs(entry.args) &&
+    isMcpRemoteEnv(entry.env)
+  );
+}
+
+function expectedProjectProxyParts(expectation: ProjectProxyExpectation): string[] {
+  const prefix = ["npx", "-y", `@dosu/cli@${expectation.packageVersion}`, "mcp", "proxy"];
+  return expectation.oss
+    ? [...prefix, "--oss"]
+    : [...prefix, "--deployment", expectation.deploymentID];
+}
+
+function exactStringArray(value: unknown, expected: readonly string[]): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length === expected.length &&
+    value.every((part, index) => part === expected[index])
+  );
+}
+
+function isExactProjectProxyEntry(
+  provider: ProviderId,
+  entry: Record<string, unknown>,
+  expectation: ProjectProxyExpectation,
+): boolean {
+  const parts = expectedProjectProxyParts(expectation);
+  const args = parts.slice(1);
+  switch (provider) {
+    case "claude":
+    case "cursor":
+    case "vscode":
+    case "copilot":
+    case "factory":
+      return (
+        exactKeys(entry, ["type", "command", "args"]) &&
+        entry.type === "stdio" &&
+        entry.command === "npx" &&
+        exactStringArray(entry.args, args)
+      );
+    case "gemini":
+    case "antigravity":
+    case "mcporter":
+      return (
+        exactKeys(entry, ["command", "args"]) &&
+        entry.command === "npx" &&
+        exactStringArray(entry.args, args)
+      );
+    case "zed":
+      return (
+        exactKeys(entry, ["command", "args", "env"]) &&
+        entry.command === "npx" &&
+        exactStringArray(entry.args, args) &&
+        isRecord(entry.env) &&
+        exactKeys(entry.env, [])
+      );
+    case "opencode":
+      return (
+        exactKeys(entry, ["type", "command", "enabled"]) &&
+        entry.type === "local" &&
+        entry.enabled === true &&
+        exactStringArray(entry.command, parts)
+      );
+    default:
+      return false;
+  }
+}
+
+function hasDuplicateObjectKey(node: JsonNode): boolean {
+  if (node.type === "object") {
+    const seen = new Set<string>();
+    for (const property of node.children ?? []) {
+      const keyNode = property.children?.[0];
+      const key = keyNode ? getNodeValue(keyNode) : undefined;
+      if (typeof key === "string") {
+        if (seen.has(key)) return true;
+        seen.add(key);
+      }
+    }
+  }
+  return (node.children ?? []).some(hasDuplicateObjectKey);
+}
+
+function objectProperty(node: JsonNode, key: string): JsonNode | undefined {
+  return objectPropertyNode(node, key)?.children?.[1];
+}
+
+function objectPropertyNode(node: JsonNode, key: string): JsonNode | undefined {
+  if (node.type !== "object") return undefined;
+  for (const property of node.children ?? []) {
+    const keyNode = property.children?.[0];
+    if (keyNode && getNodeValue(keyNode) === key) return property;
+  }
+  return undefined;
+}
+
+function jsonSeparatorComma(content: string, start: number, end: number): number | null {
+  let comma = -1;
+  let state: "normal" | "line_comment" | "block_comment" = "normal";
+  for (let index = start; index < end; index += 1) {
+    const character = content[index];
+    if (state === "line_comment") {
+      if (character === "\n" || character === "\r") state = "normal";
+      continue;
+    }
+    if (state === "block_comment") {
+      if (character === "*" && content[index + 1] === "/") {
+        state = "normal";
+        index += 1;
+      }
+      continue;
+    }
+    if (/\s/.test(character)) continue;
+    if (character === "/" && content[index + 1] === "/") {
+      state = "line_comment";
+      index += 1;
+      continue;
+    }
+    if (character === "/" && content[index + 1] === "*") {
+      state = "block_comment";
+      index += 1;
+      continue;
+    }
+    if (character === "," && comma === -1) {
+      comma = index;
+      continue;
+    }
+    return null;
+  }
+  return state === "block_comment" || comma === -1 ? null : comma;
+}
+
+/** Delete one parsed JSONC object property without rewriting any unrelated byte. */
+export function removeJsonObjectPropertyRaw(
+  content: string,
+  objectNode: JsonNode,
+  key: string,
+): string | null {
+  if (objectNode.type !== "object") return null;
+  const properties = objectNode.children ?? [];
+  const propertyIndex = properties.findIndex((property) => {
+    const keyNode = property.children?.[0];
+    return keyNode ? getNodeValue(keyNode) === key : false;
+  });
+  if (propertyIndex < 0) return null;
+  const property = properties[propertyIndex];
+  const propertyStart = property.offset;
+  const propertyEnd = property.offset + property.length;
+  const ranges: Array<{ start: number; end: number }> = [
+    { start: propertyStart, end: propertyEnd },
+  ];
+
+  const next = properties[propertyIndex + 1];
+  const previous = properties[propertyIndex - 1];
+  if (next) {
+    const comma = jsonSeparatorComma(content, propertyEnd, next.offset);
+    if (comma === null) return null;
+    ranges.push({ start: comma, end: comma + 1 });
+  } else if (previous) {
+    const previousEnd = previous.offset + previous.length;
+    const comma = jsonSeparatorComma(content, previousEnd, propertyStart);
+    if (comma === null) return null;
+    ranges.push({ start: comma, end: comma + 1 });
+  } else {
+    // With a single child, a JSONC trailing comma belongs to the removed
+    // property. Leaving it behind would turn `{ "dosu": {...}, }` into `{,}`.
+    const trailingComma = jsonSeparatorComma(
+      content,
+      propertyEnd,
+      objectNode.offset + objectNode.length - 1,
+    );
+    if (trailingComma !== null) ranges.push({ start: trailingComma, end: trailingComma + 1 });
+  }
+
+  let nextContent = content;
+  for (const range of ranges.sort((left, right) => right.start - left.start)) {
+    nextContent = nextContent.slice(0, range.start) + nextContent.slice(range.end);
+  }
+  return nextContent;
+}
+
+function candidateUrl(entry: Record<string, unknown>): unknown {
+  if ("url" in entry) return entry.url;
+  if ("serverUrl" in entry) return entry.serverUrl;
+  if (Array.isArray(entry.args)) return entry.args[2];
+  return undefined;
+}
+
+function matchesReleasedJsonShape(provider: ProviderId, entry: Record<string, unknown>): boolean {
+  if (provider === "claude-desktop") return isClaudeDesktopEntry(entry);
+  if (isStandardHttpEntry(entry)) {
+    switch (provider) {
+      case "cursor":
+      case "cline":
+      case "cline-cli":
+      case "opencode":
+      case "zed":
+      case "antigravity":
+        return isDosuBaseMcpUrl(entry.url);
+      case "copilot":
+        return false;
+      case "claude":
+      case "vscode":
+      case "gemini":
+      case "windsurf":
+      case "factory":
+      case "mcporter":
+        return true;
+      default:
+        return false;
+    }
+  }
+  switch (provider) {
+    case "cursor":
+      return isCursorEntry(entry);
+    case "cline":
+    case "cline-cli":
+      return isClineEntry(entry);
+    case "opencode":
+      return isOpenCodeEntry(entry);
+    case "zed":
+      return isZedEntry(entry);
+    case "antigravity":
+      return isAntigravityEntry(entry);
+    case "copilot":
+      return isCopilotEntry(entry);
+    default:
+      return false;
+  }
+}
+
+export function planLegacyJsonMcp(input: {
+  content: string;
+  provider: ProviderId;
+  topKey: string;
+}): ContentPlan {
+  const errors: ParseError[] = [];
+  const root = parseTree(input.content, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  if (!root || errors.length > 0) {
+    return result(input.content, "preserved_ambiguous", "parse_error");
+  }
+  if (hasDuplicateObjectKey(root)) {
+    return result(input.content, "preserved_ambiguous", "duplicate_key");
+  }
+  if (root.type !== "object") {
+    return result(input.content, "preserved_ambiguous", "root_not_object");
+  }
+
+  const parent = objectProperty(root, input.topKey);
+  if (!parent) return result(input.content, "not_found", "dosu_entry_absent");
+  if (parent.type !== "object") {
+    return result(input.content, "preserved_ambiguous", "top_key_not_object");
+  }
+  const entryNode = objectProperty(parent, "dosu");
+  if (!entryNode) return result(input.content, "not_found", "dosu_entry_absent");
+
+  const entry: unknown = getNodeValue(entryNode);
+  if (!isRecord(entry)) {
+    return result(input.content, "preserved_ambiguous", "foreign_dosu_entry");
+  }
+  const url = candidateUrl(entry);
+  if (!isDosuMcpUrl(url)) {
+    return result(input.content, "preserved_ambiguous", "foreign_dosu_entry");
+  }
+  if (!matchesReleasedJsonShape(input.provider, entry)) {
+    return result(input.content, "preserved_ambiguous", "unknown_dosu_shape");
+  }
+
+  const nextContent = removeJsonObjectPropertyRaw(input.content, parent, "dosu");
+  if (nextContent === null) {
+    return result(input.content, "preserved_ambiguous", "raw_edit_failed");
+  }
+  return result(input.content, "remove", "released_dosu_shape", "write", nextContent);
+}
+
+/** Verify only the exact, current, secretless project proxy child for a JSON/JSONC provider. */
+export function isExactProjectJsonProxy(input: {
+  content: string;
+  provider: ProviderId;
+  topKey: string;
+  expectation: ProjectProxyExpectation;
+}): boolean {
+  const errors: ParseError[] = [];
+  const root = parseTree(input.content, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  if (!root || errors.length > 0 || root.type !== "object" || hasDuplicateObjectKey(root)) {
+    return false;
+  }
+  const parent = objectProperty(root, input.topKey);
+  const entryNode = parent ? objectProperty(parent, "dosu") : undefined;
+  const entry: unknown = entryNode ? getNodeValue(entryNode) : undefined;
+  return isRecord(entry) && isExactProjectProxyEntry(input.provider, entry, input.expectation);
+}
+
+interface TomlSection {
+  name: string;
+  start: number;
+  end: number;
+  bodyStart: number;
+}
+
+interface ParsedTomlHeader {
+  section: Omit<TomlSection, "end">;
+  nextIndex: number;
+}
+
+function parseStrictTomlDocument(content: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = parseToml(content);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasSemanticDosuTable(document: Record<string, unknown>): boolean {
+  return isRecord(document.mcp_servers) && Object.hasOwn(document.mcp_servers, "dosu");
+}
+
+function parseTomlHeader(
+  content: string,
+  lineStart: number,
+  bracketIndex: number,
+): ParsedTomlHeader | null {
+  const arrayTable = content[bracketIndex + 1] === "[";
+  const openingLength = arrayTable ? 2 : 1;
+  let index = bracketIndex + openingLength;
+  let quote: "basic" | "literal" | null = null;
+  let escaped = false;
+  let closingIndex = -1;
+
+  while (index < content.length) {
+    const character = content[index];
+    if (character === "\n" || character === "\r") return null;
+    if (quote === "basic") {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') quote = null;
+      index += 1;
+      continue;
+    }
+    if (quote === "literal") {
+      if (character === "'") quote = null;
+      index += 1;
+      continue;
+    }
+    if (character === '"') {
+      quote = "basic";
+      index += 1;
+      continue;
+    }
+    if (character === "'") {
+      quote = "literal";
+      index += 1;
+      continue;
+    }
+    if (
+      (!arrayTable && character === "]") ||
+      (arrayTable && character === "]" && content[index + 1] === "]")
+    ) {
+      closingIndex = index;
+      break;
+    }
+    index += 1;
+  }
+  if (closingIndex < 0 || quote !== null) return null;
+
+  const rawName = content.slice(bracketIndex + openingLength, closingIndex).trim();
+  if (!rawName) return null;
+  index = closingIndex + (arrayTable ? 2 : 1);
+  while (index < content.length && (content[index] === " " || content[index] === "\t")) index += 1;
+  if (content[index] === "#") {
+    while (index < content.length && content[index] !== "\n" && content[index] !== "\r") index += 1;
+  }
+  if (content[index] === "\r") index += 1;
+  if (content[index] === "\n") index += 1;
+  else if (index !== content.length) return null;
+
+  return {
+    section: {
+      name: arrayTable ? `[[${rawName}]]` : rawName,
+      start: lineStart,
+      bodyStart: index,
+    },
+    nextIndex: index,
+  };
+}
+
+function scanTomlSections(content: string): TomlSection[] | null {
+  const headers: Array<Omit<TomlSection, "end">> = [];
+  let state: "normal" | "comment" | "basic" | "literal" | "multi_basic" | "multi_literal" =
+    "normal";
+  let lineStart = 0;
+  let lineOnlyWhitespace = true;
+  let arrayDepth = 0;
+  let inlineTableDepth = 0;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index];
+    if (state === "comment") {
+      if (character === "\n") {
+        state = "normal";
+        lineStart = index + 1;
+        lineOnlyWhitespace = true;
+      }
+      continue;
+    }
+    if (state === "basic") {
+      if (character === "\\") {
+        index += 1;
+        if (index >= content.length || content[index] === "\n" || content[index] === "\r") {
+          return null;
+        }
+      } else if (character === '"') state = "normal";
+      else if (character === "\n" || character === "\r") return null;
+      continue;
+    }
+    if (state === "literal") {
+      if (character === "'") state = "normal";
+      else if (character === "\n" || character === "\r") return null;
+      continue;
+    }
+    if (state === "multi_basic") {
+      if (character === "\\") index += 1;
+      else if (content.startsWith('"""', index)) {
+        state = "normal";
+        index += 2;
+      }
+      continue;
+    }
+    if (state === "multi_literal") {
+      if (content.startsWith("'''", index)) {
+        state = "normal";
+        index += 2;
+      }
+      continue;
+    }
+
+    if (character === "\n") {
+      lineStart = index + 1;
+      lineOnlyWhitespace = true;
+      continue;
+    }
+    if (lineOnlyWhitespace && (character === " " || character === "\t" || character === "\r")) {
+      continue;
+    }
+    if (lineOnlyWhitespace && character === "[" && arrayDepth === 0 && inlineTableDepth === 0) {
+      const header = parseTomlHeader(content, lineStart, index);
+      if (!header) return null;
+      headers.push(header.section);
+      index = header.nextIndex - 1;
+      lineStart = header.nextIndex;
+      lineOnlyWhitespace = true;
+      continue;
+    }
+    lineOnlyWhitespace = false;
+    if (character === "#") {
+      state = "comment";
+    } else if (content.startsWith('"""', index)) {
+      state = "multi_basic";
+      index += 2;
+    } else if (content.startsWith("'''", index)) {
+      state = "multi_literal";
+      index += 2;
+    } else if (character === '"') {
+      state = "basic";
+    } else if (character === "'") {
+      state = "literal";
+    } else if (character === "[") {
+      arrayDepth += 1;
+    } else if (character === "]") {
+      if (arrayDepth === 0) return null;
+      arrayDepth -= 1;
+    } else if (character === "{") {
+      inlineTableDepth += 1;
+    } else if (character === "}") {
+      if (inlineTableDepth === 0) return null;
+      inlineTableDepth -= 1;
+    }
+  }
+
+  if ((state !== "normal" && state !== "comment") || arrayDepth !== 0 || inlineTableDepth !== 0) {
+    return null;
+  }
+  return headers.map((header, index) => ({
+    ...header,
+    end: headers[index + 1]?.start ?? content.length,
+  }));
+}
+
+function stripTomlComment(value: string): string {
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quoted) {
+      escaped = true;
+      continue;
+    }
+    if (character === '"') quoted = !quoted;
+    if (character === "#" && !quoted) return value.slice(0, index).trim();
+  }
+  return value.trim();
+}
+
+function parseTomlValue(raw: string): unknown {
+  const value = stripTomlComment(raw);
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value.startsWith('"') || value.startsWith("[")) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function parseTomlAssignments(
+  content: string,
+  section: TomlSection,
+): { values: Record<string, unknown>; duplicate: boolean; invalid: boolean; ownedEnd: number } {
+  const values: Record<string, unknown> = {};
+  let duplicate = false;
+  let invalid = false;
+  let ownedEnd = section.bodyStart;
+  let sawAssignment = false;
+  let trailingTrivia = false;
+  const header = content.slice(section.start, section.bodyStart);
+  const expectedHeader = `[${section.name}]${header.endsWith("\r\n") ? "\r\n" : "\n"}`;
+  if (header !== expectedHeader) invalid = true;
+  const body = content.slice(section.bodyStart, section.end);
+  let bodyOffset = 0;
+  for (const match of body.matchAll(/[^\r\n]*(?:\r\n|\n|\r|$)/g)) {
+    const completeLine = match[0];
+    if (!completeLine) break;
+    const line = completeLine.replace(/(?:\r\n|\n|\r)$/, "");
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      if (sawAssignment) trailingTrivia = true;
+      else invalid = true;
+      bodyOffset += completeLine.length;
+      continue;
+    }
+    if (trailingTrivia) invalid = true;
+    const assignment = line.match(/^\s*([A-Za-z0-9_-]+)\s*=\s*(.*?)\s*$/);
+    if (!assignment) {
+      invalid = true;
+      bodyOffset += completeLine.length;
+      continue;
+    }
+    const key = assignment[1];
+    if (Object.hasOwn(values, key)) duplicate = true;
+    if (stripTomlComment(assignment[2]) !== assignment[2].trim()) invalid = true;
+    const value = parseTomlValue(assignment[2]);
+    if (value === undefined) invalid = true;
+    values[key] = value;
+    sawAssignment = true;
+    ownedEnd = section.bodyStart + bodyOffset + completeLine.length;
+    bodyOffset += completeLine.length;
+  }
+  return { values, duplicate, invalid, ownedEnd };
+}
+
+function removeTomlRanges(
+  content: string,
+  ranges: readonly { start: number; end: number }[],
+): string {
+  let nextContent = content;
+  for (const range of [...ranges].sort((left, right) => right.start - left.start)) {
+    nextContent = nextContent.slice(0, range.start) + nextContent.slice(range.end);
+  }
+  return nextContent;
+}
+
+function isRemoteCodexShape(
+  base: Record<string, unknown>,
+  nested: Record<string, unknown>,
+): boolean {
+  return (
+    exactKeys(base, ["type", "url"]) &&
+    base.type === "http" &&
+    isDosuMcpUrl(base.url) &&
+    exactKeys(nested, [API_KEY_HEADER]) &&
+    isNonEmptyString(nested[API_KEY_HEADER])
+  );
+}
+
+function isCurrentCodexShape(
+  base: Record<string, unknown>,
+  nested: Record<string, unknown>,
+): boolean {
+  return (
+    exactKeys(base, ["command", "args"]) &&
+    isAbsoluteNpx(base.command) &&
+    isMcpRemoteArgs(base.args) &&
+    exactKeys(nested, ["PATH", "X_DOSU_API_KEY"]) &&
+    isAbsolutePathList(nested.PATH) &&
+    isNonEmptyString(nested.X_DOSU_API_KEY)
+  );
+}
+
+export function planLegacyCodexMcp(content: string): ContentPlan {
+  const document = parseStrictTomlDocument(content);
+  if (!document) {
+    return result(content, "preserved_ambiguous", "parse_error");
+  }
+  const sections = scanTomlSections(content);
+  if (!sections) return result(content, "preserved_ambiguous", "parse_error");
+  const dosuSections = sections.filter(
+    (section) =>
+      section.name === "mcp_servers.dosu" || section.name.startsWith("mcp_servers.dosu."),
+  );
+  if (dosuSections.length === 0) {
+    return hasSemanticDosuTable(document)
+      ? result(content, "preserved_ambiguous", "semantic_dosu_table_unowned")
+      : result(content, "not_found", "dosu_entry_absent");
+  }
+
+  const sectionNames = new Set<string>();
+  for (const section of dosuSections) {
+    if (sectionNames.has(section.name)) {
+      return result(content, "preserved_ambiguous", "duplicate_section");
+    }
+    sectionNames.add(section.name);
+  }
+
+  const base = dosuSections.find((section) => section.name === "mcp_servers.dosu");
+  if (!base) {
+    return result(content, "preserved_ambiguous", "incomplete_dosu_shape");
+  }
+  const baseAssignments = parseTomlAssignments(content, base);
+  if (baseAssignments.duplicate) {
+    return result(content, "preserved_ambiguous", "duplicate_key");
+  }
+  if (baseAssignments.invalid) {
+    return result(content, "preserved_ambiguous", "unknown_dosu_shape");
+  }
+  const urlCandidate =
+    baseAssignments.values.url ??
+    (Array.isArray(baseAssignments.values.args) ? baseAssignments.values.args[2] : undefined);
+  if (!isDosuMcpUrl(urlCandidate)) {
+    return result(content, "preserved_ambiguous", "foreign_dosu_entry");
+  }
+  if (
+    !exactKeys(baseAssignments.values, ["type", "url"]) &&
+    !exactKeys(baseAssignments.values, ["command", "args"])
+  ) {
+    return result(content, "preserved_ambiguous", "unknown_dosu_shape");
+  }
+  if (dosuSections.length < 2) {
+    return result(content, "preserved_ambiguous", "incomplete_dosu_shape");
+  }
+  if (dosuSections.length !== 2) {
+    return result(content, "preserved_ambiguous", "unknown_dosu_shape");
+  }
+  const nested = dosuSections.find((section) => section !== base);
+  if (!nested) return result(content, "preserved_ambiguous", "incomplete_dosu_shape");
+
+  const baseIndex = sections.indexOf(base);
+  const nestedIndex = sections.indexOf(nested);
+  if (nestedIndex !== baseIndex + 1) {
+    return result(content, "preserved_ambiguous", "noncontiguous_dosu_sections");
+  }
+
+  const nestedAssignments = parseTomlAssignments(content, nested);
+  if (baseAssignments.duplicate || nestedAssignments.duplicate) {
+    return result(content, "preserved_ambiguous", "duplicate_key");
+  }
+  if (baseAssignments.invalid || nestedAssignments.invalid) {
+    return result(content, "preserved_ambiguous", "unknown_dosu_shape");
+  }
+
+  const released =
+    (nested.name === "mcp_servers.dosu.http_headers" &&
+      isRemoteCodexShape(baseAssignments.values, nestedAssignments.values)) ||
+    (nested.name === "mcp_servers.dosu.env" &&
+      isCurrentCodexShape(baseAssignments.values, nestedAssignments.values));
+  if (!released) return result(content, "preserved_ambiguous", "unknown_dosu_shape");
+
+  const nextContent = removeTomlRanges(content, [
+    { start: base.start, end: baseAssignments.ownedEnd },
+    { start: nested.start, end: nestedAssignments.ownedEnd },
+  ]);
+  return result(content, "remove", "released_dosu_shape", "write", nextContent);
+}
+
+function projectCodexArgsMatch(args: unknown, expectation: ProjectProxyExpectation): boolean {
+  return exactStringArray(args, expectedProjectProxyParts(expectation).slice(1));
+}
+
+function isAnyExactProjectCodexArgs(args: unknown): boolean {
+  if (!Array.isArray(args) || args.some((value) => typeof value !== "string")) return false;
+  const values = args as string[];
+  if (
+    values[0] !== "-y" ||
+    !/^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(values[1] ?? "") ||
+    values[2] !== "mcp" ||
+    values[3] !== "proxy"
+  ) {
+    return false;
+  }
+  return (
+    (values.length === 5 && values[4] === "--oss") ||
+    (values.length === 6 && values[4] === "--deployment" && values[5].length > 0)
+  );
+}
+
+/**
+ * Range-plan removal of one exact project proxy. This is path-independent so the
+ * Codex provider can safely reuse it for install/remove without a lossy TOML rewrite.
+ */
+export function planProjectCodexMcp(
+  content: string,
+  expectation?: ProjectProxyExpectation,
+): ContentPlan {
+  const document = parseStrictTomlDocument(content);
+  if (!document) {
+    return result(content, "preserved_ambiguous", "parse_error");
+  }
+  const sections = scanTomlSections(content);
+  if (!sections) return result(content, "preserved_ambiguous", "parse_error");
+  const dosuSections = sections.filter(
+    (section) =>
+      section.name === "mcp_servers.dosu" || section.name.startsWith("mcp_servers.dosu."),
+  );
+  if (dosuSections.length === 0) {
+    return hasSemanticDosuTable(document)
+      ? result(content, "preserved_ambiguous", "semantic_dosu_table_unowned")
+      : result(content, "not_found", "dosu_entry_absent");
+  }
+
+  const names = new Set<string>();
+  for (const section of dosuSections) {
+    if (names.has(section.name)) {
+      return result(content, "preserved_ambiguous", "duplicate_section");
+    }
+    names.add(section.name);
+  }
+  const base = dosuSections.find((section) => section.name === "mcp_servers.dosu");
+  if (!base) return result(content, "preserved_ambiguous", "incomplete_dosu_shape");
+  if (dosuSections.length !== 1) {
+    return result(content, "preserved_ambiguous", "unknown_dosu_shape");
+  }
+
+  const assignments = parseTomlAssignments(content, base);
+  if (assignments.duplicate) return result(content, "preserved_ambiguous", "duplicate_key");
+  if (assignments.invalid || !exactKeys(assignments.values, ["command", "args"])) {
+    return result(content, "preserved_ambiguous", "unknown_dosu_shape");
+  }
+  if (assignments.values.command !== "npx") {
+    return result(content, "preserved_ambiguous", "foreign_dosu_entry");
+  }
+  const proxyMatches = expectation
+    ? projectCodexArgsMatch(assignments.values.args, expectation)
+    : isAnyExactProjectCodexArgs(assignments.values.args);
+  if (!proxyMatches) {
+    return result(content, "preserved_ambiguous", "project_proxy_mismatch");
+  }
+
+  const nextContent = removeTomlRanges(content, [{ start: base.start, end: assignments.ownedEnd }]);
+  return result(content, "remove", "exact_project_proxy", "write", nextContent);
+}
+
+export function isExactProjectCodexProxy(
+  content: string,
+  expectation?: ProjectProxyExpectation,
+): boolean {
+  return planProjectCodexMcp(content, expectation).disposition === "remove";
+}
+
+/**
+ * Strict shared planner for Codex provider install/remove. It recognizes the
+ * exact secretless project proxy and, when allowed, both released global forms.
+ */
+export function planCodexDosuMcp(
+  content: string,
+  options: {
+    projectProxy?: ProjectProxyExpectation | "any";
+    allowLegacyGlobal?: boolean;
+  } = { projectProxy: "any", allowLegacyGlobal: true },
+): ContentPlan {
+  const project =
+    options.projectProxy === undefined
+      ? undefined
+      : planProjectCodexMcp(
+          content,
+          options.projectProxy === "any" ? undefined : options.projectProxy,
+        );
+  if (project?.disposition === "remove") return project;
+
+  const legacy = options.allowLegacyGlobal === false ? undefined : planLegacyCodexMcp(content);
+  if (legacy?.disposition === "remove") return legacy;
+  if (project?.reason === "duplicate_section" || legacy?.reason === "duplicate_section") {
+    return result(content, "preserved_ambiguous", "duplicate_section");
+  }
+  if (project?.reason === "parse_error" || legacy?.reason === "parse_error") {
+    return result(content, "preserved_ambiguous", "parse_error");
+  }
+  if (project && project.disposition !== "not_found") return project;
+  if (legacy) return legacy;
+  return result(content, "not_found", "dosu_entry_absent");
+}
+
+function markerIndexes(content: string, marker: string): number[] {
+  const indexes: number[] = [];
+  let offset = 0;
+  while (offset < content.length) {
+    const index = content.indexOf(marker, offset);
+    if (index === -1) break;
+    indexes.push(index);
+    offset = index + marker.length;
+  }
+  return indexes;
+}
+
+export function planLegacyRuleSection(content: string): ContentPlan {
+  const starts = markerIndexes(content, DOSU_RULE_START);
+  const ends = markerIndexes(content, DOSU_RULE_END);
+  if (starts.length === 0 && ends.length === 0) {
+    return result(content, "not_found", "dosu_rule_absent");
+  }
+  if (starts.length > 1 || ends.length > 1) {
+    return result(content, "preserved_ambiguous", "duplicate_marker");
+  }
+  if (starts.length !== 1 || ends.length !== 1 || ends[0] < starts[0]) {
+    return result(content, "preserved_ambiguous", "incomplete_marker");
+  }
+
+  const bodyStart = starts[0] + DOSU_RULE_START.length;
+  const leadingEol = content.slice(bodyStart, bodyStart + 2) === "\r\n" ? "\r\n" : "\n";
+  if (!content.startsWith(leadingEol, bodyStart)) {
+    return result(content, "preserved_ambiguous", "modified_rule_section");
+  }
+  const bodyEnd = ends[0];
+  const trailingEol = content.slice(bodyEnd - 2, bodyEnd) === "\r\n" ? "\r\n" : "\n";
+  if (
+    bodyEnd <= bodyStart + leadingEol.length ||
+    !content.slice(0, bodyEnd).endsWith(trailingEol)
+  ) {
+    return result(content, "preserved_ambiguous", "modified_rule_section");
+  }
+  const body = content.slice(bodyStart + leadingEol.length, bodyEnd - trailingEol.length);
+  const normalizedBody = `${body.replace(/\r\n/g, "\n").trimEnd()}\n`;
+  if (!RELEASED_RULE_BODY_HASHES.has(hashContent(normalizedBody))) {
+    return result(content, "preserved_ambiguous", "modified_rule_section");
+  }
+
+  let removeEnd = ends[0] + DOSU_RULE_END.length;
+  if (content.slice(removeEnd, removeEnd + 2) === "\r\n") removeEnd += 2;
+  else if (content[removeEnd] === "\n") removeEnd += 1;
+  const nextContent = content.slice(0, starts[0]) + content.slice(removeEnd);
+
+  if (!nextContent.trim()) {
+    return result(content, "remove", "released_rule_section", "delete");
+  }
+  return result(content, "remove", "released_rule_section", "write", nextContent);
+}
+
+export function planLegacyStandaloneRule(content: string, kind: "claude" | "cursor"): ContentPlan {
+  if (!RELEASED_STANDALONE_RULE_HASHES[kind].has(hashContent(content))) {
+    return result(content, "preserved_ambiguous", "modified_standalone_rule");
+  }
+  return result(content, "remove", "released_standalone_rule", "delete");
+}

--- a/src/migration/project-bundle.test.ts
+++ b/src/migration/project-bundle.test.ts
@@ -1,0 +1,528 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { migrateLegacyTargets } from "./orchestrator";
+import {
+  assertProjectBundleProof,
+  projectBundleStatus,
+  verifyProjectBundle,
+} from "./project-bundle";
+import { proveProjectScope } from "./project-proof";
+import type { LegacyTarget } from "./targets";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "dosu-project-bundle-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function gitProof() {
+  const result = proveProjectScope({
+    cwd: root,
+    gitTopLevel: root,
+    insideWorkTree: true,
+    bareRepository: false,
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.proof;
+}
+
+function writeClaudeBundle(deploymentID = "dep-project"): void {
+  // skills@1.5.22 writes a direct Claude copy for a one-agent install.
+  const skillDir = join(root, ".claude", "skills", "dosu");
+  mkdirSync(skillDir, { recursive: true });
+  const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  writeFileSync(join(skillDir, "SKILL.md"), skill);
+  const computedHash = createHash("sha256").update("SKILL.md").update(skill).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", deploymentID],
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, "AGENTS.md"),
+    "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+  );
+  writeFileSync(
+    join(root, "CLAUDE.md"),
+    "<!-- dosu:project-instructions:start v1 -->\n@AGENTS.md\n<!-- dosu:project-instructions:end -->\n",
+  );
+}
+
+function writeCanonicalSkill(): void {
+  const skillDir = join(root, ".agents", "skills", "dosu");
+  mkdirSync(skillDir, { recursive: true });
+  const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  writeFileSync(join(skillDir, "SKILL.md"), skill);
+  const computedHash = createHash("sha256").update("SKILL.md").update(skill).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+function writeFactoryBundle(includeSkill = true): void {
+  mkdirSync(join(root, ".factory"), { recursive: true });
+  writeFileSync(
+    join(root, ".factory", "mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"],
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, "AGENTS.md"),
+    "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+  );
+  if (!includeSkill) return;
+  const skillDir = join(root, ".factory", "skills", "dosu");
+  mkdirSync(skillDir, { recursive: true });
+  const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  writeFileSync(join(skillDir, "SKILL.md"), skill);
+  const computedHash = createHash("sha256").update("SKILL.md").update(skill).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+function verifyClaude() {
+  return verifyProjectBundle({
+    project: gitProof(),
+    providerIDs: ["claude"],
+    proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+    instructionContent: "Use Dosu.",
+  });
+}
+
+function writeMcporterBundle(target: "dep-project" | "oss" = "dep-project"): void {
+  mkdirSync(join(root, "config"), { recursive: true });
+  writeFileSync(
+    join(root, "config", "mcporter.json"),
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          command: "npx",
+          args:
+            target === "oss"
+              ? ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss"]
+              : ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", target],
+        },
+      },
+    }),
+  );
+}
+
+describe("file-backed project bundle proof", () => {
+  it("rejects a relative Git root instead of resolving it against process cwd", () => {
+    expect(
+      proveProjectScope({
+        cwd: root,
+        gitTopLevel: "relative-project",
+        insideWorkTree: true,
+        bareRepository: false,
+      }),
+    ).toEqual({ ok: false, reason: "invalid_git_root" });
+  });
+
+  it("authorizes only after exact MCP, instructions, adapter, skill, and lock are re-read", () => {
+    writeClaudeBundle();
+    expect(verifyClaude()).toMatchObject({ ok: true });
+  });
+
+  it("rejects unsupported providers and wrong deployment or credential-bearing proxies", () => {
+    writeClaudeBundle("wrong-deployment");
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_mcp_mismatch" });
+
+    const unsupported = verifyProjectBundle({
+      project: gitProof(),
+      providerIDs: ["cline"],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    });
+    expect(unsupported).toMatchObject({ ok: false, reason: "unsupported_provider" });
+
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: ["claude"],
+        proxy: {} as never,
+        instructionContent: "Use Dosu.",
+      }),
+    ).toEqual({ ok: false, reason: "invalid_proxy_expectation" });
+
+    writeClaudeBundle();
+    const path = join(root, ".mcp.json");
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    parsed.mcpServers.dosu.headers = { "X-Dosu-API-Key": "secret" };
+    writeFileSync(path, JSON.stringify(parsed));
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_mcp_mismatch" });
+  });
+
+  it("rejects missing exact adapter, skill provenance, or skill content hash", () => {
+    writeClaudeBundle();
+    writeFileSync(join(root, "CLAUDE.md"), "@AGENTS.md\n");
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_instructions_mismatch" });
+
+    writeClaudeBundle();
+    writeFileSync(join(root, "skills-lock.json"), '{"version":1,"skills":{}}');
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_skill_mismatch" });
+
+    writeClaudeBundle();
+    writeFileSync(join(root, ".claude", "skills", "dosu", "SKILL.md"), "user replacement");
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_skill_mismatch" });
+  });
+
+  it("revalidates proof evidence immediately before cleanup", () => {
+    writeClaudeBundle();
+    const verified = verifyClaude();
+    if (!verified.ok) throw new Error(verified.reason);
+
+    writeFileSync(join(root, ".mcp.json"), '{"mcpServers":{}}');
+    const globalPath = join(root, "legacy-global.json");
+    writeFileSync(
+      globalPath,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": "secret" },
+          },
+        },
+      }),
+    );
+    const target: LegacyTarget = {
+      id: "claude:mcp",
+      provider: "claude",
+      kind: "json_mcp",
+      path: globalPath,
+      topKey: "mcpServers",
+    };
+    const receipt = migrateLegacyTargets({
+      bundle: verified.proof,
+      targets: [target],
+      backupRoot: join(root, "backups"),
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "project_bundle_changed",
+    });
+    expect(readFileSync(globalPath, "utf8")).toContain("secret");
+  });
+
+  it("requires at least one selected project-capable provider", () => {
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: [],
+        proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+        instructionContent: "Use Dosu.",
+      }),
+    ).toEqual({ ok: false, reason: "no_selected_provider" });
+  });
+
+  it.each([
+    ["non-object", null],
+    ["array", []],
+    ["bad version", { packageVersion: "latest", deploymentID: "dep-project" }],
+    ["empty deployment", { packageVersion: "0.43.0", deploymentID: "" }],
+    ["extra field", { packageVersion: "0.43.0", deploymentID: "dep-project", extra: true }],
+    ["invalid OSS keys", { packageVersion: "0.43.0", oss: true, deploymentID: "dep" }],
+    ["non-string deployment", { packageVersion: "0.43.0", deploymentID: 7 }],
+  ])("rejects an invalid proxy expectation: %s", (_name, proxy) => {
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: ["mcporter"],
+        proxy: proxy as never,
+        instructionContent: "Use Dosu.",
+      }),
+    ).toEqual({ ok: false, reason: "invalid_proxy_expectation" });
+  });
+
+  it("verifies the MCP-only MCPorter bundle and rechecks its file evidence", () => {
+    writeMcporterBundle();
+    const verification = verifyProjectBundle({
+      project: gitProof(),
+      providerIDs: ["mcporter", "mcporter"],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    });
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+    expect(projectBundleStatus(verification.proof, "mcporter")).toBe("valid");
+    expect(projectBundleStatus(verification.proof, "cursor")).toBe("unauthorized_provider");
+
+    writeFileSync(join(root, "config", "mcporter.json"), '{"mcpServers":{}}');
+    expect(projectBundleStatus(verification.proof, "mcporter")).toBe("changed");
+  });
+
+  it("revalidates every kind of evidence in a complete Claude bundle", () => {
+    writeClaudeBundle();
+    const verification = verifyClaude();
+    if (!verification.ok) throw new Error(verification.reason);
+    expect(projectBundleStatus(verification.proof, "claude")).toBe("valid");
+
+    rmSync(join(root, ".claude", "skills", "dosu", "SKILL.md"));
+    expect(projectBundleStatus(verification.proof, "claude")).toBe("changed");
+  });
+
+  it("verifies an OSS MCP-only bundle", () => {
+    writeMcporterBundle("oss");
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: ["mcporter"],
+        proxy: { packageVersion: "0.43.0", oss: true },
+        instructionContent: "Use Dosu.",
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("rejects project config symlinks even when their content is exact", () => {
+    writeMcporterBundle();
+    const path = join(root, "config", "mcporter.json");
+    const foreign = join(root, "foreign.json");
+    writeFileSync(foreign, readFileSync(path));
+    rmSync(path);
+    symlinkSync(foreign, path);
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: ["mcporter"],
+        proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+        instructionContent: "Use Dosu.",
+      }),
+    ).toMatchObject({ ok: false, reason: "project_mcp_mismatch", provider: "mcporter" });
+  });
+
+  it.each([
+    ["cursor", ".cursor/mcp.json"],
+    ["vscode", ".vscode/mcp.json"],
+    ["gemini", ".gemini/settings.json"],
+    ["codex", ".codex/config.toml"],
+    ["zed", ".zed/settings.json"],
+    ["copilot", ".mcp.json"],
+    ["opencode", "opencode.json"],
+    ["antigravity", ".agents/mcp_config.json"],
+    ["factory", ".factory/mcp.json"],
+  ] as const)("reports the documented missing project path for %s", (provider, relativePath) => {
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: [provider],
+        proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+        instructionContent: "Use Dosu.",
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "project_mcp_mismatch",
+      provider,
+      path: join(root, ...relativePath.split("/")),
+    });
+  });
+
+  it("verifies an exact Codex TOML bundle and notices when the project disappears", () => {
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(
+      join(root, ".codex", "config.toml"),
+      '[mcp_servers.dosu]\ncommand = "npx"\nargs = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"]\n',
+    );
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+    );
+    writeCanonicalSkill();
+    const verification = verifyProjectBundle({
+      project: gitProof(),
+      providerIDs: ["codex"],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    });
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+
+    rmSync(root, { recursive: true });
+    expect(projectBundleStatus(verification.proof, "codex")).toBe("changed");
+  });
+
+  it("requires and revalidates the complete Factory MCP, instructions, and Droid skill bundle", () => {
+    writeFactoryBundle(false);
+    const input = {
+      project: gitProof(),
+      providerIDs: ["factory"],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    } as const;
+
+    expect(verifyProjectBundle(input)).toMatchObject({
+      ok: false,
+      reason: "project_skill_mismatch",
+    });
+
+    writeFactoryBundle();
+    const verification = verifyProjectBundle(input);
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+    expect(projectBundleStatus(verification.proof, "factory")).toBe("valid");
+
+    writeFileSync(join(root, ".factory", "skills", "dosu", "SKILL.md"), "user edit");
+    expect(projectBundleStatus(verification.proof, "factory")).toBe("changed");
+  });
+
+  it("accepts a Claude adapter symlink only when it resolves to canonical AGENTS.md", () => {
+    writeClaudeBundle();
+    rmSync(join(root, "CLAUDE.md"));
+    symlinkSync("AGENTS.md", join(root, "CLAUDE.md"));
+    const verification = verifyClaude();
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+
+    rmSync(join(root, "CLAUDE.md"));
+    writeFileSync(join(root, "other.md"), "@AGENTS.md");
+    symlinkSync("other.md", join(root, "CLAUDE.md"));
+    expect(projectBundleStatus(verification.proof, "claude")).toBe("changed");
+    expect(verifyClaude()).toMatchObject({
+      ok: false,
+      reason: "project_instructions_mismatch",
+      provider: "claude",
+    });
+  });
+
+  it.each([
+    "gemini",
+    "antigravity",
+  ] as const)("verifies the exact %s instruction adapter and rejects adapter symlinks", (provider) => {
+    const configPath =
+      provider === "gemini"
+        ? join(root, ".gemini", "settings.json")
+        : join(root, ".agents", "mcp_config.json");
+    mkdirSync(join(configPath, ".."), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            command: "npx",
+            args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"],
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+    );
+    const adapterPath =
+      provider === "gemini" ? join(root, "GEMINI.md") : join(root, ".agents", "rules", "dosu.md");
+    mkdirSync(join(adapterPath, ".."), { recursive: true });
+    writeFileSync(
+      adapterPath,
+      `<!-- dosu:project-instructions:start v1 -->\n${provider === "gemini" ? "@AGENTS.md" : "Use Dosu."}\n<!-- dosu:project-instructions:end -->\n`,
+    );
+    writeCanonicalSkill();
+
+    const input = {
+      project: gitProof(),
+      providerIDs: [provider],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    } as const;
+    expect(verifyProjectBundle(input)).toMatchObject({ ok: true });
+
+    rmSync(adapterPath);
+    symlinkSync(join(root, "AGENTS.md"), adapterPath);
+    expect(verifyProjectBundle(input)).toMatchObject({
+      ok: provider === "gemini",
+      ...(provider === "antigravity"
+        ? { reason: "project_instructions_mismatch", provider: "antigravity" }
+        : {}),
+    });
+  });
+
+  it("rejects duplicate or edited instruction marker blocks", () => {
+    writeClaudeBundle();
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- dosu:mcp:start v2 -->\nEdited\n<!-- dosu:mcp:end -->\n<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+    );
+    expect(verifyClaude()).toMatchObject({
+      ok: false,
+      reason: "project_instructions_mismatch",
+    });
+
+    writeClaudeBundle();
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n<!-- dosu:mcp:end -->\n",
+    );
+    expect(verifyClaude()).toMatchObject({
+      ok: false,
+      reason: "project_instructions_mismatch",
+    });
+  });
+
+  it("does not accept a structurally forged bundle proof", () => {
+    const forged = { root, providers: ["claude"] };
+    expect(() => {
+      // @ts-expect-error The runtime guard must reject an input TypeScript correctly leaves unbranded.
+      assertProjectBundleProof(forged);
+    }).toThrow(/verified project bundle proof/i);
+    // @ts-expect-error Status must also fail closed for an unbranded runtime value.
+    expect(projectBundleStatus(forged, "claude")).toBe("changed");
+  });
+});

--- a/src/migration/project-bundle.ts
+++ b/src/migration/project-bundle.ts
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import {
+  projectSkillEvidenceUnchanged,
+  verifyProjectSkillInstallation,
+} from "../commands/project-skill-ownership";
+import { projectSkillInstallTargetsForProviders } from "../commands/skill";
+import { providerUsesProjectInstructions } from "../setup/project-instructions";
+import {
+  isExactProjectCodexProxy,
+  isExactProjectJsonProxy,
+  type ProjectProxyExpectation,
+} from "./planners";
+import { assertProjectProof, type ProjectProof } from "./project-proof";
+import type { ProviderId } from "./targets";
+
+const projectBundleBrand: unique symbol = Symbol("DosuProjectBundleProof");
+const projectBundleEvidence: unique symbol = Symbol("DosuProjectBundleEvidence");
+
+const AGENTS_START = "<!-- dosu:mcp:start v2 -->";
+const AGENTS_END = "<!-- dosu:mcp:end -->";
+const ADAPTER_START = "<!-- dosu:project-instructions:start v1 -->";
+const ADAPTER_END = "<!-- dosu:project-instructions:end -->";
+
+type SupportedProjectProvider =
+  | "claude"
+  | "cursor"
+  | "vscode"
+  | "gemini"
+  | "codex"
+  | "zed"
+  | "copilot"
+  | "opencode"
+  | "antigravity"
+  | "mcporter"
+  | "factory";
+
+interface ProviderBundleSpec {
+  mcpPath(root: string): string;
+  topKey?: string;
+  adapter?: "claude" | "gemini" | "antigravity";
+}
+
+const PROJECT_BUNDLE_SPECS: Readonly<Record<SupportedProjectProvider, ProviderBundleSpec>> = {
+  claude: {
+    mcpPath: (root) => join(root, ".mcp.json"),
+    topKey: "mcpServers",
+    adapter: "claude",
+  },
+  cursor: {
+    mcpPath: (root) => join(root, ".cursor", "mcp.json"),
+    topKey: "mcpServers",
+  },
+  vscode: {
+    mcpPath: (root) => join(root, ".vscode", "mcp.json"),
+    topKey: "servers",
+  },
+  gemini: {
+    mcpPath: (root) => join(root, ".gemini", "settings.json"),
+    topKey: "mcpServers",
+    adapter: "gemini",
+  },
+  codex: {
+    mcpPath: (root) => join(root, ".codex", "config.toml"),
+  },
+  zed: {
+    mcpPath: (root) => join(root, ".zed", "settings.json"),
+    topKey: "context_servers",
+  },
+  copilot: {
+    mcpPath: (root) => join(root, ".mcp.json"),
+    topKey: "mcpServers",
+  },
+  opencode: {
+    mcpPath: (root) => join(root, "opencode.json"),
+    topKey: "mcp",
+  },
+  antigravity: {
+    mcpPath: (root) => join(root, ".agents", "mcp_config.json"),
+    topKey: "mcpServers",
+    adapter: "antigravity",
+  },
+  mcporter: {
+    mcpPath: (root) => join(root, "config", "mcporter.json"),
+    topKey: "mcpServers",
+  },
+  factory: {
+    mcpPath: (root) => join(root, ".factory", "mcp.json"),
+    topKey: "mcpServers",
+  },
+};
+
+type BundleEvidence =
+  | { kind: "file"; path: string; realPath: string; hash: string }
+  | { kind: "directory"; path: string; realPath: string; hash: string }
+  | { kind: "symlink"; path: string; realPath: string };
+
+export interface ProjectBundleProof {
+  readonly root: string;
+  readonly providers: readonly SupportedProjectProvider[];
+  readonly [projectBundleBrand]: true;
+  readonly [projectBundleEvidence]: readonly BundleEvidence[];
+}
+
+export type ProjectBundleFailureReason =
+  | "no_selected_provider"
+  | "unsupported_provider"
+  | "invalid_proxy_expectation"
+  | "project_mcp_mismatch"
+  | "project_instructions_mismatch"
+  | "project_skill_mismatch";
+
+export type ProjectBundleVerification =
+  | { ok: true; proof: ProjectBundleProof }
+  | { ok: false; reason: ProjectBundleFailureReason; provider?: ProviderId; path?: string };
+
+export type ProjectBundleStatus = "valid" | "unauthorized_provider" | "changed";
+
+function isSupportedProvider(provider: ProviderId): provider is SupportedProjectProvider {
+  return Object.hasOwn(PROJECT_BUNDLE_SPECS, provider);
+}
+
+function containsPath(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return (
+    path === "" ||
+    (path !== ".." &&
+      !path.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) &&
+      !isAbsolute(path))
+  );
+}
+
+function contentHash(content: string | Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function readRegularFile(
+  path: string,
+  realRoot: string,
+): { content: string; evidence: BundleEvidence } | null {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) return null;
+    const realPath = realpathSync(path);
+    if (!containsPath(realRoot, realPath)) return null;
+    const content = readFileSync(path, "utf8");
+    return { content, evidence: { kind: "file", path, realPath, hash: contentHash(content) } };
+  } catch {
+    return null;
+  }
+}
+
+function exactOwnedBlock(content: string, start: string, body: string, end: string): boolean {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end);
+  if (startIndex < 0 || endIndex < startIndex) return false;
+  if (content.indexOf(start, startIndex + start.length) !== -1) return false;
+  if (content.indexOf(end, endIndex + end.length) !== -1) return false;
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const expected = `${start}${eol}${body.trim().replace(/\r?\n/g, eol)}${eol}${end}`;
+  return content.slice(startIndex, endIndex + end.length) === expected;
+}
+
+function adapterPath(root: string, adapter: NonNullable<ProviderBundleSpec["adapter"]>): string {
+  switch (adapter) {
+    case "claude":
+      return join(root, "CLAUDE.md");
+    case "gemini":
+      return join(root, "GEMINI.md");
+    case "antigravity":
+      return join(root, ".agents", "rules", "dosu.md");
+  }
+}
+
+function verifyAdapter(
+  root: string,
+  realRoot: string,
+  adapter: NonNullable<ProviderBundleSpec["adapter"]>,
+  instructionContent: string,
+): BundleEvidence | null {
+  const path = adapterPath(root, adapter);
+  try {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      if (adapter === "antigravity") return null;
+      const realPath = realpathSync(path);
+      if (realPath !== realpathSync(join(root, "AGENTS.md"))) return null;
+      return { kind: "symlink", path, realPath };
+    }
+  } catch {
+    return null;
+  }
+
+  const file = readRegularFile(path, realRoot);
+  if (!file) return null;
+  const body = adapter === "antigravity" ? instructionContent : "@AGENTS.md";
+  return exactOwnedBlock(file.content, ADAPTER_START, body, ADAPTER_END) ? file.evidence : null;
+}
+
+function verifyProjectSkill(
+  root: string,
+  providers: readonly SupportedProjectProvider[],
+): BundleEvidence[] | null {
+  const targets = projectSkillInstallTargetsForProviders(providers, root);
+  const verification = verifyProjectSkillInstallation({ projectRoot: root, targets });
+  return verification.ok ? verification.evidence : null;
+}
+
+function deduplicateEvidence(evidence: readonly BundleEvidence[]): BundleEvidence[] {
+  const seen = new Set<string>();
+  return evidence.filter((item) => {
+    const key = `${item.kind}\0${item.path}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function validProxyExpectation(expectation: ProjectProxyExpectation): boolean {
+  const value = expectation as unknown;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proxy = value as Record<string, unknown>;
+  if (
+    typeof proxy.packageVersion !== "string" ||
+    !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(proxy.packageVersion)
+  ) {
+    return false;
+  }
+  const keys = Object.keys(proxy).sort();
+  if (proxy.oss === true) {
+    return keys.length === 2 && keys[0] === "oss" && keys[1] === "packageVersion";
+  }
+  const expectedKeys =
+    proxy.oss === false
+      ? ["deploymentID", "oss", "packageVersion"]
+      : ["deploymentID", "packageVersion"];
+  return (
+    keys.length === expectedKeys.length &&
+    keys.every((key, index) => key === expectedKeys[index]) &&
+    typeof proxy.deploymentID === "string" &&
+    proxy.deploymentID.length > 0
+  );
+}
+
+export function verifyProjectBundle(input: {
+  project: ProjectProof;
+  providerIDs: readonly ProviderId[];
+  proxy: ProjectProxyExpectation;
+  instructionContent: string;
+}): ProjectBundleVerification {
+  assertProjectProof(input.project);
+  const providers = [...new Set(input.providerIDs)];
+  if (providers.length === 0) return { ok: false, reason: "no_selected_provider" };
+  const unsupported = providers.find((provider) => !isSupportedProvider(provider));
+  if (unsupported) return { ok: false, reason: "unsupported_provider", provider: unsupported };
+  if (!validProxyExpectation(input.proxy)) {
+    return { ok: false, reason: "invalid_proxy_expectation" };
+  }
+
+  const supported = providers as SupportedProjectProvider[];
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(input.project.root);
+  } catch {
+    return { ok: false, reason: "project_mcp_mismatch" };
+  }
+  const evidence: BundleEvidence[] = [];
+
+  for (const provider of supported) {
+    const spec = PROJECT_BUNDLE_SPECS[provider];
+    const path = spec.mcpPath(input.project.root);
+    const file = readRegularFile(path, realRoot);
+    if (!file) return { ok: false, reason: "project_mcp_mismatch", provider, path };
+    const valid =
+      provider === "codex"
+        ? isExactProjectCodexProxy(file.content, input.proxy)
+        : isExactProjectJsonProxy({
+            content: file.content,
+            provider,
+            topKey: spec.topKey ?? "",
+            expectation: input.proxy,
+          });
+    if (!valid) return { ok: false, reason: "project_mcp_mismatch", provider, path };
+    evidence.push(file.evidence);
+  }
+
+  if (supported.some(providerUsesProjectInstructions)) {
+    const path = join(input.project.root, "AGENTS.md");
+    const agents = readRegularFile(path, realRoot);
+    if (
+      !agents ||
+      !exactOwnedBlock(agents.content, AGENTS_START, input.instructionContent, AGENTS_END)
+    ) {
+      return { ok: false, reason: "project_instructions_mismatch", path };
+    }
+    evidence.push(agents.evidence);
+
+    for (const provider of supported) {
+      const adapter = PROJECT_BUNDLE_SPECS[provider].adapter;
+      if (!adapter) continue;
+      const adapterEvidence = verifyAdapter(
+        input.project.root,
+        realRoot,
+        adapter,
+        input.instructionContent,
+      );
+      if (!adapterEvidence) {
+        return {
+          ok: false,
+          reason: "project_instructions_mismatch",
+          provider,
+          path: adapterPath(input.project.root, adapter),
+        };
+      }
+      evidence.push(adapterEvidence);
+    }
+  }
+
+  const skillProviders = supported.filter(
+    (provider) => projectSkillInstallTargetsForProviders([provider], input.project.root).length > 0,
+  );
+  if (skillProviders.length > 0) {
+    const skillEvidence = verifyProjectSkill(input.project.root, skillProviders);
+    if (!skillEvidence) return { ok: false, reason: "project_skill_mismatch" };
+    evidence.push(...skillEvidence);
+  }
+
+  const frozenProviders = Object.freeze([...supported]);
+  const frozenEvidence = Object.freeze(deduplicateEvidence(evidence));
+  const proof: ProjectBundleProof = {
+    root: resolve(input.project.root),
+    providers: frozenProviders,
+    [projectBundleBrand]: true,
+    [projectBundleEvidence]: frozenEvidence,
+  };
+  return {
+    ok: true,
+    proof: Object.freeze(proof),
+  };
+}
+
+function evidenceUnchanged(evidence: BundleEvidence, realRoot: string): boolean {
+  try {
+    const stat = lstatSync(evidence.path);
+    if (evidence.kind === "symlink") {
+      return stat.isSymbolicLink() && realpathSync(evidence.path) === evidence.realPath;
+    }
+    if (stat.isSymbolicLink() || realpathSync(evidence.path) !== evidence.realPath) return false;
+    if (evidence.kind === "file") {
+      return stat.isFile() && contentHash(readFileSync(evidence.path)) === evidence.hash;
+    }
+    return stat.isDirectory() && projectSkillEvidenceUnchanged(evidence, realRoot);
+  } catch {
+    return false;
+  }
+}
+
+export function projectBundleStatus(
+  proof: ProjectBundleProof,
+  provider: ProviderId,
+): ProjectBundleStatus {
+  if (proof?.[projectBundleBrand] !== true) return "changed";
+  if (!proof.providers.includes(provider as SupportedProjectProvider))
+    return "unauthorized_provider";
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(proof.root);
+  } catch {
+    return "changed";
+  }
+  return proof[projectBundleEvidence].every((evidence) => evidenceUnchanged(evidence, realRoot))
+    ? "valid"
+    : "changed";
+}
+
+export function assertProjectBundleProof(proof: ProjectBundleProof): void {
+  if (proof?.[projectBundleBrand] !== true) {
+    throw new Error("A verified project bundle proof is required for legacy migration");
+  }
+}

--- a/src/migration/project-proof.ts
+++ b/src/migration/project-proof.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+
+const projectProofBrand: unique symbol = Symbol("DosuProjectProof");
+
+export interface ProjectProof {
+  readonly root: string;
+  readonly cwd: string;
+  readonly [projectProofBrand]: true;
+}
+
+export type ProjectProofResult =
+  | { ok: true; proof: ProjectProof }
+  | {
+      ok: false;
+      reason:
+        | "not_git_worktree"
+        | "bare_repository"
+        | "cwd_outside_project"
+        | "invalid_git_root"
+        | "git_probe_failed";
+    };
+
+export interface ProjectFacts {
+  cwd: string;
+  gitTopLevel: string;
+  insideWorkTree: boolean;
+  bareRepository: boolean;
+}
+
+function containsPath(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return (
+    path === "" ||
+    (path !== ".." &&
+      !path.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) &&
+      !isAbsolute(path))
+  );
+}
+
+export function proveProjectScope(facts: ProjectFacts): ProjectProofResult {
+  if (!facts.insideWorkTree) return { ok: false, reason: "not_git_worktree" };
+  if (facts.bareRepository) return { ok: false, reason: "bare_repository" };
+  if (!isAbsolute(facts.gitTopLevel)) return { ok: false, reason: "invalid_git_root" };
+
+  const cwd = resolve(facts.cwd);
+  const root = resolve(facts.gitTopLevel);
+  if (!containsPath(root, cwd)) return { ok: false, reason: "cwd_outside_project" };
+  return { ok: true, proof: { root, cwd, [projectProofBrand]: true } };
+}
+
+function gitValue(cwd: string, args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+export function resolveProjectProof(cwd: string): ProjectProofResult {
+  try {
+    const realCwd = realpathSync(cwd);
+    const insideWorkTree = gitValue(realCwd, ["rev-parse", "--is-inside-work-tree"]) === "true";
+    const bareRepository = gitValue(realCwd, ["rev-parse", "--is-bare-repository"]) === "true";
+    const gitTopLevel = realpathSync(gitValue(realCwd, ["rev-parse", "--show-toplevel"]));
+    return proveProjectScope({ cwd: realCwd, gitTopLevel, insideWorkTree, bareRepository });
+  } catch {
+    return { ok: false, reason: "git_probe_failed" };
+  }
+}
+
+export function assertProjectProof(proof: ProjectProof): void {
+  if (proof?.[projectProofBrand] !== true) {
+    throw new Error("A verified project proof is required for legacy migration");
+  }
+}

--- a/src/migration/project-targets.test.ts
+++ b/src/migration/project-targets.test.ts
@@ -1,0 +1,283 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertProjectProof,
+  type ProjectProof,
+  proveProjectScope,
+  resolveProjectProof,
+} from "./project-proof";
+import { resolveLegacyTargets } from "./targets";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("strict project proof", () => {
+  it("returns an opaque proof only for a non-bare Git worktree containing cwd", () => {
+    const result = proveProjectScope({
+      cwd: "/repo/packages/app",
+      gitTopLevel: "/repo",
+      insideWorkTree: true,
+      bareRepository: false,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.proof.root).toBe(resolve("/repo"));
+      expect(result.proof.cwd).toBe(resolve("/repo/packages/app"));
+    }
+  });
+
+  it("rejects non-worktrees, bare repositories, and roots that do not contain cwd", () => {
+    expect(
+      proveProjectScope({
+        cwd: "/tmp",
+        gitTopLevel: "/repo",
+        insideWorkTree: false,
+        bareRepository: false,
+      }),
+    ).toMatchObject({ ok: false, reason: "not_git_worktree" });
+    expect(
+      proveProjectScope({
+        cwd: "/repo",
+        gitTopLevel: "/repo",
+        insideWorkTree: true,
+        bareRepository: true,
+      }),
+    ).toMatchObject({ ok: false, reason: "bare_repository" });
+    expect(
+      proveProjectScope({
+        cwd: "/other/repo-copy",
+        gitTopLevel: "/repo",
+        insideWorkTree: true,
+        bareRepository: false,
+      }),
+    ).toMatchObject({ ok: false, reason: "cwd_outside_project" });
+  });
+
+  it("resolves a real nested Git worktree and rejects a missing directory", () => {
+    const root = mkdtempSync(join(tmpdir(), "dosu-project-proof-"));
+    temporaryRoots.push(root);
+    const nested = join(root, "packages", "app");
+    mkdirSync(nested, { recursive: true });
+    execFileSync("git", ["init", "-q", root]);
+
+    const result = resolveProjectProof(nested);
+    expect(result).toMatchObject({ ok: true });
+    if (result.ok) {
+      expect(result.proof.root).toBe(realpathSync(root));
+      expect(result.proof.cwd).toBe(realpathSync(nested));
+      expect(() => assertProjectProof(result.proof)).not.toThrow();
+    }
+    expect(resolveProjectProof(join(root, "missing"))).toEqual({
+      ok: false,
+      reason: "git_probe_failed",
+    });
+  });
+
+  it("does not accept a structurally forged project proof", () => {
+    expect(() => assertProjectProof({ root: "/repo", cwd: "/repo" } as ProjectProof)).toThrow(
+      /verified project proof/i,
+    );
+  });
+});
+
+describe("platform-aware legacy target resolver", () => {
+  it("resolves macOS app support, overrides, shared rules, and all published providers", () => {
+    const result = resolveLegacyTargets(
+      [
+        "claude",
+        "claude-desktop",
+        "vscode",
+        "codex",
+        "gemini",
+        "antigravity",
+        "cline",
+        "cline-cli",
+        "mcporter",
+      ],
+      {
+        platform: "darwin",
+        homeDir: "/Users/tester",
+        env: {
+          CLAUDE_CONFIG_DIR: "/custom/claude",
+          CODEX_HOME: "/custom/codex",
+          CLINE_DIR: "/custom/cline",
+        },
+      },
+    );
+
+    expect(result.warnings).toEqual([]);
+    expect(result.targets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "/Users/tester/.claude.json", kind: "json_mcp" }),
+        expect.objectContaining({
+          path: "/Users/tester/Library/Application Support/Claude/claude_desktop_config.json",
+        }),
+        expect.objectContaining({
+          path: "/Users/tester/Library/Application Support/Code/User/mcp.json",
+          topKey: "servers",
+        }),
+        expect.objectContaining({ path: "/custom/codex/config.toml", kind: "codex_toml" }),
+        expect.objectContaining({ path: "/custom/claude/rules/dosu.md", kind: "rule_file" }),
+        expect.objectContaining({ path: "/custom/codex/AGENTS.md", kind: "rule_section" }),
+        expect.objectContaining({ path: "/custom/cline/data/settings/cline_mcp_settings.json" }),
+        expect.objectContaining({ path: "/Users/tester/.mcporter/mcporter.json" }),
+        expect.objectContaining({ path: "/Users/tester/.mcporter/mcporter.jsonc" }),
+      ]),
+    );
+
+    const sharedGeminiRules = result.targets.filter(
+      (target) =>
+        target.kind === "rule_section" && target.path === "/Users/tester/.gemini/GEMINI.md",
+    );
+    expect(sharedGeminiRules).toHaveLength(1);
+    expect(sharedGeminiRules[0]).toMatchObject({
+      requiredProviders: ["gemini", "antigravity"],
+    });
+  });
+
+  it("resolves Linux XDG paths and the released Copilot XDG path", () => {
+    const result = resolveLegacyTargets(["vscode", "zed", "copilot", "opencode"], {
+      platform: "linux",
+      homeDir: "/home/tester",
+      env: { XDG_CONFIG_HOME: "/xdg/config" },
+    });
+    expect(result.targets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: join("/xdg/config", "Code", "User", "mcp.json") }),
+        expect.objectContaining({ path: join("/xdg/config", "zed", "settings.json") }),
+        expect.objectContaining({ path: "/xdg/config/mcp-config.json" }),
+        expect.objectContaining({ path: "/home/tester/.config/opencode/opencode.json" }),
+      ]),
+    );
+  });
+
+  it("requires only effective consumers for the shared Gemini rule", () => {
+    const environment = {
+      platform: "linux" as const,
+      homeDir: "/home/tester",
+      env: {},
+    };
+    const geminiOnly = resolveLegacyTargets(["gemini"], environment).targets.find(
+      (target) => target.kind === "rule_section",
+    );
+    const antigravityOnly = resolveLegacyTargets(["antigravity"], environment).targets.find(
+      (target) => target.kind === "rule_section",
+    );
+    expect(geminiOnly?.requiredProviders).toEqual(["gemini"]);
+    expect(antigravityOnly?.requiredProviders).toEqual(["antigravity"]);
+  });
+
+  it("resolves Windows APPDATA and warns rather than inventing it when missing", () => {
+    const found = resolveLegacyTargets(["vscode", "cline"], {
+      platform: "win32",
+      homeDir: "C:\\Users\\tester",
+      env: { APPDATA: "C:\\Users\\tester\\AppData\\Roaming" },
+    });
+    expect(found.targets.some((target) => target.path.includes("AppData"))).toBe(true);
+
+    const missing = resolveLegacyTargets(["vscode", "cline"], {
+      platform: "win32",
+      homeDir: "C:\\Users\\tester",
+      env: {},
+    });
+    expect(missing.targets).toEqual([]);
+    expect(missing.warnings).toContain("APPDATA is unavailable; preserving VS Code/Cline targets");
+  });
+
+  it("never turns relative environment overrides into cleanup targets", () => {
+    const result = resolveLegacyTargets(["claude", "codex", "cline-cli", "copilot"], {
+      platform: "linux",
+      homeDir: "/home/tester",
+      env: {
+        CLAUDE_CONFIG_DIR: "relative-claude",
+        CODEX_HOME: "relative-codex",
+        CLINE_DIR: "relative-cline",
+        XDG_CONFIG_HOME: "relative-xdg",
+      },
+    });
+    expect(result.targets).toEqual([
+      expect.objectContaining({ id: "claude:mcp", path: "/home/tester/.claude.json" }),
+    ]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("CLAUDE_CONFIG_DIR"),
+        expect.stringContaining("CODEX_HOME"),
+        expect.stringContaining("CLINE_DIR"),
+        expect.stringContaining("XDG_CONFIG_HOME"),
+      ]),
+    );
+  });
+
+  it("preserves everything when the home directory itself is relative", () => {
+    expect(
+      resolveLegacyTargets(["claude", "cursor"], {
+        platform: "linux",
+        homeDir: "relative-home",
+        env: {},
+      }),
+    ).toEqual({
+      targets: [],
+      warnings: ["Home directory is not absolute; preserving every legacy target"],
+    });
+  });
+
+  it("covers every direct-path provider and deduplicates repeated requests", () => {
+    const result = resolveLegacyTargets(["cursor", "windsurf", "factory", "manual", "cursor"], {
+      platform: "linux",
+      homeDir: "/home/tester",
+      env: {},
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.targets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "cursor:mcp", path: "/home/tester/.cursor/mcp.json" }),
+        expect.objectContaining({ id: "cursor:rule", ruleKind: "cursor" }),
+        expect.objectContaining({
+          id: "windsurf:mcp",
+          path: "/home/tester/.codeium/windsurf/mcp_config.json",
+        }),
+        expect.objectContaining({ id: "factory:mcp", path: "/home/tester/.factory/mcp.json" }),
+      ]),
+    );
+    expect(result.targets.filter((target) => target.id === "cursor:mcp")).toHaveLength(1);
+  });
+
+  it("uses documented defaults when optional Linux overrides are absent", () => {
+    const result = resolveLegacyTargets(
+      ["claude", "codex", "cline-cli", "copilot", "vscode", "zed"],
+      { platform: "linux", homeDir: "/home/tester", env: {} },
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.targets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "/home/tester/.claude/rules/dosu.md" }),
+        expect.objectContaining({ path: "/home/tester/.codex/config.toml" }),
+        expect.objectContaining({
+          path: "/home/tester/.cline/data/settings/cline_mcp_settings.json",
+        }),
+        expect.objectContaining({ path: "/home/tester/.copilot/mcp-config.json" }),
+        expect.objectContaining({ path: "/home/tester/.config/Code/User/mcp.json" }),
+        expect.objectContaining({ path: "/home/tester/.config/zed/settings.json" }),
+      ]),
+    );
+  });
+
+  it("warns separately for Windows products whose APPDATA target cannot be proven", () => {
+    const result = resolveLegacyTargets(["claude-desktop", "zed"], {
+      platform: "win32",
+      homeDir: "C:\\Users\\tester",
+      env: {},
+    });
+    expect(result.targets).toEqual([]);
+    expect(result.warnings).toEqual([
+      "APPDATA is unavailable; preserving Claude Desktop target",
+      "APPDATA is unavailable; preserving Zed target",
+    ]);
+  });
+});

--- a/src/migration/targets.ts
+++ b/src/migration/targets.ts
@@ -1,0 +1,323 @@
+import { posix, win32 } from "node:path";
+
+export type ProviderId =
+  | "claude"
+  | "claude-desktop"
+  | "cursor"
+  | "vscode"
+  | "gemini"
+  | "codex"
+  | "windsurf"
+  | "zed"
+  | "cline"
+  | "cline-cli"
+  | "copilot"
+  | "opencode"
+  | "antigravity"
+  | "mcporter"
+  | "factory"
+  | "manual";
+
+interface LegacyTargetBase {
+  id: string;
+  provider: ProviderId;
+  path: string;
+  /** Every project bundle that must be proven before deleting a historically shared target. */
+  requiredProviders?: readonly ProviderId[];
+}
+
+export type LegacyTarget =
+  | (LegacyTargetBase & { kind: "json_mcp"; topKey: string })
+  | (LegacyTargetBase & { kind: "codex_toml" })
+  | (LegacyTargetBase & { kind: "rule_file"; ruleKind: "claude" | "cursor" })
+  | (LegacyTargetBase & { kind: "rule_section" });
+
+export interface LegacyTargetEnvironment {
+  platform: "darwin" | "linux" | "win32";
+  homeDir: string;
+  env: Record<string, string | undefined>;
+}
+
+export interface LegacyTargetResolution {
+  targets: LegacyTarget[];
+  warnings: string[];
+}
+
+export function resolveLegacyTargets(
+  providerIds: readonly ProviderId[],
+  environment: LegacyTargetEnvironment,
+): LegacyTargetResolution {
+  const pathApi = environment.platform === "win32" ? win32 : posix;
+  const join = (...parts: string[]) => pathApi.join(...parts);
+  const home = environment.homeDir;
+  const env = environment.env;
+  const targets: LegacyTarget[] = [];
+  const warnings: string[] = [];
+  const effectiveProviders = new Set(providerIds);
+  const sharedGeminiRuleProviders = (["gemini", "antigravity"] as const).filter((provider) =>
+    effectiveProviders.has(provider),
+  );
+  if (!pathApi.isAbsolute(home)) {
+    return {
+      targets,
+      warnings: ["Home directory is not absolute; preserving every legacy target"],
+    };
+  }
+
+  const envPaths = new Map<string, string | null | undefined>();
+  const absoluteEnvPath = (name: string): string | undefined => {
+    if (envPaths.has(name)) return envPaths.get(name) ?? undefined;
+    const value = env[name];
+    if (!value) {
+      envPaths.set(name, undefined);
+      return undefined;
+    }
+    if (!pathApi.isAbsolute(value)) {
+      warnings.push(`${name} is not absolute; preserving targets that depend on it`);
+      envPaths.set(name, null);
+      return undefined;
+    }
+    envPaths.set(name, value);
+    return value;
+  };
+  const hasInvalidEnvPath = (name: string): boolean => envPaths.get(name) === null;
+  let appSupportResolved = false;
+  let appSupportValue: string | undefined;
+  const appSupport = (): string | undefined => {
+    if (appSupportResolved) return appSupportValue;
+    appSupportResolved = true;
+    if (environment.platform === "darwin") {
+      appSupportValue = join(home, "Library", "Application Support");
+    } else if (environment.platform === "linux") {
+      const xdg = absoluteEnvPath("XDG_CONFIG_HOME");
+      appSupportValue = hasInvalidEnvPath("XDG_CONFIG_HOME")
+        ? undefined
+        : xdg || join(home, ".config");
+    } else {
+      appSupportValue = absoluteEnvPath("APPDATA");
+    }
+    return appSupportValue;
+  };
+
+  const addJson = (provider: ProviderId, id: string, path: string, topKey: string) => {
+    targets.push({ provider, id, kind: "json_mcp", path, topKey });
+  };
+  const addRuleSection = (
+    provider: ProviderId,
+    id: string,
+    path: string,
+    requiredProviders?: readonly ProviderId[],
+  ) => {
+    targets.push({
+      provider,
+      id,
+      kind: "rule_section",
+      path,
+      ...(requiredProviders ? { requiredProviders } : {}),
+    });
+  };
+
+  let warnedMissingCodeAppData = false;
+  for (const provider of providerIds) {
+    switch (provider) {
+      case "claude": {
+        addJson(provider, "claude:mcp", join(home, ".claude.json"), "mcpServers");
+        const configured = absoluteEnvPath("CLAUDE_CONFIG_DIR");
+        if (!hasInvalidEnvPath("CLAUDE_CONFIG_DIR")) {
+          const configDir = configured || join(home, ".claude");
+          targets.push({
+            provider,
+            id: "claude:rule",
+            kind: "rule_file",
+            path: join(configDir, "rules", "dosu.md"),
+            ruleKind: "claude",
+          });
+        }
+        break;
+      }
+      case "claude-desktop":
+        if (appSupport()) {
+          addJson(
+            provider,
+            "claude-desktop:mcp",
+            join(appSupportValue as string, "Claude", "claude_desktop_config.json"),
+            "mcpServers",
+          );
+        } else {
+          warnings.push("APPDATA is unavailable; preserving Claude Desktop target");
+        }
+        break;
+      case "cursor":
+        addJson(provider, "cursor:mcp", join(home, ".cursor", "mcp.json"), "mcpServers");
+        targets.push({
+          provider,
+          id: "cursor:rule",
+          kind: "rule_file",
+          path: join(home, ".cursor", "rules", "dosu.mdc"),
+          ruleKind: "cursor",
+        });
+        break;
+      case "vscode":
+        if (appSupport()) {
+          addJson(
+            provider,
+            "vscode:mcp",
+            join(appSupportValue as string, "Code", "User", "mcp.json"),
+            "servers",
+          );
+        } else {
+          warnedMissingCodeAppData = true;
+        }
+        break;
+      case "gemini":
+        addJson(provider, "gemini:mcp", join(home, ".gemini", "settings.json"), "mcpServers");
+        addRuleSection(
+          provider,
+          "gemini:rule",
+          join(home, ".gemini", "GEMINI.md"),
+          sharedGeminiRuleProviders,
+        );
+        break;
+      case "codex": {
+        const configured = absoluteEnvPath("CODEX_HOME");
+        if (!hasInvalidEnvPath("CODEX_HOME")) {
+          const codexHome = configured || join(home, ".codex");
+          targets.push({
+            provider,
+            id: "codex:mcp",
+            kind: "codex_toml",
+            path: join(codexHome, "config.toml"),
+          });
+          addRuleSection(provider, "codex:rule", join(codexHome, "AGENTS.md"));
+        }
+        break;
+      }
+      case "windsurf":
+        addJson(
+          provider,
+          "windsurf:mcp",
+          join(home, ".codeium", "windsurf", "mcp_config.json"),
+          "mcpServers",
+        );
+        break;
+      case "zed":
+        if (appSupport()) {
+          addJson(
+            provider,
+            "zed:mcp",
+            join(
+              appSupportValue as string,
+              environment.platform === "linux" ? "zed" : "Zed",
+              "settings.json",
+            ),
+            "context_servers",
+          );
+        } else {
+          warnings.push("APPDATA is unavailable; preserving Zed target");
+        }
+        break;
+      case "cline":
+        if (appSupport()) {
+          addJson(
+            provider,
+            "cline:mcp",
+            join(
+              appSupportValue as string,
+              "Code",
+              "User",
+              "globalStorage",
+              "saoudrizwan.claude-dev",
+              "settings",
+              "cline_mcp_settings.json",
+            ),
+            "mcpServers",
+          );
+        } else {
+          warnedMissingCodeAppData = true;
+        }
+        break;
+      case "cline-cli": {
+        const configured = absoluteEnvPath("CLINE_DIR");
+        if (!hasInvalidEnvPath("CLINE_DIR")) {
+          const clineDir = configured || join(home, ".cline");
+          addJson(
+            provider,
+            "cline-cli:mcp",
+            join(clineDir, "data", "settings", "cline_mcp_settings.json"),
+            "mcpServers",
+          );
+        }
+        break;
+      }
+      case "copilot": {
+        const xdg = absoluteEnvPath("XDG_CONFIG_HOME");
+        if (!hasInvalidEnvPath("XDG_CONFIG_HOME")) {
+          addJson(
+            provider,
+            "copilot:mcp",
+            xdg ? join(xdg, "mcp-config.json") : join(home, ".copilot", "mcp-config.json"),
+            "mcpServers",
+          );
+        }
+        break;
+      }
+      case "opencode":
+        addJson(
+          provider,
+          "opencode:mcp",
+          join(home, ".config", "opencode", "opencode.json"),
+          "mcp",
+        );
+        addRuleSection(provider, "opencode:rule", join(home, ".config", "opencode", "AGENTS.md"));
+        break;
+      case "antigravity":
+        addJson(
+          provider,
+          "antigravity:mcp",
+          join(home, ".gemini", "antigravity", "mcp_config.json"),
+          "mcpServers",
+        );
+        addRuleSection(
+          provider,
+          "antigravity:rule",
+          join(home, ".gemini", "GEMINI.md"),
+          sharedGeminiRuleProviders,
+        );
+        break;
+      case "mcporter":
+        addJson(
+          provider,
+          "mcporter:json:mcp",
+          join(home, ".mcporter", "mcporter.json"),
+          "mcpServers",
+        );
+        addJson(
+          provider,
+          "mcporter:jsonc:mcp",
+          join(home, ".mcporter", "mcporter.jsonc"),
+          "mcpServers",
+        );
+        break;
+      case "factory":
+        addJson(provider, "factory:mcp", join(home, ".factory", "mcp.json"), "mcpServers");
+        break;
+      case "manual":
+        break;
+    }
+  }
+
+  if (warnedMissingCodeAppData) {
+    warnings.push("APPDATA is unavailable; preserving VS Code/Cline targets");
+  }
+
+  const seen = new Set<string>();
+  return {
+    targets: targets.filter((target) => {
+      const key = `${target.kind}\0${target.path}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    }),
+    warnings,
+  };
+}

--- a/src/setup/agents-md-step.ts
+++ b/src/setup/agents-md-step.ts
@@ -9,10 +9,11 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { logger } from "../debug/logger";
+import { writeProjectFile } from "../mcp/config-helpers";
 import { FALLBACK_DOSU_RULE, fetchDosuRule } from "../rules/installer";
 import { formatSetupSummary } from "./styles";
 
@@ -81,6 +82,11 @@ function findSection(content: string): SectionLocation | null {
   if (start === -1 || end < start) {
     throw new Error("Dosu AGENTS.md markers are incomplete; refusing to overwrite the file");
   }
+  const afterStart = content.slice(start + (startMatch?.[0].length ?? 0));
+  const remaining = content.slice(end + DOSU_SECTION_END.length);
+  if (SECTION_START_RE.test(afterStart) || remaining.includes(DOSU_SECTION_END)) {
+    throw new Error("Multiple Dosu AGENTS.md marker blocks found; refusing to overwrite the file");
+  }
   return { start, end };
 }
 
@@ -92,11 +98,18 @@ export function upsertDosuAgentsSection(
   cwd: string = process.cwd(),
   content: string = FALLBACK_DOSU_RULE,
 ): AgentsMdResult {
+  if (!existsSync(cwd) || !lstatSync(cwd).isDirectory() || lstatSync(cwd).isSymbolicLink()) {
+    throw new Error(`Project root is not a regular directory: ${cwd}`);
+  }
   const path = join(cwd, "AGENTS.md");
+
+  if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+    throw new Error(`Refusing to modify symbolic link at ${path}`);
+  }
 
   if (!existsSync(path)) {
     const section = buildDosuAgentsSection(content);
-    writeFileSync(path, `${section}\n`);
+    writeProjectFile(path, `${section}\n`, null);
     return { path, action: "created" };
   }
 
@@ -116,7 +129,7 @@ export function upsertDosuAgentsSection(
   }
 
   if (next === existing) return { path, action: "unchanged" };
-  writeFileSync(path, next);
+  writeProjectFile(path, next, existing);
   return { path, action: "updated" };
 }
 

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -39,6 +47,34 @@ vi.mock("@clack/prompts", () => ({
 
 vi.mock("../auth/flow", () => ({
   startOAuthFlow: vi.fn(),
+}));
+
+vi.mock("../mcp/project-credential-store", () => ({
+  saveProjectMcpCredential: vi.fn(),
+  readProjectMcpCredential: vi.fn(),
+}));
+
+const { mockPreflightProjectProxy } = vi.hoisted(() => ({
+  mockPreflightProjectProxy: vi.fn(),
+}));
+vi.mock("../mcp/project-proxy-preflight", () => ({
+  preflightProjectProxy: (...args: unknown[]) => mockPreflightProjectProxy(...args),
+}));
+
+const { mockResolveProjectProof, mockResolveProjectPinnedTarget, mockRunProjectScopeMigration } =
+  vi.hoisted(() => ({
+    mockResolveProjectProof: vi.fn(),
+    mockResolveProjectPinnedTarget: vi.fn(),
+    mockRunProjectScopeMigration: vi.fn(),
+  }));
+vi.mock("../migration", () => ({
+  resolveProjectProof: (...args: unknown[]) => mockResolveProjectProof(...args),
+}));
+vi.mock("./project-target", () => ({
+  resolveProjectPinnedTarget: (...args: unknown[]) => mockResolveProjectPinnedTarget(...args),
+}));
+vi.mock("./project-scope-migration", () => ({
+  runProjectScopeMigration: (...args: unknown[]) => mockRunProjectScopeMigration(...args),
 }));
 
 vi.mock("../debug/logger", () => ({
@@ -145,6 +181,20 @@ vi.mock("./agents-md-step", () => ({
 const { mockStepConfigureAgentRules } = vi.hoisted(() => ({
   mockStepConfigureAgentRules: vi.fn(),
 }));
+const { mockRequireProjectRoot, mockInstallProjectInstructions, mockRemoveProjectAdapters } =
+  vi.hoisted(() => ({
+    mockRequireProjectRoot: vi.fn(),
+    mockInstallProjectInstructions: vi.fn(),
+    mockRemoveProjectAdapters: vi.fn(),
+  }));
+vi.mock("./project-root", () => ({
+  requireProjectRoot: (...args: unknown[]) => mockRequireProjectRoot(...args),
+}));
+vi.mock("./project-instructions", () => ({
+  installProjectInstructions: (...args: unknown[]) => mockInstallProjectInstructions(...args),
+  removeProjectInstructionAdapters: (...args: unknown[]) => mockRemoveProjectAdapters(...args),
+  providerUsesProjectInstructions: (providerID: string) => providerID !== "mcporter",
+}));
 vi.mock("./rules-step", () => ({
   stepConfigureAgentRules: (...args: unknown[]) => mockStepConfigureAgentRules(...args),
 }));
@@ -161,11 +211,14 @@ import { Client } from "../client/client";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
-import { loadJSONConfig, saveJSONConfig } from "../mcp/config-helpers";
+import { loadJSONConfig, saveJSONConfig, writeProjectFile } from "../mcp/config-helpers";
 import * as providersModule from "../mcp/providers";
 import { ClaudeProvider } from "../mcp/providers/claude";
 import { ClaudeDesktopProvider } from "../mcp/providers/claude-desktop";
+import { CodexProvider } from "../mcp/providers/codex";
+import { CopilotProvider } from "../mcp/providers/copilot";
 import { CursorProvider } from "../mcp/providers/cursor";
+import { GeminiProvider } from "../mcp/providers/gemini";
 import { OpenCodeProvider } from "../mcp/providers/opencode";
 import {
   type ConfigResult,
@@ -191,10 +244,30 @@ function mockToolSelection(selection: string[]) {
 }
 
 function installSetupStepDefaults() {
+  mockPreflightProjectProxy.mockResolvedValue({ ok: true, reason: "initialize_ok" });
+  mockResolveProjectPinnedTarget.mockReturnValue({ ok: true, providers: [] });
+  mockResolveProjectProof.mockImplementation((root: string) => ({
+    ok: true,
+    proof: { root, cwd: root },
+  }));
+  mockRunProjectScopeMigration.mockReturnValue({
+    ok: true,
+    cleanupAttempted: true,
+    runtimeVerified: true,
+    receiptRoot: "/tmp/dosu-test-migration-receipts",
+    counts: { removed: 0, not_found: 3, preserved: 0, failed: 0, total: 3 },
+    warnings: [],
+  });
   mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
   mockInGitWorkTree.mockReturnValue(false);
   mockStepUpdateAgentsMd.mockReturnValue(true);
   mockStepConfigureAgentRules.mockResolvedValue([]);
+  mockRequireProjectRoot.mockImplementation(() => projectDir);
+  mockInstallProjectInstructions.mockImplementation(({ projectRoot }: { projectRoot: string }) => ({
+    agentsMd: { path: join(projectRoot, "AGENTS.md"), action: "created" },
+    adapters: [],
+  }));
+  mockRemoveProjectAdapters.mockReturnValue([]);
 }
 
 function installRemoteSetupDefaults() {
@@ -216,11 +289,14 @@ function installRemoteSetupDefaults() {
 // ---------------------------------------------------------------------------
 
 let tempDir: string;
+let projectDir: string;
 let origHome: string | undefined;
 let origXdg: string | undefined;
 
 function setupTempEnv() {
   tempDir = mkdtempSync(join(tmpdir(), "dosu-flow-test-"));
+  projectDir = join(tempDir, "project");
+  mkdirSync(projectDir, { recursive: true });
   origHome = process.env.HOME;
   origXdg = process.env.XDG_CONFIG_HOME;
   process.env.HOME = tempDir;
@@ -248,6 +324,8 @@ function throwingProvider(): providersModule.SetupProvider {
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => join(tempDir, "broken.json"),
+    projectConfigPath: (root) => join(root, ".broken", "mcp.json"),
+    isProjectConfigured: () => false,
     install() {
       throw new Error("boom: provider failure");
     },
@@ -314,7 +392,7 @@ describe("stepDetectTools", () => {
     expect(detected[0].id()).toBe("cursor");
   });
 
-  it("includes Claude Desktop when its app dir exists", () => {
+  it("excludes detected agents that have no official project MCP scope", () => {
     const desktop = ClaudeDesktopProvider();
     for (const detectPath of desktop.detectPaths()) {
       mkdirSync(detectPath, { recursive: true });
@@ -325,7 +403,7 @@ describe("stepDetectTools", () => {
     });
 
     const detected = stepDetectTools();
-    expect(detected.map((p2) => p2.id())).toEqual(["claude-desktop"]);
+    expect(detected.map((p2) => p2.id())).toEqual([]);
   });
 
   it("returns empty array when no providers are installed", () => {
@@ -376,21 +454,24 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("install");
     expect(results[0].error).toBeUndefined();
 
     // Verify the file was actually written to disk
-    const configPath = cursor.globalConfigPath();
+    const configPath = cursor.projectConfigPath(projectDir) ?? "";
     expect(existsSync(configPath)).toBe(true);
 
     const written = loadJSONConfig(configPath);
     expect(written.mcpServers).toBeDefined();
     expect(written.mcpServers.dosu).toBeDefined();
-    expect(written.mcpServers.dosu.url).toContain("dep-123");
-    expect(written.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+    expect(written.mcpServers.dosu.command).toBe("npx");
+    expect(written.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "dep-123"]),
+    );
+    expect(JSON.stringify(written)).not.toContain("key-abc");
   });
 
   it("removes a provider and deletes the dosu entry from disk", () => {
@@ -398,8 +479,8 @@ describe("stepConfigureTools", () => {
     const cursor = CursorProvider();
 
     // First install so there's something to remove
-    cursor.install(cfg, true);
-    const configPath = cursor.globalConfigPath();
+    cursor.install(cfg, false, { projectRoot: projectDir });
+    const configPath = cursor.projectConfigPath(projectDir) ?? "";
     let written = loadJSONConfig(configPath);
     expect(written.mcpServers.dosu).toBeDefined();
 
@@ -409,7 +490,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("remove");
@@ -429,13 +510,13 @@ describe("stepConfigureTools", () => {
       skipped: [cursor],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("skip");
     expect(results[0].error).toBeUndefined();
     // No file should have been created
-    expect(existsSync(cursor.globalConfigPath())).toBe(false);
+    expect(existsSync(cursor.projectConfigPath(projectDir) ?? "")).toBe(false);
   });
 
   it("handles install errors and records them in results", () => {
@@ -447,7 +528,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("install");
@@ -466,7 +547,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("remove");
@@ -475,17 +556,63 @@ describe("stepConfigureTools", () => {
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Broken Tool"));
   });
 
+  it.each([
+    "install",
+    "remove",
+  ] as const)("fails before mutation when a provider's project path throws during %s planning", (action) => {
+    const broken = {
+      ...throwingProvider(),
+      projectConfigPath: () => {
+        throw new Error(`${action} path failed`);
+      },
+    };
+    const selection: ToolSelection = {
+      toInstall: action === "install" ? [broken] : [],
+      toRemove: action === "remove" ? [broken] : [],
+      skipped: [],
+    };
+
+    const results = stepConfigureTools(makeCfg(), selection, projectDir);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe(action);
+    expect(results[0].error?.message).toContain(`${action} path failed`);
+  });
+
+  it("fails before the first write when a target cannot be safely captured", () => {
+    const cursor = CursorProvider();
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const directoryPath = join(projectDir, ".unsafe-config");
+    mkdirSync(directoryPath);
+    const unsafeInstall = vi.fn();
+    const unsafe = {
+      ...throwingProvider(),
+      projectConfigPath: () => directoryPath,
+      install: unsafeInstall,
+    };
+
+    const results = stepConfigureTools(
+      makeCfg(),
+      { toInstall: [cursor, unsafe], toRemove: [], skipped: [] },
+      projectDir,
+    );
+
+    expect(existsSync(cursorPath)).toBe(false);
+    expect(unsafeInstall).not.toHaveBeenCalled();
+    expect(results[0].error?.message).toContain("not a regular file");
+  });
+
   it("handles mixed install, remove, and skip in one call", () => {
     const cfg = makeCfg();
     const _cursor = CursorProvider();
     const opencode = OpenCodeProvider();
 
     // Pre-install opencode so we can remove it
-    opencode.install(cfg, true);
+    opencode.install(cfg, false, { projectRoot: projectDir });
 
     const cursorForSkip = CursorProvider();
     // Pre-install cursor so the skip entry refers to an installed provider
-    cursorForSkip.install(cfg, true);
+    cursorForSkip.install(cfg, false, { projectRoot: projectDir });
 
     // Fresh providers for this call
     const freshCursor = CursorProvider();
@@ -498,7 +625,7 @@ describe("stepConfigureTools", () => {
       skipped: [anotherCursor],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(3);
 
@@ -513,12 +640,284 @@ describe("stepConfigureTools", () => {
     expect(skipResult).toBeDefined();
 
     // Verify cursor config was written
-    const cursorConfig = loadJSONConfig(freshCursor.globalConfigPath());
+    const cursorConfig = loadJSONConfig(freshCursor.projectConfigPath(projectDir) ?? "");
     expect(cursorConfig.mcpServers.dosu).toBeDefined();
 
     // Verify opencode dosu entry was removed
-    const opencodeConfig = loadJSONConfig(freshOpencode.globalConfigPath());
+    const opencodeConfig = loadJSONConfig(freshOpencode.projectConfigPath(projectDir) ?? "");
     expect(opencodeConfig.mcp.dosu).toBeUndefined();
+  });
+
+  it("restores an earlier Cursor retarget when a later Codex install fails", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const before = readFileSync(cursorPath, "utf8");
+    const codex = CodexProvider();
+    codex.install = () => {
+      throw new Error("codex failed");
+    };
+
+    const results = stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [cursor, codex], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(before);
+    expect(results.find((result) => result.provider.id() === "codex")?.error?.message).toContain(
+      "codex failed",
+    );
+    expect(results.find((result) => result.provider.id() === "cursor")?.error?.message).toContain(
+      "rolled back",
+    );
+  });
+
+  it("removes a newly created project config when a later provider fails", () => {
+    const cursor = CursorProvider();
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const broken = throwingProvider();
+
+    stepConfigureTools(
+      makeCfg(),
+      { toInstall: [cursor, broken], toRemove: [], skipped: [] },
+      projectDir,
+    );
+
+    expect(existsSync(cursorPath)).toBe(false);
+  });
+
+  it("restores a removed project entry when a later removal fails", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg(), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const before = readFileSync(cursorPath, "utf8");
+
+    const results = stepConfigureTools(
+      makeCfg(),
+      { toInstall: [], toRemove: [cursor, throwingProvider()], skipped: [] },
+      projectDir,
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(before);
+    expect(results[0].action).toBe("remove");
+    expect(results[0].error?.message).toContain("rolled back");
+    expect(results[1].error?.message).toContain("provider failure");
+  });
+
+  it("captures a shared .mcp.json preimage only once for rollback", () => {
+    const claude = ClaudeProvider();
+    const copilot = CopilotProvider();
+    claude.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const sharedPath = claude.projectConfigPath(projectDir) ?? "";
+    const before = readFileSync(sharedPath, "utf8");
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [claude, copilot, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    expect(copilot.projectConfigPath(projectDir)).toBe(sharedPath);
+    expect(readFileSync(sharedPath, "utf8")).toBe(before);
+  });
+
+  it("tracks the latest output when two providers write the same project path", () => {
+    const sharedPath = join(projectDir, ".mcp.json");
+    writeFileSync(sharedPath, "before");
+    const sharedProvider = (id: string, output: string): providersModule.SetupProvider => ({
+      ...throwingProvider(),
+      name: () => id,
+      id: () => id,
+      projectConfigPath: () => sharedPath,
+      install: () => writeProjectFile(sharedPath, output, readFileSync(sharedPath, "utf8")),
+    });
+
+    stepConfigureTools(
+      makeCfg(),
+      {
+        toInstall: [
+          sharedProvider("first", "first-output"),
+          sharedProvider("second", "second-output"),
+          throwingProvider(),
+        ],
+        toRemove: [],
+        skipped: [],
+      },
+      projectDir,
+    );
+
+    expect(readFileSync(sharedPath, "utf8")).toBe("before");
+  });
+
+  it("stops before a provider write when an earlier provider changed its captured target", () => {
+    const firstPath = join(projectDir, ".first.json");
+    const victimPath = join(projectDir, ".victim.json");
+    writeFileSync(victimPath, "victim-before");
+    const first = {
+      ...throwingProvider(),
+      name: () => "First",
+      id: () => "first",
+      projectConfigPath: () => firstPath,
+      install: () => {
+        const receipt = writeProjectFile(firstPath, "first-output", null);
+        writeFileSync(victimPath, "user-edit");
+        return receipt;
+      },
+    };
+    const victimInstall = vi.fn(() => undefined);
+    const victim = {
+      ...throwingProvider(),
+      name: () => "Victim",
+      id: () => "victim",
+      projectConfigPath: () => victimPath,
+      install: victimInstall,
+    };
+
+    const results = stepConfigureTools(
+      makeCfg(),
+      { toInstall: [first, victim], toRemove: [], skipped: [] },
+      projectDir,
+    );
+
+    expect(victimInstall).not.toHaveBeenCalled();
+    expect(readFileSync(victimPath, "utf8")).toBe("user-edit");
+    expect(existsSync(firstPath)).toBe(false);
+    expect(results[1].error?.message).toContain("changed after setup started");
+  });
+
+  it("preserves an unprovable provider output that is not a regular file", () => {
+    const outputPath = join(projectDir, ".unexpected-directory");
+    const provider = {
+      ...throwingProvider(),
+      projectConfigPath: () => outputPath,
+      install: () => {
+        mkdirSync(outputPath);
+        return undefined;
+      },
+    };
+
+    const results = stepConfigureTools(
+      makeCfg(),
+      { toInstall: [provider], toRemove: [], skipped: [] },
+      projectDir,
+    );
+
+    expect(lstatSync(outputPath).isDirectory()).toBe(true);
+    expect(results[0].error?.message).toContain("not a regular file");
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("preserving it for safety"));
+  });
+
+  it("preserves a concurrent user edit instead of rolling it back", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const userEdit = '{\n  "mcpServers": {\n    "dosu": { "user": "edit" }\n  }\n}\n';
+    const codex = CodexProvider();
+    codex.install = () => {
+      writeFileSync(cursorPath, userEdit);
+      throw new Error("codex failed after concurrent edit");
+    };
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [cursor, codex], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(userEdit);
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining(cursorPath));
+  });
+
+  it("preserves a sibling added inside a built-in provider install before a later failure", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const racedCursor: providersModule.SetupProvider = {
+      ...cursor,
+      install(cfg, global, opts) {
+        const current = loadJSONConfig(cursorPath);
+        current.mcpServers.user = { command: "user-owned" };
+        writeFileSync(cursorPath, JSON.stringify(current, null, 2));
+        return cursor.install(cfg, global, opts);
+      },
+    };
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [racedCursor, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    const after = loadJSONConfig(cursorPath);
+    expect(after.mcpServers.user).toEqual({ command: "user-owned" });
+    expect(after.mcpServers.dosu.args).toContain("dep-b");
+  });
+
+  it("preserves an inside-install sibling on the shared Claude and Copilot path", () => {
+    const claude = ClaudeProvider();
+    const copilot = CopilotProvider();
+    claude.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const sharedPath = claude.projectConfigPath(projectDir) ?? "";
+    const racedCopilot: providersModule.SetupProvider = {
+      ...copilot,
+      install(cfg, global, opts) {
+        const current = loadJSONConfig(sharedPath);
+        current.mcpServers.user = { command: "shared-user-owned" };
+        writeFileSync(sharedPath, JSON.stringify(current, null, 2));
+        return copilot.install(cfg, global, opts);
+      },
+    };
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [claude, racedCopilot, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    const after = loadJSONConfig(sharedPath);
+    expect(after.mcpServers.user).toEqual({ command: "shared-user-owned" });
+    expect(after.mcpServers.dosu.args).toContain("dep-b");
+  });
+
+  it("does not overwrite a replacement racing an existing-file rollback", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const userEdit = '{\n  "mcpServers": {\n    "dosu": { "user": "restore-race" }\n  }\n}\n';
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [cursor, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+      { beforeCapture: () => writeFileSync(cursorPath, userEdit) },
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(userEdit);
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("roll back"));
+  });
+
+  it("does not delete a replacement racing a newly-created-file rollback", () => {
+    const cursor = CursorProvider();
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const userEdit = '{\n  "mcpServers": {\n    "dosu": { "user": "delete-race" }\n  }\n}\n';
+
+    stepConfigureTools(
+      makeCfg(),
+      { toInstall: [cursor, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      false,
+      { beforeCapture: () => writeFileSync(cursorPath, userEdit) },
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(userEdit);
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("roll back"));
   });
 });
 
@@ -755,26 +1154,336 @@ describe("runSetup integration", () => {
     // Create Cursor detect path
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
 
-    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    const cursor = CursorProvider();
+    const undetectedCodex = CodexProvider();
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [
+      cursor,
+      undetectedCodex,
+    ]);
 
     // User selects cursor in multiselect
     mockToolSelection(["cursor"]);
 
     await runSetup();
 
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [cursor, undetectedCodex],
+      projectDir,
+    );
     // Verify the config was actually written to disk
-    const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+    const cursorConfigPath = join(projectDir, ".cursor", "mcp.json");
     expect(existsSync(cursorConfigPath)).toBe(true);
     const cursorConfig = loadJSONConfig(cursorConfigPath);
     expect(cursorConfig.mcpServers.dosu).toBeDefined();
-    expect(cursorConfig.mcpServers.dosu.url).toContain("d1");
+    expect(cursorConfig.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "d1"]),
+    );
+    expect(JSON.stringify(cursorConfig)).not.toContain("minted-key");
 
     // Verify summary was shown
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
-    expect(mockStepConfigureAgentRules).toHaveBeenCalledWith(
-      expect.objectContaining({ toInstall: [expect.objectContaining({})] }),
-      [expect.objectContaining({ action: "install" })],
+    expect(mockInstallProjectInstructions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRoot: projectDir,
+        providerIDs: ["cursor"],
+      }),
     );
+    expect(mockPreflightProjectProxy).toHaveBeenCalledWith(expect.any(Object), projectDir);
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerIDs: ["cursor"],
+        runtimeVerified: true,
+        proxy: expect.objectContaining({ deploymentID: "d1" }),
+      }),
+    );
+    expect(mockRunProjectScopeMigration.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mockInstallProjectInstructions.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("fails closed without an outro when recoverable legacy cleanup cannot finish", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockRunProjectScopeMigration.mockReturnValue({
+      ok: false,
+      cleanupAttempted: true,
+      runtimeVerified: true,
+      reason: "migration_failed",
+      receiptRoot: "/tmp/dosu-test-migration-receipts",
+      counts: { removed: 0, not_found: 0, preserved: 1, failed: 1, total: 2 },
+      warnings: [],
+    });
+
+    await runSetup();
+
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(true);
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("safe legacy cleanup could not finish"),
+    );
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("/tmp/dosu-test-migration-receipts"),
+    );
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("keeps an exact project deployment pin instead of silently following the active global target", async () => {
+    saveConfig(makeCfg({ deployment_id: "d-global", deployment_name: "Global" }));
+    const clientMethods = setupAuthenticatedClient({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([
+          makeDeployment({ deployment_id: "d-project", name: "Project" }),
+          makeDeployment({ deployment_id: "d-global", name: "Global" }),
+        ]),
+    });
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["cursor"],
+      target: { packageVersion: "0.42.0", deploymentID: "d-project" },
+    });
+
+    await runSetup();
+
+    expect(clientMethods.getDeployments).toHaveBeenCalled();
+    expect(loadConfig().active_account?.target?.deployment_id).toBe("d-project");
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "d-project"]),
+    );
+  });
+
+  it("stops before project writes when exact project configs disagree on their target", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "conflicting_project_targets",
+      providers: ["cursor", "codex"],
+      paths: [join(projectDir, ".cursor", "mcp.json"), join(projectDir, ".codex", "config.toml")],
+    });
+
+    await runSetup();
+
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(mockInstallProjectInstructions).not.toHaveBeenCalled();
+    expect(mockRunProjectScopeMigration).not.toHaveBeenCalled();
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(false);
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("stops before authentication when a project Dosu entry is ambiguous", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg({ access_token: undefined, refresh_token: undefined }));
+    const cursor = CursorProvider();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([cursor]);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ["cursor"],
+      paths: [join(projectDir, ".cursor", "mcp.json")],
+    });
+
+    await runSetup();
+
+    expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+    expect(mockClient).not.toHaveBeenCalled();
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining(".cursor/mcp.json"));
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("rejects an explicit deployment split-brain before project writes", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthenticatedClient({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "dep-explicit" })]),
+    });
+    const cursor = CursorProvider();
+    const undetectedCodex = CodexProvider();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([cursor, undetectedCodex]);
+    mockToolSelection(["cursor"]);
+    mockResolveProjectPinnedTarget
+      .mockReturnValueOnce({
+        ok: true,
+        providers: ["cursor", "codex"],
+        target: { deploymentID: "dep-old" },
+      })
+      .mockReturnValueOnce({
+        ok: false,
+        reason: "requested_project_target_conflict",
+        providers: ["codex"],
+        paths: [join(projectDir, ".codex", "config.toml")],
+      });
+
+    await runSetup({ deploymentID: "dep-explicit" });
+
+    expect(mockResolveProjectPinnedTarget).toHaveBeenNthCalledWith(
+      1,
+      [cursor, undetectedCodex],
+      projectDir,
+    );
+    expect(mockResolveProjectPinnedTarget).toHaveBeenNthCalledWith(
+      2,
+      [cursor, undetectedCodex],
+      projectDir,
+      { mode: "cloud", deploymentID: "dep-explicit" },
+      ["cursor"],
+    );
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+    expect(mockInstallProjectInstructions).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("allows one selected Cursor client to retarget its own pin explicitly", async () => {
+    saveConfig(makeCfg({ deployment_id: "dep-old", deployment_name: "Old" }));
+    setupAuthenticatedClient({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "dep-new", name: "New" })]),
+    });
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-old" }), false, { projectRoot: projectDir });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([cursor]);
+    mockToolSelection(["cursor"]);
+    mockResolveProjectPinnedTarget
+      .mockReturnValueOnce({
+        ok: true,
+        providers: ["cursor"],
+        target: { deploymentID: "dep-old" },
+      })
+      .mockReturnValueOnce({
+        ok: true,
+        providers: ["cursor"],
+        target: { deploymentID: "dep-new" },
+      });
+
+    await runSetup({ deploymentID: "dep-new" });
+
+    expect(mockResolveProjectPinnedTarget).toHaveBeenNthCalledWith(
+      2,
+      [cursor],
+      projectDir,
+      { mode: "cloud", deploymentID: "dep-new" },
+      ["cursor"],
+    );
+    const config = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(config.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["--deployment", "dep-new"]),
+    );
+  });
+
+  it("stops before project writes when the pinned deployment is not available to this account", async () => {
+    saveConfig(makeCfg({ deployment_id: "d-global", deployment_name: "Global" }));
+    setupAuthenticatedClient({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "d-global", name: "Global" })]),
+    });
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["cursor"],
+      target: { packageVersion: "0.42.0", deploymentID: "d-project" },
+    });
+
+    await runSetup();
+
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(mockRunProjectScopeMigration).not.toHaveBeenCalled();
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(false);
+  });
+
+  it("fails before every project write when the exact MCP command cannot initialize", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockPreflightProjectProxy.mockResolvedValue({ ok: false, reason: "timeout" });
+
+    await runSetup();
+
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(false);
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(mockInstallProjectInstructions).not.toHaveBeenCalled();
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No project files"));
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("removes a deselected adapter when another agent retains the shared project MCP file", async () => {
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".claude"), { recursive: true });
+    mkdirSync(join(tempDir, ".copilot"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [
+      ClaudeProvider(),
+      CopilotProvider(),
+    ]);
+    ClaudeProvider().install(makeCfg(), false, { projectRoot: projectDir });
+    expect(ClaudeProvider().isProjectConfigured(projectDir)).toBe(true);
+    expect(CopilotProvider().isProjectConfigured(projectDir)).toBe(true);
+    mockToolSelection(["copilot"]);
+
+    await runSetup();
+
+    expect(loadJSONConfig(join(projectDir, ".mcp.json")).mcpServers.dosu).toBeDefined();
+    expect(mockRemoveProjectAdapters).toHaveBeenCalledWith(projectDir, ["claude"]);
+  });
+
+  it("keeps a deselected shared-path adapter when a later MCP removal fails", async () => {
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".claude"), { recursive: true });
+    mkdirSync(join(tempDir, ".copilot"), { recursive: true });
+    mkdirSync(join(tempDir, ".gemini"), { recursive: true });
+    const claude = ClaudeProvider();
+    const copilot = CopilotProvider();
+    const gemini = GeminiProvider();
+    claude.install(makeCfg(), false, { projectRoot: projectDir });
+    gemini.install(makeCfg(), false, { projectRoot: projectDir });
+    const claudeAdapter = join(projectDir, "CLAUDE.md");
+    writeFileSync(claudeAdapter, "user-visible adapter\n");
+    gemini.remove = () => {
+      throw new Error("gemini removal failed");
+    };
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [
+      claude,
+      copilot,
+      gemini,
+    ]);
+    mockToolSelection(["copilot"]);
+
+    await runSetup();
+
+    expect(loadJSONConfig(join(projectDir, ".mcp.json")).mcpServers.dosu).toBeDefined();
+    expect(readFileSync(claudeAdapter, "utf8")).toBe("user-visible adapter\n");
+    expect(mockRemoveProjectAdapters).not.toHaveBeenCalled();
   });
 
   it("runs OAuth flow and saves tokens to real config", async () => {
@@ -875,9 +1584,11 @@ describe("runSetup integration", () => {
     expect(savedCfg.active_account?.target?.deployment_id).toBe("d2");
     expect(savedCfg.active_account?.target?.api_key).toBe("key-abc");
 
-    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
-    expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp/deployments/d2");
-    expect(cursorConfig.mcpServers.dosu.url).not.toBe(ossConfig.mcpServers.dosu.url);
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "d2"]),
+    );
+    expect(cursorConfig.mcpServers.dosu.url).toBeUndefined();
   });
 
   it("creates new API key when existing one is invalid", async () => {
@@ -919,8 +1630,10 @@ describe("runSetup integration", () => {
     await runSetup();
 
     // Cursor should have been reinstalled (not skipped) because api_key changed
-    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
-    expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("new-key");
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.args).toContain("d1");
+    expect(JSON.stringify(cursorConfig)).not.toContain("new-key");
+    expect(loadConfig().active_account?.target?.api_key).toBe("new-key");
   });
 
   it("reinstalls configured tools when setup is re-run with the same target", async () => {
@@ -928,8 +1641,8 @@ describe("runSetup integration", () => {
     const cfg = makeCfg({ deployment_id: "d1", deployment_name: "Deploy1", api_key: "key-abc" });
     saveConfig(cfg);
 
-    const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
-    saveJSONConfig(cursorConfigPath, {
+    const legacyGlobalConfigPath = join(tempDir, ".cursor", "mcp.json");
+    saveJSONConfig(legacyGlobalConfigPath, {
       mcpServers: {
         dosu: {
           type: "http",
@@ -950,9 +1663,11 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    const cursorConfig = loadJSONConfig(cursorConfigPath);
-    expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp/deployments/d1");
-    expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "d1"]),
+    );
+    expect(JSON.stringify(cursorConfig)).not.toContain("key-abc");
   });
 
   it("shows error when OAuth fails", async () => {
@@ -1389,15 +2104,13 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    // OpenCode should have been removed (configured + deselected)
+    // A global-only legacy OpenCode entry is preserved until a verified project equivalent exists.
     const opencodeConfig = loadJSONConfig(join(tempDir, ".config", "opencode", "opencode.json"));
-    expect(opencodeConfig.mcp?.dosu).toBeUndefined();
+    expect(opencodeConfig.mcp?.dosu).toBeDefined();
 
-    // Cursor config should still have dosu entry (was skipped)
-    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    // Cursor gets the selected project-scoped entry.
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
     expect(cursorConfig.mcpServers?.dosu).toBeDefined();
-
-    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 agent"));
   });
 
   it("OSS mode configures MCP but never offers the audit handoff", async () => {
@@ -1429,7 +2142,10 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], {
+      quiet: true,
+      projectRoot: projectDir,
+    });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/skills/cursor/dosu"));
   });
@@ -1460,7 +2176,10 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], {
+      quiet: true,
+      projectRoot: projectDir,
+    });
   });
 
   it("goes directly to agent selection without a component-selection prompt", async () => {
@@ -1493,7 +2212,9 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockStepUpdateAgentsMd).toHaveBeenCalledTimes(1);
+    expect(mockInstallProjectInstructions).toHaveBeenCalledWith(
+      expect.objectContaining({ projectRoot: projectDir, providerIDs: ["cursor"] }),
+    );
 
     const completed = trackedCliOnboardingEvents().find(
       (e) => e.event === "cli_onboarding_completed",
@@ -2238,9 +2959,8 @@ describe("runSetup additional branches", () => {
     expect(saved.mode).toBeUndefined();
   });
 
-  it("continues to the outro when the skill install reports failure", async () => {
-    // skillCompleted is false → the `if (skillCompleted)` tracking branch is
-    // skipped, but the flow still completes (MCP/docs unaffected).
+  it("does not claim setup completed when the project skill is missing", async () => {
+    const originalExitCode = process.exitCode;
     saveConfig(makeCfg());
     setupAuthed();
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
@@ -2251,8 +2971,36 @@ describe("runSetup additional branches", () => {
     await runSetup();
 
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Failed to install skill"));
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Project setup is incomplete"),
+    );
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
     const skillEvents = trackedCliOnboardingEvents().map((e) => e.event);
     expect(skillEvents).not.toContain("cli_onboarding_skill_installed");
+    expect(skillEvents).toContain("cli_onboarding_failed");
+    process.exitCode = originalExitCode;
+  });
+
+  it("does not claim setup completed when project instructions fail", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthed();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockInstallProjectInstructions.mockImplementation(() => {
+      throw new Error("instructions are read-only");
+    });
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Could not configure project instructions"),
+    );
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
   });
 
   it("neither installs nor removes a detected tool that is unconfigured and left unticked", async () => {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -3,6 +3,8 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { lstatSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
 import { installSkill, skillInstallTargetForProvider } from "../commands/skill";
@@ -17,12 +19,34 @@ import {
   updateTarget,
 } from "../config/config";
 import { logger } from "../debug/logger";
+import {
+  type ProjectFileMutationHooks,
+  type ProjectFileMutationReceipt,
+  removeProjectFile,
+  writeProjectFile,
+} from "../mcp/config-helpers";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
+import { recordProjectProxyEndpoint } from "../mcp/project-proxy";
+import { preflightProjectProxy } from "../mcp/project-proxy-preflight";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
-import { inGitWorkTree, stepUpdateAgentsMd } from "./agents-md-step";
+import { type ProviderId, resolveProjectProof } from "../migration";
+import { fetchDosuRule } from "../rules/installer";
+import { VERSION } from "../version/version";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
 import { launchAuditAgent, offerAuditHandoff } from "./audit-handoff";
-import { stepConfigureAgentRules } from "./rules-step";
+import {
+  installProjectInstructions,
+  providerUsesProjectInstructions,
+  removeProjectInstructionAdapters,
+} from "./project-instructions";
+import { assertSafeProjectPath } from "./project-path";
+import { requireProjectRoot } from "./project-root";
+import { runProjectScopeMigration } from "./project-scope-migration";
+import {
+  type ProjectPinnedTargetResolution,
+  type RequestedProjectTarget,
+  resolveProjectPinnedTarget,
+} from "./project-target";
 import { browserFallbackHint, dim, formatSetupSummary, IconRemove, info } from "./styles";
 
 export interface SetupOptions {
@@ -73,12 +97,33 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     }`,
   );
   p.intro("Dosu CLI Setup");
+  let projectRoot: string;
+  try {
+    projectRoot = requireProjectRoot();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    p.log.error(message);
+    process.exitCode = 1;
+    return;
+  }
+  let cfg = loadConfig();
+  const setupProviders = allSetupProviders();
+  const initialRequestedTarget = requestedProjectTarget(opts, cfg);
+  // First pass is read-only and happens before authentication: reject every
+  // foreign/invalid entry and repositories whose existing exact pins already
+  // disagree. Explicit retargeting gets a second, selection-aware check just
+  // before any project file can be written.
+  const projectTarget = resolveProjectPinnedTarget(setupProviders, projectRoot);
+  if (!projectTarget.ok) {
+    p.log.error(projectTargetFailureMessage(projectTarget));
+    process.exitCode = 1;
+    return;
+  }
+
   await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_launch_attempted", {
     has_deployment_option: Boolean(opts.deploymentID),
     mode_option: opts.mode,
   });
-
-  let cfg = loadConfig();
 
   applyModeOverride(cfg, opts);
 
@@ -169,12 +214,45 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     cloudSetupContext = refreshed;
   }
 
+  const detectedProviders = stepDetectTools(setupProviders);
+  let projectDeploymentResolved = false;
+  if (
+    !opts.deploymentID &&
+    opts.mode !== "oss" &&
+    (opts.mode !== "cloud" ||
+      initialRequestedTarget?.mode !== "cloud" ||
+      !initialRequestedTarget.deploymentID)
+  ) {
+    // Existing pins were inspected before authentication, including clients
+    // not installed on this machine. A Cloud request with no explicit ID may
+    // reuse the repository's one proven Cloud pin; an explicit ID was already
+    // checked for equality and is resolved by the normal explicit path below.
+    if (projectTarget.target?.oss && !opts.mode) {
+      cfg.mode = MODE_OSS;
+    } else if (projectTarget.target?.deploymentID) {
+      const ok = await resolveDeployment(apiClient, cfg, {
+        ...opts,
+        deploymentID: projectTarget.target.deploymentID,
+      });
+      if (!ok) {
+        await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+          reason: "project_deployment_unavailable",
+        });
+        return;
+      }
+      projectDeploymentResolved = true;
+    }
+  }
+
   // Deployment: run the picker only when nothing is locked in yet, or when
   // `--deployment` explicitly asks to switch. Everyday re-runs reuse the
   // stored deployment silently. (After an account change the handshake
   // dropped the old target, so the fresh account resolves here —
   // stepSelectDeployment auto-picks the single real MCP.)
-  if (!cfg.active_account?.target?.deployment_id || opts.deploymentID) {
+  if (
+    !projectDeploymentResolved &&
+    (!cfg.active_account?.target?.deployment_id || opts.deploymentID)
+  ) {
     const ok = await resolveDeployment(apiClient, cfg, opts);
     if (!ok) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
@@ -194,23 +272,40 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     return;
   }
   updateTarget(cfg, { api_key: apiKey });
+  recordProjectProxyEndpoint(cfg);
   saveConfig(cfg);
 
   // Agent selection is the only install choice. Every successfully configured
   // agent receives the full supported bundle: MCP, rules, and skill.
-  const configured = await stepConfigureMcpTools(cfg);
-  if (configured === null) {
+  const configuration = await stepConfigureMcpTools(
+    cfg,
+    projectRoot,
+    Boolean(opts.deploymentID || opts.mode),
+    detectedProviders,
+    setupProviders,
+    opts.deploymentID || opts.mode ? configuredProjectTarget(cfg) : undefined,
+  );
+  if (configuration === null) {
     await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
       reason: "mcp_selection_cancelled",
     });
     return;
   }
+  if (!configuration.ok) {
+    process.exitCode = 1;
+    await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+      reason: configuration.reason,
+    });
+    return;
+  }
+  const configured = configuration.results;
+  const runtimeVerified = configuration.runtimeVerified;
 
   const mcpConfiguredThisRun = configured.some(
-    (result) => result.action === "install" || result.action === "skip",
+    (result) => result.action === "install" && !result.error,
   );
   const configuredProviders = configured.filter(
-    (result) => (result.action === "install" || result.action === "skip") && !result.error,
+    (result) => result.action === "install" && !result.error,
   );
   const mcpCompleted = configuredProviders.length > 0;
   if (mcpCompleted) {
@@ -228,7 +323,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     .map((result) => result.provider)
     .filter((provider) => skillInstallTargetForProvider(provider.id()) !== null);
   if (skillProviders.length > 0) {
-    skillCompleted = await runInstallSkill(skillProviders);
+    skillCompleted = await runInstallSkill(skillProviders, projectRoot);
     if (skillCompleted) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_skill_installed");
     }
@@ -237,8 +332,97 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   // Project instructions are part of the bundle when setup runs inside a git
   // work tree and at least one agent was configured.
   let agentsMdCompleted = false;
-  if (mcpCompleted && inGitWorkTree()) {
-    agentsMdCompleted = await stepUpdateAgentsMd();
+  let instructionContent = "";
+  const instructionProviderIDs = configuredProviders
+    .map((result) => result.provider.id())
+    .filter(providerUsesProjectInstructions);
+  if (instructionProviderIDs.length > 0) {
+    try {
+      instructionContent = await fetchDosuRule();
+      const projectInstructions = installProjectInstructions({
+        projectRoot,
+        providerIDs: instructionProviderIDs,
+        content: instructionContent,
+      });
+      agentsMdCompleted = true;
+      p.log.success(
+        formatSetupSummary("Project instructions ready:", [
+          { path: projectInstructions.agentsMd.path },
+          ...projectInstructions.adapters.map((adapter) => ({ path: adapter.path })),
+        ]),
+      );
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("setup", `Project instruction install failed: ${message}`);
+      p.log.error(`Could not configure project instructions: ${message}`);
+    }
+  }
+
+  const projectBundleIncomplete =
+    configured.some((result) => Boolean(result.error)) ||
+    (skillProviders.length > 0 && !skillCompleted) ||
+    (instructionProviderIDs.length > 0 && !agentsMdCompleted);
+  if (projectBundleIncomplete) {
+    p.log.error(
+      "Project setup is incomplete. Legacy global configuration was preserved; fix the error above and re-run `dosu setup`.",
+    );
+    process.exitCode = 1;
+    await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+      reason: "project_bundle_incomplete",
+    });
+    return;
+  }
+
+  if (configuredProviders.length > 0) {
+    const project = resolveProjectProof(projectRoot);
+    if (!project.ok) {
+      p.log.error(
+        "Could not re-verify the Git project before legacy cleanup. Project files remain installed and global configuration was preserved.",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    const providerIDs = configuredProviders.map((result) => result.provider.id()) as ProviderId[];
+    const proxy =
+      cfg.mode === MODE_OSS
+        ? ({ packageVersion: VERSION, oss: true } as const)
+        : {
+            packageVersion: VERSION,
+            deploymentID: cfg.active_account?.target?.deployment_id as string,
+          };
+    const migration = runProjectScopeMigration({
+      project: project.proof,
+      providerIDs,
+      proxy,
+      instructionContent,
+      runtimeVerified,
+    });
+    for (const warning of migration.warnings) logger.warn("setup", warning);
+    if (!migration.ok) {
+      const cleanupProgress =
+        migration.counts.removed > 0
+          ? `${migration.counts.removed} proven global item(s) were already backed up and removed before cleanup stopped.`
+          : "No global item was removed.";
+      p.log.error(
+        `Project setup succeeded, but safe legacy cleanup could not finish (${migration.reason}). ` +
+          `${cleanupProgress} Nothing ambiguous was deleted. Recovery receipts: ${migration.receiptRoot}`,
+      );
+      process.exitCode = 1;
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+        reason: "legacy_migration_failed",
+      });
+      return;
+    }
+    if (migration.counts.removed > 0) {
+      p.log.success(
+        `Migrated ${migration.counts.removed} legacy global item(s). Recovery receipts: ${migration.receiptRoot}`,
+      );
+    }
+    if (migration.counts.preserved > 0) {
+      p.log.warn(
+        `Preserved ${migration.counts.preserved} ambiguous global item(s); nothing unproven was deleted. Receipts: ${migration.receiptRoot}`,
+      );
+    }
   }
 
   // Codebase audit handoff (cloud mode only — it acts on the user's own
@@ -298,32 +482,130 @@ function applyModeOverride(cfg: Config, opts: SetupOptions): void {
   saveConfig(cfg);
 }
 
+function requestedProjectTarget(
+  opts: SetupOptions,
+  cfg: Config,
+): RequestedProjectTarget | undefined {
+  if (opts.deploymentID) return { mode: "cloud", deploymentID: opts.deploymentID };
+  if (opts.mode === "oss") return { mode: "oss" };
+  if (opts.mode === "cloud") {
+    return {
+      mode: "cloud",
+      deploymentID: cfg.active_account?.target?.deployment_id,
+    };
+  }
+  return undefined;
+}
+
+function configuredProjectTarget(cfg: Config): RequestedProjectTarget {
+  return cfg.mode === MODE_OSS
+    ? { mode: "oss" }
+    : {
+        mode: "cloud",
+        deploymentID: cfg.active_account?.target?.deployment_id,
+      };
+}
+
+function projectTargetFailureMessage(
+  result: Extract<ProjectPinnedTargetResolution, { ok: false }>,
+): string {
+  const locations = result.paths.join(", ");
+  if (result.reason === "ambiguous_project_config") {
+    return (
+      `Cannot safely use the project's Dosu MCP config because these entries are foreign or invalid: ${locations}. ` +
+      "No project file was changed; inspect or remove those entries, then retry."
+    );
+  }
+  if (result.reason === "requested_project_target_conflict") {
+    return (
+      `The requested Dosu target conflicts with existing project clients (${result.providers.join(", ")}): ${locations}. ` +
+      "Make every listed client use the same target before retrying; no project file was changed."
+    );
+  }
+  return (
+    `This project has Dosu agent configs pointing at different MCPs (${result.providers.join(", ")}): ${locations}. ` +
+    "Make every listed client use the same target before retrying; no project file was changed."
+  );
+}
+
 /**
  * Runs MCP tool detection → selection → configuration as a single unit.
  * Returns the ConfigResult array on success, or null if the user cancelled.
  * An empty detection pool is treated as success (nothing to do).
  */
-async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null> {
-  const detected = stepDetectTools();
+async function stepConfigureMcpTools(
+  cfg: Config,
+  projectRoot: string,
+  allowProjectRetarget = false,
+  detected: SetupProvider[] = stepDetectTools(),
+  allProviders: readonly SetupProvider[] = detected,
+  requestedTarget?: RequestedProjectTarget,
+): Promise<
+  | { ok: true; results: ConfigResult[]; runtimeVerified: boolean }
+  | {
+      ok: false;
+      reason: "project_proxy_preflight_failed" | "project_target_conflict";
+    }
+  | null
+> {
   if (detected.length === 0) {
     p.log.warn(
       `No supported AI agents detected on your system.\nRun ${info("dosu mcp add <agent>")} to manually configure an agent.`,
     );
-    return [];
+    return { ok: true, results: [], runtimeVerified: false };
   }
-  const selection = await stepSelectTools(detected);
+  const selection = await stepSelectTools(detected, projectRoot);
   if (!selection) return null;
-  const results = stepConfigureTools(cfg, selection);
-  stepShowSummary(results);
-  await stepConfigureAgentRules(selection, results);
-  return results;
+  if (allowProjectRetarget && requestedTarget && selection.toInstall.length > 0) {
+    const targetCheck = resolveProjectPinnedTarget(
+      allProviders,
+      projectRoot,
+      requestedTarget,
+      selection.toInstall.map((provider) => provider.id()),
+    );
+    if (!targetCheck.ok) {
+      p.log.error(projectTargetFailureMessage(targetCheck));
+      return { ok: false, reason: "project_target_conflict" };
+    }
+  }
+  let runtimeVerified = false;
+  if (selection.toInstall.length > 0) {
+    const preflight = await preflightProjectProxy(cfg, projectRoot);
+    if (!preflight.ok) {
+      p.log.error(
+        `Could not start the project MCP (${preflight.reason}). No project files or legacy globals were changed.`,
+      );
+      return { ok: false, reason: "project_proxy_preflight_failed" };
+    }
+    runtimeVerified = true;
+  }
+  const results = stepConfigureTools(cfg, selection, projectRoot, allowProjectRetarget);
+  stepShowSummary(results, projectRoot);
+  // MCP writes/removals are one transaction. A shared-path skip (Claude while
+  // Copilot retains .mcp.json) must not trigger adapter cleanup if any later
+  // provider failed and caused the MCP batch to roll back.
+  if (results.every((result) => !result.error)) {
+    const deselectedProviders = new Set(selection.toRemove.map((provider) => provider.id()));
+    const removedProviders = results
+      .filter(
+        (result) =>
+          result.action === "remove" ||
+          (result.action === "skip" && deselectedProviders.has(result.provider.id())),
+      )
+      .map((result) => result.provider.id());
+    removeProjectInstructionAdapters(projectRoot, removedProviders);
+  }
+  return { ok: true, results, runtimeVerified };
 }
 
 /**
  * Install the skill for the same providers selected during MCP setup.
  * Returns `true` on success.
  */
-export async function runInstallSkill(providers: readonly SetupProvider[]): Promise<boolean> {
+export async function runInstallSkill(
+  providers: readonly SetupProvider[],
+  projectRoot?: string,
+): Promise<boolean> {
   logger.info("setup", "Step: install skill");
   const spinner = p.spinner();
   const agentLabel = providers.length === 1 ? "agent" : "agents";
@@ -335,12 +617,12 @@ export async function runInstallSkill(providers: readonly SetupProvider[]): Prom
     // verbose.
     const result = await installSkill(
       providers.map((provider) => provider.id()),
-      { quiet: true },
+      { quiet: true, projectRoot },
     );
     if (result.success) {
       logger.info("setup", `Skill installed${result.sha ? ` sha=${result.sha}` : ""}`);
       const items = providers.flatMap((provider) => {
-        const target = skillInstallTargetForProvider(provider.id());
+        const target = skillInstallTargetForProvider(provider.id(), projectRoot);
         if (!target) return [];
         return [
           {
@@ -759,26 +1041,42 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
   }
 }
 
-export function stepDetectTools(): SetupProvider[] {
-  return allSetupProviders().filter((p) => p.isInstalled());
+export function stepDetectTools(
+  providers: readonly SetupProvider[] = allSetupProviders(),
+): SetupProvider[] {
+  return providers.filter((provider) => provider.supportsLocal() && provider.isInstalled());
 }
 
-async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection | null> {
-  const configuredMap = new Map<string, boolean>();
+async function stepSelectTools(
+  detected: SetupProvider[],
+  projectRoot: string,
+): Promise<ToolSelection | null> {
+  const projectConfiguredMap = new Map<string, boolean>();
+  const legacyGlobalMap = new Map<string, boolean>();
   for (const p of detected) {
-    configuredMap.set(p.id(), p.isConfigured());
+    projectConfiguredMap.set(p.id(), p.isProjectConfigured(projectRoot));
+    legacyGlobalMap.set(p.id(), p.isConfigured());
   }
 
   const options = detected.map((p) => {
-    const configured = configuredMap.get(p.id()) ?? false;
+    const projectConfigured = projectConfiguredMap.get(p.id()) ?? false;
+    const legacyGlobal = legacyGlobalMap.get(p.id()) ?? false;
     return {
       label: p.name(),
       value: p.id(),
-      hint: configured ? "configured — untick to remove" : undefined,
+      hint: projectConfigured
+        ? "configured here — untick to remove the project MCP"
+        : legacyGlobal
+          ? "legacy global config — selected to migrate"
+          : undefined,
     };
   });
 
-  const preselected = detected.filter((p) => configuredMap.get(p.id())).map((p) => p.id());
+  const preselected = detected
+    .filter(
+      (provider) => projectConfiguredMap.get(provider.id()) || legacyGlobalMap.get(provider.id()),
+    )
+    .map((provider) => provider.id());
 
   const selected = await p.multiselect({
     message: "Select agents — tick to configure, untick to remove",
@@ -793,49 +1091,316 @@ async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection
 
   for (const provider of detected) {
     const isSelected = selectedSet.has(provider.id());
-    const isConfigured = configuredMap.get(provider.id()) ?? false;
+    const isProjectConfigured = projectConfiguredMap.get(provider.id()) ?? false;
 
     if (isSelected) result.toInstall.push(provider);
-    else if (isConfigured) result.toRemove.push(provider);
+    else if (isProjectConfigured) result.toRemove.push(provider);
   }
 
   return result;
 }
 
-export function stepConfigureTools(cfg: Config, selection: ToolSelection): ConfigResult[] {
-  const results: ConfigResult[] = [];
+type ProjectConfigFileState =
+  | { kind: "absent" }
+  | {
+      kind: "file";
+      content: string;
+      mode: number;
+    };
 
-  for (const provider of selection.toInstall) {
+interface ProjectConfigSnapshot {
+  before: ProjectConfigFileState;
+  /** Last exact state observed immediately after one of this batch's provider calls. */
+  output?: ProjectConfigFileState;
+  /** Actual writer preimage diverged from the batch view; whole-file rollback would lose edits. */
+  rollbackConflict?: boolean;
+}
+
+function errnoCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String(error.code)
+    : undefined;
+}
+
+/**
+ * Capture an exact project-config state without following a target symlink.
+ * Metadata checks around the byte read reject a torn preimage.
+ */
+function captureProjectConfigState(
+  projectRoot: string,
+  configPath: string,
+): ProjectConfigFileState {
+  assertSafeProjectPath(projectRoot, configPath);
+  try {
+    const before = lstatSync(configPath, { bigint: true });
+    if (!before.isFile()) throw new Error(`Project config is not a regular file: ${configPath}`);
+    const content = readFileSync(configPath, "utf8");
+    const after = lstatSync(configPath, { bigint: true });
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeNs !== after.mtimeNs
+    ) {
+      throw new Error(`Project config changed while it was being read: ${configPath}`);
+    }
+    return { kind: "file", content, mode: Number(after.mode & 0o777n) };
+  } catch (error: unknown) {
+    if (errnoCode(error) === "ENOENT") return { kind: "absent" };
+    throw error;
+  }
+}
+
+function sameProjectConfigState(
+  left: ProjectConfigFileState,
+  right: ProjectConfigFileState,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "absent" || right.kind === "absent") return true;
+  return left.mode === right.mode && left.content === right.content;
+}
+
+function rememberProjectConfigOutput(
+  snapshot: ProjectConfigSnapshot,
+  state: ProjectConfigFileState,
+): void {
+  const previous = snapshot.output ?? snapshot.before;
+  if (!sameProjectConfigState(previous, state)) snapshot.output = state;
+}
+
+function receiptState(content: string | null, mode: number | null): ProjectConfigFileState | null {
+  if (content === null) return mode === null ? { kind: "absent" } : null;
+  return mode === null ? null : { kind: "file", content, mode };
+}
+
+function receiptProvesMutation(
+  receipt: ProjectFileMutationReceipt | undefined,
+  path: string,
+  expectedBefore: ProjectConfigFileState,
+  observedAfter: ProjectConfigFileState,
+): boolean {
+  if (!receipt || resolve(receipt.path) !== path) return false;
+  const actualBefore = receiptState(receipt.beforeContent, receipt.beforeMode);
+  const actualAfter = receiptState(receipt.afterContent, receipt.afterMode);
+  return Boolean(
+    actualBefore &&
+      actualAfter &&
+      sameProjectConfigState(actualBefore, expectedBefore) &&
+      sameProjectConfigState(actualAfter, observedAfter),
+  );
+}
+
+interface ProjectConfigRollback {
+  restored: Set<string>;
+  conflicts: Set<string>;
+}
+
+function rollbackProjectConfigs(
+  projectRoot: string,
+  snapshots: ReadonlyMap<string, ProjectConfigSnapshot>,
+  changedPaths: readonly string[],
+  mutationHooks?: ProjectFileMutationHooks,
+): ProjectConfigRollback {
+  const restored = new Set<string>();
+  const conflicts = new Set<string>();
+
+  for (const path of [...changedPaths].reverse()) {
+    const snapshot = snapshots.get(path);
+    if (!snapshot?.output) continue;
+    if (snapshot.rollbackConflict) {
+      conflicts.add(path);
+      p.log.warn(`Kept ${path} because it changed inside a provider operation.`);
+      continue;
+    }
     try {
-      provider.install(cfg, true);
-      logger.info("setup", `Configured ${provider.name()}`);
-      results.push({ provider, action: "install" });
-    } catch (err: unknown) {
-      /* v8 ignore next -- err is always Error in practice */
-      const error = err instanceof Error ? err : new Error(String(err));
-      logger.error(
-        "setup",
-        `Config failed for ${provider.name()}: ${error.stack ?? error.message}`,
-      );
-      p.log.error(`Failed to configure ${provider.name()}: ${error.message}`);
-      results.push({ provider, action: "install", error });
+      const current = captureProjectConfigState(projectRoot, path);
+      if (!sameProjectConfigState(current, snapshot.output)) {
+        conflicts.add(path);
+        p.log.warn(`Kept ${path} because it changed while setup was rolling back.`);
+        continue;
+      }
+
+      if (snapshot.before.kind === "absent") {
+        if (current.kind === "file") removeProjectFile(path, current.content, mutationHooks);
+      } else {
+        writeProjectFile(
+          path,
+          snapshot.before.content,
+          current.kind === "file" ? current.content : null,
+          mutationHooks,
+        );
+      }
+      restored.add(path);
+    } catch (error: unknown) {
+      conflicts.add(path);
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error("setup", `Could not safely roll back ${path}: ${message}`);
+      p.log.warn(`Could not safely roll back ${path}: ${message}`);
     }
   }
 
+  return { restored, conflicts };
+}
+
+function configOperationError(provider: SetupProvider, action: "install" | "remove", error: Error) {
+  const verb = action === "install" ? "configure" : "remove";
+  logger.error(
+    "setup",
+    `${action === "install" ? "Config" : "Remove"} failed for ${provider.name()}: ${error.stack ?? error.message}`,
+  );
+  p.log.error(`Failed to ${verb} ${provider.name()}: ${error.message}`);
+}
+
+export function stepConfigureTools(
+  cfg: Config,
+  selection: ToolSelection,
+  projectRoot: string,
+  allowProjectRetarget = false,
+  rollbackHooks?: ProjectFileMutationHooks,
+): ConfigResult[] {
+  const results: ConfigResult[] = [];
+
+  type ProjectConfigOperation = {
+    provider: SetupProvider;
+    action: "install" | "remove" | "skip";
+    path: string | null;
+  };
+
+  const operations: ProjectConfigOperation[] = [];
+  const addOperation = (provider: SetupProvider, action: "install" | "remove"): boolean => {
+    try {
+      const path = provider.projectConfigPath(projectRoot);
+      operations.push({ provider, action, path: path ? resolve(path) : null });
+      return true;
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      configOperationError(provider, action, error);
+      results.push({ provider, action, error });
+      return false;
+    }
+  };
+
+  for (const provider of selection.toInstall) {
+    if (!addOperation(provider, "install")) return results;
+  }
+  const installedPaths = new Set(
+    operations.map((operation) => operation.path).filter((path): path is string => path !== null),
+  );
   for (const provider of selection.toRemove) {
     try {
-      provider.remove(true);
-      logger.info("setup", `Removed ${provider.name()}`);
-      results.push({ provider, action: "remove" });
+      const path = provider.projectConfigPath(projectRoot);
+      const normalizedPath = path ? resolve(path) : null;
+      if (normalizedPath && installedPaths.has(normalizedPath)) {
+        operations.push({ provider, action: "skip", path: normalizedPath });
+      } else {
+        operations.push({ provider, action: "remove", path: normalizedPath });
+      }
     } catch (err: unknown) {
-      /* v8 ignore next -- err is always Error in practice */
       const error = err instanceof Error ? err : new Error(String(err));
-      logger.error(
-        "setup",
-        `Remove failed for ${provider.name()}: ${error.stack ?? error.message}`,
-      );
-      p.log.error(`Failed to remove ${provider.name()}: ${error.message}`);
+      configOperationError(provider, "remove", error);
       results.push({ provider, action: "remove", error });
+      return results;
+    }
+  }
+
+  // Capture every unique project config before the first provider can write.
+  // Claude and Copilot intentionally share .mcp.json, so path-keying is part
+  // of the transaction contract rather than an optimization.
+  const snapshots = new Map<string, ProjectConfigSnapshot>();
+  for (const operation of operations) {
+    if (operation.action === "skip" || !operation.path || snapshots.has(operation.path)) continue;
+    try {
+      snapshots.set(operation.path, {
+        before: captureProjectConfigState(projectRoot, operation.path),
+      });
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      configOperationError(operation.provider, operation.action, error);
+      results.push({ provider: operation.provider, action: operation.action, error });
+      return results;
+    }
+  }
+
+  const changedPaths: string[] = [];
+  let failedProvider: SetupProvider | null = null;
+
+  for (const operation of operations) {
+    if (operation.action === "skip") {
+      results.push({ provider: operation.provider, action: "skip" });
+      continue;
+    }
+    let providerCompleted = false;
+    try {
+      let expectedBefore: ProjectConfigFileState | undefined;
+      if (operation.path) {
+        const snapshot = snapshots.get(operation.path);
+        if (snapshot) {
+          const current = captureProjectConfigState(projectRoot, operation.path);
+          const expected = snapshot.output ?? snapshot.before;
+          if (!sameProjectConfigState(current, expected)) {
+            throw new Error(
+              `Project config changed after setup started; refusing to overwrite ${operation.path}`,
+            );
+          }
+          expectedBefore = expected;
+        }
+      }
+      let receipt: ProjectFileMutationReceipt | undefined;
+      if (operation.action === "install") {
+        receipt = operation.provider.install(cfg, false, { projectRoot, allowProjectRetarget });
+        logger.info("setup", `Configured ${operation.provider.name()}`);
+      } else {
+        receipt = operation.provider.remove(false, { projectRoot });
+        logger.info("setup", `Removed ${operation.provider.name()}`);
+      }
+      providerCompleted = true;
+      if (operation.path) {
+        const snapshot = snapshots.get(operation.path);
+        if (snapshot) {
+          const observedAfter = captureProjectConfigState(projectRoot, operation.path);
+          const previousOutput = snapshot.output;
+          rememberProjectConfigOutput(snapshot, observedAfter);
+          if (!previousOutput && snapshot.output) changedPaths.push(operation.path);
+          if (
+            snapshot.output &&
+            expectedBefore &&
+            !receiptProvesMutation(receipt, operation.path, expectedBefore, observedAfter)
+          ) {
+            snapshot.rollbackConflict = true;
+          }
+        }
+      }
+      results.push({ provider: operation.provider, action: operation.action });
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      failedProvider = operation.provider;
+      configOperationError(operation.provider, operation.action, error);
+      results.push({ provider: operation.provider, action: operation.action, error });
+      if (providerCompleted && operation.path) {
+        p.log.warn(
+          `Could not prove the completed output at ${operation.path}; preserving it for safety.`,
+        );
+      }
+      break;
+    }
+  }
+
+  if (failedProvider) {
+    const rollback = rollbackProjectConfigs(projectRoot, snapshots, changedPaths, rollbackHooks);
+    for (const result of results) {
+      if (result.error || result.action === "skip") continue;
+      const path = result.provider.projectConfigPath(projectRoot);
+      const normalizedPath = path ? resolve(path) : null;
+      const rollbackStatus = normalizedPath
+        ? rollback.restored.has(normalizedPath)
+          ? "rolled back"
+          : rollback.conflicts.has(normalizedPath)
+            ? "not rolled back because the project file changed concurrently"
+            : "cancelled"
+        : "cancelled";
+      result.error = new Error(
+        `${result.provider.name()} was ${rollbackStatus} after ${failedProvider.name()} failed`,
+      );
     }
   }
 
@@ -846,7 +1411,10 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
   return results;
 }
 
-export function stepShowSummary(results: ConfigResult[]): void {
+export function stepShowSummary(
+  results: ConfigResult[],
+  projectRoot: string = process.cwd(),
+): void {
   const installed = results.filter((r) => r.action === "install" && !r.error);
   const removed = results.filter((r) => r.action === "remove" && !r.error);
   const skipped = results.filter((r) => r.action === "skip");
@@ -857,7 +1425,7 @@ export function stepShowSummary(results: ConfigResult[]): void {
         `Configured ${installed.length} agent(s):`,
         installed.map((result) => ({
           label: result.provider.name(),
-          path: result.provider.globalConfigPath(),
+          path: result.provider.projectConfigPath(projectRoot) ?? "unsupported",
         })),
       ),
     );
@@ -869,7 +1437,7 @@ export function stepShowSummary(results: ConfigResult[]): void {
         `Removed from ${removed.length} agent(s):`,
         removed.map((result) => ({
           label: result.provider.name(),
-          path: result.provider.globalConfigPath(),
+          path: result.provider.projectConfigPath(projectRoot) ?? "unsupported",
         })),
         IconRemove,
       ),

--- a/src/setup/project-instructions.test.ts
+++ b/src/setup/project-instructions.test.ts
@@ -1,0 +1,231 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DOSU_SECTION_START } from "./agents-md-step";
+import {
+  installProjectInstructions,
+  PROJECT_ADAPTER_END,
+  PROJECT_ADAPTER_START,
+  removeProjectInstructionAdapters,
+  verifyProjectInstructions,
+} from "./project-instructions";
+
+let projectRoot: string;
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "dosu-project-instructions-"));
+});
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe("installProjectInstructions", () => {
+  it("keeps one canonical rule in AGENTS.md and adds only thin provider adapters", () => {
+    const result = installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude", "codex", "gemini", "cursor"],
+      content: "Always consult Dosu.",
+    });
+
+    expect(readFileSync(join(projectRoot, "AGENTS.md"), "utf8")).toContain(DOSU_SECTION_START);
+    expect(readFileSync(join(projectRoot, "AGENTS.md"), "utf8")).toContain("Always consult Dosu.");
+    expect(readFileSync(join(projectRoot, "CLAUDE.md"), "utf8")).toContain("@AGENTS.md");
+    expect(readFileSync(join(projectRoot, "GEMINI.md"), "utf8")).toContain("@AGENTS.md");
+    expect(result.adapters.map((adapter) => adapter.provider)).toEqual(["claude", "gemini"]);
+    expect(existsSync(join(projectRoot, ".codex", "AGENTS.md"))).toBe(false);
+    expect(existsSync(join(projectRoot, ".cursor", "rules", "dosu.mdc"))).toBe(false);
+  });
+
+  it("writes Antigravity's official project rule adapter", () => {
+    installProjectInstructions({
+      projectRoot,
+      providerIDs: ["antigravity"],
+      content: "Use Dosu knowledge.",
+    });
+
+    const rule = readFileSync(join(projectRoot, ".agents", "rules", "dosu.md"), "utf8");
+    expect(rule).toContain(PROJECT_ADAPTER_START);
+    expect(rule).toContain("Use Dosu knowledge.");
+  });
+
+  it("preserves user content and updates its marker block idempotently", () => {
+    writeFileSync(join(projectRoot, "CLAUDE.md"), "# User instructions\n");
+
+    installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude"],
+      content: "first",
+    });
+    const second = installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude"],
+      content: "second",
+    });
+
+    const content = readFileSync(join(projectRoot, "CLAUDE.md"), "utf8");
+    expect(content).toContain("# User instructions");
+    expect(content.match(new RegExp(PROJECT_ADAPTER_START, "g"))).toHaveLength(1);
+    expect(content).toContain("@AGENTS.md");
+    expect(second.adapters[0]?.action).toBe("unchanged");
+  });
+
+  it("keeps a CLAUDE.md symlink to AGENTS.md instead of replacing it", () => {
+    writeFileSync(join(projectRoot, "AGENTS.md"), "# Team instructions\n");
+    symlinkSync("AGENTS.md", join(projectRoot, "CLAUDE.md"));
+
+    installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude"],
+      content: "Use Dosu knowledge.",
+    });
+
+    expect(lstatSync(join(projectRoot, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+    expect(verifyProjectInstructions(projectRoot, ["claude"])).toBe(true);
+  });
+
+  it("refuses to follow a foreign project-instruction symlink", () => {
+    const outside = join(projectRoot, "outside.md");
+    writeFileSync(outside, "# Do not edit\n");
+    symlinkSync("outside.md", join(projectRoot, "CLAUDE.md"));
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["claude"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).toThrow(/symbolic link/i);
+    expect(readFileSync(outside, "utf8")).toBe("# Do not edit\n");
+  });
+
+  it("does not follow a predictable adapter temporary-file symlink", () => {
+    const victim = join(projectRoot, "user-data.md");
+    const adapter = join(projectRoot, "CLAUDE.md");
+    writeFileSync(victim, "USER DATA\n");
+    symlinkSync("user-data.md", `${adapter}.${process.pid}.tmp`);
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["claude"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).not.toThrow();
+
+    expect(readFileSync(victim, "utf8")).toBe("USER DATA\n");
+    expect(lstatSync(adapter).isFile()).toBe(true);
+  });
+
+  it("refuses a canonical AGENTS.md symlink that could escape the repository", () => {
+    const outside = join(projectRoot, "outside-agents.md");
+    writeFileSync(outside, "# Do not edit\n");
+    symlinkSync("outside-agents.md", join(projectRoot, "AGENTS.md"));
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["codex"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).toThrow(/symbolic link/i);
+    expect(readFileSync(outside, "utf8")).toBe("# Do not edit\n");
+  });
+
+  it("refuses a symlinked adapter parent directory", () => {
+    const outside = join(projectRoot, "outside-agents-dir");
+    mkdirSync(outside);
+    symlinkSync("outside-agents-dir", join(projectRoot, ".agents"));
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["antigravity"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).toThrow(/symbolic link/i);
+    expect(existsSync(join(outside, "rules", "dosu.md"))).toBe(false);
+  });
+
+  it("refuses an incomplete adapter marker without changing the file", () => {
+    const path = join(projectRoot, "GEMINI.md");
+    const original = `${PROJECT_ADAPTER_START}\n@AGENTS.md\n`;
+    writeFileSync(path, original);
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["gemini"],
+        content: "rule",
+      }),
+    ).toThrow(/markers are incomplete/i);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it("refuses duplicate canonical AGENTS.md marker blocks", () => {
+    writeFileSync(
+      join(projectRoot, "AGENTS.md"),
+      `${DOSU_SECTION_START}\none\n<!-- dosu:mcp:end -->\n${DOSU_SECTION_START}\ntwo\n<!-- dosu:mcp:end -->\n`,
+    );
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["codex"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).toThrow(/multiple/i);
+  });
+});
+
+describe("verifyProjectInstructions", () => {
+  it("requires both the canonical section and each required adapter", () => {
+    installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude", "gemini", "codex"],
+      content: "rule",
+    });
+    expect(verifyProjectInstructions(projectRoot, ["claude", "gemini", "codex"])).toBe(true);
+
+    rmSync(join(projectRoot, "CLAUDE.md"));
+    expect(verifyProjectInstructions(projectRoot, ["claude", "gemini", "codex"])).toBe(false);
+  });
+});
+
+describe("removeProjectInstructionAdapters", () => {
+  it("removes only Dosu's adapter block and leaves user content", () => {
+    writeFileSync(join(projectRoot, "CLAUDE.md"), "# User instructions\n");
+    installProjectInstructions({ projectRoot, providerIDs: ["claude"], content: "rule" });
+
+    removeProjectInstructionAdapters(projectRoot, ["claude"]);
+
+    const content = readFileSync(join(projectRoot, "CLAUDE.md"), "utf8");
+    expect(content).toContain("# User instructions");
+    expect(content).not.toContain(PROJECT_ADAPTER_START);
+    expect(content).not.toContain(PROJECT_ADAPTER_END);
+  });
+
+  it("removes only the marker bytes and preserves all surrounding whitespace", () => {
+    const path = join(projectRoot, "CLAUDE.md");
+    const before = "  user prefix\n\n\n\n";
+    const after = "\n\n\nuser suffix  \n";
+    writeFileSync(
+      path,
+      `${before}${PROJECT_ADAPTER_START}\n@AGENTS.md\n${PROJECT_ADAPTER_END}${after}`,
+    );
+
+    removeProjectInstructionAdapters(projectRoot, ["claude"]);
+
+    expect(readFileSync(path, "utf8")).toBe(`${before}${after}`);
+  });
+});

--- a/src/setup/project-instructions.ts
+++ b/src/setup/project-instructions.ts
@@ -1,0 +1,238 @@
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { removeProjectFile, writeProjectFile } from "../mcp/config-helpers";
+import { DOSU_SECTION_END, upsertDosuAgentsSection } from "./agents-md-step";
+import { assertSafeProjectPath } from "./project-path";
+
+export const PROJECT_ADAPTER_START = "<!-- dosu:project-instructions:start v1 -->";
+export const PROJECT_ADAPTER_END = "<!-- dosu:project-instructions:end -->";
+
+const DOSU_SECTION_START_RE = /<!-- dosu:mcp:start(?: v\d+)? -->/;
+
+export type ProjectInstructionAction =
+  | "created"
+  | "updated"
+  | "unchanged"
+  | "removed"
+  | "not_found";
+
+export interface ProjectInstructionAdapterResult {
+  provider: string;
+  path: string;
+  action: ProjectInstructionAction;
+}
+
+export interface ProjectInstructionsResult {
+  agentsMd: ReturnType<typeof upsertDosuAgentsSection>;
+  adapters: ProjectInstructionAdapterResult[];
+}
+
+export function providerUsesProjectInstructions(providerID: string): boolean {
+  return providerID !== "mcporter";
+}
+
+interface ProjectAdapter {
+  provider: "claude" | "gemini" | "antigravity";
+  path(projectRoot: string): string;
+  body(content: string): string;
+}
+
+const PROJECT_ADAPTERS: readonly ProjectAdapter[] = [
+  {
+    provider: "claude",
+    path: (root) => join(root, "CLAUDE.md"),
+    body: () => "@AGENTS.md",
+  },
+  {
+    provider: "gemini",
+    path: (root) => join(root, "GEMINI.md"),
+    body: () => "@AGENTS.md",
+  },
+  {
+    provider: "antigravity",
+    path: (root) => join(root, ".agents", "rules", "dosu.md"),
+    body: (content) => content.trim(),
+  },
+];
+
+function atomicProjectWrite(path: string, content: string, expectedContent: string | null): void {
+  writeProjectFile(path, content, expectedContent);
+}
+
+function block(body: string, eol: "\n" | "\r\n"): string {
+  return `${PROJECT_ADAPTER_START}${eol}${body.trim().replace(/\r?\n/g, eol)}${eol}${PROJECT_ADAPTER_END}`;
+}
+
+function locateAdapter(content: string): { start: number; end: number } | null {
+  const start = content.indexOf(PROJECT_ADAPTER_START);
+  const end = content.indexOf(PROJECT_ADAPTER_END);
+  if (start === -1 && end === -1) return null;
+  if (start === -1 || end < start) {
+    throw new Error("Dosu project instruction markers are incomplete; refusing to modify the file");
+  }
+  if (
+    content.indexOf(PROJECT_ADAPTER_START, start + PROJECT_ADAPTER_START.length) !== -1 ||
+    content.indexOf(PROJECT_ADAPTER_END, end + PROJECT_ADAPTER_END.length) !== -1
+  ) {
+    throw new Error(
+      "Multiple Dosu project instruction marker blocks found; refusing to modify the file",
+    );
+  }
+  return { start, end: end + PROJECT_ADAPTER_END.length };
+}
+
+function pointsToCanonicalAgents(path: string, projectRoot: string): boolean {
+  try {
+    return (
+      lstatSync(path).isSymbolicLink() &&
+      realpathSync(path) === realpathSync(join(projectRoot, "AGENTS.md"))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function upsertAdapter(
+  path: string,
+  body: string,
+  projectRoot: string,
+  allowAgentsSymlink: boolean,
+): ProjectInstructionAction {
+  if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+    if (allowAgentsSymlink && pointsToCanonicalAgents(path, projectRoot)) return "unchanged";
+    throw new Error(`Refusing to modify symbolic link at ${path}`);
+  }
+  const existed = existsSync(path);
+  const existing = existed ? readFileSync(path, "utf8") : "";
+  const eol = existing.includes("\r\n") ? "\r\n" : "\n";
+  const nextBlock = block(body, eol);
+  const location = locateAdapter(existing);
+  let next: string;
+  if (location) {
+    next = `${existing.slice(0, location.start)}${nextBlock}${existing.slice(location.end)}`;
+  } else if (existing) {
+    next = `${existing.trimEnd()}${eol}${eol}${nextBlock}${eol}`;
+  } else {
+    next = `${nextBlock}${eol}`;
+  }
+  if (next === existing) return "unchanged";
+  atomicProjectWrite(path, next, existed ? existing : null);
+  return existing ? "updated" : "created";
+}
+
+function adapterFor(provider: string): ProjectAdapter | undefined {
+  return PROJECT_ADAPTERS.find((adapter) => adapter.provider === provider);
+}
+
+export function installProjectInstructions(input: {
+  projectRoot: string;
+  providerIDs: readonly string[];
+  content: string;
+}): ProjectInstructionsResult {
+  const agentsPath = join(input.projectRoot, "AGENTS.md");
+  assertSafeProjectPath(input.projectRoot, agentsPath);
+  if (existsSync(agentsPath) && lstatSync(agentsPath).isSymbolicLink()) {
+    throw new Error(`Refusing to modify symbolic link at ${agentsPath}`);
+  }
+  const plannedAdapters = [...new Set(input.providerIDs)].flatMap((provider) => {
+    const adapter = adapterFor(provider);
+    if (!adapter) return [];
+    const path = adapter.path(input.projectRoot);
+    const allowAgentsSymlink = adapter.provider === "claude" || adapter.provider === "gemini";
+    if (allowAgentsSymlink && existsSync(path) && lstatSync(path).isSymbolicLink()) {
+      assertSafeProjectPath(input.projectRoot, dirname(path));
+    } else {
+      assertSafeProjectPath(input.projectRoot, path);
+    }
+    return [{ provider, adapter, path }];
+  });
+  const agentsMd = upsertDosuAgentsSection(input.projectRoot, input.content);
+  const adapters: ProjectInstructionAdapterResult[] = [];
+  for (const { provider, adapter, path } of plannedAdapters) {
+    adapters.push({
+      provider,
+      path,
+      action: upsertAdapter(
+        path,
+        adapter.body(input.content),
+        input.projectRoot,
+        adapter.provider === "claude" || adapter.provider === "gemini",
+      ),
+    });
+  }
+  return { agentsMd, adapters };
+}
+
+function hasCompleteAgentsSection(path: string): boolean {
+  if (!existsSync(path)) return false;
+  const content = readFileSync(path, "utf8");
+  const start = content.search(DOSU_SECTION_START_RE);
+  const end = content.indexOf(DOSU_SECTION_END, Math.max(start, 0));
+  return start >= 0 && end > start;
+}
+
+function hasCompleteAdapter(
+  path: string,
+  projectRoot: string,
+  allowAgentsSymlink: boolean,
+): boolean {
+  if (!existsSync(path)) return false;
+  if (lstatSync(path).isSymbolicLink()) {
+    return allowAgentsSymlink && pointsToCanonicalAgents(path, projectRoot);
+  }
+  try {
+    return locateAdapter(readFileSync(path, "utf8")) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function verifyProjectInstructions(
+  projectRoot: string,
+  providerIDs: readonly string[],
+): boolean {
+  if (!hasCompleteAgentsSection(join(projectRoot, "AGENTS.md"))) return false;
+  return [...new Set(providerIDs)].every((provider) => {
+    const adapter = adapterFor(provider);
+    return (
+      !adapter ||
+      hasCompleteAdapter(
+        adapter.path(projectRoot),
+        projectRoot,
+        adapter.provider === "claude" || adapter.provider === "gemini",
+      )
+    );
+  });
+}
+
+function removeAdapter(path: string): ProjectInstructionAction {
+  if (!existsSync(path)) return "not_found";
+  if (lstatSync(path).isSymbolicLink()) return "not_found";
+  const existing = readFileSync(path, "utf8");
+  const location = locateAdapter(existing);
+  if (!location) return "not_found";
+  const before = existing.slice(0, location.start);
+  const after = existing.slice(location.end);
+  const next = `${before}${after}`;
+  const eol = existing.includes("\r\n") ? "\r\n" : "\n";
+  if (before === "" && after === eol) removeProjectFile(path, existing);
+  else atomicProjectWrite(path, next, existing);
+  return "removed";
+}
+
+export function removeProjectInstructionAdapters(
+  projectRoot: string,
+  providerIDs: readonly string[],
+): ProjectInstructionAdapterResult[] {
+  return [...new Set(providerIDs)].flatMap((provider) => {
+    const adapter = adapterFor(provider);
+    if (!adapter) return [];
+    const path = adapter.path(projectRoot);
+    if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+      assertSafeProjectPath(projectRoot, dirname(path));
+    } else {
+      assertSafeProjectPath(projectRoot, path);
+    }
+    return [{ provider, path, action: removeAdapter(path) }];
+  });
+}

--- a/src/setup/project-path.test.ts
+++ b/src/setup/project-path.test.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { assertSafeProjectPath } from "./project-path";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "dosu-safe-project-path-"));
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+describe("assertSafeProjectPath", () => {
+  it("accepts existing and not-yet-created paths under the project", () => {
+    mkdirSync(join(root, ".cursor"));
+    writeFileSync(join(root, ".cursor", "mcp.json"), "{}");
+
+    expect(() => assertSafeProjectPath(root, join(root, ".cursor", "mcp.json"))).not.toThrow();
+    expect(() => assertSafeProjectPath(root, join(root, ".codex", "config.toml"))).not.toThrow();
+  });
+
+  it("rejects a lexical escape and a symlinked parent directory", () => {
+    const outside = mkdtempSync(join(tmpdir(), "dosu-safe-project-outside-"));
+    try {
+      symlinkSync(outside, join(root, ".cursor"));
+      expect(() => assertSafeProjectPath(root, join(root, "..", "outside.json"))).toThrow(
+        /escapes/i,
+      );
+      expect(() => assertSafeProjectPath(root, join(root, ".cursor", "mcp.json"))).toThrow(
+        /symbolic link/i,
+      );
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects dangling target and parent symlinks without creating their outside targets", () => {
+    const outsideFile = join(root, "..", `outside-${process.pid}.json`);
+    const outsideDirectory = join(root, "..", `outside-dir-${process.pid}`);
+    symlinkSync(outsideFile, join(root, "AGENTS.md"));
+    symlinkSync(outsideDirectory, join(root, ".cursor"));
+
+    expect(() => assertSafeProjectPath(root, join(root, "AGENTS.md"))).toThrow(/symbolic link/i);
+    expect(() => assertSafeProjectPath(root, join(root, ".cursor", "mcp.json"))).toThrow(
+      /symbolic link/i,
+    );
+  });
+});

--- a/src/setup/project-path.ts
+++ b/src/setup/project-path.ts
@@ -1,0 +1,45 @@
+import { existsSync, lstatSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel));
+}
+
+function entryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** Refuse project writes that escape through `..` or an existing symlink component. */
+export function assertSafeProjectPath(projectRoot: string, targetPath: string): void {
+  const root = resolve(projectRoot);
+  const target = resolve(targetPath);
+  if (!isInside(root, target)) {
+    throw new Error(`Project path escapes the repository: ${targetPath}`);
+  }
+  if (!existsSync(root) || !statSync(root).isDirectory()) {
+    throw new Error(`Project root is not a directory: ${projectRoot}`);
+  }
+
+  const canonicalRoot = realpathSync(root);
+  const rel = relative(root, target);
+  let current = root;
+  for (const segment of rel.split(sep).filter(Boolean)) {
+    current = resolve(current, segment);
+    if (!entryExists(current)) continue;
+    if (lstatSync(current).isSymbolicLink()) {
+      throw new Error(`Refusing to write through symbolic link at ${current}`);
+    }
+    if (!isInside(canonicalRoot, realpathSync(current))) {
+      throw new Error(`Project path resolves outside the repository: ${current}`);
+    }
+  }
+}

--- a/src/setup/project-root.test.ts
+++ b/src/setup/project-root.test.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { requireProjectRoot, resolveProjectRoot } from "./project-root";
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = realpathSync(mkdtempSync(join(tmpdir(), "dosu-project-root-")));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("resolveProjectRoot", () => {
+  it("returns the worktree root when invoked from a nested directory", () => {
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+    const nested = join(tempDir, "packages", "api");
+    mkdirSync(nested, { recursive: true });
+
+    expect(resolveProjectRoot(nested)).toBe(tempDir);
+  });
+
+  it("returns null outside a Git worktree", () => {
+    expect(resolveProjectRoot(tempDir)).toBeNull();
+  });
+
+  it("returns null for a bare repository", () => {
+    execFileSync("git", ["init", "--bare"], { cwd: tempDir, stdio: "ignore" });
+    expect(resolveProjectRoot(tempDir)).toBeNull();
+  });
+});
+
+describe("requireProjectRoot", () => {
+  it("explains that project-scoped setup must run inside a Git worktree", () => {
+    expect(() => requireProjectRoot(tempDir)).toThrow(/inside a Git worktree/i);
+  });
+});

--- a/src/setup/project-root.ts
+++ b/src/setup/project-root.ts
@@ -1,0 +1,34 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+/** Resolve the Git worktree root that owns `cwd`; bare and non-Git directories return null. */
+export function resolveProjectRoot(cwd: string = process.cwd()): string | null {
+  try {
+    const inside = execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+    if (inside !== "true") return null;
+
+    const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+    return root ? resolve(root) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Project-scoped commands must never fall back to writing in an arbitrary cwd. */
+export function requireProjectRoot(cwd: string = process.cwd()): string {
+  const root = resolveProjectRoot(cwd);
+  if (!root) {
+    throw new Error(
+      "Project-scoped setup must run inside a Git worktree. Change to the project and retry.",
+    );
+  }
+  return root;
+}

--- a/src/setup/project-scope-migration.test.ts
+++ b/src/setup/project-scope-migration.test.ts
@@ -1,0 +1,557 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type ProjectProof, type ProviderId, proveProjectScope } from "../migration";
+import {
+  finalizeGlobalMcpIntent,
+  globalMcpIntentMarkerPath,
+  prepareGlobalMcpIntent,
+  releaseGlobalMcpIntent,
+} from "../migration/global-intent";
+import {
+  inspectProjectScopeMigration,
+  type ProjectScopeMigrationInput,
+  runProjectScopeMigration,
+} from "./project-scope-migration";
+
+const INSTRUCTIONS = "Use Dosu.";
+const SKILL = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+const RELEASED_RULE = readFileSync(join(process.cwd(), "rules", "dosu.md"), "utf8");
+const PROXY_ARGS = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"];
+
+let tempDir: string;
+let homeDir: string;
+let projectRoot: string;
+let backupRoot: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-project-scope-runner-"));
+  homeDir = join(tempDir, "home");
+  projectRoot = join(tempDir, "project");
+  backupRoot = join(tempDir, "config", "migrations", "project-scope-v1");
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(projectRoot, { recursive: true });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function projectProof(): ProjectProof {
+  const result = proveProjectScope({
+    cwd: projectRoot,
+    gitTopLevel: projectRoot,
+    insideWorkTree: true,
+    bareRepository: false,
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.proof;
+}
+
+function writeProjectSkill(path: string): void {
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, "SKILL.md"), SKILL);
+  const computedHash = createHash("sha256").update("SKILL.md").update(SKILL).digest("hex");
+  writeFileSync(
+    join(projectRoot, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+function writeProjectBundle(provider: "claude" | "gemini" | "antigravity" | "factory"): void {
+  const proxy = { command: "npx", args: PROXY_ARGS };
+  writeFileSync(
+    join(projectRoot, "AGENTS.md"),
+    `<!-- dosu:mcp:start v2 -->\n${INSTRUCTIONS}\n<!-- dosu:mcp:end -->\n`,
+  );
+
+  if (provider === "claude") {
+    writeFileSync(
+      join(projectRoot, ".mcp.json"),
+      JSON.stringify({ mcpServers: { dosu: { type: "stdio", ...proxy } } }),
+    );
+    writeFileSync(
+      join(projectRoot, "CLAUDE.md"),
+      "<!-- dosu:project-instructions:start v1 -->\n@AGENTS.md\n<!-- dosu:project-instructions:end -->\n",
+    );
+    writeProjectSkill(join(projectRoot, ".claude", "skills", "dosu"));
+    return;
+  }
+
+  if (provider === "gemini") {
+    mkdirSync(join(projectRoot, ".gemini"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".gemini", "settings.json"),
+      JSON.stringify({ mcpServers: { dosu: proxy } }),
+    );
+    writeFileSync(
+      join(projectRoot, "GEMINI.md"),
+      "<!-- dosu:project-instructions:start v1 -->\n@AGENTS.md\n<!-- dosu:project-instructions:end -->\n",
+    );
+  } else if (provider === "antigravity") {
+    mkdirSync(join(projectRoot, ".agents", "rules"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".agents", "mcp_config.json"),
+      JSON.stringify({ mcpServers: { dosu: proxy } }),
+    );
+    writeFileSync(
+      join(projectRoot, ".agents", "rules", "dosu.md"),
+      `<!-- dosu:project-instructions:start v1 -->\n${INSTRUCTIONS}\n<!-- dosu:project-instructions:end -->\n`,
+    );
+  } else {
+    mkdirSync(join(projectRoot, ".factory"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".factory", "mcp.json"),
+      JSON.stringify({ mcpServers: { dosu: { type: "stdio", ...proxy } } }),
+    );
+    writeProjectSkill(join(projectRoot, ".factory", "skills", "dosu"));
+    return;
+  }
+  writeProjectSkill(join(projectRoot, ".agents", "skills", "dosu"));
+}
+
+function input(
+  provider: "claude" | "gemini" | "antigravity" | "factory" = "claude",
+): ProjectScopeMigrationInput {
+  writeProjectBundle(provider);
+  return {
+    project: projectProof(),
+    providerIDs: [provider],
+    proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+    instructionContent: INSTRUCTIONS,
+    environment: { platform: "linux", homeDir, env: {} },
+    backupRoot,
+    globalIntentRoot: join(tempDir, "config", "migrations", "global-mcp-intent-v1"),
+  };
+}
+
+function writeOwnedGlobalMcp(provider: ProviderId, path: string): string {
+  const secret = "global-secret-must-never-appear-in-summary";
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep-old",
+          headers: { "X-Dosu-API-Key": secret },
+        },
+        user: { url: `https://example.com/${provider}` },
+      },
+    }),
+  );
+  return secret;
+}
+
+describe("project-scope migration runner", () => {
+  it("creates durable not-found tombstones for a new user and is idempotent", () => {
+    const migration = input();
+    const inspection = inspectProjectScopeMigration(migration);
+    expect(inspection).toMatchObject({ ok: true, needsRuntimeVerification: false });
+    expect(existsSync(backupRoot)).toBe(false);
+
+    const first = runProjectScopeMigration({ ...migration, runtimeVerified: false });
+    expect(first).toMatchObject({
+      ok: true,
+      cleanupAttempted: true,
+      counts: { removed: 0, not_found: 2, preserved: 0, failed: 0, total: 2 },
+    });
+    expect(existsSync(backupRoot)).toBe(true);
+
+    const second = runProjectScopeMigration({ ...migration, runtimeVerified: false });
+    expect(second).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 2, preserved: 0, failed: 0, total: 2 },
+    });
+  });
+
+  it("keeps an exact legacy target when runtime was not verified", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+    const before = readFileSync(globalPath, "utf8");
+
+    expect(inspectProjectScopeMigration(migration)).toMatchObject({
+      ok: true,
+      needsRuntimeVerification: true,
+    });
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: false });
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 1, preserved: 1, failed: 0, total: 2 },
+    });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("removes a markerless v0.43 legacy global entry after runtime verification", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 1, not_found: 1, preserved: 0, failed: 0, total: 2 },
+      receiptRoot: backupRoot,
+    });
+    const remaining = readFileSync(globalPath, "utf8");
+    expect(remaining).toContain("https://example.com/claude");
+    expect(remaining).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain(secret);
+
+    const second = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(second).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 2, preserved: 0, failed: 0, total: 2 },
+    });
+  });
+
+  it("preserves the first explicit global opt-in on later project setup", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const pending = prepareGlobalMcpIntent({
+      provider: "claude",
+      targetPath: globalPath,
+      intentRoot: migration.globalIntentRoot,
+    });
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+    finalizeGlobalMcpIntent(pending);
+
+    expect(inspectProjectScopeMigration(migration)).toMatchObject({
+      ok: true,
+      needsRuntimeVerification: false,
+    });
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({ ok: true, counts: { removed: 0, preserved: 1, total: 2 } });
+    expect(readFileSync(globalPath, "utf8")).toContain(secret);
+    expect(result.warnings.join("\n")).toContain("explicit global MCP");
+  });
+
+  it.each([
+    "pending",
+    "installed",
+    "tampered",
+  ] as const)("preserves a concurrent %s explicit-global intent created after the initial partition", (markerState) => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+    const before = readFileSync(globalPath, "utf8");
+    let injected = false;
+    let pendingIntent: ReturnType<typeof prepareGlobalMcpIntent> | undefined;
+
+    const result = runProjectScopeMigration({
+      ...migration,
+      runtimeVerified: true,
+      _testHooks: {
+        afterExplicitGlobalIntentPartition: () => {
+          if (injected) return;
+          injected = true;
+          const pending = prepareGlobalMcpIntent({
+            provider: "claude",
+            targetPath: globalPath,
+            intentRoot: migration.globalIntentRoot,
+          });
+          pendingIntent = pending;
+          if (markerState === "installed") finalizeGlobalMcpIntent(pending);
+          if (markerState === "tampered") {
+            writeFileSync(pending.markerPath, "not-json");
+            releaseGlobalMcpIntent(pending);
+          }
+        },
+      },
+    });
+
+    expect(injected).toBe(true);
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 1, preserved: 1, failed: 0, total: 2 },
+    });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+    expect(readFileSync(globalPath, "utf8")).toContain(secret);
+    expect(result.warnings.join("\n")).toContain("explicit global MCP");
+    if (markerState === "pending" && pendingIntent) releaseGlobalMcpIntent(pendingIntent);
+  });
+
+  it("restores the target when a pending marker appears after final authorization but before capture", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+    const before = readFileSync(globalPath, "utf8");
+
+    const result = runProjectScopeMigration({
+      ...migration,
+      runtimeVerified: true,
+      _testHooks: {
+        beforeLegacyTargetCapture: () => {
+          mkdirSync(migration.globalIntentRoot as string, { recursive: true });
+          const markerPath = globalMcpIntentMarkerPath({
+            provider: "claude",
+            targetPath: globalPath,
+            intentRoot: migration.globalIntentRoot,
+          });
+          writeFileSync(
+            markerPath,
+            `${JSON.stringify({
+              version: 1,
+              state: "pending",
+              provider: "claude",
+              targetPath: globalPath,
+              nonce: "a".repeat(32),
+            })}\n`,
+          );
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 1, preserved: 1, failed: 0, total: 2 },
+    });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+    expect(readFileSync(globalPath, "utf8")).toContain(secret);
+    expect(result.warnings.join("\n")).toContain("global_intent_pending");
+    expect(
+      readdirSync(homeDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("preserves a shared canonical target when another provider recorded the opt-in", () => {
+    const migration = input();
+    const sharedGlobalPath = join(homeDir, ".claude.json");
+    const pending = prepareGlobalMcpIntent({
+      provider: "copilot",
+      targetPath: sharedGlobalPath,
+      intentRoot: migration.globalIntentRoot,
+    });
+    writeOwnedGlobalMcp("claude", sharedGlobalPath);
+    finalizeGlobalMcpIntent(pending);
+
+    const before = readFileSync(sharedGlobalPath, "utf8");
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({ ok: true, counts: { removed: 0, preserved: 1, total: 2 } });
+    expect(readFileSync(sharedGlobalPath, "utf8")).toBe(before);
+  });
+
+  it.each([
+    "damaged",
+    "symlinked",
+  ])("fails closed when the explicit global intent marker is %s", (markerState) => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    writeOwnedGlobalMcp("claude", globalPath);
+    const pending = prepareGlobalMcpIntent({
+      provider: "claude",
+      targetPath: globalPath,
+      intentRoot: migration.globalIntentRoot,
+    });
+    if (markerState === "damaged") {
+      writeFileSync(pending.markerPath, "not-json");
+    } else {
+      rmSync(pending.markerPath);
+      symlinkSync(join(tempDir, "foreign-marker"), pending.markerPath);
+    }
+
+    const before = readFileSync(globalPath, "utf8");
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({ ok: true, counts: { removed: 0, preserved: 1, total: 2 } });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+  });
+
+  it("fails closed when global config changed after explicit intent was recorded", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    writeOwnedGlobalMcp("claude", globalPath);
+    const pending = prepareGlobalMcpIntent({
+      provider: "claude",
+      targetPath: globalPath,
+      intentRoot: migration.globalIntentRoot,
+    });
+    finalizeGlobalMcpIntent(pending);
+    const changed = JSON.parse(readFileSync(globalPath, "utf8"));
+    changed.userChangedAfterInstall = true;
+    writeFileSync(globalPath, JSON.stringify(changed));
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({ ok: true, counts: { removed: 0, preserved: 1, total: 2 } });
+    expect(JSON.parse(readFileSync(globalPath, "utf8")).userChangedAfterInstall).toBe(true);
+    expect(result.warnings.join("\n")).toContain("global_intent_content_changed");
+  });
+
+  it("migrates Factory MCP", () => {
+    const migration = input("factory");
+    const globalMcpPath = join(homeDir, ".factory", "mcp.json");
+    const secret = writeOwnedGlobalMcp("factory", globalMcpPath);
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 1, not_found: 0, preserved: 0, failed: 0, total: 1 },
+    });
+    expect(readFileSync(globalMcpPath, "utf8")).not.toContain(secret);
+  });
+
+  it("never touches an indistinguishable legacy global skill", () => {
+    const migration = input();
+    const skillPath = join(homeDir, ".agents", "skills", "dosu", "SKILL.md");
+    const lockPath = join(homeDir, ".agents", ".skill-lock.json");
+    mkdirSync(join(skillPath, ".."), { recursive: true });
+    writeFileSync(skillPath, "user explicitly requested this global Dosu skill\n");
+    writeFileSync(lockPath, '{"version":3,"skills":{"dosu":{"source":"dosu-ai/dosu-skill"}}}\n');
+    const skillBefore = readFileSync(skillPath, "utf8");
+    const lockBefore = readFileSync(lockPath, "utf8");
+
+    runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(readFileSync(skillPath, "utf8")).toBe(skillBefore);
+    expect(readFileSync(lockPath, "utf8")).toBe(lockBefore);
+  });
+
+  it("fails before any cleanup when the project bundle no longer matches", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    writeOwnedGlobalMcp("claude", globalPath);
+    const before = readFileSync(globalPath, "utf8");
+    writeFileSync(join(projectRoot, ".mcp.json"), '{"mcpServers":{}}');
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({
+      ok: false,
+      cleanupAttempted: false,
+      reason: "project_mcp_mismatch",
+      counts: { total: 0 },
+    });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+    expect(existsSync(backupRoot)).toBe(false);
+  });
+
+  it("preserves the shared Gemini rule when an unselected Antigravity target is ambiguous", () => {
+    const migration = input("gemini");
+    const antigravityPath = join(homeDir, ".gemini", "antigravity", "mcp_config.json");
+    mkdirSync(join(antigravityPath, ".."), { recursive: true });
+    writeFileSync(
+      antigravityPath,
+      '{"mcpServers":{"dosu":{"url":"https://example.com/user-owned"}}}',
+    );
+    const sharedRulePath = join(homeDir, ".gemini", "GEMINI.md");
+    writeFileSync(sharedRulePath, "<!-- dosu:rules:start v1 -->\nowned\n<!-- dosu:rules:end -->\n");
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 1, preserved: 2, failed: 0, total: 3 },
+    });
+    expect(readFileSync(sharedRulePath, "utf8")).toContain("dosu:rules:start");
+    expect(readFileSync(antigravityPath, "utf8")).toContain("user-owned");
+  });
+
+  it("removes the shared Gemini rule when the counterpart MCP target is strictly absent", () => {
+    const migration = input("gemini");
+    const sharedRulePath = join(homeDir, ".gemini", "GEMINI.md");
+    mkdirSync(join(sharedRulePath, ".."), { recursive: true });
+    writeFileSync(
+      sharedRulePath,
+      `<!-- dosu:rules:start v1 -->\n${RELEASED_RULE.trimEnd()}\n<!-- dosu:rules:end -->\n`,
+    );
+
+    expect(inspectProjectScopeMigration(migration)).toMatchObject({
+      ok: true,
+      needsRuntimeVerification: true,
+    });
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 1, not_found: 1, preserved: 0, failed: 0, total: 2 },
+    });
+    expect(existsSync(sharedRulePath)).toBe(false);
+  });
+
+  it("uses the versioned private config receipt root by default and rejects relative overrides", () => {
+    const migration = input();
+    delete migration.backupRoot;
+    const xdgConfig = join(tempDir, "xdg-config");
+    vi.stubEnv("XDG_CONFIG_HOME", xdgConfig);
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: false });
+    expect(result).toMatchObject({
+      ok: true,
+      receiptRoot: join(xdgConfig, "dosu-cli", "migrations", "project-scope-v1"),
+    });
+
+    const unsafe = runProjectScopeMigration({
+      ...migration,
+      backupRoot: "relative-receipts",
+      runtimeVerified: true,
+    });
+    expect(unsafe).toMatchObject({
+      ok: false,
+      cleanupAttempted: false,
+      reason: "unsafe_backup_root",
+    });
+    expect(
+      inspectProjectScopeMigration({ ...migration, backupRoot: "relative-receipts" }),
+    ).toMatchObject({ ok: false, reason: "unsafe_backup_root" });
+  });
+
+  it("fails closed on an unsupported runtime platform when no environment was injected", () => {
+    const migration = input();
+    delete migration.environment;
+    vi.spyOn(process, "platform", "get").mockReturnValue("freebsd" as NodeJS.Platform);
+
+    expect(inspectProjectScopeMigration(migration)).toMatchObject({
+      ok: false,
+      reason: "unsupported_platform",
+    });
+    expect(runProjectScopeMigration({ ...migration, runtimeVerified: true })).toMatchObject({
+      ok: false,
+      cleanupAttempted: false,
+      reason: "unsupported_platform",
+    });
+  });
+
+  it("preserves the shared Gemini rule for an unselected Gemini target seen by Antigravity setup", () => {
+    const migration = input("antigravity");
+    const geminiPath = join(homeDir, ".gemini", "settings.json");
+    mkdirSync(join(geminiPath, ".."), { recursive: true });
+    writeFileSync(geminiPath, '{"mcpServers":{"dosu":{"url":"https://example.com/user"}}}');
+    const sharedRulePath = join(homeDir, ".gemini", "GEMINI.md");
+    writeFileSync(
+      sharedRulePath,
+      "<!-- dosu:rules:start v1 -->\nuser edit\n<!-- dosu:rules:end -->\n",
+    );
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({ ok: true, counts: { preserved: 2 } });
+    expect(readFileSync(sharedRulePath, "utf8")).toContain("user edit");
+    expect(readFileSync(geminiPath, "utf8")).toContain("example.com/user");
+  });
+});

--- a/src/setup/project-scope-migration.ts
+++ b/src/setup/project-scope-migration.ts
@@ -1,0 +1,389 @@
+import { lstatSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { getConfigDir } from "../config/config";
+import {
+  inspectLegacyTarget,
+  type LegacyTarget,
+  type LegacyTargetEnvironment,
+  legacyTargetsNeedCleanup,
+  type MigrationOutcome,
+  migrateLegacyTargets,
+  type ProjectBundleFailureReason,
+  type ProjectBundleProof,
+  type ProjectProof,
+  type ProjectProxyExpectation,
+  type ProviderId,
+  resolveLegacyTargets,
+  verifyProjectBundle,
+} from "../migration";
+import { inspectGlobalMcpIntent } from "../migration/global-intent";
+
+export interface ProjectScopeMigrationEnvironment extends LegacyTargetEnvironment {}
+
+export interface ProjectScopeMigrationInput {
+  /** Opaque proof returned by resolveProjectProof/proveProjectScope. */
+  project: ProjectProof;
+  /** Providers whose complete project bundle was successfully installed. */
+  providerIDs: readonly ProviderId[];
+  /** Exact secretless proxy command expected in every selected project config. */
+  proxy: ProjectProxyExpectation;
+  instructionContent: string;
+  environment?: ProjectScopeMigrationEnvironment;
+  /** Test override. Production receipts live under getConfigDir(). */
+  backupRoot?: string;
+  /** Test override. Production global intent lives under getConfigDir(). */
+  globalIntentRoot?: string;
+  /** @internal Deterministic race injection for migration tests only. */
+  _testHooks?: {
+    afterExplicitGlobalIntentPartition?: () => void;
+    beforeLegacyTargetCapture?: (target: LegacyTarget) => void;
+  };
+}
+
+export interface ProjectScopeMigrationCounts {
+  removed: number;
+  not_found: number;
+  preserved: number;
+  failed: number;
+  total: number;
+}
+
+type ProjectScopeMigrationFailureReason =
+  | ProjectBundleFailureReason
+  | "unsupported_platform"
+  | "unsafe_backup_root"
+  | "migration_failed";
+
+export type ProjectScopeMigrationInspection =
+  | {
+      ok: true;
+      needsRuntimeVerification: boolean;
+      receiptRoot: string;
+      warnings: string[];
+    }
+  | {
+      ok: false;
+      reason: Exclude<ProjectScopeMigrationFailureReason, "migration_failed">;
+      receiptRoot: string;
+      warnings: string[];
+    };
+
+export type ProjectScopeMigrationResult =
+  | {
+      ok: true;
+      cleanupAttempted: true;
+      runtimeVerified: boolean;
+      receiptRoot: string;
+      counts: ProjectScopeMigrationCounts;
+      warnings: string[];
+    }
+  | {
+      ok: false;
+      cleanupAttempted: boolean;
+      runtimeVerified: boolean;
+      reason: ProjectScopeMigrationFailureReason;
+      receiptRoot: string;
+      counts: ProjectScopeMigrationCounts;
+      warnings: string[];
+    };
+
+interface ResolvedMigration {
+  bundle: ProjectBundleProof;
+  providerIDs: ProviderId[];
+  targets: LegacyTarget[];
+  environment: ProjectScopeMigrationEnvironment;
+  receiptRoot: string;
+  globalIntentRoot: string;
+  warnings: string[];
+}
+
+type Resolution =
+  | { ok: true; value: ResolvedMigration }
+  | {
+      ok: false;
+      reason: Exclude<ProjectScopeMigrationFailureReason, "migration_failed">;
+      receiptRoot: string;
+      warnings: string[];
+    };
+
+const EMPTY_COUNTS: ProjectScopeMigrationCounts = Object.freeze({
+  removed: 0,
+  not_found: 0,
+  preserved: 0,
+  failed: 0,
+  total: 0,
+});
+
+function runtimeEnvironment(): ProjectScopeMigrationEnvironment | null {
+  const platform = process.platform;
+  if (platform !== "darwin" && platform !== "linux" && platform !== "win32") return null;
+  return { platform, homeDir: homedir(), env: process.env };
+}
+
+function receiptRoot(input: ProjectScopeMigrationInput): string {
+  return input.backupRoot ?? join(getConfigDir(), "migrations", "project-scope-v1");
+}
+
+function globalIntentRoot(input: ProjectScopeMigrationInput): string {
+  return input.globalIntentRoot ?? join(getConfigDir(), "migrations", "global-mcp-intent-v1");
+}
+
+function safeExistingReceiptRoot(path: string): boolean {
+  if (!isAbsolute(path)) return false;
+  try {
+    const stat = lstatSync(path);
+    return stat.isDirectory() && !stat.isSymbolicLink();
+  } catch (error: unknown) {
+    return (
+      typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"
+    );
+  }
+}
+
+function counterpart(provider: ProviderId): ProviderId | null {
+  if (provider === "gemini") return "antigravity";
+  if (provider === "antigravity") return "gemini";
+  return null;
+}
+
+/**
+ * Old Gemini and Antigravity setup shared one global GEMINI.md section. If an
+ * unselected counterpart MCP target is anything except strictly absent, keep
+ * that provider in the authorization set so the shared rule cannot be removed.
+ */
+function effectiveProviderIDs(
+  selected: readonly ProviderId[],
+  environment: ProjectScopeMigrationEnvironment,
+): { providerIDs: ProviderId[]; warnings: string[] } {
+  const effective = new Set(selected);
+  const warnings: string[] = [];
+
+  for (const provider of selected) {
+    const other = counterpart(provider);
+    if (!other || effective.has(other)) continue;
+    const resolution = resolveLegacyTargets([other], environment);
+    warnings.push(...resolution.warnings);
+    const mcpTarget = resolution.targets.find(
+      (target) => target.provider === other && target.id === `${other}:mcp`,
+    );
+    if (!mcpTarget || inspectLegacyTarget(mcpTarget).disposition !== "not_found") {
+      effective.add(other);
+    }
+  }
+
+  return { providerIDs: [...effective], warnings };
+}
+
+function resolveMigration(input: ProjectScopeMigrationInput): Resolution {
+  const root = receiptRoot(input);
+  const verified = verifyProjectBundle({
+    project: input.project,
+    providerIDs: input.providerIDs,
+    proxy: input.proxy,
+    instructionContent: input.instructionContent,
+  });
+  if (!verified.ok) {
+    return { ok: false, reason: verified.reason, receiptRoot: root, warnings: [] };
+  }
+
+  const environment = input.environment ?? runtimeEnvironment();
+  if (!environment) {
+    return { ok: false, reason: "unsupported_platform", receiptRoot: root, warnings: [] };
+  }
+  if (!safeExistingReceiptRoot(root)) {
+    return { ok: false, reason: "unsafe_backup_root", receiptRoot: root, warnings: [] };
+  }
+
+  const selected = [...new Set(input.providerIDs)];
+  const effective = effectiveProviderIDs(selected, environment);
+  const legacy = resolveLegacyTargets(effective.providerIDs, environment);
+  return {
+    ok: true,
+    value: {
+      bundle: verified.proof,
+      providerIDs: effective.providerIDs,
+      targets: legacy.targets,
+      environment,
+      receiptRoot: root,
+      globalIntentRoot: globalIntentRoot(input),
+      warnings: [...new Set([...effective.warnings, ...legacy.warnings])],
+    },
+  };
+}
+
+function partitionExplicitGlobalIntent(
+  targets: readonly LegacyTarget[],
+  intentRoot: string,
+): { migratable: LegacyTarget[]; preserved: LegacyTarget[]; warnings: string[] } {
+  const migratable: LegacyTarget[] = [];
+  const preserved: LegacyTarget[] = [];
+  const warnings: string[] = [];
+  for (const target of targets) {
+    if (target.kind !== "json_mcp" && target.kind !== "codex_toml") {
+      migratable.push(target);
+      continue;
+    }
+    const intent = inspectGlobalMcpIntent({
+      provider: target.provider,
+      targetPath: target.path,
+      intentRoot,
+    });
+    if (intent.status === "absent") {
+      migratable.push(target);
+      continue;
+    }
+    preserved.push(target);
+    warnings.push(
+      `Preserved explicit global MCP configuration for ${target.provider} (${intent.reason})`,
+    );
+  }
+  return { migratable, preserved, warnings };
+}
+
+function finalGlobalMcpAuthorization(target: LegacyTarget, intentRoot: string): string | null {
+  if (target.kind !== "json_mcp" && target.kind !== "codex_toml") return null;
+  const intent = inspectGlobalMcpIntent({
+    provider: target.provider,
+    targetPath: target.path,
+    intentRoot,
+  });
+  return intent.status === "absent" ? null : intent.reason;
+}
+
+/**
+ * Read-only ownership inspection. Callers may use this to avoid a cleanup-only
+ * runtime check when no removable legacy target exists.
+ */
+export function inspectProjectScopeMigration(
+  input: ProjectScopeMigrationInput,
+): ProjectScopeMigrationInspection {
+  const resolved = resolveMigration(input);
+  if (!resolved.ok) return resolved;
+  const { globalIntentRoot: intentRoot, receiptRoot: root, targets, warnings } = resolved.value;
+  const explicitIntent = partitionExplicitGlobalIntent(targets, intentRoot);
+  return {
+    ok: true,
+    needsRuntimeVerification: legacyTargetsNeedCleanup(explicitIntent.migratable),
+    receiptRoot: root,
+    warnings: [...new Set([...warnings, ...explicitIntent.warnings])],
+  };
+}
+
+function summarizeOutcomes(outcomes: readonly MigrationOutcome[]): ProjectScopeMigrationCounts {
+  const counts: ProjectScopeMigrationCounts = { ...EMPTY_COUNTS };
+  for (const outcome of outcomes) {
+    counts.total += 1;
+    switch (outcome) {
+      case "removed":
+        counts.removed += 1;
+        break;
+      case "not_found":
+        counts.not_found += 1;
+        break;
+      case "preserved_ambiguous":
+      case "concurrent_conflict":
+        counts.preserved += 1;
+        break;
+      case "pending":
+      case "failed":
+        counts.failed += 1;
+        break;
+    }
+  }
+  return counts;
+}
+
+/**
+ * Re-verifies the complete project bundle, then performs only strict,
+ * recoverable legacy cleanup. This function never starts the MCP runtime.
+ */
+export function runProjectScopeMigration(
+  input: ProjectScopeMigrationInput & { runtimeVerified: boolean },
+): ProjectScopeMigrationResult {
+  const resolved = resolveMigration(input);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      cleanupAttempted: false,
+      runtimeVerified: input.runtimeVerified,
+      reason: resolved.reason,
+      receiptRoot: resolved.receiptRoot,
+      counts: { ...EMPTY_COUNTS },
+      warnings: resolved.warnings,
+    };
+  }
+
+  const {
+    bundle,
+    globalIntentRoot: intentRoot,
+    receiptRoot: root,
+    targets,
+    warnings,
+  } = resolved.value;
+  const resultWarnings = [...warnings];
+  const outcomes: MigrationOutcome[] = [];
+  try {
+    const explicitIntent = partitionExplicitGlobalIntent(targets, intentRoot);
+    input._testHooks?.afterExplicitGlobalIntentPartition?.();
+    resultWarnings.push(...explicitIntent.warnings);
+    outcomes.push(...explicitIntent.preserved.map(() => "preserved_ambiguous" as const));
+    const targetReceipts = migrateLegacyTargets({
+      bundle,
+      targets: explicitIntent.migratable,
+      backupRoot: root,
+      allowRemoval: input.runtimeVerified,
+      finalMutationAuthorization: (target) => finalGlobalMcpAuthorization(target, intentRoot),
+      ...(input._testHooks?.beforeLegacyTargetCapture
+        ? {
+            _testHooks: {
+              beforeCapture: input._testHooks.beforeLegacyTargetCapture,
+            },
+          }
+        : {}),
+    });
+    outcomes.push(...targetReceipts.map((receipt) => receipt.outcome));
+    for (const receipt of targetReceipts) {
+      if (
+        !receipt.reason.startsWith("global_intent_") &&
+        receipt.reason !== "explicit_global_intent"
+      ) {
+        continue;
+      }
+      resultWarnings.push(
+        `Preserved explicit global MCP configuration for ${receipt.provider} (${receipt.reason})`,
+      );
+    }
+  } catch {
+    return {
+      ok: false,
+      cleanupAttempted: true,
+      runtimeVerified: input.runtimeVerified,
+      reason: "migration_failed",
+      receiptRoot: root,
+      counts: summarizeOutcomes([...outcomes, "failed"]),
+      warnings: [...new Set(resultWarnings)],
+    };
+  }
+
+  const counts = summarizeOutcomes(outcomes);
+  if (counts.failed > 0) {
+    return {
+      ok: false,
+      cleanupAttempted: true,
+      runtimeVerified: input.runtimeVerified,
+      reason: "migration_failed",
+      receiptRoot: root,
+      counts,
+      warnings: [...new Set(resultWarnings)],
+    };
+  }
+  return {
+    ok: true,
+    cleanupAttempted: true,
+    runtimeVerified: input.runtimeVerified,
+    receiptRoot: root,
+    counts,
+    warnings: [...new Set(resultWarnings)],
+  };
+}

--- a/src/setup/project-target.test.ts
+++ b/src/setup/project-target.test.ts
@@ -1,0 +1,385 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTestConfig } from "../config/config.test-utils";
+import { allSetupProviders } from "../mcp/providers";
+import { ClaudeProvider } from "../mcp/providers/claude";
+import { ClaudeDesktopProvider } from "../mcp/providers/claude-desktop";
+import { CodexProvider } from "../mcp/providers/codex";
+import { CopilotProvider } from "../mcp/providers/copilot";
+import { CursorProvider } from "../mcp/providers/cursor";
+import { inspectProviderProjectTarget, resolveProjectPinnedTarget } from "./project-target";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "dosu-project-target-"));
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+function args(target: string): string[] {
+  return ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", target];
+}
+
+function writeCursor(target: string): void {
+  const path = join(root, ".cursor", "mcp.json");
+  mkdirSync(join(root, ".cursor"), { recursive: true });
+  writeFileSync(
+    path,
+    `{// preserved\n  "mcpServers": {"dosu": ${JSON.stringify({
+      type: "stdio",
+      command: "npx",
+      args: args(target),
+    })}}\n}`,
+  );
+}
+
+function writeCodex(target: string): void {
+  mkdirSync(join(root, ".codex"), { recursive: true });
+  writeFileSync(
+    join(root, ".codex", "config.toml"),
+    `[mcp_servers.dosu]\ncommand = "npx"\nargs = ${JSON.stringify(args(target))}\n`,
+  );
+}
+
+describe("project MCP target recovery", () => {
+  it("resolves pins from every provider with an official project config", () => {
+    const providers = allSetupProviders().filter(
+      (provider) => provider.projectConfigPath(root) !== null,
+    );
+    const expectedProviderIDs = [
+      "claude",
+      "cursor",
+      "vscode",
+      "gemini",
+      "codex",
+      "zed",
+      "copilot",
+      "opencode",
+      "antigravity",
+      "mcporter",
+      "factory",
+    ];
+    expect(providers.map((provider) => provider.id())).toEqual(expectedProviderIDs);
+
+    const cfg = makeTestConfig({
+      access_token: "access",
+      refresh_token: "refresh",
+      expires_at: Date.now() + 60_000,
+      deployment_id: "dep-all-providers",
+      deployment_name: "Project",
+      api_key: "private-key",
+    });
+    for (const provider of providers) provider.install(cfg, false, { projectRoot: root });
+
+    expect(resolveProjectPinnedTarget(providers, root)).toEqual({
+      ok: true,
+      target: { deploymentID: "dep-all-providers" },
+      providers: expectedProviderIDs,
+    });
+  });
+
+  it("recovers an exact historical-version JSON or Codex project pin", () => {
+    writeCursor("dep-a");
+    writeCodex("dep-a");
+
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "owned",
+      target: { deploymentID: "dep-a" },
+    });
+    expect(inspectProviderProjectTarget(CodexProvider(), root)).toMatchObject({
+      disposition: "owned",
+      target: { deploymentID: "dep-a" },
+    });
+    expect(resolveProjectPinnedTarget([CursorProvider(), CodexProvider()], root)).toMatchObject({
+      ok: true,
+      target: { deploymentID: "dep-a" },
+    });
+  });
+
+  it("fails closed when exact project configs pin different deployments", () => {
+    writeCursor("dep-a");
+    writeCodex("dep-b");
+
+    expect(resolveProjectPinnedTarget([CursorProvider(), CodexProvider()], root)).toEqual({
+      ok: false,
+      reason: "conflicting_project_targets",
+      providers: ["cursor", "codex"],
+      paths: [join(root, ".cursor", "mcp.json"), join(root, ".codex", "config.toml")],
+    });
+  });
+
+  it("fails closed with the provider and path for a foreign server named dosu", () => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    const path = join(root, ".cursor", "mcp.json");
+    writeFileSync(path, JSON.stringify({ mcpServers: { dosu: { command: "foreign", args: [] } } }));
+
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+    });
+    expect(resolveProjectPinnedTarget([CursorProvider()], root)).toEqual({
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ["cursor"],
+      paths: [path],
+    });
+  });
+
+  it("fails closed with the provider and path for ambiguous Codex TOML", () => {
+    const path = join(root, ".codex", "config.toml");
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(path, "[[unterminated");
+
+    expect(resolveProjectPinnedTarget([CursorProvider(), CodexProvider()], root)).toEqual({
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ["codex"],
+      paths: [path],
+    });
+  });
+
+  it("rejects an explicit deployment that would split an undetected client's exact pin", () => {
+    writeCursor("dep-a");
+
+    expect(
+      resolveProjectPinnedTarget([CursorProvider()], root, {
+        mode: "cloud",
+        deploymentID: "dep-b",
+      }),
+    ).toEqual({
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: ["cursor"],
+      paths: [join(root, ".cursor", "mcp.json")],
+    });
+  });
+
+  it("allows an explicit rerun when every exact project pin already has that target", () => {
+    writeCursor("dep-a");
+    writeCodex("dep-a");
+
+    expect(
+      resolveProjectPinnedTarget([CursorProvider(), CodexProvider()], root, {
+        mode: "cloud",
+        deploymentID: "dep-a",
+      }),
+    ).toMatchObject({
+      ok: true,
+      target: { deploymentID: "dep-a" },
+      providers: ["cursor", "codex"],
+    });
+  });
+
+  it("allows an explicitly selected client to retarget its own exact pin", () => {
+    writeCursor("dep-a");
+
+    expect(
+      resolveProjectPinnedTarget(
+        [CursorProvider()],
+        root,
+        { mode: "cloud", deploymentID: "dep-b" },
+        ["cursor"],
+      ),
+    ).toEqual({
+      ok: true,
+      target: { deploymentID: "dep-b" },
+      providers: ["cursor"],
+    });
+  });
+
+  it("does not recover an OSS pin as the target of an explicit Cloud request", () => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(
+      join(root, ".cursor", "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "stdio",
+            command: "npx",
+            args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--oss"],
+          },
+        },
+      }),
+    );
+
+    expect(
+      resolveProjectPinnedTarget([CursorProvider()], root, { mode: "cloud" }, ["cursor"]),
+    ).toEqual({ ok: true, providers: ["cursor"] });
+  });
+
+  it("still rejects an unselected client's pin when the selected client can retarget", () => {
+    writeCursor("dep-a");
+    writeCodex("dep-a");
+
+    expect(
+      resolveProjectPinnedTarget(
+        [CursorProvider(), CodexProvider()],
+        root,
+        { mode: "cloud", deploymentID: "dep-b" },
+        ["cursor"],
+      ),
+    ).toEqual({
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: ["codex"],
+      paths: [join(root, ".codex", "config.toml")],
+    });
+  });
+
+  it("treats every client sharing a selected project file as mutable", () => {
+    writeFileSync(
+      join(root, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "stdio",
+            command: "npx",
+            args: args("dep-a"),
+          },
+        },
+      }),
+    );
+
+    expect(
+      resolveProjectPinnedTarget(
+        [ClaudeProvider(), CopilotProvider()],
+        root,
+        { mode: "cloud", deploymentID: "dep-b" },
+        ["claude"],
+      ),
+    ).toEqual({
+      ok: true,
+      target: { deploymentID: "dep-b" },
+      providers: ["claude", "copilot"],
+    });
+  });
+
+  it.each([
+    ["OSS over Cloud", { mode: "oss" } as const, "dep-a"],
+    ["Cloud over OSS", { mode: "cloud" } as const, null],
+  ])("rejects an explicit %s mode that conflicts with the repository", (_name, request, cloud) => {
+    if (cloud) {
+      writeCursor(cloud);
+    } else {
+      mkdirSync(join(root, ".cursor"), { recursive: true });
+      writeFileSync(
+        join(root, ".cursor", "mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            dosu: {
+              type: "stdio",
+              command: "npx",
+              args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--oss"],
+            },
+          },
+        }),
+      );
+    }
+
+    expect(resolveProjectPinnedTarget([CursorProvider()], root, request)).toMatchObject({
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: ["cursor"],
+      paths: [join(root, ".cursor", "mcp.json")],
+    });
+  });
+
+  it("treats unsupported, missing, and Dosu-free project files as unpinned", () => {
+    expect(inspectProviderProjectTarget(ClaudeDesktopProvider(), root)).toEqual({
+      disposition: "not_found",
+      providerID: "claude-desktop",
+    });
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "not_found",
+      providerID: "cursor",
+    });
+
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(join(root, ".cursor", "mcp.json"), '{"mcpServers":{"other":{}}}');
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "not_found",
+      providerID: "cursor",
+    });
+
+    writeFileSync(join(root, ".cursor", "mcp.json"), "{}");
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "not_found",
+      providerID: "cursor",
+    });
+  });
+
+  it.each([
+    ["invalid JSON", "{"],
+    ["duplicate top-level key", '{"mcpServers":{},"mcpServers":{}}'],
+    ["duplicate Dosu key", '{"mcpServers":{"dosu":{},"dosu":{}}}'],
+    ["array root", "[]"],
+    ["non-object MCP section", '{"mcpServers":[]}'],
+  ])("fails closed for %s", (_name, content) => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(join(root, ".cursor", "mcp.json"), content);
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+      providerID: "cursor",
+    });
+  });
+
+  it("fails closed for a symlink or directory at the project config path", () => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(join(root, "foreign.json"), '{"mcpServers":{}}');
+    symlinkSync(join(root, "foreign.json"), join(root, ".cursor", "mcp.json"));
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+    });
+
+    rmSync(join(root, ".cursor", "mcp.json"));
+    mkdirSync(join(root, ".cursor", "mcp.json"));
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+    });
+  });
+
+  it("recognizes an exact OSS pin and rejects malformed Codex TOML", () => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(
+      join(root, ".cursor", "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "stdio",
+            command: "npx",
+            args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--oss"],
+          },
+        },
+      }),
+    );
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "owned",
+      target: { oss: true },
+    });
+
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(join(root, ".codex", "config.toml"), "[[unterminated");
+    expect(inspectProviderProjectTarget(CodexProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+      providerID: "codex",
+    });
+  });
+
+  it("treats valid Codex TOML without a Dosu table as unpinned", () => {
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(join(root, ".codex", "config.toml"), '[model]\nname = "gpt"\n');
+    expect(inspectProviderProjectTarget(CodexProvider(), root)).toMatchObject({
+      disposition: "not_found",
+      providerID: "codex",
+    });
+  });
+
+  it("returns no pin when no selected provider has an owned entry", () => {
+    expect(resolveProjectPinnedTarget([ClaudeDesktopProvider(), CursorProvider()], root)).toEqual({
+      ok: true,
+      providers: [],
+    });
+  });
+});

--- a/src/setup/project-target.ts
+++ b/src/setup/project-target.ts
@@ -1,0 +1,237 @@
+import { lstatSync, readFileSync } from "node:fs";
+import {
+  getNodeValue,
+  type Node as JsonNode,
+  type ParseError,
+  parseTree,
+} from "jsonc-parser/lib/esm/main.js";
+import { parse as parseToml } from "smol-toml";
+import {
+  ownedProjectProxyOptionsForProvider,
+  type ProjectProxyOptions,
+  sameProjectProxyTarget,
+} from "../mcp/project-proxy";
+import type { SetupProvider } from "../mcp/providers";
+
+export type ProviderProjectTargetInspection =
+  | { disposition: "owned"; providerID: string; path: string; target: ProjectProxyOptions }
+  | { disposition: "not_found"; providerID: string; path?: string }
+  | { disposition: "ambiguous"; providerID: string; path: string };
+
+export type ProjectPinnedTargetResolution =
+  | { ok: true; target?: ProjectProxyOptions; providers: string[] }
+  | {
+      ok: false;
+      reason:
+        | "ambiguous_project_config"
+        | "conflicting_project_targets"
+        | "requested_project_target_conflict";
+      providers: string[];
+      paths: string[];
+    };
+
+export type RequestedProjectTarget = { mode: "oss" } | { mode: "cloud"; deploymentID?: string };
+
+function entryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function duplicateJsonKey(node: JsonNode): boolean {
+  if (node.type === "object") {
+    const seen = new Set<string>();
+    for (const property of node.children ?? []) {
+      const key = property.children?.[0] ? getNodeValue(property.children[0]) : undefined;
+      if (typeof key !== "string") continue;
+      if (seen.has(key)) return true;
+      seen.add(key);
+    }
+  }
+  return (node.children ?? []).some(duplicateJsonKey);
+}
+
+function jsonTopKey(providerID: string): string {
+  switch (providerID) {
+    case "vscode":
+      return "servers";
+    case "zed":
+      return "context_servers";
+    case "opencode":
+      return "mcp";
+    default:
+      return "mcpServers";
+  }
+}
+
+function projectEntryFromJson(content: string, providerID: string): unknown {
+  const errors: ParseError[] = [];
+  const root = parseTree(content, errors, { allowTrailingComma: true, disallowComments: false });
+  if (!root || errors.length > 0 || root.type !== "object" || duplicateJsonKey(root)) {
+    throw new Error("invalid project JSON");
+  }
+  const parsed: unknown = getNodeValue(root);
+  if (!isRecord(parsed)) throw new Error("invalid project JSON");
+  const section = parsed[jsonTopKey(providerID)];
+  if (section === undefined) return undefined;
+  if (!isRecord(section)) throw new Error("invalid project MCP section");
+  return section.dosu;
+}
+
+function projectEntryFromToml(content: string): unknown {
+  const parsed: unknown = parseToml(content);
+  if (!isRecord(parsed) || !isRecord(parsed.mcp_servers)) return undefined;
+  return parsed.mcp_servers.dosu;
+}
+
+/** Read a project pin only from an exact, secretless Dosu proxy emitted by a released CLI. */
+export function inspectProviderProjectTarget(
+  provider: SetupProvider,
+  projectRoot: string,
+): ProviderProjectTargetInspection {
+  const providerID = provider.id();
+  const path = provider.projectConfigPath(projectRoot);
+  if (!path) return { disposition: "not_found", providerID };
+  try {
+    if (!entryExists(path)) return { disposition: "not_found", providerID, path };
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return { disposition: "ambiguous", providerID, path };
+    }
+    const content = readFileSync(path, "utf8");
+    const entry =
+      providerID === "codex"
+        ? projectEntryFromToml(content)
+        : projectEntryFromJson(content, providerID);
+    if (entry === undefined) return { disposition: "not_found", providerID, path };
+    const target = ownedProjectProxyOptionsForProvider(providerID, entry);
+    return target
+      ? { disposition: "owned", providerID, path, target }
+      : { disposition: "ambiguous", providerID, path };
+  } catch {
+    return { disposition: "ambiguous", providerID, path };
+  }
+}
+
+export function resolveProjectPinnedTarget(
+  providers: readonly SetupProvider[],
+  projectRoot: string,
+  requested?: RequestedProjectTarget,
+  retargetProviderIDs: readonly string[] = [],
+): ProjectPinnedTargetResolution {
+  const inspections = providers.map((provider) =>
+    inspectProviderProjectTarget(provider, projectRoot),
+  );
+  const ambiguous = inspections.filter(
+    (
+      inspection,
+    ): inspection is Extract<ProviderProjectTargetInspection, { disposition: "ambiguous" }> =>
+      inspection.disposition === "ambiguous",
+  );
+  if (ambiguous.length > 0) {
+    return {
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ambiguous.map((inspection) => inspection.providerID),
+      paths: uniqueStrings(ambiguous.map((inspection) => inspection.path)),
+    };
+  }
+  const owned = inspections.filter(
+    (
+      inspection,
+    ): inspection is Extract<ProviderProjectTargetInspection, { disposition: "owned" }> =>
+      inspection.disposition === "owned",
+  );
+  if (owned.length === 0) return { ok: true, providers: [] };
+  const mutableProviders = new Set(retargetProviderIDs);
+  const mutablePaths = new Set(
+    owned
+      .filter((inspection) => mutableProviders.has(inspection.providerID))
+      .map((inspection) => inspection.path),
+  );
+  const fixed = requested
+    ? owned.filter(
+        (inspection) =>
+          !mutableProviders.has(inspection.providerID) && !mutablePaths.has(inspection.path),
+      )
+    : owned;
+  const firstFixed = fixed[0]?.target;
+  if (
+    firstFixed &&
+    fixed.some((inspection) => !sameProjectProxyTarget(firstFixed, inspection.target))
+  ) {
+    return {
+      ok: false,
+      reason: "conflicting_project_targets",
+      providers: fixed.map((inspection) => inspection.providerID),
+      paths: uniqueStrings(fixed.map((inspection) => inspection.path)),
+    };
+  }
+  const requestedConflicts =
+    requested?.mode === "oss"
+      ? fixed.some((inspection) => inspection.target.oss !== true)
+      : requested?.mode === "cloud"
+        ? fixed.some(
+            (inspection) =>
+              inspection.target.oss === true ||
+              (requested.deploymentID !== undefined &&
+                inspection.target.deploymentID !== requested.deploymentID),
+          )
+        : false;
+  if (requestedConflicts) {
+    return {
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: fixed.map((inspection) => inspection.providerID),
+      paths: uniqueStrings(fixed.map((inspection) => inspection.path)),
+    };
+  }
+  let resolvedTarget: ProjectProxyOptions | undefined;
+  if (requested?.mode === "oss") {
+    resolvedTarget = { oss: true };
+  } else if (requested?.mode === "cloud" && requested.deploymentID) {
+    resolvedTarget = { deploymentID: requested.deploymentID };
+  } else if (firstFixed) {
+    resolvedTarget = firstFixed;
+  } else if (requested?.mode === "cloud") {
+    const firstOwned = owned[0].target;
+    const allOwnedShareOneCloudTarget =
+      firstOwned.oss !== true &&
+      owned.every(
+        (inspection) =>
+          inspection.target.oss !== true && sameProjectProxyTarget(firstOwned, inspection.target),
+      );
+    resolvedTarget = allOwnedShareOneCloudTarget ? firstOwned : undefined;
+  } else {
+    const firstOwned = owned[0].target;
+    if (owned.some((inspection) => !sameProjectProxyTarget(firstOwned, inspection.target))) {
+      return {
+        ok: false,
+        reason: "conflicting_project_targets",
+        providers: owned.map((inspection) => inspection.providerID),
+        paths: uniqueStrings(owned.map((inspection) => inspection.path)),
+      };
+    }
+    resolvedTarget = firstOwned;
+  }
+  const result: ProjectPinnedTargetResolution = {
+    ok: true,
+    providers: owned.map((inspection) => inspection.providerID),
+  };
+  if (resolvedTarget) result.target = resolvedTarget;
+  return result;
+}

--- a/src/setup/rules-step.test.ts
+++ b/src/setup/rules-step.test.ts
@@ -51,6 +51,8 @@ function makeProvider(id: string): SetupProvider {
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => `/config/${id}`,
+    projectConfigPath: (root) => `${root}/.${id}/mcp.json`,
+    isProjectConfigured: () => false,
     priority: () => 0,
   };
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -15,6 +15,7 @@ import {
   replaceLoginSession,
   saveConfig,
 } from "../config/config";
+import { clearProjectMcpCredentials } from "../mcp/project-credential-store";
 import { runSetup } from "../setup/flow";
 import { browserFallbackHint } from "../setup/styles";
 
@@ -160,10 +161,12 @@ async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<v
 
 export function handleLogout(cfg: ReturnType<typeof loadConfig>): void {
   if (!isAuthenticated(cfg)) {
+    clearProjectMcpCredentials();
     p.log.warn("You are not logged in.");
     return;
   }
   clearConfigInPlace(cfg);
   saveConfig(cfg);
+  clearProjectMcpCredentials();
   p.log.success("Credentials cleared.");
 }


### PR DESCRIPTION
<!-- Is this PR related to a Linear issue? -->
<!-- Example: Fixes [ENG-123](https://linear.app/dosu/issue/ENG-123) -->

### Description

Scope `dosu setup`, agent setup, and `dosu mcp add` to the current Git project instead of silently writing agent-global configuration.

- Install one verified project bundle: project MCP config, canonical `AGENTS.md` plus provider adapters, and only the selected agents' project skills. Project files contain a pinned, secretless proxy command; credentials stay in a private per-user/per-project record.
- After the new bundle passes an MCP initialize preflight and exact read-back, remove only legacy global MCP/rule data whose complete historical shape proves Dosu ownership. Backups, locks, receipts, crash recovery, and byte-preserving edits make cleanup retryable; ambiguous or user-edited data is preserved.
- Keep global-only clients, all legacy global skills, and hooks untouched because v0.43 cannot prove those artifacts came from setup. Add explicit `--global` and `--retarget` escape hatches instead of silently falling back or overwriting a conflicting project target.
- Harden proxy process-tree shutdown, signal handling, private credential writes/logout, and packed Windows smoke coverage.

The [project-scope evidence matrix](https://github.com/dosu-ai/dosu-cli/blob/a8083f0cf308e0127ad3208473256a5a101b2e7f/docs/project-scoped-agent-setup.md) links each supported path to official agent documentation and each cleanup shape to fixed v0.43 source.

Validation:

- `bunx vitest run --coverage`: 89 files, 2,187 tests; 95.50% statements, 90.53% branches, 98.19% functions, 96.82% lines.
- Migration-focused suite: 220 tests. Real process-tree E2E: 42 assertions, repeated for 10 clean rounds.
- `bun run check`, `bun run typecheck`, `git diff --check`, workflow YAML, and `actionlint` passed.
- Standalone build and all 7 release targets passed; npm tarball dry-run, pack, clean install, version/help, and exact four-file contents passed.
- The packed CLI configured Codex and Cursor in a fresh Git project with `@dosu/cli@0.43.0`, no secret or endpoint in project files, and one private credential record; the same command refused a non-Git directory without writing files.
- The production `installSkill` path invoked pinned `skills@1.5.22` for Factory + Codex and produced one canonical project skill plus the expected Factory symlink.

This is a Draft only. It does not merge or publish a release. Local manual verification was on macOS; the packed Windows proxy/credential scenarios run in CI.

### Review Tasks - Only request review after completing these.

* [ ] I self-reviewed this PR
* [ ] Testing is adequate for this change
* [ ] I reviewed AI-generated code and resolved suggestions

### Details (for context) - Not tasks; tooling uses tasks to determine review readiness

- Generated with AI: (N/Claude/Codex/Other)
- Manual testing: (Y/N/NA)
- Tests updated: (Y/N/NA)

<!-- Describe any manual testing or special testing approach -->
