### PR TITLE
feat(mcp): add secretless project proxy runtime (2/8)

### DIFF
--- a/src/cli/signal-policy.test.ts
+++ b/src/cli/signal-policy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  dispatchCliSignal,
+  installsImmediateSigintHandler,
+  registerCliSignalCleanup,
+} from "./signal-policy";
+
+describe("SIGINT policy", () => {
+  it("lets the project MCP proxy forward shutdown to its child", () => {
+    expect(installsImmediateSigintHandler(["node", "dosu", "mcp", "proxy", "--oss"])).toBe(false);
+  });
+
+  it("keeps immediate Ctrl+C handling for interactive commands", () => {
+    expect(installsImmediateSigintHandler(["dosu", "setup"])).toBe(true);
+  });
+
+  it("keeps ordinary Ctrl+C immediate when no guarded operation is active", async () => {
+    const exit = vi.fn();
+
+    await dispatchCliSignal("SIGINT", exit);
+
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it.each([
+    ["SIGINT", 0],
+    ["SIGTERM", 143],
+    ["SIGHUP", 129],
+  ] as const)("waits for guarded cleanup before exiting on %s", async (signal, exitCode) => {
+    let finishCleanup: (() => void) | undefined;
+    const cleanup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCleanup = resolve;
+        }),
+    );
+    const unregister = registerCliSignalCleanup(cleanup);
+    const exit = vi.fn();
+
+    const dispatched = dispatchCliSignal(signal, exit);
+    await Promise.resolve();
+    expect(cleanup).toHaveBeenCalledWith(signal);
+    expect(exit).not.toHaveBeenCalled();
+
+    finishCleanup?.();
+    await dispatched;
+    expect(exit).toHaveBeenCalledWith(exitCode);
+    unregister();
+  });
+
+  it("coalesces repeated signals while cleanup is in progress", async () => {
+    let finishCleanup: (() => void) | undefined;
+    const unregister = registerCliSignalCleanup(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCleanup = resolve;
+        }),
+    );
+    const exit = vi.fn();
+
+    const first = dispatchCliSignal("SIGTERM", exit);
+    const second = dispatchCliSignal("SIGINT", exit);
+    await Promise.resolve();
+    finishCleanup?.();
+    await Promise.all([first, second]);
+
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(143);
+    unregister();
+  });
+
+  it("exits with failure when guarded cleanup cannot be confirmed", async () => {
+    const unregister = registerCliSignalCleanup(async () => {
+      throw new Error("shutdown unconfirmed");
+    });
+    const exit = vi.fn();
+
+    await dispatchCliSignal("SIGINT", exit);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    unregister();
+  });
+});

--- a/src/cli/signal-policy.ts
+++ b/src/cli/signal-policy.ts
@@ -1,0 +1,58 @@
+export const CLI_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+
+export type CliSignal = (typeof CLI_SIGNALS)[number];
+export type CliSignalCleanup = (signal: CliSignal) => Promise<void> | void;
+type ExitProcess = (code: number) => void;
+
+const activeCleanups = new Set<CliSignalCleanup>();
+let pendingDispatch: Promise<void> | undefined;
+
+function exitCodeForSignal(signal: CliSignal): number {
+  if (signal === "SIGINT") return 0;
+  if (signal === "SIGTERM") return 143;
+  return 129;
+}
+
+/**
+ * Guard a short-lived operation whose children must be reaped before the CLI
+ * exits. The returned function removes only this exact registration.
+ */
+export function registerCliSignalCleanup(cleanup: CliSignalCleanup): () => void {
+  activeCleanups.add(cleanup);
+  return () => {
+    activeCleanups.delete(cleanup);
+  };
+}
+
+/**
+ * Keep ordinary prompt cancellation immediate, but wait for any active
+ * guarded operation before exiting. Repeated signals share one cleanup pass.
+ */
+export function dispatchCliSignal(
+  signal: CliSignal,
+  exit: ExitProcess = (code) => process.exit(code),
+): Promise<void> {
+  if (pendingDispatch) return pendingDispatch;
+  const cleanups = [...activeCleanups];
+  if (cleanups.length === 0) {
+    exit(exitCodeForSignal(signal));
+    return Promise.resolve();
+  }
+
+  pendingDispatch = Promise.allSettled(
+    cleanups.map((cleanup) => Promise.resolve().then(() => cleanup(signal))),
+  )
+    .then((results) => {
+      exit(results.some((result) => result.status === "rejected") ? 1 : exitCodeForSignal(signal));
+    })
+    .finally(() => {
+      pendingDispatch = undefined;
+    });
+  return pendingDispatch;
+}
+
+/** The long-lived MCP proxy owns signal forwarding to its child bridge. */
+export function installsImmediateSigintHandler(argv: readonly string[]): boolean {
+  const mcpIndex = argv.indexOf("mcp");
+  return !(mcpIndex >= 0 && argv[mcpIndex + 1] === "proxy");
+}

--- a/src/mcp/detect.ts
+++ b/src/mcp/detect.ts
@@ -4,7 +4,7 @@
 
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, join, win32 } from "node:path";
 
 /**
  * Checks if any of the given paths exist on the filesystem.
@@ -48,13 +48,11 @@ export function appSupportDir(): string {
 /* v8 ignore stop */
 
 /**
- * Locates `npx` by absolute path on the current (shell) PATH.
- *
- * GUI hosts that spawn config-file stdio servers (Codex desktop, Claude
- * Desktop) launch them with the minimal launchd PATH that lacks
- * Homebrew/nvm, so entries must reference npx absolutely and carry a PATH
- * under which npx's `#!/usr/bin/env node` shebang resolves. Resolved at
- * install time from the user's shell PATH.
+ * Locates `npx` by absolute path on the current process PATH. Setup uses this
+ * as an install-time availability check; the private proxy runtime uses the
+ * absolute result to give its child a PATH that also resolves Node.js.
+ * Project files deliberately keep the portable command name `npx`, so GUI
+ * clients with a restricted PATH may still need to be restarted from a shell.
  */
 export function findNpx(): string {
   /* v8 ignore next -- platform dispatch, win32 arm not exercised on POSIX CI */
@@ -64,9 +62,7 @@ export function findNpx(): string {
     const candidate = join(dir, bin);
     if (existsSync(candidate)) return candidate;
   }
-  throw new Error(
-    "npx not found on PATH — Node.js is required (the MCP entry runs `npx mcp-remote`).",
-  );
+  throw new Error("npx not found on PATH — Node.js 22+ is required for this MCP configuration.");
 }
 
 /**
@@ -75,5 +71,10 @@ export function findNpx(): string {
  * fallbacks are harmless on Windows.
  */
 export function npxPathEnv(npx: string): string {
-  return [dirname(npx), "/usr/bin", "/bin"].join(delimiter);
+  const windowsStyle = /^[A-Za-z]:[\\/]/.test(npx) || npx.startsWith("\\\\");
+  const parent = windowsStyle ? win32.dirname(npx) : dirname(npx);
+  const separator = windowsStyle ? ";" : delimiter;
+  const inherited = process.env.PATH?.split(separator).filter(Boolean) ?? [];
+  const fallback = windowsStyle ? [] : ["/usr/bin", "/bin"];
+  return [...new Set([parent, ...inherited, ...fallback])].join(separator);
 }

--- a/src/mcp/process-tree.test.ts
+++ b/src/mcp/process-tree.test.ts
@@ -1,0 +1,322 @@
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { terminatePosixProcessTree, terminateWindowsProcessTree } from "./process-tree";
+
+function fakeChild(pid?: number) {
+  return { pid, kill: vi.fn((_signal: NodeJS.Signals) => true) };
+}
+
+function fakeTreeKiller() {
+  const process = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+  process.kill = vi.fn(() => true);
+  return process;
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return predicate();
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return !(
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ESRCH"
+    );
+  }
+}
+
+function readPositivePID(path: string): number | undefined {
+  try {
+    const content = readFileSync(path, "utf8").trim();
+    if (!/^[1-9][0-9]*$/.test(content)) return;
+    const pid = Number.parseInt(content, 10);
+    return Number.isSafeInteger(pid) ? pid : undefined;
+  } catch {
+    return;
+  }
+}
+
+describe("Windows process-tree shutdown", () => {
+  it("runs taskkill against the complete PID tree without a shell", async () => {
+    const child = fakeChild(4321);
+    const treeKiller = fakeTreeKiller();
+    const spawnTreeKiller = vi.fn(() => {
+      queueMicrotask(() => treeKiller.emit("close", 0));
+      return treeKiller;
+    });
+
+    await expect(
+      terminateWindowsProcessTree(child, { spawnTreeKiller: spawnTreeKiller as never }),
+    ).resolves.toBe("terminated");
+
+    expect(spawnTreeKiller).toHaveBeenCalledWith("taskkill", ["/PID", "4321", "/T", "/F"], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "missing pid",
+    "spawn throw",
+    "taskkill error",
+    "taskkill nonzero",
+  ])("falls back to the shell kill for %s", async (scenario) => {
+    const child = fakeChild(scenario === "missing pid" ? undefined : 1234);
+    const treeKiller = fakeTreeKiller();
+    const spawnTreeKiller = vi.fn(() => {
+      if (scenario === "spawn throw") throw new Error("taskkill unavailable");
+      if (scenario === "taskkill error") queueMicrotask(() => treeKiller.emit("error"));
+      if (scenario === "taskkill nonzero") queueMicrotask(() => treeKiller.emit("close", 1));
+      return treeKiller;
+    });
+
+    await expect(
+      terminateWindowsProcessTree(child, { spawnTreeKiller: spawnTreeKiller as never }),
+    ).resolves.toBe("unconfirmed");
+
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(spawnTreeKiller).toHaveBeenCalledTimes(scenario === "missing pid" ? 0 : 1);
+  });
+
+  it("resolves at the hard deadline even when both kill calls throw", async () => {
+    const child = fakeChild(9999);
+    child.kill.mockImplementation(() => {
+      throw new Error("already exited");
+    });
+    const treeKiller = fakeTreeKiller();
+    treeKiller.kill.mockImplementation(() => {
+      throw new Error("already exited");
+    });
+
+    await expect(
+      terminateWindowsProcessTree(child, {
+        spawnTreeKiller: (() => treeKiller) as never,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toBe("unconfirmed");
+    expect(treeKiller.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+});
+
+describe("POSIX process-group shutdown", () => {
+  it.skipIf(process.platform === "win32")(
+    "kills a real SIGTERM-resistant descendant in the detached process group",
+    async () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "dosu-process-tree-"));
+      const descendantPIDPath = join(fixtureRoot, "descendant.pid");
+      const descendantHeartbeatPath = join(fixtureRoot, "descendant.heartbeat");
+      const descendantScript = [
+        'const { writeFileSync } = require("node:fs");',
+        'process.on("SIGTERM", () => {});',
+        "writeFileSync(process.argv[1], String(process.pid));",
+        "let heartbeat = 0;",
+        "setInterval(() => writeFileSync(process.argv[2], String(++heartbeat)), 20);",
+      ].join("");
+      const leaderScript = [
+        'const { spawn } = require("node:child_process");',
+        'process.on("SIGTERM", () => {});',
+        `spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}, process.argv[1], process.argv[2]], { stdio: "ignore" });`,
+        "setInterval(() => {}, 1_000);",
+      ].join("");
+      const leader = spawn(
+        process.execPath,
+        ["-e", leaderScript, descendantPIDPath, descendantHeartbeatPath],
+        {
+          detached: true,
+          stdio: "ignore",
+        },
+      );
+      const leaderClosed = new Promise<void>((resolve) => leader.once("close", () => resolve()));
+      let descendantPID: number | undefined;
+      let testFailure: unknown;
+      let statusChecks = 0;
+      let lastGroupError:
+        | { signal: NodeJS.Signals | 0; code: unknown; message: string }
+        | undefined;
+      const killProcessGroup = (pid: number, signal: NodeJS.Signals | 0) => {
+        if (signal === 0) statusChecks += 1;
+        try {
+          process.kill(pid, signal);
+        } catch (error: unknown) {
+          lastGroupError = {
+            signal,
+            code:
+              typeof error === "object" && error !== null && "code" in error
+                ? error.code
+                : undefined,
+            message: error instanceof Error ? error.message : String(error),
+          };
+          throw error;
+        }
+      };
+
+      try {
+        expect(await waitUntil(() => readPositivePID(descendantPIDPath) !== undefined, 2_000)).toBe(
+          true,
+        );
+        const parsedDescendantPID = readPositivePID(descendantPIDPath);
+        if (parsedDescendantPID === undefined) throw new Error("descendant PID was not published");
+        descendantPID = parsedDescendantPID;
+        expect(processExists(parsedDescendantPID)).toBe(true);
+        expect(
+          await waitUntil(
+            () =>
+              existsSync(descendantHeartbeatPath) &&
+              readFileSync(descendantHeartbeatPath).length > 0,
+            2_000,
+          ),
+        ).toBe(true);
+
+        const shutdownResult = await terminatePosixProcessTree(leader, {
+          killProcessGroup,
+          killGraceMs: 50,
+          // Under the full parallel suite, SIGKILLed grandchildren can remain
+          // visible as zombies or transiently return EPERM from kill(0) until
+          // the OS schedules their reaper.
+          // Keep the production hard deadline unchanged; this E2E gets a
+          // generous confirmation window because it asserts confirmed reaping.
+          shutdownDeadlineMs: 10_000,
+        });
+        expect(
+          shutdownResult,
+          `status checks=${statusChecks}; last group error=${JSON.stringify(lastGroupError)}`,
+        ).toBe("terminated");
+        const stoppedHeartbeat = readFileSync(descendantHeartbeatPath, "utf8");
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(readFileSync(descendantHeartbeatPath, "utf8")).toBe(stoppedHeartbeat);
+      } catch (error: unknown) {
+        testFailure = error;
+      }
+
+      let cleanupFailure: Error | undefined;
+      if (leader.pid) {
+        try {
+          process.kill(-leader.pid, "SIGKILL");
+        } catch {
+          // The helper normally removes the complete group before cleanup.
+        }
+      }
+      const leaderWasReaped = await Promise.race([
+        leaderClosed.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 10_000)),
+      ]);
+      if (!leaderWasReaped) cleanupFailure = new Error("test process-group leader was not reaped");
+      const pidToReap = descendantPID;
+      if (pidToReap !== undefined) {
+        try {
+          process.kill(pidToReap, "SIGKILL");
+        } catch {
+          // The helper normally leaves no executing descendant. A zombie may
+          // remain PID-visible until the platform's orphan reaper schedules it.
+        }
+      }
+      rmSync(fixtureRoot, { recursive: true, force: true });
+      if (cleanupFailure) throw cleanupFailure;
+      if (testFailure) throw testFailure;
+    },
+    30_000,
+  );
+
+  it("signals the negative group PID with TERM then KILL and confirms its exit", async () => {
+    const child = fakeChild(4321);
+    let present = true;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGKILL") present = false;
+      if (signal === 0 && !present) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+
+    await expect(
+      terminatePosixProcessTree(child, {
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toBe("terminated");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4321, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4321, "SIGKILL");
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("falls back to direct TERM/KILL without claiming confirmed cleanup when PID is absent", async () => {
+    const child = fakeChild();
+
+    await expect(
+      terminatePosixProcessTree(child, { killGraceMs: 1, shutdownDeadlineMs: 1 }),
+    ).resolves.toBe("unconfirmed");
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("returns unconfirmed by the hard deadline when a group survives SIGKILL", async () => {
+    const child = fakeChild(2468);
+    const killProcessGroup = vi.fn(() => {});
+
+    await expect(
+      terminatePosixProcessTree(child, {
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toBe("unconfirmed");
+    expect(killProcessGroup).toHaveBeenCalledWith(-2468, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-2468, "SIGKILL");
+  });
+
+  it("continues from transient EPERM probes through KILL until absence is confirmed", async () => {
+    const child = fakeChild(8642);
+    let killed = false;
+    let checksAfterKill = 0;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGKILL") killed = true;
+      if (signal !== 0) return;
+      if (!killed) throw Object.assign(new Error("term reaping"), { code: "EPERM" });
+      checksAfterKill += 1;
+      throw Object.assign(new Error(checksAfterKill === 1 ? "reaping" : "gone"), {
+        code: checksAfterKill === 1 ? "EPERM" : "ESRCH",
+      });
+    });
+
+    await expect(
+      terminatePosixProcessTree(child, {
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 50,
+      }),
+    ).resolves.toBe("terminated");
+    expect(killProcessGroup).toHaveBeenCalledWith(-8642, "SIGKILL");
+    expect(checksAfterKill).toBe(2);
+  });
+
+  it.each(["gone", "forbidden"])("handles a group that is immediately %s", async (scenario) => {
+    const child = fakeChild(777);
+    const killProcessGroup = vi.fn(() => {
+      throw Object.assign(new Error(scenario), { code: scenario === "gone" ? "ESRCH" : "EPERM" });
+    });
+
+    await expect(
+      terminatePosixProcessTree(child, {
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toBe(scenario === "gone" ? "terminated" : "unconfirmed");
+  });
+});

--- a/src/mcp/process-tree.ts
+++ b/src/mcp/process-tree.ts
@@ -1,0 +1,195 @@
+import { spawn as nodeSpawn } from "node:child_process";
+
+export interface KillableProcess {
+  pid?: number;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+interface TreeKillerProcess {
+  once(event: "error", listener: () => void): TreeKillerProcess;
+  once(event: "close", listener: (code: number | null) => void): TreeKillerProcess;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+export type SpawnTreeKiller = (
+  command: string,
+  args: string[],
+  options: {
+    shell: false;
+    stdio: "ignore";
+    windowsHide: true;
+  },
+) => TreeKillerProcess;
+
+export interface WindowsTreeShutdownDependencies {
+  spawnTreeKiller?: SpawnTreeKiller;
+  shutdownDeadlineMs?: number;
+}
+
+export type ProcessTreeShutdownResult = "terminated" | "unconfirmed";
+
+export type KillProcessGroup = (pid: number, signal: NodeJS.Signals | 0) => void;
+
+export interface PosixTreeShutdownDependencies {
+  killProcessGroup?: KillProcessGroup;
+  killGraceMs?: number;
+  shutdownDeadlineMs?: number;
+}
+
+function isPositivePID(pid: number | undefined): pid is number {
+  return Number.isSafeInteger(pid) && (pid ?? 0) > 0;
+}
+
+function codeOf(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(1, ms)));
+}
+
+/**
+ * Terminate a Windows shell and every descendant without putting runtime
+ * secrets on a second command line. The promise always resolves by its hard
+ * deadline, even if taskkill and the original child never emit `close`.
+ */
+export async function terminateWindowsProcessTree(
+  child: KillableProcess,
+  deps: WindowsTreeShutdownDependencies = {},
+): Promise<ProcessTreeShutdownResult> {
+  return await new Promise<ProcessTreeShutdownResult>((resolve) => {
+    let settled = false;
+    let treeKiller: TreeKillerProcess | undefined;
+
+    const settle = (result: ProcessTreeShutdownResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      resolve(result);
+    };
+    const killShellFallback = () => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // The shell may already have exited while taskkill was running.
+      }
+      settle("unconfirmed");
+    };
+    const deadline = setTimeout(
+      () => {
+        try {
+          treeKiller?.kill("SIGKILL");
+        } catch {
+          // A concurrently closed taskkill process needs no cleanup.
+        }
+        killShellFallback();
+      },
+      Math.max(1, deps.shutdownDeadlineMs ?? 1_000),
+    );
+
+    if (!isPositivePID(child.pid)) {
+      killShellFallback();
+      return;
+    }
+
+    try {
+      treeKiller = (deps.spawnTreeKiller ?? (nodeSpawn as unknown as SpawnTreeKiller))(
+        "taskkill",
+        ["/PID", String(child.pid), "/T", "/F"],
+        { shell: false, stdio: "ignore", windowsHide: true },
+      );
+      treeKiller.once("error", killShellFallback);
+      treeKiller.once("close", (code) => {
+        if (code === 0) settle("terminated");
+        else killShellFallback();
+      });
+    } catch {
+      killShellFallback();
+    }
+  });
+}
+
+type GroupStatus = "present" | "absent" | "unknown";
+
+function processGroupStatus(groupID: number, killProcessGroup: KillProcessGroup): GroupStatus {
+  try {
+    killProcessGroup(groupID, 0);
+    return "present";
+  } catch (error: unknown) {
+    return codeOf(error) === "ESRCH" ? "absent" : "unknown";
+  }
+}
+
+function signalProcessGroup(
+  groupID: number,
+  signal: NodeJS.Signals,
+  killProcessGroup: KillProcessGroup,
+): GroupStatus {
+  try {
+    killProcessGroup(groupID, signal);
+    return "present";
+  } catch (error: unknown) {
+    return codeOf(error) === "ESRCH" ? "absent" : "unknown";
+  }
+}
+
+async function waitForGroupExit(
+  groupID: number,
+  timeoutMs: number,
+  killProcessGroup: KillProcessGroup,
+): Promise<GroupStatus> {
+  const deadline = Date.now() + Math.max(1, timeoutMs);
+  while (true) {
+    const status = processGroupStatus(groupID, killProcessGroup);
+    // EPERM can be transient while a killed descendant is being reparented or
+    // reaped (notably under Darwin sandbox/load). It is not proof of cleanup,
+    // but neither should it bypass the remaining TERM/KILL deadline. Only
+    // ESRCH confirms that the group is gone.
+    if (status === "absent") return status;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return status;
+    await delay(Math.min(10, remaining));
+  }
+}
+
+/**
+ * Terminate the dedicated process group created for npx and all descendants.
+ * A missing PID cannot prove tree cleanup, so it deliberately returns
+ * `unconfirmed` after best-effort direct-child TERM/KILL signals.
+ */
+export async function terminatePosixProcessTree(
+  child: KillableProcess,
+  deps: PosixTreeShutdownDependencies = {},
+): Promise<ProcessTreeShutdownResult> {
+  const graceMs = Math.max(1, deps.killGraceMs ?? 250);
+  const deadlineMs = Math.max(1, deps.shutdownDeadlineMs ?? 1_000);
+  if (!isPositivePID(child.pid)) {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // Continue to the forced best-effort signal.
+    }
+    await delay(graceMs);
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Cleanup cannot be confirmed without a process-group ID.
+    }
+    return "unconfirmed";
+  }
+
+  const groupID = -child.pid;
+  const killProcessGroup = deps.killProcessGroup ?? process.kill.bind(process);
+  const termStatus = signalProcessGroup(groupID, "SIGTERM", killProcessGroup);
+  if (termStatus === "absent") return "terminated";
+  if (termStatus === "unknown") return "unconfirmed";
+
+  const afterTerm = await waitForGroupExit(groupID, graceMs, killProcessGroup);
+  if (afterTerm === "absent") return "terminated";
+
+  const killStatus = signalProcessGroup(groupID, "SIGKILL", killProcessGroup);
+  if (killStatus === "absent") return "terminated";
+
+  const afterKill = await waitForGroupExit(groupID, deadlineMs, killProcessGroup);
+  return afterKill === "absent" ? "terminated" : "unconfirmed";
+}

--- a/src/mcp/project-credential-store.test.ts
+++ b/src/mcp/project-credential-store.test.ts
@@ -1,0 +1,492 @@
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearProjectMcpCredentials,
+  getProjectMcpCredentialStorePath,
+  readProjectMcpCredential,
+  saveProjectMcpCredential,
+} from "./project-credential-store";
+
+let directory: string;
+let path: string;
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "dosu-project-credentials-"));
+  path = join(directory, "credentials.json");
+});
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("project MCP credential store", () => {
+  it("derives the default store outside project configuration", () => {
+    expect(getProjectMcpCredentialStorePath()).toMatch(/project-mcp-credentials\.v1$/);
+  });
+
+  it.each([
+    { userID: "", targetKey: "deployment:dep-a" },
+    { userID: "user-a", targetKey: "" },
+  ])("rejects an incomplete credential identity before writing", ({ userID, targetKey }) => {
+    expect(() =>
+      saveProjectMcpCredential({
+        userID,
+        targetKey,
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+        path,
+      }),
+    ).toThrow(/identity is required/i);
+    expect(() => lstatSync(path)).toThrow();
+  });
+
+  it("retains credentials for multiple deployments without exposing them to a project", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-b",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-b", api_key: "key-b" },
+      path,
+    });
+
+    expect(
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toEqual({ endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" });
+    expect(
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-b", path }),
+    ).toEqual({ endpoint: "https://api.test/v1/mcp/deployments/dep-b", api_key: "key-b" });
+    const records = readdirSync(path);
+    expect(records).toHaveLength(2);
+    expect(records.every((record) => (lstatSync(join(path, record)).mode & 0o777) === 0o600)).toBe(
+      true,
+    );
+  });
+
+  it("isolates credentials by authenticated account", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    expect(
+      readProjectMcpCredential({ userID: "user-b", targetKey: "deployment:dep-a", path }),
+    ).toBeUndefined();
+
+    saveProjectMcpCredential({
+      userID: "user-b",
+      targetKey: "deployment:dep-b",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-b", api_key: "key-b" },
+      path,
+    });
+    expect(
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toEqual({ endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" });
+  });
+
+  it.each([
+    ["array record", []],
+    [
+      "extra record field",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+        foreign: true,
+      },
+    ],
+    [
+      "wrong schema",
+      {
+        schema_version: 2,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      },
+    ],
+    [
+      "empty user",
+      {
+        schema_version: 1,
+        user_id: "",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      },
+    ],
+    [
+      "empty target",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      },
+    ],
+    [
+      "non-object credential",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: [],
+      },
+    ],
+    [
+      "extra credential field",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: {
+          endpoint: "https://api.test/v1/mcp",
+          api_key: "key-a",
+          foreign: true,
+        },
+      },
+    ],
+    [
+      "empty endpoint",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "", api_key: "key-a" },
+      },
+    ],
+    [
+      "empty API key",
+      {
+        schema_version: 1,
+        user_id: "user-a",
+        target_key: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "" },
+      },
+    ],
+  ])("rejects a syntactically valid but unsafe %s", (_name, unsafeRecord) => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    writeFileSync(record, `${JSON.stringify(unsafeRecord)}\n`);
+
+    expect(() =>
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toThrow(/invalid project MCP credential record/i);
+    expect(readFileSync(record, "utf8")).toBe(`${JSON.stringify(unsafeRecord)}\n`);
+  });
+
+  it("detects a valid record moved under another identity's hashed filename", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const parsed = JSON.parse(readFileSync(record, "utf8"));
+    parsed.user_id = "user-b";
+    writeFileSync(record, `${JSON.stringify(parsed)}\n`);
+
+    expect(() =>
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toThrow(/identity mismatch/i);
+    expect(() =>
+      saveProjectMcpCredential({
+        userID: "user-a",
+        targetKey: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp", api_key: "replacement" },
+        path,
+      }),
+    ).toThrow(/identity mismatch/i);
+    expect(JSON.parse(readFileSync(record, "utf8")).user_id).toBe("user-b");
+  });
+
+  it("fails closed for a malformed file or symlink", () => {
+    writeFileSync(path, "not json");
+    expect(() =>
+      readProjectMcpCredential({ userID: "user-a", targetKey: "deployment:dep-a", path }),
+    ).toThrow(/invalid project MCP credential store/i);
+
+    rmSync(path);
+    const outside = join(directory, "outside.json");
+    writeFileSync(outside, "{}");
+    symlinkSync(outside, path);
+    expect(() =>
+      saveProjectMcpCredential({
+        userID: "user-a",
+        targetKey: "deployment:dep-a",
+        credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+        path,
+      }),
+    ).toThrow(/invalid project MCP credential store/i);
+    expect(readFileSync(outside, "utf8")).toBe("{}");
+  });
+
+  it("removes only strictly validated credential records on logout", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    clearProjectMcpCredentials(path);
+    expect(() => lstatSync(path)).toThrow();
+  });
+
+  it("removes a strictly proven 0600 crash temporary on logout", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const crashTemporary = `${record}.4321.abcdef012345.tmp`;
+    writeFileSync(crashTemporary, readFileSync(record), { mode: 0o600 });
+
+    clearProjectMcpCredentials(path);
+
+    expect(() => lstatSync(path)).toThrow();
+  });
+
+  it("accepts libuv's 0666 Windows mode for an otherwise proven crash temporary", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const crashTemporary = `${record}.4321.abcdef012345.tmp`;
+    writeFileSync(crashTemporary, readFileSync(record), { mode: 0o600 });
+    chmodSync(crashTemporary, 0o666);
+
+    clearProjectMcpCredentials(path, { platform: "win32" });
+
+    expect(() => lstatSync(path)).toThrow();
+  });
+
+  it("keeps POSIX mode and owner checks strict for crash temporaries", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const crashTemporary = `${record}.4321.abcdef012345.tmp`;
+    writeFileSync(crashTemporary, readFileSync(record), { mode: 0o600 });
+    chmodSync(crashTemporary, 0o666);
+
+    expect(() => clearProjectMcpCredentials(path, { platform: "darwin" })).toThrow(
+      /invalid project MCP credential temporary/i,
+    );
+    expect(readFileSync(record, "utf8")).toContain('"api_key": "key-a"');
+    expect(readFileSync(crashTemporary, "utf8")).toContain('"api_key": "key-a"');
+
+    chmodSync(crashTemporary, 0o600);
+    const currentUID = lstatSync(crashTemporary).uid;
+    expect(() =>
+      clearProjectMcpCredentials(path, {
+        platform: "linux",
+        getuid: () => currentUID + 1,
+      }),
+    ).toThrow(/invalid project MCP credential temporary/i);
+    expect(readFileSync(record, "utf8")).toContain('"api_key": "key-a"');
+    expect(readFileSync(crashTemporary, "utf8")).toContain('"api_key": "key-a"');
+  });
+
+  it.each([
+    "malformed",
+    "foreign",
+    "symlink",
+  ] as const)("preserves the entire store for a %s crash temporary", (scenario) => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: {
+        endpoint: "https://api.test/v1/mcp/deployments/dep-a",
+        api_key: "key-a",
+      },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const temporaryBase = scenario === "foreign" ? `${"0".repeat(64)}.json` : recordName;
+    const temporary = join(path, `${temporaryBase}.4321.abcdef012345.tmp`);
+    if (scenario === "symlink") {
+      const outside = join(directory, "outside-tmp");
+      writeFileSync(outside, "keep me");
+      symlinkSync(outside, temporary);
+    } else {
+      writeFileSync(temporary, scenario === "malformed" ? "not json" : readFileSync(record), {
+        mode: 0o600,
+      });
+    }
+    const before = readdirSync(path).sort();
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow();
+    expect(() => clearProjectMcpCredentials(path, { platform: "win32" })).toThrow();
+
+    expect(readdirSync(path).sort()).toEqual(before);
+    expect(readFileSync(record, "utf8")).toContain('"api_key": "key-a"');
+    expect(lstatSync(temporary).isSymbolicLink()).toBe(scenario === "symlink");
+  });
+
+  it("preserves the entire store for a crash temporary with public permissions", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const record = join(path, recordName);
+    const temporary = `${record}.4321.abcdef012345.tmp`;
+    writeFileSync(temporary, readFileSync(record), { mode: 0o600 });
+    chmodSync(temporary, 0o644);
+    const before = readdirSync(path).sort();
+
+    expect(() => clearProjectMcpCredentials(path, { platform: "darwin" })).toThrow(
+      /invalid.*temporary/i,
+    );
+
+    expect(readdirSync(path).sort()).toEqual(before);
+    expect(readFileSync(record, "utf8")).toContain('"api_key": "key-a"');
+  });
+
+  it("preserves every record when a valid record has the wrong hashed filename", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    const original = join(path, recordName);
+    const misplaced = join(path, `${"0".repeat(64)}.json`);
+    writeFileSync(misplaced, readFileSync(original), { mode: 0o600 });
+    const before = readdirSync(path).sort();
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow(
+      /invalid project MCP credential record/i,
+    );
+
+    expect(readdirSync(path).sort()).toEqual(before);
+    expect(readFileSync(original, "utf8")).toContain('"api_key": "key-a"');
+  });
+
+  it("preserves every record when the store contains a nested directory", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp", api_key: "key-a" },
+      path,
+    });
+    const nested = join(path, "foreign-directory");
+    mkdirSync(nested);
+    writeFileSync(join(nested, "important.txt"), "user data");
+    const recordsBefore = readdirSync(path).sort();
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow(/unrecognized file/i);
+
+    expect(readdirSync(path).sort()).toEqual(recordsBefore);
+    expect(readFileSync(join(nested, "important.txt"), "utf8")).toBe("user data");
+  });
+
+  it("does not leave a temporary after a successful save", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+
+    expect(readdirSync(path)).toEqual([expect.stringMatching(/^[a-f0-9]{64}\.json$/)]);
+  });
+
+  it("cleans its temporary when publishing a save fails", () => {
+    saveProjectMcpCredential({
+      userID: "user-a",
+      targetKey: "deployment:dep-a",
+      credential: { endpoint: "https://api.test/v1/mcp/deployments/dep-a", api_key: "key-a" },
+      path,
+    });
+    const [recordName] = readdirSync(path);
+    rmSync(join(path, recordName));
+    mkdirSync(join(path, recordName));
+
+    expect(() =>
+      saveProjectMcpCredential({
+        userID: "user-a",
+        targetKey: "deployment:dep-a",
+        credential: {
+          endpoint: "https://api.test/v1/mcp/deployments/dep-a",
+          api_key: "key-b",
+        },
+        path,
+      }),
+    ).toThrow();
+
+    expect(readdirSync(path)).toEqual([recordName]);
+  });
+
+  it("closes and removes its temporary when record serialization fails", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() =>
+      saveProjectMcpCredential({
+        userID: "user-a",
+        targetKey: "deployment:dep-a",
+        credential: circular as unknown as { endpoint: string; api_key: string },
+        path,
+      }),
+    ).toThrow(/circular/i);
+
+    expect(readdirSync(path)).toEqual([]);
+  });
+
+  it("preserves a foreign file instead of recursively deleting the store", () => {
+    mkdirSync(path);
+    const foreign = join(path, "important.txt");
+    writeFileSync(foreign, "keep me");
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow(/unrecognized file/i);
+
+    expect(readFileSync(foreign, "utf8")).toBe("keep me");
+  });
+
+  it("preserves a dangling credential-store symlink on logout", () => {
+    symlinkSync(join(directory, "missing-store"), path);
+
+    expect(() => clearProjectMcpCredentials(path)).toThrow(/invalid project MCP credential store/i);
+
+    expect(lstatSync(path).isSymbolicLink()).toBe(true);
+  });
+});

--- a/src/mcp/project-credential-store.ts
+++ b/src/mcp/project-credential-store.ts
@@ -1,0 +1,249 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { getConfigDir } from "../config/config";
+
+const STORE_VERSION = 1 as const;
+
+function entryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export interface StoredProjectMcpCredential {
+  endpoint: string;
+  api_key: string;
+}
+
+interface ProjectMcpCredentialRecord {
+  schema_version: typeof STORE_VERSION;
+  user_id: string;
+  target_key: string;
+  credential: StoredProjectMcpCredential;
+}
+
+export interface ProjectMcpCredentialCleanupDependencies {
+  platform?: NodeJS.Platform;
+  getuid?: () => number;
+}
+
+export function getProjectMcpCredentialStorePath(): string {
+  return join(getConfigDir(), "project-mcp-credentials.v1");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function credentialFileName(userID: string, targetKey: string): string {
+  return `${createHash("sha256").update(userID).update("\0").update(targetKey).digest("hex")}.json`;
+}
+
+function assertStoreDirectory(path: string): void {
+  if (!entryExists(path)) return;
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Invalid project MCP credential store at ${path}`);
+  }
+}
+
+function recordPath(storePath: string, userID: string, targetKey: string): string {
+  assertStoreDirectory(storePath);
+  return join(storePath, credentialFileName(userID, targetKey));
+}
+
+function parseRecord(path: string): ProjectMcpCredentialRecord | null {
+  if (!entryExists(path)) return null;
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`Invalid project MCP credential record at ${path}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    throw new Error(`Invalid project MCP credential record at ${path}`);
+  }
+  if (
+    !isRecord(parsed) ||
+    !exactKeys(parsed, ["schema_version", "user_id", "target_key", "credential"]) ||
+    parsed.schema_version !== STORE_VERSION ||
+    typeof parsed.user_id !== "string" ||
+    !parsed.user_id ||
+    typeof parsed.target_key !== "string" ||
+    !parsed.target_key ||
+    !isRecord(parsed.credential) ||
+    !exactKeys(parsed.credential, ["endpoint", "api_key"]) ||
+    typeof parsed.credential.endpoint !== "string" ||
+    !parsed.credential.endpoint ||
+    typeof parsed.credential.api_key !== "string" ||
+    !parsed.credential.api_key
+  ) {
+    throw new Error(`Invalid project MCP credential record at ${path}`);
+  }
+  return {
+    schema_version: STORE_VERSION,
+    user_id: parsed.user_id,
+    target_key: parsed.target_key,
+    credential: {
+      endpoint: parsed.credential.endpoint,
+      api_key: parsed.credential.api_key,
+    },
+  };
+}
+
+function assertOwnedCrashTemporary(
+  path: string,
+  expectedRecordName: string,
+  deps: ProjectMcpCredentialCleanupDependencies,
+): ProjectMcpCredentialRecord {
+  const stat = lstatSync(path);
+  const platform = deps.platform ?? process.platform;
+  const permissions = stat.mode & 0o777;
+  // libuv exposes Windows files as 0666 even when Node created them with
+  // mode 0600. Windows therefore relies on the private, non-symlink store plus
+  // the exact random filename, record hash, schema, and identity checks below.
+  const hasExpectedPermissions =
+    platform === "win32" ? permissions === 0o600 || permissions === 0o666 : permissions === 0o600;
+  const getuid =
+    deps.getuid ??
+    (typeof process.getuid === "function" ? process.getuid.bind(process) : undefined);
+  const hasExpectedOwner = platform === "win32" || (getuid !== undefined && stat.uid === getuid());
+  if (!stat.isFile() || stat.isSymbolicLink() || !hasExpectedPermissions || !hasExpectedOwner) {
+    throw new Error(`Invalid project MCP credential temporary at ${path}`);
+  }
+  const parsed = parseRecord(path);
+  if (!parsed || expectedRecordName !== credentialFileName(parsed.user_id, parsed.target_key)) {
+    throw new Error(`Invalid project MCP credential temporary at ${path}`);
+  }
+  return parsed;
+}
+
+export function saveProjectMcpCredential(input: {
+  userID: string;
+  targetKey: string;
+  credential: StoredProjectMcpCredential;
+  path?: string;
+}): void {
+  if (!input.userID || !input.targetKey)
+    throw new Error("Project MCP credential identity is required");
+  const storePath = input.path ?? getProjectMcpCredentialStorePath();
+  assertStoreDirectory(storePath);
+  if (!entryExists(storePath)) mkdirSync(storePath, { recursive: true, mode: 0o700 });
+  chmodSync(storePath, 0o700);
+  const path = recordPath(storePath, input.userID, input.targetKey);
+  const existing = parseRecord(path);
+  if (existing && (existing.user_id !== input.userID || existing.target_key !== input.targetKey)) {
+    throw new Error("Project MCP credential record identity mismatch");
+  }
+  const temporary = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  const record: ProjectMcpCredentialRecord = {
+    schema_version: STORE_VERSION,
+    user_id: input.userID,
+    target_key: input.targetKey,
+    credential: input.credential,
+  };
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(
+      temporary,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+    writeFileSync(descriptor, `${JSON.stringify(record, null, 2)}\n`);
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(temporary, path);
+    chmodSync(path, 0o600);
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        // Continue to remove the exact random temporary created with O_EXCL.
+      }
+    }
+    if (entryExists(temporary)) unlinkSync(temporary);
+  }
+}
+
+export function readProjectMcpCredential(input: {
+  userID: string;
+  targetKey: string;
+  path?: string;
+}): StoredProjectMcpCredential | undefined {
+  const storePath = input.path ?? getProjectMcpCredentialStorePath();
+  const record = parseRecord(recordPath(storePath, input.userID, input.targetKey));
+  if (!record) return undefined;
+  if (record.user_id !== input.userID || record.target_key !== input.targetKey) {
+    throw new Error("Project MCP credential record identity mismatch");
+  }
+  return record.credential;
+}
+
+export function clearProjectMcpCredentials(
+  path: string = getProjectMcpCredentialStorePath(),
+  deps: ProjectMcpCredentialCleanupDependencies = {},
+): void {
+  if (!entryExists(path)) return;
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Invalid project MCP credential store at ${path}`);
+  }
+
+  // Plan the whole cleanup before deleting anything. A dedicated directory is
+  // not sufficient ownership proof: preserve it byte-for-byte if it contains
+  // a foreign file, malformed record, symlink, or nested directory.
+  const ownedRecords = readdirSync(path, { withFileTypes: true }).map((entry) => {
+    const record = join(path, entry.name);
+    if (!entry.isFile()) {
+      throw new Error(`Unrecognized file in project MCP credential store: ${record}`);
+    }
+    if (/^[a-f0-9]{64}\.json$/.test(entry.name)) {
+      const parsed = parseRecord(record);
+      if (!parsed || entry.name !== credentialFileName(parsed.user_id, parsed.target_key)) {
+        throw new Error(`Invalid project MCP credential record at ${record}`);
+      }
+      return record;
+    }
+    const temporary = entry.name.match(
+      /^([a-f0-9]{64}\.json)\.([1-9][0-9]*)\.([a-f0-9]{12})\.tmp$/,
+    );
+    if (!temporary) {
+      throw new Error(`Unrecognized file in project MCP credential store: ${record}`);
+    }
+    assertOwnedCrashTemporary(record, temporary[1], deps);
+    return record;
+  });
+
+  for (const record of ownedRecords) unlinkSync(record);
+  rmdirSync(path);
+}

--- a/src/mcp/project-proxy-preflight.test.ts
+++ b/src/mcp/project-proxy-preflight.test.ts
@@ -1,0 +1,911 @@
+import { spawn as spawnProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliSignalCleanup } from "../cli/signal-policy";
+import { makeTestConfig } from "../config/config.test-utils";
+import { preflightProjectProxy } from "./project-proxy-preflight";
+
+const realProcessKill = process.kill.bind(process);
+
+function config() {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: 1,
+    deployment_id: "dep-a",
+    api_key: "never-in-argv",
+  });
+}
+
+function fakeChild(onWrite?: (value: string, stdout: EventEmitter) => void) {
+  const child = new EventEmitter() as EventEmitter & {
+    pid?: number;
+    stdin: { write(value: string): boolean };
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 2_147_483_647;
+  child.stdin = {
+    write(value: string) {
+      onWrite?.(value, child.stdout);
+      return true;
+    },
+  };
+  child.kill = vi.fn(() => {
+    queueMicrotask(() => child.emit("close"));
+    return true;
+  });
+  return child;
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return predicate();
+}
+
+function processExists(pid: number): boolean {
+  try {
+    realProcessKill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return !(
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ESRCH"
+    );
+  }
+}
+
+function readPositivePID(path: string): number | undefined {
+  try {
+    const content = readFileSync(path, "utf8").trim();
+    if (!/^[1-9][0-9]*$/.test(content)) return;
+    const pid = Number.parseInt(content, 10);
+    return Number.isSafeInteger(pid) ? pid : undefined;
+  } catch {
+    return;
+  }
+}
+
+describe("project proxy preflight", () => {
+  beforeEach(() => {
+    vi.spyOn(process, "kill").mockImplementation((pid) => {
+      if (pid === -2_147_483_647) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      return true;
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("runs the exact project command and requires an MCP initialize response", async () => {
+    const child = fakeChild((value, stdout) => {
+      const message = JSON.parse(value);
+      if (message.method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: {
+                protocolVersion: "2025-03-26",
+                capabilities: {},
+                serverInfo: { name: "dosu", version: "1" },
+              },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    const spawn = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: { cwd: string; shell: boolean; detached: boolean },
+      ) => child as never,
+    );
+
+    await expect(
+      preflightProjectProxy(config(), "/repo", { spawn, timeoutMs: 100 }),
+    ).resolves.toEqual({ ok: true, reason: "initialize_ok" });
+
+    const [command, args, options] = spawn.mock.calls[0];
+    expect(command).toBe("npx");
+    expect(args).toEqual(expect.arrayContaining(["-y", "mcp", "proxy", "--deployment", "dep-a"]));
+    expect(JSON.stringify(args)).not.toContain("never-in-argv");
+    expect(options.cwd).toBe("/repo");
+    expect(options.shell).toBe(false);
+    expect(options.detached).toBe(true);
+    expect(process.kill).toHaveBeenCalledWith(-2_147_483_647, "SIGTERM");
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("launches the checked-in npx command through a shell on Windows", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: {
+                protocolVersion: "2025-03-26",
+                serverInfo: { name: "dosu", version: "1" },
+              },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    const spawn = vi.fn(
+      (
+        _command: string,
+        _args: string[],
+        _options: { cwd: string; shell: boolean; detached: boolean },
+      ) => child as never,
+    );
+    child.pid = 4321;
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+    const spawnTreeKiller = vi.fn(() => {
+      queueMicrotask(() => treeKiller.emit("close", 0));
+      return treeKiller;
+    });
+
+    await expect(
+      preflightProjectProxy(config(), "C:\\repo", {
+        spawn,
+        platform: "win32",
+        timeoutMs: 100,
+        spawnTreeKiller: spawnTreeKiller as never,
+      }),
+    ).resolves.toEqual({ ok: true, reason: "initialize_ok" });
+
+    expect(spawn.mock.calls[0][0]).toBe("npx");
+    expect(spawn.mock.calls[0][2]).toMatchObject({
+      cwd: "C:\\repo",
+      shell: true,
+      detached: false,
+    });
+    expect(spawnTreeKiller).toHaveBeenCalledWith("taskkill", ["/PID", "4321", "/T", "/F"], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("resolves by a hard deadline when neither taskkill nor the proxy closes on Windows", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = 9876;
+    child.kill.mockImplementation(() => true);
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+    const spawnTreeKiller = vi.fn(() => treeKiller);
+
+    await expect(
+      preflightProjectProxy(config(), "C:\\repo", {
+        spawn: (() => child) as never,
+        platform: "win32",
+        timeoutMs: 100,
+        shutdownDeadlineMs: 1,
+        spawnTreeKiller: spawnTreeKiller as never,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+
+    expect(spawnTreeKiller).toHaveBeenCalledTimes(1);
+    expect(treeKiller.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("fails closed when the exact proxy cannot initialize before the timeout", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 1,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "timeout" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("waits for a delayed child close before resolving", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+    child.kill.mockImplementation(() => {
+      setTimeout(() => child.emit("close"), 5);
+      return true;
+    });
+    let resolved = false;
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1,
+      killGraceMs: 50,
+    }).then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    expect(resolved).toBe(false);
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "timeout" });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("escalates to SIGKILL and reaps a child that ignores SIGTERM", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+    child.kill.mockImplementation((signal: NodeJS.Signals) => {
+      if (signal === "SIGKILL") queueMicrotask(() => child.emit("close"));
+      return true;
+    });
+
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 1,
+        killGraceMs: 1,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "timeout" });
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("reports a synchronous spawn failure without attempting protocol I/O", async () => {
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => {
+          throw new Error("npx unavailable");
+        }) as never,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "spawn_failed" });
+  });
+
+  it("distinguishes child startup errors and early exits", async () => {
+    const failed = fakeChild();
+    const failedResult = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => failed) as never,
+      timeoutMs: 100,
+    });
+    queueMicrotask(() => failed.emit("error", new Error("spawn failed")));
+    await expect(failedResult).resolves.toEqual({ ok: false, reason: "spawn_failed" });
+
+    const exited = fakeChild();
+    const exitedResult = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => exited) as never,
+      timeoutMs: 100,
+    });
+    queueMicrotask(() => exited.emit("close", 1));
+    await expect(exitedResult).resolves.toEqual({ ok: false, reason: "process_exited" });
+  });
+
+  it("terminates and confirms a surviving POSIX group after the leader closes", async () => {
+    const child = fakeChild();
+    child.pid = 4242;
+    let groupPresent = true;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGKILL") groupPresent = false;
+      if (signal === 0 && !groupPresent) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 1,
+      shutdownDeadlineMs: 20,
+      killProcessGroup,
+    });
+
+    child.emit("close", 1);
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "process_exited" });
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, "SIGKILL");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, 0);
+  });
+
+  it("terminates and confirms the POSIX group after a child error", async () => {
+    const child = fakeChild();
+    child.pid = 4243;
+    let groupPresent = true;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") groupPresent = false;
+      if (signal === 0 && !groupPresent) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 20,
+      killProcessGroup,
+    });
+
+    child.emit("error", new Error("leader failed"));
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "spawn_failed" });
+    expect(killProcessGroup).toHaveBeenCalledWith(-4243, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-4243, 0);
+  });
+
+  it("uses taskkill to confirm the Windows tree after the shell closes", async () => {
+    const child = fakeChild();
+    child.pid = 4321;
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+    const spawnTreeKiller = vi.fn(() => {
+      queueMicrotask(() => treeKiller.emit("close", 0));
+      return treeKiller;
+    });
+    const preflight = preflightProjectProxy(config(), "C:\\repo", {
+      spawn: (() => child) as never,
+      platform: "win32",
+      timeoutMs: 1_000,
+      spawnTreeKiller: spawnTreeKiller as never,
+    });
+
+    child.emit("close", 1);
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "process_exited" });
+    expect(spawnTreeKiller).toHaveBeenCalledWith("taskkill", ["/PID", "4321", "/T", "/F"], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  });
+
+  it("fails closed when a surviving group cannot be confirmed gone after leader close", async () => {
+    const child = fakeChild();
+    child.pid = 2468;
+    const killProcessGroup = vi.fn(() => {});
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 1,
+      shutdownDeadlineMs: 1,
+      killProcessGroup,
+    });
+
+    child.emit("close", 1);
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+  });
+
+  it("rejects explicit initialize errors and malformed protocol replies", async () => {
+    const cases: Array<[string, unknown]> = [
+      ["initialize_rejected", { jsonrpc: "2.0", id: 1, error: { code: -32_000 } }],
+      ["invalid_response", { jsonrpc: "2.0", id: 1, result: { protocolVersion: 7 } }],
+      [
+        "invalid_response",
+        { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-03-26", serverInfo: [] } },
+      ],
+    ];
+
+    for (const [reason, response] of cases) {
+      const child = fakeChild((value, stdout) => {
+        if (JSON.parse(value).method === "initialize") {
+          queueMicrotask(() => stdout.emit("data", `${JSON.stringify(response)}\n`));
+        }
+      });
+      await expect(
+        preflightProjectProxy(config(), "/repo", {
+          spawn: (() => child) as never,
+          timeoutMs: 100,
+        }),
+      ).resolves.toEqual({ ok: false, reason });
+    }
+  });
+
+  it("handles split lines, ignores unrelated messages, and accepts CRLF", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method !== "initialize") return;
+      queueMicrotask(() => {
+        stdout.emit("data", '{"jsonrpc":"2.0","id":99,"result":{}}\n');
+        stdout.emit("data", '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025');
+        stdout.emit("data", '-03-26","serverInfo":{"name":"dosu"}}}\r\n');
+      });
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: true, reason: "initialize_ok" });
+  });
+
+  it("rejects malformed JSON and caps untrusted protocol output", async () => {
+    const malformed = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() => stdout.emit("data", "not-json\n"));
+      }
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => malformed) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "invalid_response" });
+
+    const noisy = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() => stdout.emit("data", "x".repeat(1024 * 1024 + 1)));
+      }
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => noisy) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "invalid_response" });
+  });
+
+  it("fails closed when the initialize write throws", async () => {
+    const child = fakeChild();
+    child.stdin.write = () => {
+      throw new Error("broken pipe");
+    };
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "spawn_failed" });
+  });
+
+  it("still resolves after signaling races with an already exiting child", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = undefined;
+    child.kill.mockImplementation(() => {
+      setTimeout(() => child.emit("close"), 1);
+      throw new Error("already exited");
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+        killGraceMs: 20,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+  });
+
+  it("ignores blank and non-object messages and makes completion idempotent", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method !== "initialize") return;
+      queueMicrotask(() => {
+        stdout.emit("data", "\nnull\n");
+        stdout.emit(
+          "data",
+          `${JSON.stringify({
+            id: 1,
+            result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+          })}\n`,
+        );
+        stdout.emit("data", "not-json\n");
+      });
+    });
+    child.kill.mockImplementation(() => {
+      setTimeout(() => child.emit("close"), 2);
+      return true;
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: true, reason: "initialize_ok" });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("handles a child that closes synchronously while SIGTERM is sent", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = undefined;
+    child.kill.mockImplementation(() => {
+      child.emit("close");
+      return true;
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+        killGraceMs: 1,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    expect(child.kill).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not authorize cleanup when the direct child closes before its POSIX group is gone", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = 4242;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") queueMicrotask(() => child.emit("close"));
+      // Signal 0 continues to report a surviving descendant after SIGKILL.
+    });
+
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+        killProcessGroup,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, "SIGKILL");
+  });
+
+  it.each([
+    "SIGINT",
+    "SIGTERM",
+    "SIGHUP",
+  ] as const)("turns %s into an interrupted result and waits for the whole group after an early close", async (signal) => {
+    const child = fakeChild();
+    child.pid = 4242;
+    let groupPresent = true;
+    const killProcessGroup = vi.fn((_pid: number, sent: NodeJS.Signals | 0) => {
+      if (sent === "SIGTERM") queueMicrotask(() => child.emit("close"));
+      if (sent === "SIGKILL") groupPresent = false;
+      if (sent === 0 && !groupPresent) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+    let signalCleanup: CliSignalCleanup | undefined;
+    const unregister = vi.fn();
+    const registerSignalCleanup = vi.fn((cleanup) => {
+      signalCleanup = cleanup;
+      return unregister;
+    });
+
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 1,
+      shutdownDeadlineMs: 20,
+      killProcessGroup,
+      registerSignalCleanup,
+    });
+    expect(signalCleanup).toBeTypeOf("function");
+
+    const cleanup = signalCleanup?.(signal);
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "interrupted" });
+    await cleanup;
+
+    expect(killProcessGroup).toHaveBeenCalledWith(-4242, "SIGKILL");
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects guarded signal cleanup when tree shutdown cannot be confirmed", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+    let signalCleanup: CliSignalCleanup | undefined;
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 1,
+      registerSignalCleanup: (cleanup) => {
+        signalCleanup = cleanup;
+        return () => {};
+      },
+    });
+
+    const cleanup = Promise.resolve().then(() => signalCleanup?.("SIGINT"));
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "shutdown_unconfirmed" });
+    await expect(cleanup).rejects.toThrow(/could not be confirmed/i);
+  });
+
+  it("does not authorize setup when a signal arrives during successful shutdown", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method === "initialize") {
+        queueMicrotask(() =>
+          stdout.emit(
+            "data",
+            `${JSON.stringify({
+              id: 1,
+              result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+            })}\n`,
+          ),
+        );
+      }
+    });
+    child.pid = 8765;
+    let groupPresent = true;
+    let signalCleanup: CliSignalCleanup | undefined;
+    let cleanup: Promise<void> | undefined;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") {
+        queueMicrotask(() => {
+          cleanup = Promise.resolve().then(() => signalCleanup?.("SIGINT"));
+          groupPresent = false;
+        });
+      }
+      if (signal === 0 && !groupPresent) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+
+    const preflight = preflightProjectProxy(config(), "/repo", {
+      spawn: (() => child) as never,
+      timeoutMs: 1_000,
+      killGraceMs: 20,
+      killProcessGroup,
+      registerSignalCleanup: (registered) => {
+        signalCleanup = registered;
+        return () => {};
+      },
+    });
+
+    await expect(preflight).resolves.toEqual({ ok: false, reason: "interrupted" });
+    await cleanup;
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "reaps a real detached descendant when interrupted during preflight",
+    async () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "dosu-preflight-signal-"));
+      const descendantPIDPath = join(fixtureRoot, "descendant.pid");
+      const descendantTerminatedPath = join(fixtureRoot, "descendant-terminated");
+      const descendantScript = [
+        'const { writeFileSync } = require("node:fs");',
+        'process.on("SIGTERM", () => { writeFileSync(process.argv[2], "SIGTERM"); process.exit(0); });',
+        "writeFileSync(process.argv[1], String(process.pid));",
+        "setInterval(() => {}, 1_000);",
+      ].join("");
+      const leaderScript = [
+        'const { spawn } = require("node:child_process");',
+        'process.on("SIGTERM", () => {});',
+        `const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}, process.argv[1], process.argv[2]], { stdio: "ignore" });`,
+        'child.once("exit", () => process.exit(0));',
+        "process.stdin.resume();",
+        "setInterval(() => {}, 1_000);",
+      ].join("");
+      let leaderPID: number | undefined;
+      let descendantPID: number | undefined;
+      let signalCleanup: CliSignalCleanup | undefined;
+      let testFailure: unknown;
+
+      try {
+        const preflight = preflightProjectProxy(config(), fixtureRoot, {
+          spawn: ((
+            _command: string,
+            _args: string[],
+            options: {
+              cwd: string;
+              env: NodeJS.ProcessEnv;
+              stdio: ["pipe", "pipe", "pipe"];
+              shell: boolean;
+              detached: boolean;
+            },
+          ) => {
+            const child = spawnProcess(
+              process.execPath,
+              ["-e", leaderScript, descendantPIDPath, descendantTerminatedPath],
+              options,
+            );
+            leaderPID = child.pid;
+            return child as never;
+          }) as never,
+          timeoutMs: 10_000,
+          killGraceMs: 50,
+          shutdownDeadlineMs: 10_000,
+          killProcessGroup: realProcessKill,
+          registerSignalCleanup: (cleanup) => {
+            signalCleanup = cleanup;
+            return () => {
+              signalCleanup = undefined;
+            };
+          },
+        });
+
+        expect(await waitUntil(() => readPositivePID(descendantPIDPath) !== undefined, 2_000)).toBe(
+          true,
+        );
+        descendantPID = readPositivePID(descendantPIDPath);
+        if (descendantPID === undefined) throw new Error("descendant PID was not published");
+        expect(processExists(descendantPID)).toBe(true);
+        expect(signalCleanup).toBeTypeOf("function");
+
+        const cleanup = signalCleanup?.("SIGTERM");
+        await expect(preflight).resolves.toEqual({ ok: false, reason: "interrupted" });
+        await cleanup;
+        expect(await waitUntil(() => existsSync(descendantTerminatedPath), 2_000)).toBe(true);
+        expect(processExists(-(leaderPID as number))).toBe(false);
+      } catch (error: unknown) {
+        testFailure = error;
+      }
+
+      if (leaderPID) {
+        try {
+          realProcessKill(-leaderPID, "SIGKILL");
+        } catch {
+          // The guarded shutdown normally removes the complete group.
+        }
+      }
+      rmSync(fixtureRoot, { recursive: true, force: true });
+      if (testFailure) throw testFailure;
+    },
+    30_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "reaps a real surviving descendant after its detached leader exits early",
+    async () => {
+      const fixtureRoot = mkdtempSync(join(tmpdir(), "dosu-preflight-early-exit-"));
+      const descendantPIDPath = join(fixtureRoot, "descendant.pid");
+      const descendantTerminatedPath = join(fixtureRoot, "descendant-terminated");
+      const descendantScript = [
+        'const { writeFileSync } = require("node:fs");',
+        'process.on("SIGTERM", () => { writeFileSync(process.argv[2], "SIGTERM"); process.exit(0); });',
+        "writeFileSync(process.argv[1], String(process.pid));",
+        "setInterval(() => {}, 1_000);",
+      ].join("");
+      const leaderScript = [
+        'const { spawn } = require("node:child_process");',
+        `spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}, process.argv[1], process.argv[2]], { stdio: "ignore" });`,
+        "setTimeout(() => process.exit(7), 100);",
+      ].join("");
+      let leaderPID: number | undefined;
+      let descendantPID: number | undefined;
+      let testFailure: unknown;
+
+      try {
+        const preflight = preflightProjectProxy(config(), fixtureRoot, {
+          spawn: ((
+            _command: string,
+            _args: string[],
+            options: {
+              cwd: string;
+              env: NodeJS.ProcessEnv;
+              stdio: ["pipe", "pipe", "pipe"];
+              shell: boolean;
+              detached: boolean;
+            },
+          ) => {
+            const child = spawnProcess(
+              process.execPath,
+              ["-e", leaderScript, descendantPIDPath, descendantTerminatedPath],
+              options,
+            );
+            leaderPID = child.pid;
+            return child as never;
+          }) as never,
+          timeoutMs: 2_000,
+          killGraceMs: 250,
+          shutdownDeadlineMs: 10_000,
+          killProcessGroup: realProcessKill,
+        });
+
+        expect(await waitUntil(() => readPositivePID(descendantPIDPath) !== undefined, 2_000)).toBe(
+          true,
+        );
+        descendantPID = readPositivePID(descendantPIDPath);
+        if (descendantPID === undefined) throw new Error("descendant PID was not published");
+        expect(processExists(descendantPID)).toBe(true);
+        await expect(preflight).resolves.toEqual({ ok: false, reason: "process_exited" });
+        expect(await waitUntil(() => existsSync(descendantTerminatedPath), 2_000)).toBe(true);
+        // An orphaned, already-dead descendant can remain visible as a zombie
+        // until the host's PID 1 reaps it. The process-group probe is the
+        // production contract: ESRCH proves no member remains signalable.
+        expect(processExists(-(leaderPID as number))).toBe(false);
+      } catch (error: unknown) {
+        testFailure = error;
+      }
+
+      if (leaderPID) {
+        try {
+          realProcessKill(-leaderPID, "SIGKILL");
+        } catch {
+          // The guarded shutdown normally removes the complete group.
+        }
+      }
+      rmSync(fixtureRoot, { recursive: true, force: true });
+      if (testFailure) throw testFailure;
+    },
+    30_000,
+  );
+
+  it("resolves a protocol result received after an early close without double-settling", async () => {
+    const child = fakeChild((value, stdout) => {
+      if (JSON.parse(value).method !== "initialize") return;
+      child.emit("close");
+      stdout.emit(
+        "data",
+        `${JSON.stringify({
+          id: 1,
+          result: { protocolVersion: "2025-03-26", serverInfo: { name: "dosu" } },
+        })}\n`,
+      );
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "process_exited" });
+  });
+
+  it("survives a SIGKILL race after an ignored SIGTERM", async () => {
+    const child = fakeChild();
+    child.pid = undefined;
+    child.kill.mockImplementation((signal: NodeJS.Signals) => {
+      if (signal === "SIGKILL") {
+        setTimeout(() => child.emit("close"), 1);
+        throw new Error("already exited");
+      }
+      return true;
+    });
+    await expect(
+      preflightProjectProxy(config(), "/repo", {
+        spawn: (() => child) as never,
+        timeoutMs: 1,
+        killGraceMs: 1,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "timeout" });
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+});

--- a/src/mcp/project-proxy-preflight.ts
+++ b/src/mcp/project-proxy-preflight.ts
@@ -1,0 +1,245 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { type CliSignalCleanup, registerCliSignalCleanup } from "../cli/signal-policy";
+import type { Config } from "../config/config";
+import { VERSION } from "../version/version";
+import {
+  type KillProcessGroup,
+  type SpawnTreeKiller,
+  terminatePosixProcessTree,
+  terminateWindowsProcessTree,
+} from "./process-tree";
+import { buildProjectProxyCommand } from "./project-proxy";
+
+export type ProjectProxyPreflightReason =
+  | "initialize_ok"
+  | "spawn_failed"
+  | "initialize_rejected"
+  | "invalid_response"
+  | "interrupted"
+  | "process_exited"
+  | "shutdown_unconfirmed"
+  | "timeout";
+
+export type ProjectProxyPreflightResult =
+  | { ok: true; reason: "initialize_ok" }
+  | { ok: false; reason: Exclude<ProjectProxyPreflightReason, "initialize_ok"> };
+
+interface PreflightInput {
+  write(value: string): boolean;
+}
+
+interface PreflightOutput {
+  on(event: "data", listener: (chunk: Uint8Array | string) => void): PreflightOutput;
+}
+
+interface PreflightChild {
+  pid?: number;
+  stdin: PreflightInput;
+  stdout: PreflightOutput;
+  stderr: PreflightOutput;
+  once(event: "error", listener: () => void): PreflightChild;
+  once(event: "close", listener: () => void): PreflightChild;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+type SpawnPreflight = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    stdio: ["pipe", "pipe", "pipe"];
+    shell: boolean;
+    detached: boolean;
+  },
+) => PreflightChild;
+
+export interface ProjectProxyPreflightDependencies {
+  spawn?: SpawnPreflight;
+  timeoutMs?: number;
+  killGraceMs?: number;
+  shutdownDeadlineMs?: number;
+  platform?: NodeJS.Platform;
+  spawnTreeKiller?: SpawnTreeKiller;
+  killProcessGroup?: KillProcessGroup;
+  registerSignalCleanup?: (cleanup: CliSignalCleanup) => () => void;
+}
+
+const INITIALIZE_ID = 1;
+const MAX_PROTOCOL_OUTPUT = 1024 * 1024;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Start the exact checked-in stdio command and complete an MCP initialize round-trip.
+ * Legacy globals are preserved unless this succeeds.
+ */
+export async function preflightProjectProxy(
+  cfg: Config,
+  projectRoot: string,
+  deps: ProjectProxyPreflightDependencies = {},
+): Promise<ProjectProxyPreflightResult> {
+  const command = buildProjectProxyCommand(cfg);
+  const platform = deps.platform ?? process.platform;
+  let child: PreflightChild;
+  try {
+    child = (deps.spawn ?? (nodeSpawn as unknown as SpawnPreflight))(
+      command.command,
+      command.args,
+      {
+        cwd: projectRoot,
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"],
+        // The exact project command is `npx`; on Windows it resolves to
+        // npx.cmd, which Node can execute only through a shell.
+        shell: platform === "win32",
+        // npm exec launches the requested binary through a child shell even
+        // on POSIX. A dedicated group lets shutdown reach every descendant.
+        detached: platform !== "win32",
+      },
+    );
+  } catch {
+    return { ok: false, reason: "spawn_failed" };
+  }
+
+  return await new Promise<ProjectProxyPreflightResult>((resolve) => {
+    let finalResult: ProjectProxyPreflightResult | undefined;
+    let shutdownStarted = false;
+    let shutdownMustBeConfirmed = false;
+    let interrupted = false;
+    let shutdownComplete: Promise<void> | undefined;
+    let shutdownStatus: "terminated" | "unconfirmed" | undefined;
+    let unregisterSignalCleanup = () => {};
+    let stdout = "";
+    // Codex currently allows roughly ten seconds for stdio startup. Passing a
+    // slower check would authorize cleanup for a project entry Codex still times out on.
+    const timeout = setTimeout(
+      () => finish({ ok: false, reason: "timeout" }),
+      deps.timeoutMs ?? 8_000,
+    );
+
+    function resolveClosed(result: ProjectProxyPreflightResult): void {
+      clearTimeout(timeout);
+      unregisterSignalCleanup();
+      resolve(result);
+    }
+
+    function resolveAfterShutdown(
+      result: ProjectProxyPreflightResult,
+      status: "terminated" | "unconfirmed",
+    ): void {
+      const effectiveResult: ProjectProxyPreflightResult = interrupted
+        ? { ok: false, reason: "interrupted" }
+        : result;
+      resolveClosed(
+        status !== "terminated" &&
+          (shutdownMustBeConfirmed ||
+            effectiveResult.ok ||
+            effectiveResult.reason === "interrupted")
+          ? { ok: false, reason: "shutdown_unconfirmed" }
+          : effectiveResult,
+      );
+    }
+
+    function finish(result: ProjectProxyPreflightResult, requireConfirmedShutdown = false): void {
+      if (requireConfirmedShutdown) shutdownMustBeConfirmed = true;
+      if (finalResult) return;
+      finalResult = result;
+      clearTimeout(timeout);
+      shutdownStarted = true;
+      if (platform === "win32") {
+        shutdownComplete = terminateWindowsProcessTree(child, {
+          spawnTreeKiller: deps.spawnTreeKiller,
+          shutdownDeadlineMs: deps.shutdownDeadlineMs,
+        }).then((status) => {
+          shutdownStatus = status;
+          resolveAfterShutdown(result, status);
+        });
+        return;
+      }
+      shutdownComplete = terminatePosixProcessTree(child, {
+        killProcessGroup: deps.killProcessGroup,
+        killGraceMs: deps.killGraceMs,
+        shutdownDeadlineMs: deps.shutdownDeadlineMs,
+      }).then((status) => {
+        shutdownStatus = status;
+        resolveAfterShutdown(result, status);
+      });
+    }
+
+    unregisterSignalCleanup = (deps.registerSignalCleanup ?? registerCliSignalCleanup)(async () => {
+      interrupted = true;
+      finish({ ok: false, reason: "interrupted" }, true);
+      await shutdownComplete;
+      if (shutdownStatus !== "terminated") {
+        throw new Error("Project MCP preflight shutdown could not be confirmed");
+      }
+    });
+
+    child.once("error", () => {
+      if (shutdownStarted) return;
+      finish({ ok: false, reason: "spawn_failed" }, true);
+    });
+    child.once("close", () => {
+      if (shutdownStarted) return;
+      finish({ ok: false, reason: "process_exited" }, true);
+    });
+    child.stderr.on("data", () => {
+      // Drain diagnostics so a noisy package runner cannot block. Never echo it:
+      // nested process errors can contain private paths or endpoint details.
+    });
+    child.stdout.on("data", (chunk) => {
+      stdout += Buffer.from(chunk).toString("utf8");
+      if (stdout.length > MAX_PROTOCOL_OUTPUT) {
+        finish({ ok: false, reason: "invalid_response" });
+        return;
+      }
+      const lines = stdout.split(/\r?\n/);
+      stdout = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let message: unknown;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          finish({ ok: false, reason: "invalid_response" });
+          return;
+        }
+        if (!isRecord(message) || message.id !== INITIALIZE_ID) continue;
+        if (isRecord(message.error)) {
+          finish({ ok: false, reason: "initialize_rejected" });
+          return;
+        }
+        const result = isRecord(message.result) ? message.result : undefined;
+        if (!result || typeof result.protocolVersion !== "string" || !isRecord(result.serverInfo)) {
+          finish({ ok: false, reason: "invalid_response" });
+          return;
+        }
+        child.stdin.write(
+          `${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`,
+        );
+        finish({ ok: true, reason: "initialize_ok" });
+        return;
+      }
+    });
+
+    try {
+      child.stdin.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: INITIALIZE_ID,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "dosu-cli-project-preflight", version: VERSION },
+          },
+        })}\n`,
+      );
+    } catch {
+      finish({ ok: false, reason: "spawn_failed" });
+    }
+  });
+}

--- a/src/mcp/project-proxy.test.ts
+++ b/src/mcp/project-proxy.test.ts
@@ -1,0 +1,653 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../config/config";
+import { makeTestConfig } from "../config/config.test-utils";
+import {
+  buildProjectProxyCommand,
+  isDosuMcpEntry,
+  isDosuMcpEntryForProvider,
+  isProjectProxyEntry,
+  isProjectProxyEntryForProvider,
+  isSafeProjectDeploymentID,
+  ownedProjectProxyOptionsForProvider,
+  ownedProjectProxyOptionsFromEntry,
+  projectProxyOptionsFromEntry,
+  recordProjectProxyEndpoint,
+  resolveProjectProxyRuntime,
+  runProjectProxy,
+  sameProjectProxyTarget,
+} from "./project-proxy";
+
+const API_KEY = "dosu-secret-never-write-to-project";
+
+function cloudConfig(overrides: Record<string, unknown> = {}): Config {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 60_000,
+    deployment_id: "dep-123",
+    deployment_name: "Knowledge",
+    api_key: API_KEY,
+    mcp_endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+    ...overrides,
+  });
+}
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-project-proxy-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("buildProjectProxyCommand", () => {
+  it("writes only a non-secret deployment reference into project config", () => {
+    const command = buildProjectProxyCommand(cloudConfig());
+    const serialized = JSON.stringify(command);
+
+    expect(command.command).toBe("npx");
+    expect(command.args).toContain("mcp");
+    expect(command.args).toContain("proxy");
+    expect(command.args).toContain("dep-123");
+    expect(serialized).not.toContain(API_KEY);
+    expect(serialized).not.toContain("X-Dosu-API-Key");
+    expect(serialized).not.toContain("api.dosu.dev");
+  });
+
+  it("marks OSS project entries without inventing a deployment", () => {
+    const command = buildProjectProxyCommand(
+      cloudConfig({ mode: "oss", deployment_id: undefined }),
+    );
+
+    expect(command.args).toContain("--oss");
+    expect(command.args).not.toContain("--deployment");
+  });
+
+  it("rejects deployment IDs that could become Windows shell syntax", () => {
+    expect(() =>
+      buildProjectProxyCommand(cloudConfig({ deployment_id: "dep-a & calc.exe" })),
+    ).toThrow(/invalid project deployment ID/i);
+  });
+
+  it("accepts only bounded identifiers with no shell metacharacters", () => {
+    expect(isSafeProjectDeploymentID("dep-A_1.2:prod")).toBe(true);
+    expect(isSafeProjectDeploymentID("x".repeat(256))).toBe(true);
+    expect(isSafeProjectDeploymentID("x".repeat(257))).toBe(false);
+    expect(isSafeProjectDeploymentID("-starts-with-dash")).toBe(false);
+    expect(isSafeProjectDeploymentID(123)).toBe(false);
+  });
+});
+
+describe("project proxy ownership", () => {
+  it("recognizes only the exact checked-in command shape", () => {
+    const command = buildProjectProxyCommand(cloudConfig());
+
+    expect(isProjectProxyEntry(command)).toBe(true);
+    expect(projectProxyOptionsFromEntry(command)).toEqual({ deploymentID: "dep-123" });
+    expect(
+      isProjectProxyEntry({
+        type: "local",
+        command: [command.command, ...command.args],
+        enabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a lookalike command, extra args, and secret-bearing entries", () => {
+    const command = buildProjectProxyCommand(cloudConfig());
+
+    expect(isProjectProxyEntry({ command: "npx", args: ["dosu", "mcp", "proxy"] })).toBe(false);
+    expect(isProjectProxyEntry({ ...command, args: [...command.args, "--unexpected"] })).toBe(
+      false,
+    );
+    expect(
+      isProjectProxyEntry({
+        ...command,
+        headers: { "X-Dosu-API-Key": API_KEY },
+      }),
+    ).toBe(false);
+    expect(isDosuMcpEntry({ command: "wrapper", args: ["dosu", "mcp", "proxy", "--oss"] })).toBe(
+      false,
+    );
+    expect(
+      isDosuMcpEntry({
+        command: "npx",
+        args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", "dep-a & calc.exe"],
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes an exact proxy emitted by an older released CLI for safe replacement", () => {
+    expect(
+      isDosuMcpEntry({
+        command: "npx",
+        args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", "dep-old"],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not claim ownership of edited proxy or HTTP shapes with extra fields", () => {
+    const command = buildProjectProxyCommand(cloudConfig());
+    expect(isDosuMcpEntry({ ...command, userSetting: true })).toBe(false);
+    expect(
+      isDosuMcpEntry({
+        type: "http",
+        url: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+        headers: { "X-Dosu-API-Key": API_KEY },
+        userSetting: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat another provider's released shape as ownership", () => {
+    const standardDeployment = {
+      type: "http",
+      url: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+      headers: { "X-Dosu-API-Key": API_KEY },
+    };
+    expect(isDosuMcpEntryForProvider("cursor", standardDeployment)).toBe(false);
+    expect(isDosuMcpEntryForProvider("opencode", standardDeployment)).toBe(false);
+    expect(isDosuMcpEntryForProvider("copilot", standardDeployment)).toBe(false);
+
+    const ossStandard = { ...standardDeployment, url: "https://api.dosu.dev/v1/mcp" };
+    expect(isDosuMcpEntryForProvider("cursor", ossStandard)).toBe(true);
+    expect(isDosuMcpEntryForProvider("opencode", ossStandard)).toBe(true);
+    expect(isDosuMcpEntryForProvider("copilot", ossStandard)).toBe(false);
+  });
+
+  it("parses every exact provider-specific proxy shape and rejects cross-provider shapes", () => {
+    const args = ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", "dep-old"];
+    const entries: Record<string, unknown> = {
+      claude: { type: "stdio", command: "npx", args },
+      gemini: { command: "npx", args },
+      zed: { command: "npx", args, env: {} },
+      opencode: { type: "local", command: ["npx", ...args], enabled: true },
+    };
+
+    for (const [provider, entry] of Object.entries(entries)) {
+      expect(ownedProjectProxyOptionsForProvider(provider, entry)).toEqual({
+        deploymentID: "dep-old",
+      });
+    }
+    expect(ownedProjectProxyOptionsForProvider("zed", entries.gemini)).toBeNull();
+    expect(ownedProjectProxyOptionsForProvider("opencode", entries.claude)).toBeNull();
+    const current = buildProjectProxyCommand(cloudConfig());
+    expect(isProjectProxyEntryForProvider("claude", { type: "stdio", ...current })).toBe(true);
+    expect(isProjectProxyEntryForProvider("claude", null)).toBe(false);
+  });
+
+  it("rejects malformed command arrays, args, versions, and target tails", () => {
+    const cases: unknown[] = [
+      null,
+      [],
+      { command: ["npx", 7], type: "local", enabled: true },
+      { command: 7, args: [] },
+      { command: "npx", args: [7] },
+      { command: "npx", args: ["-y", "@dosu/cli@latest", "mcp", "proxy", "--oss"] },
+      { command: "npx", args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy"] },
+      {
+        command: "npx",
+        args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", "bad value"],
+      },
+      { command: "npx", args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--oss"], env: [] },
+    ];
+    for (const entry of cases) expect(ownedProjectProxyOptionsFromEntry(entry)).toBeNull();
+  });
+
+  it("recognizes each released HTTP provider shape but rejects unsafe URLs", () => {
+    const headers = { "X-Dosu-API-Key": API_KEY };
+    const deploymentURL = "https://api.dosu.dev/v1/mcp/deployments/dep-123";
+    const shapes: Array<[string, Record<string, unknown>]> = [
+      ["claude", { type: "http", url: deploymentURL, headers }],
+      ["cursor", { url: deploymentURL, headers }],
+      ["opencode", { type: "remote", enabled: true, url: deploymentURL, headers }],
+      ["zed", { source: "custom", type: "http", url: deploymentURL, headers }],
+      ["antigravity", { serverUrl: deploymentURL, headers }],
+      ["copilot", { type: "http", url: deploymentURL, tools: ["*"], headers }],
+    ];
+    for (const [provider, entry] of shapes) {
+      expect(isDosuMcpEntry(entry)).toBe(true);
+      expect(isDosuMcpEntryForProvider(provider, entry)).toBe(true);
+    }
+    for (const url of [
+      "file:///v1/mcp",
+      "not a URL",
+      `${deploymentURL}?leak=true`,
+      `${deploymentURL}#fragment`,
+      "https://api.dosu.dev/v1/mcp/deployments/a/b",
+    ]) {
+      expect(isDosuMcpEntry({ type: "http", url, headers })).toBe(false);
+    }
+    expect(
+      isDosuMcpEntry({ type: "streamableHttp", disabled: true, url: deploymentURL, headers }),
+    ).toBe(false);
+    expect(isDosuMcpEntryForProvider("unknown", shapes[0][1])).toBe(false);
+  });
+
+  it("never claims a same-shaped MCP server on a foreign origin", () => {
+    const headers = { "X-Dosu-API-Key": API_KEY };
+    const url = "https://foreign.example/v1/mcp/deployments/dep-123";
+    const shapes: Array<[string, Record<string, unknown>]> = [
+      ["claude", { type: "http", url, headers }],
+      ["cursor", { url, headers }],
+      ["vscode", { type: "http", url, headers }],
+      ["gemini", { type: "http", url, headers }],
+      ["zed", { source: "custom", type: "http", url, headers }],
+      ["copilot", { type: "http", url, tools: ["*"], headers }],
+      ["opencode", { type: "remote", enabled: true, url, headers }],
+      ["antigravity", { serverUrl: url, headers }],
+      ["mcporter", { type: "http", url, headers }],
+      ["factory", { type: "http", url, headers }],
+    ];
+
+    for (const [provider, entry] of shapes) {
+      expect(isDosuMcpEntry(entry)).toBe(false);
+      expect(isDosuMcpEntryForProvider(provider, entry)).toBe(false);
+    }
+  });
+
+  it("compares OSS and deployment targets without conflating them", () => {
+    expect(sameProjectProxyTarget({ oss: true }, { oss: true })).toBe(true);
+    expect(sameProjectProxyTarget({ oss: true }, { deploymentID: "dep-a" })).toBe(false);
+    expect(sameProjectProxyTarget({ deploymentID: "dep-a" }, { deploymentID: "dep-a" })).toBe(true);
+    expect(sameProjectProxyTarget({ deploymentID: "dep-a" }, { deploymentID: "dep-b" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("recordProjectProxyEndpoint", () => {
+  it("stores the trusted endpoint in private user config state", () => {
+    const cfg = cloudConfig({ mcp_endpoint: undefined });
+    const saveCredential = vi.fn();
+    recordProjectProxyEndpoint(cfg, { saveCredential });
+
+    expect(cfg.active_account?.target?.mcp_endpoint).toContain("/v1/mcp/deployments/dep-123");
+    expect(saveCredential).toHaveBeenCalledWith({
+      userID: "test-user-id",
+      targetKey: "deployment:dep-123",
+      credential: {
+        endpoint: expect.stringContaining("/v1/mcp/deployments/dep-123"),
+        api_key: API_KEY,
+      },
+    });
+  });
+
+  it("records an OSS endpoint and rejects incomplete cloud credentials", () => {
+    const saveCredential = vi.fn();
+    const oss = cloudConfig({ mode: "oss", deployment_id: undefined, mcp_endpoint: undefined });
+    recordProjectProxyEndpoint(oss, { saveCredential });
+    expect(saveCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetKey: "oss",
+        credential: expect.objectContaining({ endpoint: expect.stringMatching(/\/v1\/mcp$/) }),
+      }),
+    );
+
+    expect(() => recordProjectProxyEndpoint(cloudConfig({ deployment_id: undefined }))).toThrow(
+      /deployment ID/i,
+    );
+    expect(() => recordProjectProxyEndpoint(cloudConfig({ api_key: undefined }))).toThrow(
+      /API key/i,
+    );
+  });
+});
+
+describe("resolveProjectProxyRuntime", () => {
+  it("loads the endpoint and key only from the matching user-level target", () => {
+    expect(resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep-123" })).toEqual({
+      endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+      apiKey: API_KEY,
+    });
+  });
+
+  it("fails closed after the user switches to a different deployment", () => {
+    expect(() => resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep-other" })).toThrow(
+      /re-run.*setup/i,
+    );
+  });
+
+  it("keeps different projects usable after the active deployment changes", () => {
+    const cfg = cloudConfig({
+      deployment_id: "dep-456",
+      api_key: "key-for-dep-456",
+      mcp_endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-456",
+    });
+    const credentials = {
+      "deployment:dep-123": {
+        endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+        api_key: API_KEY,
+      },
+      "deployment:dep-456": {
+        endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-456",
+        api_key: "key-for-dep-456",
+      },
+    };
+    const readCredential = ({ targetKey }: { targetKey: string }) =>
+      credentials[targetKey as keyof typeof credentials];
+
+    expect(resolveProjectProxyRuntime(cfg, { deploymentID: "dep-123" }, readCredential)).toEqual({
+      endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+      apiKey: API_KEY,
+    });
+    expect(
+      resolveProjectProxyRuntime(cfg, { deploymentID: "dep-456" }, readCredential).apiKey,
+    ).toBe("key-for-dep-456");
+  });
+
+  it("refuses a stored endpoint that is not a Dosu MCP path", () => {
+    expect(() =>
+      resolveProjectProxyRuntime(cloudConfig({ mcp_endpoint: "https://evil.test/collect" }), {
+        deploymentID: "dep-123",
+      }),
+    ).toThrow(/invalid MCP endpoint/i);
+  });
+
+  it("fails closed when the user-level API key is missing", () => {
+    expect(() =>
+      resolveProjectProxyRuntime(cloudConfig({ api_key: undefined }), {
+        deploymentID: "dep-123",
+      }),
+    ).toThrow(/API key/i);
+  });
+
+  it("resolves OSS credentials and rejects missing or contradictory targets", () => {
+    const oss = cloudConfig({
+      mode: "oss",
+      deployment_id: undefined,
+      mcp_endpoint: "https://api.dosu.dev/v1/mcp",
+    });
+    expect(resolveProjectProxyRuntime(oss, { oss: true })).toEqual({
+      endpoint: "https://api.dosu.dev/v1/mcp",
+      apiKey: API_KEY,
+    });
+    expect(() => resolveProjectProxyRuntime(oss, {})).toThrow(/exactly one project MCP target/i);
+    expect(() => resolveProjectProxyRuntime(oss, { oss: true, deploymentID: "dep-a" })).toThrow(
+      /exactly one project MCP target/i,
+    );
+  });
+
+  it.each([
+    ["invalid URL", "not a URL"],
+    ["unsupported scheme", "file:///v1/mcp/deployments/dep-123"],
+    ["wrong path", "https://api.dosu.dev/v1/mcp/deployments/other"],
+    ["query", "https://api.dosu.dev/v1/mcp/deployments/dep-123?token=x"],
+    ["fragment", "https://api.dosu.dev/v1/mcp/deployments/dep-123#x"],
+    [
+      "Windows shell metacharacters in userinfo",
+      "https://user&whoami@api.dosu.dev/v1/mcp/deployments/dep-123",
+    ],
+    ["percent expansion syntax", "https://%25PATH%25@api.dosu.dev/v1/mcp/deployments/dep-123"],
+  ])("rejects a stored endpoint with %s", (_name, endpoint) => {
+    expect(() =>
+      resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep-123" }, () => ({
+        endpoint,
+        api_key: API_KEY,
+      })),
+    ).toThrow(/invalid MCP endpoint/i);
+  });
+
+  it("does not fall back to the active API key when a stored record omits its key", () => {
+    expect(() =>
+      resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep-123" }, () => ({
+        endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-123",
+        api_key: "",
+      })),
+    ).toThrow(/API key/i);
+  });
+});
+
+describe("runProjectProxy", () => {
+  it("passes the key through child env, never argv", async () => {
+    const spawn = vi.fn().mockReturnValue({
+      once(event: string, listener: (value: number) => void) {
+        if (event === "close") listener(0);
+        return this;
+      },
+    });
+
+    await expect(
+      runProjectProxy(
+        { deploymentID: "dep-123" },
+        {
+          loadConfig: () => cloudConfig(),
+          spawn: spawn as never,
+          readCredential: () => undefined,
+        },
+      ),
+    ).resolves.toBe(0);
+
+    const [_command, args, options] = spawn.mock.calls[0];
+    expect(JSON.stringify(args)).not.toContain(API_KEY);
+    expect(options.env.X_DOSU_API_KEY).toBe(API_KEY);
+    expect(options.stdio).toBe("inherit");
+    expect(options.shell).toBe(false);
+    expect(options.detached).toBe(true);
+  });
+
+  it("launches npx.cmd through a shell on Windows without putting the key in argv", async () => {
+    const spawn = vi.fn().mockReturnValue({
+      once(event: string, listener: (value: number) => void) {
+        if (event === "close") listener(0);
+        return this;
+      },
+    });
+
+    await expect(
+      runProjectProxy(
+        { deploymentID: "dep-123" },
+        {
+          loadConfig: () => cloudConfig(),
+          spawn: spawn as never,
+          readCredential: () => undefined,
+          platform: "win32",
+          findNpx: () => "C:\\Program Files\\nodejs\\npx.cmd",
+        },
+      ),
+    ).resolves.toBe(0);
+
+    const [command, args, options] = spawn.mock.calls[0];
+    expect(command).toBe("npx.cmd");
+    expect(options.shell).toBe(true);
+    expect(options.detached).toBe(false);
+    expect(options.env.PATH).toMatch(/^C:\\Program Files\\nodejs;/);
+    expect(JSON.stringify(args)).not.toContain(API_KEY);
+  });
+
+  it("forwards shutdown signals to the bridge and removes its listeners", async () => {
+    const signals = new EventEmitter();
+    const kill = vi.fn(() => true);
+    const spawn = vi.fn().mockReturnValue({
+      pid: 4321,
+      once(_event: string, _listener: (value: number | null) => void) {
+        return this;
+      },
+      kill,
+    });
+    let present = true;
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") present = false;
+      if (signal === 0 && !present) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+
+    const result = runProjectProxy(
+      { deploymentID: "dep-123" },
+      {
+        loadConfig: () => cloudConfig(),
+        spawn: spawn as never,
+        signalSource: signals,
+        readCredential: () => undefined,
+        killProcessGroup,
+      },
+    );
+    signals.emit("SIGTERM");
+
+    await expect(result).resolves.toBe(0);
+    expect(killProcessGroup).toHaveBeenCalledWith(-4321, "SIGTERM");
+    expect(kill).not.toHaveBeenCalled();
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+    expect(signals.listenerCount("SIGHUP")).toBe(0);
+  });
+
+  it("does not let an early leader close hide a surviving POSIX descendant", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.pid = 9753;
+    child.kill = vi.fn(() => true);
+    const killProcessGroup = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") queueMicrotask(() => child.emit("close", 0));
+      // Signal 0 continues to report a surviving descendant after SIGKILL.
+    });
+
+    const result = runProjectProxy(
+      { deploymentID: "dep-123" },
+      {
+        loadConfig: () => cloudConfig(),
+        spawn: (() => child) as never,
+        signalSource: signals,
+        readCredential: () => undefined,
+        killProcessGroup,
+        killGraceMs: 1,
+        shutdownDeadlineMs: 1,
+      },
+    );
+    signals.emit("SIGTERM");
+
+    await expect(result).resolves.toBe(1);
+    expect(killProcessGroup).toHaveBeenCalledWith(-9753, "SIGTERM");
+    expect(killProcessGroup).toHaveBeenCalledWith(-9753, "SIGKILL");
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(signals.eventNames()).toEqual([]);
+  });
+
+  it("terminates the full Windows proxy tree and settles even without a child close event", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.pid = 2468;
+    child.kill = vi.fn(() => true);
+    const spawn = vi.fn(() => child);
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+    const spawnTreeKiller = vi.fn(() => {
+      queueMicrotask(() => treeKiller.emit("close", 0));
+      return treeKiller;
+    });
+
+    const result = runProjectProxy(
+      { deploymentID: "dep-123" },
+      {
+        loadConfig: () => cloudConfig(),
+        spawn: spawn as never,
+        signalSource: signals,
+        readCredential: () => undefined,
+        platform: "win32",
+        findNpx: () => "C:\\Program Files\\nodejs\\npx.cmd",
+        spawnTreeKiller: spawnTreeKiller as never,
+      },
+    );
+    signals.emit("SIGTERM");
+
+    await expect(result).resolves.toBe(0);
+    expect(spawnTreeKiller).toHaveBeenCalledWith("taskkill", ["/PID", "2468", "/T", "/F"], {
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(signals.eventNames()).toEqual([]);
+  });
+
+  it("ignores an early Windows proxy close until taskkill reaches its hard deadline", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.pid = 1357;
+    child.kill = vi.fn(() => true);
+    const treeKiller = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    treeKiller.kill = vi.fn(() => true);
+
+    const result = runProjectProxy(
+      { deploymentID: "dep-123" },
+      {
+        loadConfig: () => cloudConfig(),
+        spawn: (() => child) as never,
+        signalSource: signals,
+        readCredential: () => undefined,
+        platform: "win32",
+        findNpx: () => "C:\\node\\npx.cmd",
+        spawnTreeKiller: (() => treeKiller) as never,
+        shutdownDeadlineMs: 1,
+      },
+    );
+    signals.emit("SIGHUP");
+    queueMicrotask(() => child.emit("close", 0));
+
+    await expect(result).resolves.toBe(1);
+    expect(treeKiller.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(signals.eventNames()).toEqual([]);
+  });
+
+  it("returns one for a signal-like null exit and removes listeners", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    child.kill = vi.fn(() => true);
+    const spawn = vi.fn(() => {
+      queueMicrotask(() => child.emit("close", null));
+      return child;
+    });
+    await expect(
+      runProjectProxy(
+        { deploymentID: "dep-123" },
+        {
+          loadConfig: () => cloudConfig(),
+          spawn: spawn as never,
+          signalSource: signals,
+          readCredential: () => undefined,
+        },
+      ),
+    ).resolves.toBe(1);
+    expect(signals.eventNames()).toEqual([]);
+  });
+
+  it("rejects bridge spawn errors and removes all signal listeners", async () => {
+    const signals = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+    child.kill = vi.fn(() => true);
+    const failure = new Error("bridge failed");
+    const spawn = vi.fn(() => {
+      queueMicrotask(() => child.emit("error", failure));
+      return child;
+    });
+    await expect(
+      runProjectProxy(
+        { deploymentID: "dep-123" },
+        {
+          loadConfig: () => cloudConfig(),
+          spawn: spawn as never,
+          signalSource: signals,
+          readCredential: () => undefined,
+        },
+      ),
+    ).rejects.toThrow("bridge failed");
+    expect(signals.eventNames()).toEqual([]);
+  });
+});

--- a/src/mcp/project-proxy.ts
+++ b/src/mcp/project-proxy.ts
@@ -1,0 +1,600 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { win32 } from "node:path";
+import type { Config } from "../config/config";
+import { getConfigUserID, loadConfig, MODE_OSS, updateTarget } from "../config/config";
+import { VERSION } from "../version/version";
+import { mcpBaseURL, mcpRemoteServer, mcpURL } from "./config-helpers";
+import { findNpx, npxPathEnv } from "./detect";
+import {
+  type KillProcessGroup,
+  type SpawnTreeKiller,
+  terminatePosixProcessTree,
+  terminateWindowsProcessTree,
+} from "./process-tree";
+import {
+  readProjectMcpCredential,
+  type StoredProjectMcpCredential,
+  saveProjectMcpCredential,
+} from "./project-credential-store";
+
+export interface ProjectProxyCommand {
+  command: string;
+  args: string[];
+}
+
+export interface ProjectProxyOptions {
+  deploymentID?: string;
+  oss?: boolean;
+}
+
+export interface ProjectProxyRuntime {
+  endpoint: string;
+  apiKey: string;
+}
+
+function credentialKey(opts: ProjectProxyOptions): string {
+  if (Boolean(opts.deploymentID) === Boolean(opts.oss)) {
+    throw new Error("Exactly one project MCP target is required. Re-run `dosu setup`.");
+  }
+  return opts.oss ? "oss" : `deployment:${requireSafeProjectDeploymentID(opts.deploymentID)}`;
+}
+
+interface SpawnedProcess {
+  pid?: number;
+  once(event: "error", listener: (error: Error) => void): SpawnedProcess;
+  once(event: "close", listener: (code: number | null) => void): SpawnedProcess;
+  kill(signal: NodeJS.Signals): boolean;
+}
+
+type ProxySignal = "SIGINT" | "SIGTERM" | "SIGHUP";
+
+interface SignalSource {
+  once(event: ProxySignal, listener: () => void): unknown;
+  removeListener(event: ProxySignal, listener: () => void): unknown;
+}
+
+type SpawnProxy = (
+  command: string,
+  args: string[],
+  options: { stdio: "inherit"; env: NodeJS.ProcessEnv; shell: boolean; detached: boolean },
+) => SpawnedProcess;
+
+export interface ProjectProxyDependencies {
+  loadConfig?: () => Config;
+  spawn?: SpawnProxy;
+  signalSource?: SignalSource;
+  platform?: NodeJS.Platform;
+  findNpx?: () => string;
+  spawnTreeKiller?: SpawnTreeKiller;
+  killProcessGroup?: KillProcessGroup;
+  killGraceMs?: number;
+  shutdownDeadlineMs?: number;
+  readCredential?: (input: {
+    userID: string;
+    targetKey: string;
+  }) => StoredProjectMcpCredential | undefined;
+}
+
+export interface ProjectProxyRecordDependencies {
+  saveCredential?: typeof saveProjectMcpCredential;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function containsProjectSecretField(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsProjectSecretField);
+  if (!isRecord(value)) return false;
+  return Object.entries(value).some(([key, child]) => {
+    const normalized = key.toLowerCase().replace(/_/g, "-");
+    return normalized === "x-dosu-api-key" || containsProjectSecretField(child);
+  });
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function hasExactProjectProxyShape(value: Record<string, unknown>): boolean {
+  if (Array.isArray(value.command)) {
+    return (
+      hasExactKeys(value, ["type", "command", "enabled"]) &&
+      value.type === "local" &&
+      value.enabled === true
+    );
+  }
+  if (hasExactKeys(value, ["command", "args"])) return true;
+  if (hasExactKeys(value, ["type", "command", "args"])) return value.type === "stdio";
+  if (hasExactKeys(value, ["command", "args", "env"])) {
+    return isRecord(value.env) && Object.keys(value.env).length === 0;
+  }
+  return false;
+}
+
+function projectProxyParts(value: Record<string, unknown>): string[] | null {
+  if (Array.isArray(value.command)) {
+    if (value.command.some((part) => typeof part !== "string")) return null;
+    return value.command as string[];
+  }
+  if (typeof value.command !== "string") return null;
+  if (!Array.isArray(value.args) || value.args.some((part) => typeof part !== "string")) {
+    return null;
+  }
+  return [value.command, ...(value.args as string[])];
+}
+
+function optionsFromParts(
+  parts: readonly string[],
+  packageSpec: string | RegExp,
+): ProjectProxyOptions | null {
+  const expectedPackage = parts[2];
+  const packageMatches =
+    typeof packageSpec === "string"
+      ? expectedPackage === packageSpec
+      : typeof expectedPackage === "string" && packageSpec.test(expectedPackage);
+  const prefixMatches =
+    parts[0] === "npx" &&
+    parts[1] === "-y" &&
+    packageMatches &&
+    parts[3] === "mcp" &&
+    parts[4] === "proxy";
+  if (!prefixMatches) return null;
+  const tail = parts.slice(5);
+  if (tail.length === 1 && tail[0] === "--oss") return { oss: true };
+  if (tail.length === 2 && tail[0] === "--deployment" && isSafeProjectDeploymentID(tail[1])) {
+    return { deploymentID: tail[1] };
+  }
+  return null;
+}
+
+// Project deployment IDs cross a shell boundary on Windows because Node cannot
+// execute npx.cmd directly. Keep the accepted syntax deliberately narrower
+// than cmd.exe's metacharacter set before an ID can enter a checked-in command.
+const SAFE_PROJECT_DEPLOYMENT_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+
+export function isSafeProjectDeploymentID(value: unknown): value is string {
+  return typeof value === "string" && SAFE_PROJECT_DEPLOYMENT_ID.test(value);
+}
+
+function requireSafeProjectDeploymentID(value: unknown): string {
+  if (!isSafeProjectDeploymentID(value)) {
+    throw new Error("Invalid project deployment ID. Re-run `dosu setup`.");
+  }
+  return value;
+}
+
+/** Parse only the exact, current, secretless command emitted into project files. */
+export function projectProxyOptionsFromEntry(value: unknown): ProjectProxyOptions | null {
+  if (!isRecord(value) || !hasExactProjectProxyShape(value) || containsProjectSecretField(value)) {
+    return null;
+  }
+  const parts = projectProxyParts(value);
+  if (!parts) return null;
+  return optionsFromParts(parts, `@dosu/cli@${VERSION}`);
+}
+
+/** Parse an exact secretless project proxy emitted by any released Dosu CLI version. */
+export function ownedProjectProxyOptionsFromEntry(value: unknown): ProjectProxyOptions | null {
+  if (!isRecord(value) || !hasExactProjectProxyShape(value) || containsProjectSecretField(value)) {
+    return null;
+  }
+  const parts = projectProxyParts(value);
+  if (!parts) return null;
+  return optionsFromParts(parts, /^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+}
+
+export function isProjectProxyEntry(value: unknown): boolean {
+  return projectProxyOptionsFromEntry(value) !== null;
+}
+
+function hasProviderProjectShape(providerID: string, value: Record<string, unknown>): boolean {
+  switch (providerID) {
+    case "gemini":
+    case "antigravity":
+    case "mcporter":
+    case "codex":
+      return hasExactKeys(value, ["command", "args"]);
+    case "zed":
+      return (
+        hasExactKeys(value, ["command", "args", "env"]) &&
+        isRecord(value.env) &&
+        Object.keys(value.env).length === 0
+      );
+    case "opencode":
+      return (
+        hasExactKeys(value, ["type", "command", "enabled"]) &&
+        value.type === "local" &&
+        value.enabled === true
+      );
+    default:
+      return hasExactKeys(value, ["type", "command", "args"]) && value.type === "stdio";
+  }
+}
+
+export function isProjectProxyEntryForProvider(providerID: string, value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasProviderProjectShape(providerID, value) &&
+    projectProxyOptionsFromEntry(value) !== null
+  );
+}
+
+export function ownedProjectProxyOptionsForProvider(
+  providerID: string,
+  value: unknown,
+): ProjectProxyOptions | null {
+  return isRecord(value) && hasProviderProjectShape(providerID, value)
+    ? ownedProjectProxyOptionsFromEntry(value)
+    : null;
+}
+
+export function sameProjectProxyTarget(
+  left: ProjectProxyOptions,
+  right: ProjectProxyOptions,
+): boolean {
+  return left.oss === true
+    ? right.oss === true
+    : right.oss !== true && left.deploymentID === right.deploymentID;
+}
+
+// Only released production URLs prove that a historical HTTP entry belongs to
+// Dosu. A matching path/header on localhost, staging, or a third-party origin
+// is user-owned and must never be removed automatically.
+const RELEASED_DOSU_MCP_ORIGIN = "https://api.dosu.dev";
+
+function hasDosuMcpPath(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.origin === RELEASED_DOSU_MCP_ORIGIN &&
+      !parsed.username &&
+      !parsed.password &&
+      !parsed.search &&
+      !parsed.hash &&
+      (/^\/v1\/mcp$/.test(parsed.pathname) ||
+        /^\/v1\/mcp\/deployments\/[^/]+$/.test(parsed.pathname))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasBaseDosuMcpPath(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.origin === RELEASED_DOSU_MCP_ORIGIN &&
+      !parsed.username &&
+      !parsed.password &&
+      !parsed.search &&
+      !parsed.hash &&
+      parsed.pathname === "/v1/mcp"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasExactDosuHeaders(value: Record<string, unknown>): boolean {
+  const headers = isRecord(value.headers) ? value.headers : undefined;
+  return Boolean(
+    headers &&
+      hasExactKeys(headers, ["X-Dosu-API-Key"]) &&
+      typeof headers["X-Dosu-API-Key"] === "string" &&
+      headers["X-Dosu-API-Key"].length > 0,
+  );
+}
+
+function isStandardHttpEntry(value: Record<string, unknown>, baseOnly = false): boolean {
+  return (
+    hasExactKeys(value, ["type", "url", "headers"]) &&
+    value.type === "http" &&
+    hasExactDosuHeaders(value) &&
+    (baseOnly ? hasBaseDosuMcpPath(value.url) : hasDosuMcpPath(value.url))
+  );
+}
+
+/** Recognize entries written by released Dosu CLIs or by this project proxy. */
+export function isDosuMcpEntry(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (isProjectProxyEntry(value)) return true;
+  const parts = projectProxyParts(value);
+  if (
+    hasExactProjectProxyShape(value) &&
+    !containsProjectSecretField(value) &&
+    parts &&
+    optionsFromParts(parts, /^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+  ) {
+    return true;
+  }
+
+  const headers = isRecord(value.headers) ? value.headers : undefined;
+  if (
+    !headers ||
+    !hasExactKeys(headers, ["X-Dosu-API-Key"]) ||
+    typeof headers["X-Dosu-API-Key"] !== "string" ||
+    headers["X-Dosu-API-Key"].length === 0
+  ) {
+    return false;
+  }
+  if (hasExactKeys(value, ["type", "url", "headers"])) {
+    return value.type === "http" && hasDosuMcpPath(value.url);
+  }
+  if (hasExactKeys(value, ["url", "headers"])) return hasDosuMcpPath(value.url);
+  if (hasExactKeys(value, ["type", "disabled", "url", "headers"])) {
+    return value.type === "streamableHttp" && value.disabled === false && hasDosuMcpPath(value.url);
+  }
+  if (hasExactKeys(value, ["type", "enabled", "url", "headers"])) {
+    return value.type === "remote" && value.enabled === true && hasDosuMcpPath(value.url);
+  }
+  if (hasExactKeys(value, ["source", "type", "url", "headers"])) {
+    return value.source === "custom" && value.type === "http" && hasDosuMcpPath(value.url);
+  }
+  if (hasExactKeys(value, ["serverUrl", "headers"])) return hasDosuMcpPath(value.serverUrl);
+  if (hasExactKeys(value, ["type", "url", "tools", "headers"])) {
+    return (
+      value.type === "http" &&
+      hasDosuMcpPath(value.url) &&
+      Array.isArray(value.tools) &&
+      value.tools.length === 1 &&
+      value.tools[0] === "*"
+    );
+  }
+  return false;
+}
+
+/** Provider-specific ownership used before replacing or removing a project entry. */
+export function isDosuMcpEntryForProvider(providerID: string, value: unknown): boolean {
+  if (!isRecord(value)) return false;
+
+  const parts = projectProxyParts(value);
+  if (
+    hasProviderProjectShape(providerID, value) &&
+    !containsProjectSecretField(value) &&
+    parts &&
+    optionsFromParts(parts, /^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+  ) {
+    return true;
+  }
+
+  switch (providerID) {
+    case "claude":
+    case "vscode":
+    case "gemini":
+    case "factory":
+    case "mcporter":
+      return isStandardHttpEntry(value);
+    case "cursor":
+      return (
+        (hasExactKeys(value, ["url", "headers"]) &&
+          hasExactDosuHeaders(value) &&
+          hasDosuMcpPath(value.url)) ||
+        isStandardHttpEntry(value, true)
+      );
+    case "opencode":
+      return (
+        (hasExactKeys(value, ["type", "enabled", "url", "headers"]) &&
+          value.type === "remote" &&
+          value.enabled === true &&
+          hasExactDosuHeaders(value) &&
+          hasDosuMcpPath(value.url)) ||
+        isStandardHttpEntry(value, true)
+      );
+    case "zed":
+      return (
+        (hasExactKeys(value, ["source", "type", "url", "headers"]) &&
+          value.source === "custom" &&
+          value.type === "http" &&
+          hasExactDosuHeaders(value) &&
+          hasDosuMcpPath(value.url)) ||
+        isStandardHttpEntry(value, true)
+      );
+    case "antigravity":
+      return (
+        (hasExactKeys(value, ["serverUrl", "headers"]) &&
+          hasExactDosuHeaders(value) &&
+          hasDosuMcpPath(value.serverUrl)) ||
+        isStandardHttpEntry(value, true)
+      );
+    case "copilot":
+      return (
+        hasExactKeys(value, ["type", "url", "tools", "headers"]) &&
+        value.type === "http" &&
+        hasExactDosuHeaders(value) &&
+        hasDosuMcpPath(value.url) &&
+        Array.isArray(value.tools) &&
+        value.tools.length === 1 &&
+        value.tools[0] === "*"
+      );
+    default:
+      return false;
+  }
+}
+
+/**
+ * Build the checked-in command. It contains a deployment identifier, but no endpoint or secret;
+ * both are resolved from the user's private Dosu config when the agent starts the MCP server.
+ */
+export function buildProjectProxyCommand(cfg: Config): ProjectProxyCommand {
+  // Fail during setup, before writing a config that cannot start.
+  findNpx();
+  const args = ["-y", `@dosu/cli@${VERSION}`, "mcp", "proxy"];
+  if (cfg.mode === MODE_OSS) {
+    args.push("--oss");
+  } else {
+    const deploymentID = requireSafeProjectDeploymentID(cfg.active_account?.target?.deployment_id);
+    args.push("--deployment", deploymentID);
+  }
+  return { command: "npx", args };
+}
+
+/** Persist the endpoint beside the API key in the private user config before project files refer to it. */
+export function recordProjectProxyEndpoint(
+  cfg: Config,
+  deps: ProjectProxyRecordDependencies = {},
+): void {
+  const deploymentID = cfg.active_account?.target?.deployment_id;
+  if (cfg.mode !== MODE_OSS && !deploymentID) throw new Error("deployment ID is required");
+  const apiKey = cfg.active_account?.target?.api_key;
+  if (!apiKey) throw new Error("API key is required");
+  const key = credentialKey(
+    cfg.mode === MODE_OSS ? { oss: true } : { deploymentID: deploymentID as string },
+  );
+  const endpoint = cfg.mode === MODE_OSS ? mcpBaseURL() : mcpURL(deploymentID as string);
+  updateTarget(cfg, {
+    mcp_endpoint: endpoint,
+  });
+  const userID = getConfigUserID(cfg);
+  if (!userID) throw new Error("authenticated account identity is required");
+  (deps.saveCredential ?? saveProjectMcpCredential)({
+    userID,
+    targetKey: key,
+    credential: { endpoint, api_key: apiKey },
+  });
+}
+
+function validateStoredEndpoint(endpoint: string, deploymentID?: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    throw new Error("Invalid MCP endpoint in Dosu user config. Re-run `dosu setup`.");
+  }
+
+  const expectedPath = deploymentID
+    ? `/v1/mcp/deployments/${encodeURIComponent(deploymentID)}`
+    : "/v1/mcp";
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("Invalid MCP endpoint in Dosu user config. Re-run `dosu setup`.");
+  }
+  if (
+    parsed.username ||
+    parsed.password ||
+    /[\s"&|<>()^%!]/.test(endpoint) ||
+    parsed.pathname !== expectedPath ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error("Invalid MCP endpoint in Dosu user config. Re-run `dosu setup`.");
+  }
+}
+
+/** Resolve secret runtime state without trusting any endpoint supplied by a project file. */
+export function resolveProjectProxyRuntime(
+  cfg: Config,
+  opts: ProjectProxyOptions,
+  readCredential: ProjectProxyDependencies["readCredential"] = readProjectMcpCredential,
+): ProjectProxyRuntime {
+  const key = credentialKey(opts);
+  const target = cfg.active_account?.target;
+  const userID = getConfigUserID(cfg);
+  const stored = userID ? readCredential?.({ userID, targetKey: key }) : undefined;
+  const canUseActiveTarget = opts.oss
+    ? cfg.mode === MODE_OSS
+    : Boolean(opts.deploymentID && target?.deployment_id === opts.deploymentID);
+  const endpoint = stored?.endpoint ?? (canUseActiveTarget ? target?.mcp_endpoint : undefined);
+  if (!endpoint) {
+    throw new Error(
+      "This project's Dosu credentials are missing. Re-run `dosu setup` in the project.",
+    );
+  }
+  validateStoredEndpoint(endpoint, opts.oss ? undefined : opts.deploymentID);
+
+  const apiKey = stored?.api_key ?? (canUseActiveTarget ? target?.api_key : undefined);
+  if (!apiKey) throw new Error("Dosu API key is missing. Re-run `dosu setup` in the project.");
+  return { endpoint, apiKey };
+}
+
+/** Run the pinned HTTP-to-stdio bridge used by project configuration entries. */
+export async function runProjectProxy(
+  opts: ProjectProxyOptions,
+  deps: ProjectProxyDependencies = {},
+): Promise<number> {
+  const runtime = resolveProjectProxyRuntime(
+    (deps.loadConfig ?? loadConfig)(),
+    opts,
+    deps.readCredential,
+  );
+  const npx = (deps.findNpx ?? findNpx)();
+  const platform = deps.platform ?? process.platform;
+  const remote = mcpRemoteServer(runtime.endpoint, runtime.apiKey);
+  // Node's shell mode concatenates the executable and arguments without
+  // quoting the executable. Use the basename on Windows and prepend the
+  // already-verified directory to PATH so `C:\\Program Files\\...` works.
+  const executable = platform === "win32" ? win32.basename(npx) : npx;
+  const child = (deps.spawn ?? (nodeSpawn as unknown as SpawnProxy))(executable, remote.args, {
+    stdio: "inherit",
+    // On Windows npm exposes npx as npx.cmd. Node documents that .cmd files
+    // cannot be launched directly; they must run through a shell.
+    shell: platform === "win32",
+    detached: platform !== "win32",
+    env: {
+      ...process.env,
+      PATH: npxPathEnv(npx),
+      ...remote.env,
+    },
+  });
+
+  return await new Promise<number>((resolve, reject) => {
+    const signalSource = deps.signalSource ?? (process as SignalSource);
+    const signals: readonly ProxySignal[] = ["SIGINT", "SIGTERM", "SIGHUP"];
+    const forwarders = new Map<ProxySignal, () => void>();
+    let settled = false;
+    let shuttingDown = false;
+    const cleanup = () => {
+      for (const [signal, listener] of forwarders) {
+        signalSource.removeListener(signal, listener);
+      }
+      forwarders.clear();
+    };
+    const settleResolve = (code: number) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(code);
+    };
+    const settleReject = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    for (const signal of signals) {
+      const forward = () => {
+        if (platform !== "win32") {
+          if (shuttingDown) return;
+          shuttingDown = true;
+          void terminatePosixProcessTree(child, {
+            killProcessGroup: deps.killProcessGroup,
+            killGraceMs: deps.killGraceMs,
+            shutdownDeadlineMs: deps.shutdownDeadlineMs,
+          }).then((status) => settleResolve(status === "terminated" ? 0 : 1));
+          return;
+        }
+        if (shuttingDown) return;
+        shuttingDown = true;
+        void terminateWindowsProcessTree(child, {
+          spawnTreeKiller: deps.spawnTreeKiller,
+          shutdownDeadlineMs: deps.shutdownDeadlineMs,
+        }).then((status) => settleResolve(status === "terminated" ? 0 : 1));
+      };
+      forwarders.set(signal, forward);
+      signalSource.once(signal, forward);
+    }
+
+    child.once("error", (error) => {
+      if (shuttingDown) return;
+      settleReject(error);
+    });
+    child.once("close", (code) => {
+      if (shuttingDown) return;
+      settleResolve(code ?? 1);
+    });
+  });
+}


### PR DESCRIPTION
<!-- Is this PR related to a Linear issue? -->
<!-- Example: Fixes [ENG-123](https://linear.app/dosu/issue/ENG-123) -->

### Description

Stack 2/8, based on #157. Adds the private credential store, secretless project proxy command builder, MCP initialize preflight, bounded process-tree cleanup, and shared signal policy.

No CLI entrypoint uses this runtime in this layer, so setup behavior and user configuration remain unchanged. The next layers wire it into project providers and setup.

Validated locally with `bun run typecheck`, `bun run check`, all 1,891 tests, 119 focused runtime tests, `git diff --check`, and `bun run build:npm`.

Stack review order:

1. #157 feat(mcp): add safe project file foundation
2. #158 feat(mcp): add secretless project proxy runtime
3. #159 feat(setup): add project agent assets
4. #160 feat(migration): prove complete project bundles
5. #161 feat(migration): add proof-gated global cleanup
6. #162 feat(mcp): enable project-scoped providers
7. #163 feat(setup): scope setup to the current project
8. #164 docs(setup): document project-scoped agent setup

Because this repository is squash-only, land by collapsing leaf into base: #164 -> #163 -> #162 -> #161 -> #160 -> #159 -> #158 -> #157 -> main.

### Review Tasks - Only request review after completing these.

* [ ] I self-reviewed this PR
* [ ] Testing is adequate for this change
* [ ] I reviewed AI-generated code and resolved suggestions

### Details (for context) - Not tasks; tooling uses tasks to determine review readiness

- Generated with AI: (N/Claude/Codex/Other)
- Manual testing: (Y/N/NA)
- Tests updated: (Y/N/NA)

<!-- Describe any manual testing or special testing approach -->
