### PR TITLE
feat(setup): add project agent assets (3/8)

### DIFF
--- a/src/commands/project-skill-ownership.test.ts
+++ b/src/commands/project-skill-ownership.test.ts
@@ -1,0 +1,507 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assertProjectSkillInstallSafe,
+  projectSkillEvidenceUnchanged,
+  verifyProjectSkillInstallation,
+} from "./project-skill-ownership";
+
+let root: string;
+const extraRoots: string[] = [];
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "dosu-project-skill-ownership-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  for (const extraRoot of extraRoots.splice(0)) {
+    rmSync(extraRoot, { recursive: true, force: true });
+  }
+});
+
+function writeOwnedSkill(target: string): void {
+  const content = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  mkdirSync(target, { recursive: true });
+  writeFileSync(join(target, "SKILL.md"), content);
+  const computedHash = createHash("sha256").update("SKILL.md").update(content).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+function writeLock(computedHash: string, skills: Record<string, unknown> = {}): void {
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        ...skills,
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+describe("project skill ownership", () => {
+  it("verifies the actual Claude-only direct layout from skills@1.5.22", () => {
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(claude);
+
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: claude, symlink: false }],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("verifies the actual mixed canonical plus Claude symlink layout", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", claude, "dir");
+
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [
+          { path: canonical, symlink: false },
+          { path: claude, symlink: true },
+        ],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("verifies the actual Factory-only direct layout from skills@1.5.22", () => {
+    const factory = join(root, ".factory", "skills", "dosu");
+    writeOwnedSkill(factory);
+
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: factory, symlink: false }],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("verifies the mixed Factory symlink and accepts a later Factory-only rerun", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const factory = join(root, ".factory", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".factory", "skills"), { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", factory, "dir");
+    const mixedTargets = [
+      { path: canonical, symlink: false },
+      { path: factory, symlink: true },
+    ];
+
+    expect(
+      verifyProjectSkillInstallation({ projectRoot: root, targets: mixedTargets }),
+    ).toMatchObject({ ok: true });
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: factory, symlink: false }],
+      }),
+    ).not.toThrow();
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: factory, symlink: false }],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("rejects a foreign Factory skill symlink before install", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const factory = join(root, ".factory", "skills", "dosu");
+    const external = mkdtempSync(join(tmpdir(), "dosu-foreign-factory-skill-"));
+    extraRoots.push(external);
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".factory", "skills"), { recursive: true });
+    symlinkSync(external, factory, "dir");
+
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: factory, symlink: false }],
+      }),
+    ).toThrow(/ownership/i);
+  });
+
+  it("accepts a Claude-only rerun of the previously owned mixed layout", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", claude, "dir");
+    const claudeOnlyTargets = [{ path: claude, symlink: false }];
+
+    expect(() =>
+      assertProjectSkillInstallSafe({ projectRoot: root, targets: claudeOnlyTargets }),
+    ).not.toThrow();
+    expect(
+      verifyProjectSkillInstallation({ projectRoot: root, targets: claudeOnlyTargets }),
+    ).toMatchObject({
+      ok: true,
+      evidence: expect.arrayContaining([
+        expect.objectContaining({ kind: "directory", path: canonical }),
+        expect.objectContaining({ kind: "symlink", path: claude }),
+      ]),
+    });
+  });
+
+  it("rejects foreign and edited shared layouts during a Claude-only rerun", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+
+    const external = mkdtempSync(join(tmpdir(), "dosu-foreign-shared-skill-"));
+    extraRoots.push(external);
+    const externalSkill = join(external, "dosu");
+    mkdirSync(externalSkill, { recursive: true });
+    writeFileSync(
+      join(externalSkill, "SKILL.md"),
+      "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n",
+    );
+    symlinkSync(externalSkill, claude, "dir");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: claude, symlink: false }],
+      }),
+    ).toThrow(/ownership/i);
+
+    rmSync(claude);
+    symlinkSync("../../.agents/skills/dosu", claude, "dir");
+    writeFileSync(join(canonical, "SKILL.md"), "---\nname: dosu\n---\nuser edited\n");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: claude, symlink: false }],
+      }),
+    ).toThrow(/ownership/i);
+  });
+
+  it("rejects a duplicate-key lock and a foreign mixed-layout symlink", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    const validLock = `{"version":1,"skills":{"dosu":${JSON.stringify({
+      source: "dosu-ai/dosu-skill",
+      sourceType: "github",
+      skillPath: "skills/dosu/SKILL.md",
+      computedHash: "a".repeat(64),
+    })},"dosu":{}}}`;
+    writeFileSync(join(root, "skills-lock.json"), validLock);
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: canonical, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_lock_mismatch" });
+
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync("../../../foreign", claude, "dir");
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [
+          { path: canonical, symlink: false },
+          { path: claude, symlink: true },
+        ],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_foreign_symlink" });
+  });
+
+  it("allows a clean install but rejects pre-existing skill content without an ownership lock", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).not.toThrow();
+
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), "user-authored");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toThrow(/cannot prove ownership/i);
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_lock_mismatch" });
+  });
+
+  it("treats an unclaimed lock as safe only while no Dosu target exists", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    writeFileSync(
+      join(root, "skills-lock.json"),
+      JSON.stringify({ version: 1, skills: { other: { source: "example" } } }),
+    );
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).not.toThrow();
+
+    mkdirSync(target, { recursive: true });
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toThrow(/cannot prove ownership/i);
+  });
+
+  it("rejects malformed, symlinked, and semantically foreign ownership locks", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    const lockPath = join(root, "skills-lock.json");
+    writeFileSync(lockPath, "not-json");
+    expect(() => assertProjectSkillInstallSafe({ projectRoot: root, targets: [] })).toThrow(
+      /cannot prove ownership/i,
+    );
+
+    rmSync(lockPath);
+    writeFileSync(join(root, "foreign-lock.json"), '{"version":1,"skills":{}}');
+    symlinkSync(join(root, "foreign-lock.json"), lockPath);
+    expect(verifyProjectSkillInstallation({ projectRoot: root, targets: [] })).toMatchObject({
+      ok: false,
+      reason: "project_skill_lock_mismatch",
+    });
+
+    rmSync(lockPath);
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        version: 1,
+        skills: {
+          dosu: {
+            source: "someone/else",
+            sourceType: "github",
+            skillPath: "skills/dosu/SKILL.md",
+            computedHash: "a".repeat(64),
+          },
+        },
+      }),
+    );
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toThrow(/cannot prove ownership/i);
+  });
+
+  it("hashes nested regular files deterministically while ignoring package and VCS metadata", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+    mkdirSync(join(target, "references"), { recursive: true });
+    mkdirSync(join(target, ".git"), { recursive: true });
+    mkdirSync(join(target, "node_modules"), { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), skill);
+    writeFileSync(join(target, "references", "guide.md"), "guide");
+    writeFileSync(join(target, ".git", "ignored"), "changes freely");
+    writeFileSync(join(target, "node_modules", "ignored"), "changes freely");
+    const computedHash = createHash("sha256")
+      .update("references/guide.md")
+      .update("guide")
+      .update("SKILL.md")
+      .update(skill)
+      .digest("hex");
+    writeLock(computedHash);
+
+    const verification = verifyProjectSkillInstallation({
+      projectRoot: root,
+      targets: [{ path: target, symlink: false }],
+    });
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+    expect(verification.evidence.some((item) => item.kind === "directory")).toBe(true);
+
+    writeFileSync(join(target, ".git", "ignored"), "still ignored");
+    for (const evidence of verification.evidence) {
+      expect(projectSkillEvidenceUnchanged(evidence, root)).toBe(true);
+    }
+    writeFileSync(join(target, "references", "guide.md"), "user edit");
+    expect(verification.evidence.some((item) => !projectSkillEvidenceUnchanged(item, root))).toBe(
+      true,
+    );
+  });
+
+  it("rejects missing targets, ordinary files, bad frontmatter, and nested symlinks", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    writeLock("a".repeat(64));
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_missing", path: target });
+
+    mkdirSync(join(root, ".agents", "skills"), { recursive: true });
+    writeFileSync(target, "ordinary file", { flag: "w" });
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+
+    rmSync(target);
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), "---\nname: other\n---\n");
+    const other = readFileSync(join(target, "SKILL.md"));
+    writeLock(createHash("sha256").update("SKILL.md").update(other).digest("hex"));
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+
+    writeFileSync(join(target, "SKILL.md"), "---\nname: dosu\n---\n");
+    symlinkSync(join(root, "foreign-lock.json"), join(target, "nested-link"));
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+  });
+
+  it("revalidates mixed-layout symlink and lock evidence after verification", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const claude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", claude, "dir");
+    const verification = verifyProjectSkillInstallation({
+      projectRoot: root,
+      targets: [
+        { path: canonical, symlink: false },
+        { path: claude, symlink: true },
+      ],
+    });
+    if (!verification.ok) throw new Error(verification.reason);
+
+    const lockEvidence = verification.evidence.find((item) => item.kind === "file");
+    const symlinkEvidence = verification.evidence.find((item) => item.kind === "symlink");
+    expect(lockEvidence && projectSkillEvidenceUnchanged(lockEvidence, root)).toBe(true);
+    expect(symlinkEvidence && projectSkillEvidenceUnchanged(symlinkEvidence, root)).toBe(true);
+
+    writeFileSync(join(root, "skills-lock.json"), '{"version":1,"skills":{}}');
+    expect(lockEvidence && projectSkillEvidenceUnchanged(lockEvidence, root)).toBe(false);
+    rmSync(claude);
+    symlinkSync("../../.agents/skills", claude, "dir");
+    expect(symlinkEvidence && projectSkillEvidenceUnchanged(symlinkEvidence, root)).toBe(false);
+  });
+
+  it("allows an owned reinstall when present targets are intact and missing adapters are optional", () => {
+    const canonical = join(root, ".agents", "skills", "dosu");
+    const optionalClaude = join(root, ".claude", "skills", "dosu");
+    writeOwnedSkill(canonical);
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [
+          { path: canonical, symlink: false },
+          { path: optionalClaude, symlink: true },
+        ],
+      }),
+    ).not.toThrow();
+
+    writeFileSync(join(canonical, "SKILL.md"), "user changed");
+    expect(() =>
+      assertProjectSkillInstallSafe({
+        projectRoot: root,
+        targets: [{ path: canonical, symlink: false }],
+      }),
+    ).toThrow(/cannot prove ownership/i);
+  });
+
+  it("rejects an ordinary target that resolves outside the verified project root", () => {
+    const external = mkdtempSync(join(tmpdir(), "dosu-external-skill-"));
+    extraRoots.push(external);
+    const externalSkill = join(external, "skills", "dosu");
+    const content = "---\nname: dosu\n---\n";
+    mkdirSync(externalSkill, { recursive: true });
+    writeFileSync(join(externalSkill, "SKILL.md"), content);
+    const computedHash = createHash("sha256").update("SKILL.md").update(content).digest("hex");
+    writeLock(computedHash);
+    symlinkSync(external, join(root, ".agents"), "dir");
+
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: join(root, ".agents", "skills", "dosu"), symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+  });
+
+  it("rejects an empty directory even when its digest matches because SKILL.md is required", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    mkdirSync(target, { recursive: true });
+    writeLock(createHash("sha256").digest("hex"));
+    expect(
+      verifyProjectSkillInstallation({
+        projectRoot: root,
+        targets: [{ path: target, symlink: false }],
+      }),
+    ).toMatchObject({ ok: false, reason: "project_skill_modified" });
+  });
+
+  it("treats replaced and removed evidence as changed", () => {
+    const target = join(root, ".agents", "skills", "dosu");
+    writeOwnedSkill(target);
+    const verification = verifyProjectSkillInstallation({
+      projectRoot: root,
+      targets: [{ path: target, symlink: false }],
+    });
+    if (!verification.ok) throw new Error(verification.reason);
+    const lockEvidence = verification.evidence.find((item) => item.kind === "file");
+    const directoryEvidence = verification.evidence.find((item) => item.kind === "directory");
+    if (!lockEvidence || !directoryEvidence)
+      throw new Error("expected lock and directory evidence");
+
+    const lockPath = join(root, "skills-lock.json");
+    const foreignLock = join(root, "foreign-lock.json");
+    writeFileSync(foreignLock, readFileSync(lockPath));
+    rmSync(lockPath);
+    symlinkSync(foreignLock, lockPath);
+    expect(projectSkillEvidenceUnchanged(lockEvidence, root)).toBe(false);
+
+    rmSync(target, { recursive: true });
+    expect(projectSkillEvidenceUnchanged(directoryEvidence, root)).toBe(false);
+  });
+});

--- a/src/commands/project-skill-ownership.ts
+++ b/src/commands/project-skill-ownership.ts
@@ -1,0 +1,332 @@
+import { createHash } from "node:crypto";
+import { type Dirent, lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import {
+  getNodeValue,
+  type Node as JsonNode,
+  type ParseError,
+  parseTree,
+} from "jsonc-parser/lib/esm/main.js";
+import { assertSafeProjectPath } from "../setup/project-path";
+
+const LOCK_NAME = "skills-lock.json";
+const DOSU_SOURCE = "dosu-ai/dosu-skill";
+const DOSU_SKILL_PATH = "skills/dosu/SKILL.md";
+
+export interface ProjectSkillTarget {
+  path: string;
+  symlink: boolean;
+}
+
+export type ProjectSkillEvidence =
+  | { kind: "file"; path: string; realPath: string; hash: string }
+  | { kind: "directory"; path: string; realPath: string; hash: string }
+  | { kind: "symlink"; path: string; realPath: string };
+
+export type ProjectSkillVerification =
+  | { ok: true; evidence: ProjectSkillEvidence[] }
+  | { ok: false; reason: string; path?: string };
+
+interface OwnedLock {
+  kind: "owned";
+  computedHash: string;
+  evidence: ProjectSkillEvidence;
+}
+
+type LockInspection =
+  | { kind: "absent" }
+  | { kind: "unclaimed"; evidence: ProjectSkillEvidence }
+  | OwnedLock
+  | { kind: "invalid"; path: string };
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  const separator = process.platform === "win32" ? "\\" : "/";
+  return rel === "" || (rel !== ".." && !rel.startsWith(`..${separator}`) && !isAbsolute(rel));
+}
+
+function entryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function duplicateJsonKey(node: JsonNode): boolean {
+  if (node.type === "object") {
+    const seen = new Set<string>();
+    for (const property of node.children ?? []) {
+      const keyNode = property.children?.[0];
+      const key = keyNode ? getNodeValue(keyNode) : undefined;
+      if (typeof key !== "string") continue;
+      if (seen.has(key)) return true;
+      seen.add(key);
+    }
+  }
+  return (node.children ?? []).some(duplicateJsonKey);
+}
+
+function parseStrictJsonObject(content: string): Record<string, unknown> | null {
+  const errors: ParseError[] = [];
+  const root = parseTree(content, errors, { allowTrailingComma: false, disallowComments: true });
+  if (root?.type !== "object" || errors.length > 0 || duplicateJsonKey(root)) return null;
+  const value: unknown = getNodeValue(root);
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function inspectLock(projectRoot: string): LockInspection {
+  const path = join(projectRoot, LOCK_NAME);
+  if (!entryExists(path)) return { kind: "absent" };
+  try {
+    const stat = lstatSync(path);
+    const realRoot = realpathSync(projectRoot);
+    const realPath = realpathSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || !isInside(realRoot, realPath)) {
+      return { kind: "invalid", path };
+    }
+    const content = readFileSync(path, "utf8");
+    const parsed = parseStrictJsonObject(content);
+    if (parsed?.version !== 1 || !isRecord(parsed.skills)) {
+      return { kind: "invalid", path };
+    }
+    const evidence: ProjectSkillEvidence = {
+      kind: "file",
+      path,
+      realPath,
+      hash: createHash("sha256").update(content).digest("hex"),
+    };
+    if (!Object.hasOwn(parsed.skills, "dosu")) return { kind: "unclaimed", evidence };
+    const entry = parsed.skills.dosu;
+    if (
+      !isRecord(entry) ||
+      entry.source !== DOSU_SOURCE ||
+      entry.sourceType !== "github" ||
+      entry.skillPath !== DOSU_SKILL_PATH ||
+      typeof entry.computedHash !== "string" ||
+      !/^[a-f0-9]{64}$/.test(entry.computedHash)
+    ) {
+      return { kind: "invalid", path };
+    }
+    return { kind: "owned", computedHash: entry.computedHash, evidence };
+  } catch {
+    return { kind: "invalid", path };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectDirectoryFiles(
+  base: string,
+  current: string,
+  files: Array<{ relativePath: string; content: Buffer }>,
+): boolean {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(current, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (entry.name === ".git" || entry.name === "node_modules") continue;
+    if (entry.isSymbolicLink()) return false;
+    const path = join(current, entry.name);
+    if (entry.isDirectory()) {
+      if (!collectDirectoryFiles(base, path, files)) return false;
+    } else if (entry.isFile()) {
+      files.push({
+        relativePath: relative(base, path).split("\\").join("/"),
+        content: readFileSync(path),
+      });
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+function inspectDirectory(
+  path: string,
+  projectRoot: string,
+  expectedHash: string,
+): Extract<ProjectSkillEvidence, { kind: "directory" }> | null {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+    const realRoot = realpathSync(projectRoot);
+    const realPath = realpathSync(path);
+    if (!isInside(realRoot, realPath)) return null;
+    const files: Array<{ relativePath: string; content: Buffer }> = [];
+    if (!collectDirectoryFiles(path, path, files)) return null;
+    files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+    const hash = createHash("sha256");
+    for (const file of files) hash.update(file.relativePath).update(file.content);
+    const digest = hash.digest("hex");
+    if (digest !== expectedHash) return null;
+    const skillPath = join(path, "SKILL.md");
+    const frontmatter = readFileSync(skillPath, "utf8").match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1];
+    if (!frontmatter?.split(/\r?\n/).some((line) => /^name:\s*dosu\s*$/.test(line))) return null;
+    return { kind: "directory", path, realPath, hash: digest };
+  } catch {
+    return null;
+  }
+}
+
+function inspectTargets(input: {
+  projectRoot: string;
+  targets: readonly ProjectSkillTarget[];
+  expectedHash: string;
+  requireAll: boolean;
+}): ProjectSkillVerification {
+  const uniqueTargets = [
+    ...new Map(input.targets.map((target) => [resolve(target.path), target])).values(),
+  ];
+  const evidence: ProjectSkillEvidence[] = [];
+  const directRealPaths = new Set<string>();
+  const sharedCanonicalPath = join(input.projectRoot, ".agents", "skills", "dosu");
+  const claudeTargetPath = join(input.projectRoot, ".claude", "skills", "dosu");
+  const factoryTargetPath = join(input.projectRoot, ".factory", "skills", "dosu");
+  const reusableCanonicalAdapterPaths = new Set(
+    [claudeTargetPath, factoryTargetPath].map((path) => resolve(path)),
+  );
+  let sharedCanonical: Extract<ProjectSkillEvidence, { kind: "directory" }> | null | undefined;
+  const inspectSharedCanonical = () => {
+    if (sharedCanonical === undefined) {
+      sharedCanonical = inspectDirectory(
+        sharedCanonicalPath,
+        input.projectRoot,
+        input.expectedHash,
+      );
+    }
+    return sharedCanonical;
+  };
+
+  for (const target of uniqueTargets) {
+    if (!entryExists(target.path)) {
+      if (input.requireAll)
+        return { ok: false, reason: "project_skill_missing", path: target.path };
+      continue;
+    }
+    const stat = lstatSync(target.path);
+    if (stat.isSymbolicLink()) continue;
+    const directory = inspectDirectory(target.path, input.projectRoot, input.expectedHash);
+    if (!directory) return { ok: false, reason: "project_skill_modified", path: target.path };
+    directRealPaths.add(directory.realPath);
+    evidence.push(directory);
+  }
+
+  for (const target of uniqueTargets) {
+    if (!entryExists(target.path) || !lstatSync(target.path).isSymbolicLink()) continue;
+    try {
+      const realPath = realpathSync(target.path);
+      if (!directRealPaths.has(realPath)) {
+        // A prior multi-agent install uses `.agents/skills/dosu` as the owned
+        // canonical directory and makes a non-universal agent's target a
+        // symlink to it. A later single-agent run asks skills@1.5.22 for a
+        // direct target, but the existing exact Claude or Factory layout is
+        // still ours and must remain idempotent.
+        if (target.symlink || !reusableCanonicalAdapterPaths.has(resolve(target.path))) {
+          return { ok: false, reason: "project_skill_foreign_symlink", path: target.path };
+        }
+        let canonicalRealPath: string;
+        try {
+          canonicalRealPath = realpathSync(sharedCanonicalPath);
+        } catch {
+          return { ok: false, reason: "project_skill_foreign_symlink", path: target.path };
+        }
+        if (realPath !== canonicalRealPath) {
+          return { ok: false, reason: "project_skill_foreign_symlink", path: target.path };
+        }
+        const canonical = inspectSharedCanonical();
+        if (!canonical) {
+          return { ok: false, reason: "project_skill_modified", path: sharedCanonicalPath };
+        }
+        directRealPaths.add(canonical.realPath);
+        if (!evidence.some((item) => item.path === canonical.path)) evidence.push(canonical);
+      }
+      evidence.push({ kind: "symlink", path: target.path, realPath });
+    } catch {
+      return { ok: false, reason: "project_skill_foreign_symlink", path: target.path };
+    }
+  }
+
+  return { ok: true, evidence };
+}
+
+export function assertProjectSkillInstallSafe(input: {
+  projectRoot: string;
+  targets: readonly ProjectSkillTarget[];
+}): void {
+  const lockPath = join(input.projectRoot, LOCK_NAME);
+  assertSafeProjectPath(input.projectRoot, lockPath);
+  for (const target of input.targets) {
+    assertSafeProjectPath(input.projectRoot, join(target.path, ".."));
+  }
+
+  const lock = inspectLock(input.projectRoot);
+  const anyTargetExists = input.targets.some((target) => entryExists(target.path));
+  if (lock.kind === "invalid" || (lock.kind === "absent" && anyTargetExists)) {
+    throw new Error("Cannot prove ownership of the existing project Dosu skill");
+  }
+  if (lock.kind === "unclaimed" && anyTargetExists) {
+    throw new Error("Cannot prove ownership of the existing project Dosu skill");
+  }
+  if (lock.kind !== "owned") return;
+
+  const targets = inspectTargets({
+    ...input,
+    expectedHash: lock.computedHash,
+    requireAll: false,
+  });
+  if (!targets.ok) throw new Error("Cannot prove ownership of the existing project Dosu skill");
+}
+
+export function verifyProjectSkillInstallation(input: {
+  projectRoot: string;
+  targets: readonly ProjectSkillTarget[];
+}): ProjectSkillVerification {
+  const lock = inspectLock(input.projectRoot);
+  if (lock.kind !== "owned") {
+    return {
+      ok: false,
+      reason: "project_skill_lock_mismatch",
+      path: join(input.projectRoot, LOCK_NAME),
+    };
+  }
+  const targets = inspectTargets({
+    ...input,
+    expectedHash: lock.computedHash,
+    requireAll: true,
+  });
+  return targets.ok ? { ok: true, evidence: [lock.evidence, ...targets.evidence] } : targets;
+}
+
+export function projectSkillEvidenceUnchanged(
+  evidence: ProjectSkillEvidence,
+  projectRoot: string,
+): boolean {
+  try {
+    const stat = lstatSync(evidence.path);
+    if (evidence.kind === "symlink") {
+      return stat.isSymbolicLink() && realpathSync(evidence.path) === evidence.realPath;
+    }
+    if (stat.isSymbolicLink() || realpathSync(evidence.path) !== evidence.realPath) return false;
+    if (evidence.kind === "file") {
+      return (
+        stat.isFile() &&
+        createHash("sha256").update(readFileSync(evidence.path)).digest("hex") === evidence.hash
+      );
+    }
+    return Boolean(inspectDirectory(evidence.path, projectRoot, evidence.hash));
+  } catch {
+    return false;
+  }
+}

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +13,8 @@ vi.mock("node:child_process", () => ({
 
 import {
   installSkill,
+  projectSkillInstallTargetsForProviders,
+  SKILLS_CLI_VERSION,
   skillAgentIDsForProviders,
   skillCommand,
   skillInstallTargetForProvider,
@@ -83,13 +86,13 @@ afterEach(() => {
 });
 
 describe("skill install", () => {
-  it("runs npx skills add with correct args", async () => {
+  it("passes every agent through the installer's single variadic agent flag", async () => {
     await run("install");
     expect(mockExecSync).toHaveBeenCalledWith(
       [
-        "npx skills add dosu-ai/dosu-skill -g",
-        "-a claude-code -a cursor -a gemini-cli -a codex -a windsurf",
-        "-a zed -a cline -a github-copilot -a opencode -a antigravity",
+        `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -g`,
+        "-a claude-code cursor gemini-cli codex windsurf",
+        "zed cline github-copilot opencode antigravity",
         "-s dosu -y",
       ].join(" "),
       {
@@ -122,9 +125,12 @@ describe("skill install", () => {
 describe("skill remove", () => {
   it("runs npx skills remove with correct args", async () => {
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g -s dosu -y", {
-      stdio: "inherit",
-    });
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `npx -y skills@${SKILLS_CLI_VERSION} remove -g -s dosu -y`,
+      {
+        stdio: "inherit",
+      },
+    );
   });
 
   it("prints success message", async () => {
@@ -145,7 +151,7 @@ describe("skill update", () => {
   it("reinstalls via npx skills add (update can't follow repo-layout moves)", async () => {
     await run("update");
     expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringContaining("npx skills add dosu-ai/dosu-skill -g"),
+      expect.stringContaining(`npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -g`),
       { stdio: "inherit" },
     );
     expect(mockExecSync).not.toHaveBeenCalledWith(
@@ -185,13 +191,175 @@ describe("skill update", () => {
 });
 
 describe("installSkill helper", () => {
+  function writeOwnedProjectSkill(
+    projectRoot: string,
+    relativeTarget = ".agents/skills/dosu",
+  ): string {
+    const target = join(projectRoot, relativeTarget);
+    const content = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), content);
+    const computedHash = createHash("sha256").update("SKILL.md").update(content).digest("hex");
+    writeFileSync(
+      join(projectRoot, "skills-lock.json"),
+      JSON.stringify({
+        version: 1,
+        skills: {
+          dosu: {
+            source: "dosu-ai/dosu-skill",
+            sourceType: "github",
+            skillPath: "skills/dosu/SKILL.md",
+            computedHash,
+          },
+        },
+      }),
+    );
+    return computedHash;
+  }
+
   it("installs only for the selected MCP providers", async () => {
     const result = await installSkill(["claude", "codex"]);
 
     expect(result.success).toBe(true);
     expect(mockExecSync).toHaveBeenCalledWith(
-      "npx skills add dosu-ai/dosu-skill -g -a claude-code -a codex -s dosu -y",
+      `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -g -a claude-code codex -s dosu -y`,
       { stdio: "inherit" },
+    );
+  });
+
+  it("installs selected skills into the project when a project root is provided", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    const result = await installSkill(["claude", "codex"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -a claude-code codex -s dosu -y`,
+      { stdio: "inherit", cwd: projectRoot },
+    );
+  });
+
+  it("installs the Factory skill with the pinned Droid agent ID", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+
+    const result = await installSkill(["factory"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -a droid -s dosu -y`,
+      { stdio: "inherit", cwd: projectRoot },
+    );
+  });
+
+  it("refuses a project skill parent symlink before invoking the third-party installer", async () => {
+    const projectRoot = join(tempDir, "repo");
+    const outside = join(tempDir, "outside");
+    mkdirSync(projectRoot);
+    mkdirSync(outside);
+    symlinkSync(outside, join(projectRoot, ".agents"));
+
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/symbolic link/i);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("refuses dangling project skill and lock symlinks before invoking the installer", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(join(projectRoot, ".agents", "skills"), { recursive: true });
+    symlinkSync(join(tempDir, "missing-skill"), join(projectRoot, ".agents", "skills", "dosu"));
+
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/ownership/i);
+    expect(mockExecSync).not.toHaveBeenCalled();
+
+    rmSync(join(projectRoot, ".agents", "skills", "dosu"));
+    symlinkSync(join(tempDir, "missing-lock"), join(projectRoot, "skills-lock.json"));
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/symbolic link/i);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("refuses to overwrite a foreign project skill directory without a Dosu lock receipt", async () => {
+    const projectRoot = join(tempDir, "repo");
+    const target = join(projectRoot, ".agents", "skills", "dosu");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "SKILL.md"), "user-owned\n");
+
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/ownership/i);
+    expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("user-owned\n");
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("refuses a foreign Dosu lock entry even when the target directory is absent", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeFileSync(
+      join(projectRoot, "skills-lock.json"),
+      JSON.stringify({
+        version: 1,
+        skills: {
+          dosu: {
+            source: "someone-else/dosu",
+            sourceType: "github",
+            skillPath: "skills/dosu/SKILL.md",
+            computedHash: "a".repeat(64),
+          },
+        },
+      }),
+    );
+
+    await expect(installSkill(["codex"], { projectRoot })).rejects.toThrow(/ownership/i);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("allows an exact lock-backed project skill to be refreshed", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeOwnedProjectSkill(projectRoot);
+
+    const result = await installSkill(["codex"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledOnce();
+  });
+
+  it("allows the actual Claude-only direct project layout", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeOwnedProjectSkill(projectRoot, ".claude/skills/dosu");
+
+    const result = await installSkill(["claude"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledOnce();
+  });
+
+  it("allows the actual mixed canonical plus Claude symlink layout", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeOwnedProjectSkill(projectRoot);
+    const claudeParent = join(projectRoot, ".claude", "skills");
+    mkdirSync(claudeParent, { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", join(claudeParent, "dosu"), "dir");
+
+    const result = await installSkill(["claude", "codex"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledOnce();
+  });
+
+  it("allows a Claude-only refresh after an owned mixed-layout install", async () => {
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(projectRoot);
+    writeOwnedProjectSkill(projectRoot);
+    const claudeParent = join(projectRoot, ".claude", "skills");
+    mkdirSync(claudeParent, { recursive: true });
+    symlinkSync("../../.agents/skills/dosu", join(claudeParent, "dosu"), "dir");
+
+    const result = await installSkill(["claude"], { projectRoot });
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `npx -y skills@${SKILLS_CLI_VERSION} add dosu-ai/dosu-skill -a claude-code -s dosu -y`,
+      { stdio: "inherit", cwd: projectRoot },
     );
   });
 
@@ -199,6 +367,7 @@ describe("installSkill helper", () => {
     expect(
       skillAgentIDsForProviders(["vscode", "copilot", "cline", "cline-cli", "manual"]),
     ).toEqual(["github-copilot", "cline"]);
+    expect(skillAgentIDsForProviders(["factory", "factory"])).toEqual(["droid"]);
   });
 
   it("reports the Claude symlink target and respects CLAUDE_CONFIG_DIR", () => {
@@ -215,6 +384,31 @@ describe("installSkill helper", () => {
       path: join(homedir(), ".agents", "skills", "dosu"),
       symlink: false,
     });
+  });
+
+  it("reports project-local adapter paths when a project root is provided", () => {
+    expect(skillInstallTargetForProvider("claude", "/repo")).toEqual({
+      path: "/repo/.claude/skills/dosu",
+      symlink: false,
+    });
+    expect(skillInstallTargetForProvider("codex", "/repo")).toEqual({
+      path: "/repo/.agents/skills/dosu",
+      symlink: false,
+    });
+    expect(skillInstallTargetForProvider("factory", "/repo")).toEqual({
+      path: "/repo/.factory/skills/dosu",
+      symlink: false,
+    });
+  });
+
+  it("models the pinned Factory-only and mixed Droid project layouts", () => {
+    expect(projectSkillInstallTargetsForProviders(["factory"], "/repo")).toEqual([
+      { path: "/repo/.factory/skills/dosu", symlink: false },
+    ]);
+    expect(projectSkillInstallTargetsForProviders(["factory", "codex"], "/repo")).toEqual([
+      { path: "/repo/.agents/skills/dosu", symlink: false },
+      { path: "/repo/.factory/skills/dosu", symlink: true },
+    ]);
   });
 
   it("reports the Windsurf symlink target", () => {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -9,10 +9,15 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { logger } from "../debug/logger";
 import { fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
+import { assertProjectSkillInstallSafe, type ProjectSkillTarget } from "./project-skill-ownership";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
 const SKILL_NAME = "dosu";
-const SUPPORTED_SKILL_AGENTS = [
+export const SKILLS_CLI_VERSION = "1.5.22";
+// The standalone `dosu skill install` command remains an explicit global
+// legacy operation. Project setup passes its selected provider IDs instead,
+// so new project-only mappings do not silently broaden that global footprint.
+const DEFAULT_GLOBAL_SKILL_AGENTS = [
   "claude-code",
   "cursor",
   "gemini-cli",
@@ -38,6 +43,7 @@ const SKILL_AGENT_BY_PROVIDER: Readonly<Record<string, string>> = {
   copilot: "github-copilot",
   opencode: "opencode",
   antigravity: "antigravity",
+  factory: "droid",
 };
 
 export function skillAgentIDsForProviders(providerIDs: readonly string[]): string[] {
@@ -55,37 +61,93 @@ export interface SkillInstallTarget {
   symlink: boolean;
 }
 
-export function skillInstallTargetForProvider(providerID: string): SkillInstallTarget | null {
+export function skillInstallTargetForProvider(
+  providerID: string,
+  projectRoot?: string,
+): SkillInstallTarget | null {
   const agentID = SKILL_AGENT_BY_PROVIDER[providerID];
   if (!agentID) return null;
 
   if (agentID === "claude-code") {
+    if (projectRoot) {
+      return { path: join(projectRoot, ".claude", "skills", SKILL_NAME), symlink: false };
+    }
     const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude");
     return { path: join(claudeConfigDir, "skills", SKILL_NAME), symlink: true };
   }
 
   if (agentID === "windsurf") {
+    if (projectRoot) {
+      return { path: join(projectRoot, ".windsurf", "skills", SKILL_NAME), symlink: false };
+    }
     return {
       path: join(homedir(), ".codeium", "windsurf", "skills", SKILL_NAME),
       symlink: true,
     };
   }
 
+  if (agentID === "droid") {
+    return {
+      path: projectRoot
+        ? join(projectRoot, ".factory", "skills", SKILL_NAME)
+        : join(homedir(), ".factory", "skills", SKILL_NAME),
+      symlink: !projectRoot,
+    };
+  }
+
   return {
-    path: join(homedir(), ".agents", "skills", SKILL_NAME),
+    path: projectRoot
+      ? join(projectRoot, ".agents", "skills", SKILL_NAME)
+      : join(homedir(), ".agents", "skills", SKILL_NAME),
     symlink: false,
   };
 }
 
-function skillAgentArgs(providerIDs?: readonly string[]): string {
-  const agents =
-    providerIDs === undefined ? SUPPORTED_SKILL_AGENTS : skillAgentIDsForProviders(providerIDs);
-  return agents.map((agent) => `-a ${agent}`).join(" ");
+/** Exact paths that pinned skills@1.5.22 mutates for a project install. */
+export function projectSkillInstallTargetsForProviders(
+  providerIDs: readonly string[],
+  projectRoot: string,
+): ProjectSkillTarget[] {
+  const agents = skillAgentIDsForProviders(providerIDs);
+  if (agents.length === 0) return [];
+  if (agents.length === 1) {
+    if (agents[0] === "claude-code") {
+      return [{ path: join(projectRoot, ".claude", "skills", SKILL_NAME), symlink: false }];
+    }
+    if (agents[0] === "windsurf") {
+      return [{ path: join(projectRoot, ".windsurf", "skills", SKILL_NAME), symlink: false }];
+    }
+    if (agents[0] === "droid") {
+      return [{ path: join(projectRoot, ".factory", "skills", SKILL_NAME), symlink: false }];
+    }
+    return [{ path: join(projectRoot, ".agents", "skills", SKILL_NAME), symlink: false }];
+  }
+
+  const targets: ProjectSkillTarget[] = [
+    { path: join(projectRoot, ".agents", "skills", SKILL_NAME), symlink: false },
+  ];
+  if (agents.includes("claude-code")) {
+    targets.push({ path: join(projectRoot, ".claude", "skills", SKILL_NAME), symlink: true });
+  }
+  if (agents.includes("droid")) {
+    targets.push({ path: join(projectRoot, ".factory", "skills", SKILL_NAME), symlink: true });
+  }
+  return targets;
 }
 
-function execQuiet(command: string): Promise<void> {
+function skillAgentArgs(providerIDs?: readonly string[]): string {
+  const agents =
+    providerIDs === undefined
+      ? DEFAULT_GLOBAL_SKILL_AGENTS
+      : skillAgentIDsForProviders(providerIDs);
+  // skills@1.5.22 defines --agent as one variadic option. Repeating `-a`
+  // replaces the previous value, so only the final agent would be installed.
+  return agents.length > 0 ? `-a ${agents.join(" ")}` : "";
+}
+
+function execQuiet(command: string, cwd?: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    exec(command, { windowsHide: true }, (error) => {
+    exec(command, { windowsHide: true, ...(cwd ? { cwd } : {}) }, (error) => {
       if (error) reject(error);
       else resolve();
     });
@@ -101,7 +163,7 @@ function execQuiet(command: string): Promise<void> {
  */
 export async function installSkill(
   providerIDs?: readonly string[],
-  options: { quiet?: boolean } = {},
+  options: { quiet?: boolean; projectRoot?: string } = {},
 ): Promise<{ success: boolean; sha?: string }> {
   const agentArgs = skillAgentArgs(providerIDs);
   if (!agentArgs) {
@@ -109,10 +171,23 @@ export async function installSkill(
     return { success: true };
   }
 
+  if (options.projectRoot) {
+    const targets = projectSkillInstallTargetsForProviders(
+      providerIDs ?? Object.keys(SKILL_AGENT_BY_PROVIDER),
+      options.projectRoot,
+    );
+    assertProjectSkillInstallSafe({ projectRoot: options.projectRoot, targets });
+  }
+
   try {
-    const command = `npx skills add ${SKILL_REPO} -g ${agentArgs} -s ${SKILL_NAME} -y`;
-    if (options.quiet) await execQuiet(command);
-    else execSync(command, { stdio: "inherit" });
+    const scope = options.projectRoot ? "" : " -g";
+    const command = `npx -y skills@${SKILLS_CLI_VERSION} add ${SKILL_REPO}${scope} ${agentArgs} -s ${SKILL_NAME} -y`;
+    if (options.quiet) await execQuiet(command, options.projectRoot);
+    else
+      execSync(command, {
+        stdio: "inherit",
+        ...(options.projectRoot ? { cwd: options.projectRoot } : {}),
+      });
   } catch (err) {
     logger.error("skill", `Failed to install skill: ${err}`);
     return { success: false };
@@ -154,7 +229,7 @@ export function skillCommand(): Command {
     .action(() => {
       console.log(`Removing ${SKILL_NAME} skill...`);
       try {
-        execSync(`npx skills remove -g -s ${SKILL_NAME} -y`, {
+        execSync(`npx -y skills@${SKILLS_CLI_VERSION} remove -g -s ${SKILL_NAME} -y`, {
           stdio: "inherit",
         });
         console.log(pc.green(`\n✓ Skill "${SKILL_NAME}" removed.`));

--- a/src/setup/agents-md-step.ts
+++ b/src/setup/agents-md-step.ts
@@ -9,10 +9,11 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { logger } from "../debug/logger";
+import { writeProjectFile } from "../mcp/config-helpers";
 import { FALLBACK_DOSU_RULE, fetchDosuRule } from "../rules/installer";
 import { formatSetupSummary } from "./styles";
 
@@ -81,6 +82,11 @@ function findSection(content: string): SectionLocation | null {
   if (start === -1 || end < start) {
     throw new Error("Dosu AGENTS.md markers are incomplete; refusing to overwrite the file");
   }
+  const afterStart = content.slice(start + (startMatch?.[0].length ?? 0));
+  const remaining = content.slice(end + DOSU_SECTION_END.length);
+  if (SECTION_START_RE.test(afterStart) || remaining.includes(DOSU_SECTION_END)) {
+    throw new Error("Multiple Dosu AGENTS.md marker blocks found; refusing to overwrite the file");
+  }
   return { start, end };
 }
 
@@ -92,11 +98,18 @@ export function upsertDosuAgentsSection(
   cwd: string = process.cwd(),
   content: string = FALLBACK_DOSU_RULE,
 ): AgentsMdResult {
+  if (!existsSync(cwd) || !lstatSync(cwd).isDirectory() || lstatSync(cwd).isSymbolicLink()) {
+    throw new Error(`Project root is not a regular directory: ${cwd}`);
+  }
   const path = join(cwd, "AGENTS.md");
+
+  if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+    throw new Error(`Refusing to modify symbolic link at ${path}`);
+  }
 
   if (!existsSync(path)) {
     const section = buildDosuAgentsSection(content);
-    writeFileSync(path, `${section}\n`);
+    writeProjectFile(path, `${section}\n`, null);
     return { path, action: "created" };
   }
 
@@ -116,7 +129,7 @@ export function upsertDosuAgentsSection(
   }
 
   if (next === existing) return { path, action: "unchanged" };
-  writeFileSync(path, next);
+  writeProjectFile(path, next, existing);
   return { path, action: "updated" };
 }
 

--- a/src/setup/project-instructions.test.ts
+++ b/src/setup/project-instructions.test.ts
@@ -1,0 +1,231 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DOSU_SECTION_START } from "./agents-md-step";
+import {
+  installProjectInstructions,
+  PROJECT_ADAPTER_END,
+  PROJECT_ADAPTER_START,
+  removeProjectInstructionAdapters,
+  verifyProjectInstructions,
+} from "./project-instructions";
+
+let projectRoot: string;
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "dosu-project-instructions-"));
+});
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe("installProjectInstructions", () => {
+  it("keeps one canonical rule in AGENTS.md and adds only thin provider adapters", () => {
+    const result = installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude", "codex", "gemini", "cursor"],
+      content: "Always consult Dosu.",
+    });
+
+    expect(readFileSync(join(projectRoot, "AGENTS.md"), "utf8")).toContain(DOSU_SECTION_START);
+    expect(readFileSync(join(projectRoot, "AGENTS.md"), "utf8")).toContain("Always consult Dosu.");
+    expect(readFileSync(join(projectRoot, "CLAUDE.md"), "utf8")).toContain("@AGENTS.md");
+    expect(readFileSync(join(projectRoot, "GEMINI.md"), "utf8")).toContain("@AGENTS.md");
+    expect(result.adapters.map((adapter) => adapter.provider)).toEqual(["claude", "gemini"]);
+    expect(existsSync(join(projectRoot, ".codex", "AGENTS.md"))).toBe(false);
+    expect(existsSync(join(projectRoot, ".cursor", "rules", "dosu.mdc"))).toBe(false);
+  });
+
+  it("writes Antigravity's official project rule adapter", () => {
+    installProjectInstructions({
+      projectRoot,
+      providerIDs: ["antigravity"],
+      content: "Use Dosu knowledge.",
+    });
+
+    const rule = readFileSync(join(projectRoot, ".agents", "rules", "dosu.md"), "utf8");
+    expect(rule).toContain(PROJECT_ADAPTER_START);
+    expect(rule).toContain("Use Dosu knowledge.");
+  });
+
+  it("preserves user content and updates its marker block idempotently", () => {
+    writeFileSync(join(projectRoot, "CLAUDE.md"), "# User instructions\n");
+
+    installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude"],
+      content: "first",
+    });
+    const second = installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude"],
+      content: "second",
+    });
+
+    const content = readFileSync(join(projectRoot, "CLAUDE.md"), "utf8");
+    expect(content).toContain("# User instructions");
+    expect(content.match(new RegExp(PROJECT_ADAPTER_START, "g"))).toHaveLength(1);
+    expect(content).toContain("@AGENTS.md");
+    expect(second.adapters[0]?.action).toBe("unchanged");
+  });
+
+  it("keeps a CLAUDE.md symlink to AGENTS.md instead of replacing it", () => {
+    writeFileSync(join(projectRoot, "AGENTS.md"), "# Team instructions\n");
+    symlinkSync("AGENTS.md", join(projectRoot, "CLAUDE.md"));
+
+    installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude"],
+      content: "Use Dosu knowledge.",
+    });
+
+    expect(lstatSync(join(projectRoot, "CLAUDE.md")).isSymbolicLink()).toBe(true);
+    expect(verifyProjectInstructions(projectRoot, ["claude"])).toBe(true);
+  });
+
+  it("refuses to follow a foreign project-instruction symlink", () => {
+    const outside = join(projectRoot, "outside.md");
+    writeFileSync(outside, "# Do not edit\n");
+    symlinkSync("outside.md", join(projectRoot, "CLAUDE.md"));
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["claude"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).toThrow(/symbolic link/i);
+    expect(readFileSync(outside, "utf8")).toBe("# Do not edit\n");
+  });
+
+  it("does not follow a predictable adapter temporary-file symlink", () => {
+    const victim = join(projectRoot, "user-data.md");
+    const adapter = join(projectRoot, "CLAUDE.md");
+    writeFileSync(victim, "USER DATA\n");
+    symlinkSync("user-data.md", `${adapter}.${process.pid}.tmp`);
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["claude"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).not.toThrow();
+
+    expect(readFileSync(victim, "utf8")).toBe("USER DATA\n");
+    expect(lstatSync(adapter).isFile()).toBe(true);
+  });
+
+  it("refuses a canonical AGENTS.md symlink that could escape the repository", () => {
+    const outside = join(projectRoot, "outside-agents.md");
+    writeFileSync(outside, "# Do not edit\n");
+    symlinkSync("outside-agents.md", join(projectRoot, "AGENTS.md"));
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["codex"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).toThrow(/symbolic link/i);
+    expect(readFileSync(outside, "utf8")).toBe("# Do not edit\n");
+  });
+
+  it("refuses a symlinked adapter parent directory", () => {
+    const outside = join(projectRoot, "outside-agents-dir");
+    mkdirSync(outside);
+    symlinkSync("outside-agents-dir", join(projectRoot, ".agents"));
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["antigravity"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).toThrow(/symbolic link/i);
+    expect(existsSync(join(outside, "rules", "dosu.md"))).toBe(false);
+  });
+
+  it("refuses an incomplete adapter marker without changing the file", () => {
+    const path = join(projectRoot, "GEMINI.md");
+    const original = `${PROJECT_ADAPTER_START}\n@AGENTS.md\n`;
+    writeFileSync(path, original);
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["gemini"],
+        content: "rule",
+      }),
+    ).toThrow(/markers are incomplete/i);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it("refuses duplicate canonical AGENTS.md marker blocks", () => {
+    writeFileSync(
+      join(projectRoot, "AGENTS.md"),
+      `${DOSU_SECTION_START}\none\n<!-- dosu:mcp:end -->\n${DOSU_SECTION_START}\ntwo\n<!-- dosu:mcp:end -->\n`,
+    );
+
+    expect(() =>
+      installProjectInstructions({
+        projectRoot,
+        providerIDs: ["codex"],
+        content: "Use Dosu knowledge.",
+      }),
+    ).toThrow(/multiple/i);
+  });
+});
+
+describe("verifyProjectInstructions", () => {
+  it("requires both the canonical section and each required adapter", () => {
+    installProjectInstructions({
+      projectRoot,
+      providerIDs: ["claude", "gemini", "codex"],
+      content: "rule",
+    });
+    expect(verifyProjectInstructions(projectRoot, ["claude", "gemini", "codex"])).toBe(true);
+
+    rmSync(join(projectRoot, "CLAUDE.md"));
+    expect(verifyProjectInstructions(projectRoot, ["claude", "gemini", "codex"])).toBe(false);
+  });
+});
+
+describe("removeProjectInstructionAdapters", () => {
+  it("removes only Dosu's adapter block and leaves user content", () => {
+    writeFileSync(join(projectRoot, "CLAUDE.md"), "# User instructions\n");
+    installProjectInstructions({ projectRoot, providerIDs: ["claude"], content: "rule" });
+
+    removeProjectInstructionAdapters(projectRoot, ["claude"]);
+
+    const content = readFileSync(join(projectRoot, "CLAUDE.md"), "utf8");
+    expect(content).toContain("# User instructions");
+    expect(content).not.toContain(PROJECT_ADAPTER_START);
+    expect(content).not.toContain(PROJECT_ADAPTER_END);
+  });
+
+  it("removes only the marker bytes and preserves all surrounding whitespace", () => {
+    const path = join(projectRoot, "CLAUDE.md");
+    const before = "  user prefix\n\n\n\n";
+    const after = "\n\n\nuser suffix  \n";
+    writeFileSync(
+      path,
+      `${before}${PROJECT_ADAPTER_START}\n@AGENTS.md\n${PROJECT_ADAPTER_END}${after}`,
+    );
+
+    removeProjectInstructionAdapters(projectRoot, ["claude"]);
+
+    expect(readFileSync(path, "utf8")).toBe(`${before}${after}`);
+  });
+});

--- a/src/setup/project-instructions.ts
+++ b/src/setup/project-instructions.ts
@@ -1,0 +1,238 @@
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { removeProjectFile, writeProjectFile } from "../mcp/config-helpers";
+import { DOSU_SECTION_END, upsertDosuAgentsSection } from "./agents-md-step";
+import { assertSafeProjectPath } from "./project-path";
+
+export const PROJECT_ADAPTER_START = "<!-- dosu:project-instructions:start v1 -->";
+export const PROJECT_ADAPTER_END = "<!-- dosu:project-instructions:end -->";
+
+const DOSU_SECTION_START_RE = /<!-- dosu:mcp:start(?: v\d+)? -->/;
+
+export type ProjectInstructionAction =
+  | "created"
+  | "updated"
+  | "unchanged"
+  | "removed"
+  | "not_found";
+
+export interface ProjectInstructionAdapterResult {
+  provider: string;
+  path: string;
+  action: ProjectInstructionAction;
+}
+
+export interface ProjectInstructionsResult {
+  agentsMd: ReturnType<typeof upsertDosuAgentsSection>;
+  adapters: ProjectInstructionAdapterResult[];
+}
+
+export function providerUsesProjectInstructions(providerID: string): boolean {
+  return providerID !== "mcporter";
+}
+
+interface ProjectAdapter {
+  provider: "claude" | "gemini" | "antigravity";
+  path(projectRoot: string): string;
+  body(content: string): string;
+}
+
+const PROJECT_ADAPTERS: readonly ProjectAdapter[] = [
+  {
+    provider: "claude",
+    path: (root) => join(root, "CLAUDE.md"),
+    body: () => "@AGENTS.md",
+  },
+  {
+    provider: "gemini",
+    path: (root) => join(root, "GEMINI.md"),
+    body: () => "@AGENTS.md",
+  },
+  {
+    provider: "antigravity",
+    path: (root) => join(root, ".agents", "rules", "dosu.md"),
+    body: (content) => content.trim(),
+  },
+];
+
+function atomicProjectWrite(path: string, content: string, expectedContent: string | null): void {
+  writeProjectFile(path, content, expectedContent);
+}
+
+function block(body: string, eol: "\n" | "\r\n"): string {
+  return `${PROJECT_ADAPTER_START}${eol}${body.trim().replace(/\r?\n/g, eol)}${eol}${PROJECT_ADAPTER_END}`;
+}
+
+function locateAdapter(content: string): { start: number; end: number } | null {
+  const start = content.indexOf(PROJECT_ADAPTER_START);
+  const end = content.indexOf(PROJECT_ADAPTER_END);
+  if (start === -1 && end === -1) return null;
+  if (start === -1 || end < start) {
+    throw new Error("Dosu project instruction markers are incomplete; refusing to modify the file");
+  }
+  if (
+    content.indexOf(PROJECT_ADAPTER_START, start + PROJECT_ADAPTER_START.length) !== -1 ||
+    content.indexOf(PROJECT_ADAPTER_END, end + PROJECT_ADAPTER_END.length) !== -1
+  ) {
+    throw new Error(
+      "Multiple Dosu project instruction marker blocks found; refusing to modify the file",
+    );
+  }
+  return { start, end: end + PROJECT_ADAPTER_END.length };
+}
+
+function pointsToCanonicalAgents(path: string, projectRoot: string): boolean {
+  try {
+    return (
+      lstatSync(path).isSymbolicLink() &&
+      realpathSync(path) === realpathSync(join(projectRoot, "AGENTS.md"))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function upsertAdapter(
+  path: string,
+  body: string,
+  projectRoot: string,
+  allowAgentsSymlink: boolean,
+): ProjectInstructionAction {
+  if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+    if (allowAgentsSymlink && pointsToCanonicalAgents(path, projectRoot)) return "unchanged";
+    throw new Error(`Refusing to modify symbolic link at ${path}`);
+  }
+  const existed = existsSync(path);
+  const existing = existed ? readFileSync(path, "utf8") : "";
+  const eol = existing.includes("\r\n") ? "\r\n" : "\n";
+  const nextBlock = block(body, eol);
+  const location = locateAdapter(existing);
+  let next: string;
+  if (location) {
+    next = `${existing.slice(0, location.start)}${nextBlock}${existing.slice(location.end)}`;
+  } else if (existing) {
+    next = `${existing.trimEnd()}${eol}${eol}${nextBlock}${eol}`;
+  } else {
+    next = `${nextBlock}${eol}`;
+  }
+  if (next === existing) return "unchanged";
+  atomicProjectWrite(path, next, existed ? existing : null);
+  return existing ? "updated" : "created";
+}
+
+function adapterFor(provider: string): ProjectAdapter | undefined {
+  return PROJECT_ADAPTERS.find((adapter) => adapter.provider === provider);
+}
+
+export function installProjectInstructions(input: {
+  projectRoot: string;
+  providerIDs: readonly string[];
+  content: string;
+}): ProjectInstructionsResult {
+  const agentsPath = join(input.projectRoot, "AGENTS.md");
+  assertSafeProjectPath(input.projectRoot, agentsPath);
+  if (existsSync(agentsPath) && lstatSync(agentsPath).isSymbolicLink()) {
+    throw new Error(`Refusing to modify symbolic link at ${agentsPath}`);
+  }
+  const plannedAdapters = [...new Set(input.providerIDs)].flatMap((provider) => {
+    const adapter = adapterFor(provider);
+    if (!adapter) return [];
+    const path = adapter.path(input.projectRoot);
+    const allowAgentsSymlink = adapter.provider === "claude" || adapter.provider === "gemini";
+    if (allowAgentsSymlink && existsSync(path) && lstatSync(path).isSymbolicLink()) {
+      assertSafeProjectPath(input.projectRoot, dirname(path));
+    } else {
+      assertSafeProjectPath(input.projectRoot, path);
+    }
+    return [{ provider, adapter, path }];
+  });
+  const agentsMd = upsertDosuAgentsSection(input.projectRoot, input.content);
+  const adapters: ProjectInstructionAdapterResult[] = [];
+  for (const { provider, adapter, path } of plannedAdapters) {
+    adapters.push({
+      provider,
+      path,
+      action: upsertAdapter(
+        path,
+        adapter.body(input.content),
+        input.projectRoot,
+        adapter.provider === "claude" || adapter.provider === "gemini",
+      ),
+    });
+  }
+  return { agentsMd, adapters };
+}
+
+function hasCompleteAgentsSection(path: string): boolean {
+  if (!existsSync(path)) return false;
+  const content = readFileSync(path, "utf8");
+  const start = content.search(DOSU_SECTION_START_RE);
+  const end = content.indexOf(DOSU_SECTION_END, Math.max(start, 0));
+  return start >= 0 && end > start;
+}
+
+function hasCompleteAdapter(
+  path: string,
+  projectRoot: string,
+  allowAgentsSymlink: boolean,
+): boolean {
+  if (!existsSync(path)) return false;
+  if (lstatSync(path).isSymbolicLink()) {
+    return allowAgentsSymlink && pointsToCanonicalAgents(path, projectRoot);
+  }
+  try {
+    return locateAdapter(readFileSync(path, "utf8")) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function verifyProjectInstructions(
+  projectRoot: string,
+  providerIDs: readonly string[],
+): boolean {
+  if (!hasCompleteAgentsSection(join(projectRoot, "AGENTS.md"))) return false;
+  return [...new Set(providerIDs)].every((provider) => {
+    const adapter = adapterFor(provider);
+    return (
+      !adapter ||
+      hasCompleteAdapter(
+        adapter.path(projectRoot),
+        projectRoot,
+        adapter.provider === "claude" || adapter.provider === "gemini",
+      )
+    );
+  });
+}
+
+function removeAdapter(path: string): ProjectInstructionAction {
+  if (!existsSync(path)) return "not_found";
+  if (lstatSync(path).isSymbolicLink()) return "not_found";
+  const existing = readFileSync(path, "utf8");
+  const location = locateAdapter(existing);
+  if (!location) return "not_found";
+  const before = existing.slice(0, location.start);
+  const after = existing.slice(location.end);
+  const next = `${before}${after}`;
+  const eol = existing.includes("\r\n") ? "\r\n" : "\n";
+  if (before === "" && after === eol) removeProjectFile(path, existing);
+  else atomicProjectWrite(path, next, existing);
+  return "removed";
+}
+
+export function removeProjectInstructionAdapters(
+  projectRoot: string,
+  providerIDs: readonly string[],
+): ProjectInstructionAdapterResult[] {
+  return [...new Set(providerIDs)].flatMap((provider) => {
+    const adapter = adapterFor(provider);
+    if (!adapter) return [];
+    const path = adapter.path(projectRoot);
+    if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+      assertSafeProjectPath(projectRoot, dirname(path));
+    } else {
+      assertSafeProjectPath(projectRoot, path);
+    }
+    return [{ provider, path, action: removeAdapter(path) }];
+  });
+}


### PR DESCRIPTION
<!-- Is this PR related to a Linear issue? -->
<!-- Example: Fixes [ENG-123](https://linear.app/dosu/issue/ENG-123) -->

### Description

Stack 3/8, based on #158. Adds the project-owned `AGENTS.md`/adapter contract, project-local Dosu skill installation, strict ownership receipts, and pinned `skills@1.5.22` invocation.

This layer contains only project assets and their safety checks. It does not enable provider writes or legacy global cleanup.

Validated locally with `bun run typecheck`, `bun run check`, all 1,934 tests, 68 focused asset tests, `git diff --check`, and `bun run build:npm`.

Stack review order:

1. #157 feat(mcp): add safe project file foundation
2. #158 feat(mcp): add secretless project proxy runtime
3. #159 feat(setup): add project agent assets
4. #160 feat(migration): prove complete project bundles
5. #161 feat(migration): add proof-gated global cleanup
6. #162 feat(mcp): enable project-scoped providers
7. #163 feat(setup): scope setup to the current project
8. #164 docs(setup): document project-scoped agent setup

Because this repository is squash-only, land by collapsing leaf into base: #164 -> #163 -> #162 -> #161 -> #160 -> #159 -> #158 -> #157 -> main.

### Review Tasks - Only request review after completing these.

* [ ] I self-reviewed this PR
* [ ] Testing is adequate for this change
* [ ] I reviewed AI-generated code and resolved suggestions

### Details (for context) - Not tasks; tooling uses tasks to determine review readiness

- Generated with AI: (N/Claude/Codex/Other)
- Manual testing: (Y/N/NA)
- Tests updated: (Y/N/NA)

<!-- Describe any manual testing or special testing approach -->
