### PR TITLE
feat(migration): prove complete project bundles (4/8)

### DIFF
--- a/src/migration/project-bundle.test.ts
+++ b/src/migration/project-bundle.test.ts
@@ -1,0 +1,487 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assertProjectBundleProof,
+  projectBundleStatus,
+  verifyProjectBundle,
+} from "./project-bundle";
+import { proveProjectScope } from "./project-proof";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "dosu-project-bundle-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function gitProof() {
+  const result = proveProjectScope({
+    cwd: root,
+    gitTopLevel: root,
+    insideWorkTree: true,
+    bareRepository: false,
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.proof;
+}
+
+function writeClaudeBundle(deploymentID = "dep-project"): void {
+  // skills@1.5.22 writes a direct Claude copy for a one-agent install.
+  const skillDir = join(root, ".claude", "skills", "dosu");
+  mkdirSync(skillDir, { recursive: true });
+  const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  writeFileSync(join(skillDir, "SKILL.md"), skill);
+  const computedHash = createHash("sha256").update("SKILL.md").update(skill).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", deploymentID],
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, "AGENTS.md"),
+    "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+  );
+  writeFileSync(
+    join(root, "CLAUDE.md"),
+    "<!-- dosu:project-instructions:start v1 -->\n@AGENTS.md\n<!-- dosu:project-instructions:end -->\n",
+  );
+}
+
+function writeCanonicalSkill(): void {
+  const skillDir = join(root, ".agents", "skills", "dosu");
+  mkdirSync(skillDir, { recursive: true });
+  const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  writeFileSync(join(skillDir, "SKILL.md"), skill);
+  const computedHash = createHash("sha256").update("SKILL.md").update(skill).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+function writeFactoryBundle(includeSkill = true): void {
+  mkdirSync(join(root, ".factory"), { recursive: true });
+  writeFileSync(
+    join(root, ".factory", "mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"],
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, "AGENTS.md"),
+    "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+  );
+  if (!includeSkill) return;
+  const skillDir = join(root, ".factory", "skills", "dosu");
+  mkdirSync(skillDir, { recursive: true });
+  const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  writeFileSync(join(skillDir, "SKILL.md"), skill);
+  const computedHash = createHash("sha256").update("SKILL.md").update(skill).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+function verifyClaude() {
+  return verifyProjectBundle({
+    project: gitProof(),
+    providerIDs: ["claude"],
+    proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+    instructionContent: "Use Dosu.",
+  });
+}
+
+function writeMcporterBundle(target: "dep-project" | "oss" = "dep-project"): void {
+  mkdirSync(join(root, "config"), { recursive: true });
+  writeFileSync(
+    join(root, "config", "mcporter.json"),
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          command: "npx",
+          args:
+            target === "oss"
+              ? ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss"]
+              : ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", target],
+        },
+      },
+    }),
+  );
+}
+
+describe("file-backed project bundle proof", () => {
+  it("rejects a relative Git root instead of resolving it against process cwd", () => {
+    expect(
+      proveProjectScope({
+        cwd: root,
+        gitTopLevel: "relative-project",
+        insideWorkTree: true,
+        bareRepository: false,
+      }),
+    ).toEqual({ ok: false, reason: "invalid_git_root" });
+  });
+
+  it("authorizes only after exact MCP, instructions, adapter, skill, and lock are re-read", () => {
+    writeClaudeBundle();
+    expect(verifyClaude()).toMatchObject({ ok: true });
+  });
+
+  it("rejects unsupported providers and wrong deployment or credential-bearing proxies", () => {
+    writeClaudeBundle("wrong-deployment");
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_mcp_mismatch" });
+
+    const unsupported = verifyProjectBundle({
+      project: gitProof(),
+      providerIDs: ["cline"],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    });
+    expect(unsupported).toMatchObject({ ok: false, reason: "unsupported_provider" });
+
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: ["claude"],
+        proxy: {} as never,
+        instructionContent: "Use Dosu.",
+      }),
+    ).toEqual({ ok: false, reason: "invalid_proxy_expectation" });
+
+    writeClaudeBundle();
+    const path = join(root, ".mcp.json");
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    parsed.mcpServers.dosu.headers = { "X-Dosu-API-Key": "secret" };
+    writeFileSync(path, JSON.stringify(parsed));
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_mcp_mismatch" });
+  });
+
+  it("rejects missing exact adapter, skill provenance, or skill content hash", () => {
+    writeClaudeBundle();
+    writeFileSync(join(root, "CLAUDE.md"), "@AGENTS.md\n");
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_instructions_mismatch" });
+
+    writeClaudeBundle();
+    writeFileSync(join(root, "skills-lock.json"), '{"version":1,"skills":{}}');
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_skill_mismatch" });
+
+    writeClaudeBundle();
+    writeFileSync(join(root, ".claude", "skills", "dosu", "SKILL.md"), "user replacement");
+    expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_skill_mismatch" });
+  });
+
+  it("requires at least one selected project-capable provider", () => {
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: [],
+        proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+        instructionContent: "Use Dosu.",
+      }),
+    ).toEqual({ ok: false, reason: "no_selected_provider" });
+  });
+
+  it.each([
+    ["non-object", null],
+    ["array", []],
+    ["bad version", { packageVersion: "latest", deploymentID: "dep-project" }],
+    ["empty deployment", { packageVersion: "0.43.0", deploymentID: "" }],
+    ["extra field", { packageVersion: "0.43.0", deploymentID: "dep-project", extra: true }],
+    ["invalid OSS keys", { packageVersion: "0.43.0", oss: true, deploymentID: "dep" }],
+    ["non-string deployment", { packageVersion: "0.43.0", deploymentID: 7 }],
+  ])("rejects an invalid proxy expectation: %s", (_name, proxy) => {
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: ["mcporter"],
+        proxy: proxy as never,
+        instructionContent: "Use Dosu.",
+      }),
+    ).toEqual({ ok: false, reason: "invalid_proxy_expectation" });
+  });
+
+  it("verifies the MCP-only MCPorter bundle and rechecks its file evidence", () => {
+    writeMcporterBundle();
+    const verification = verifyProjectBundle({
+      project: gitProof(),
+      providerIDs: ["mcporter", "mcporter"],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    });
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+    expect(projectBundleStatus(verification.proof, "mcporter")).toBe("valid");
+    expect(projectBundleStatus(verification.proof, "cursor")).toBe("unauthorized_provider");
+
+    writeFileSync(join(root, "config", "mcporter.json"), '{"mcpServers":{}}');
+    expect(projectBundleStatus(verification.proof, "mcporter")).toBe("changed");
+  });
+
+  it("revalidates every kind of evidence in a complete Claude bundle", () => {
+    writeClaudeBundle();
+    const verification = verifyClaude();
+    if (!verification.ok) throw new Error(verification.reason);
+    expect(projectBundleStatus(verification.proof, "claude")).toBe("valid");
+
+    rmSync(join(root, ".claude", "skills", "dosu", "SKILL.md"));
+    expect(projectBundleStatus(verification.proof, "claude")).toBe("changed");
+  });
+
+  it("verifies an OSS MCP-only bundle", () => {
+    writeMcporterBundle("oss");
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: ["mcporter"],
+        proxy: { packageVersion: "0.43.0", oss: true },
+        instructionContent: "Use Dosu.",
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("rejects project config symlinks even when their content is exact", () => {
+    writeMcporterBundle();
+    const path = join(root, "config", "mcporter.json");
+    const foreign = join(root, "foreign.json");
+    writeFileSync(foreign, readFileSync(path));
+    rmSync(path);
+    symlinkSync(foreign, path);
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: ["mcporter"],
+        proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+        instructionContent: "Use Dosu.",
+      }),
+    ).toMatchObject({ ok: false, reason: "project_mcp_mismatch", provider: "mcporter" });
+  });
+
+  it.each([
+    ["cursor", ".cursor/mcp.json"],
+    ["vscode", ".vscode/mcp.json"],
+    ["gemini", ".gemini/settings.json"],
+    ["codex", ".codex/config.toml"],
+    ["zed", ".zed/settings.json"],
+    ["copilot", ".mcp.json"],
+    ["opencode", "opencode.json"],
+    ["antigravity", ".agents/mcp_config.json"],
+    ["factory", ".factory/mcp.json"],
+  ] as const)("reports the documented missing project path for %s", (provider, relativePath) => {
+    expect(
+      verifyProjectBundle({
+        project: gitProof(),
+        providerIDs: [provider],
+        proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+        instructionContent: "Use Dosu.",
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: "project_mcp_mismatch",
+      provider,
+      path: join(root, ...relativePath.split("/")),
+    });
+  });
+
+  it("verifies an exact Codex TOML bundle and notices when the project disappears", () => {
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(
+      join(root, ".codex", "config.toml"),
+      '[mcp_servers.dosu]\ncommand = "npx"\nargs = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"]\n',
+    );
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+    );
+    writeCanonicalSkill();
+    const verification = verifyProjectBundle({
+      project: gitProof(),
+      providerIDs: ["codex"],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    });
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+
+    rmSync(root, { recursive: true });
+    expect(projectBundleStatus(verification.proof, "codex")).toBe("changed");
+  });
+
+  it("requires and revalidates the complete Factory MCP, instructions, and Droid skill bundle", () => {
+    writeFactoryBundle(false);
+    const input = {
+      project: gitProof(),
+      providerIDs: ["factory"],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    } as const;
+
+    expect(verifyProjectBundle(input)).toMatchObject({
+      ok: false,
+      reason: "project_skill_mismatch",
+    });
+
+    writeFactoryBundle();
+    const verification = verifyProjectBundle(input);
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+    expect(projectBundleStatus(verification.proof, "factory")).toBe("valid");
+
+    writeFileSync(join(root, ".factory", "skills", "dosu", "SKILL.md"), "user edit");
+    expect(projectBundleStatus(verification.proof, "factory")).toBe("changed");
+  });
+
+  it("accepts a Claude adapter symlink only when it resolves to canonical AGENTS.md", () => {
+    writeClaudeBundle();
+    rmSync(join(root, "CLAUDE.md"));
+    symlinkSync("AGENTS.md", join(root, "CLAUDE.md"));
+    const verification = verifyClaude();
+    expect(verification).toMatchObject({ ok: true });
+    if (!verification.ok) throw new Error(verification.reason);
+
+    rmSync(join(root, "CLAUDE.md"));
+    writeFileSync(join(root, "other.md"), "@AGENTS.md");
+    symlinkSync("other.md", join(root, "CLAUDE.md"));
+    expect(projectBundleStatus(verification.proof, "claude")).toBe("changed");
+    expect(verifyClaude()).toMatchObject({
+      ok: false,
+      reason: "project_instructions_mismatch",
+      provider: "claude",
+    });
+  });
+
+  it.each([
+    "gemini",
+    "antigravity",
+  ] as const)("verifies the exact %s instruction adapter and rejects adapter symlinks", (provider) => {
+    const configPath =
+      provider === "gemini"
+        ? join(root, ".gemini", "settings.json")
+        : join(root, ".agents", "mcp_config.json");
+    mkdirSync(join(configPath, ".."), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            command: "npx",
+            args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"],
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+    );
+    const adapterPath =
+      provider === "gemini" ? join(root, "GEMINI.md") : join(root, ".agents", "rules", "dosu.md");
+    mkdirSync(join(adapterPath, ".."), { recursive: true });
+    writeFileSync(
+      adapterPath,
+      `<!-- dosu:project-instructions:start v1 -->\n${provider === "gemini" ? "@AGENTS.md" : "Use Dosu."}\n<!-- dosu:project-instructions:end -->\n`,
+    );
+    writeCanonicalSkill();
+
+    const input = {
+      project: gitProof(),
+      providerIDs: [provider],
+      proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+      instructionContent: "Use Dosu.",
+    } as const;
+    expect(verifyProjectBundle(input)).toMatchObject({ ok: true });
+
+    rmSync(adapterPath);
+    symlinkSync(join(root, "AGENTS.md"), adapterPath);
+    expect(verifyProjectBundle(input)).toMatchObject({
+      ok: provider === "gemini",
+      ...(provider === "antigravity"
+        ? { reason: "project_instructions_mismatch", provider: "antigravity" }
+        : {}),
+    });
+  });
+
+  it("rejects duplicate or edited instruction marker blocks", () => {
+    writeClaudeBundle();
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- dosu:mcp:start v2 -->\nEdited\n<!-- dosu:mcp:end -->\n<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+    );
+    expect(verifyClaude()).toMatchObject({
+      ok: false,
+      reason: "project_instructions_mismatch",
+    });
+
+    writeClaudeBundle();
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n<!-- dosu:mcp:end -->\n",
+    );
+    expect(verifyClaude()).toMatchObject({
+      ok: false,
+      reason: "project_instructions_mismatch",
+    });
+  });
+
+  it("does not accept a structurally forged bundle proof", () => {
+    const forged = { root, providers: ["claude"] };
+    expect(() => {
+      // @ts-expect-error The runtime guard must reject an input TypeScript correctly leaves unbranded.
+      assertProjectBundleProof(forged);
+    }).toThrow(/verified project bundle proof/i);
+    // @ts-expect-error Status must also fail closed for an unbranded runtime value.
+    expect(projectBundleStatus(forged, "claude")).toBe("changed");
+  });
+});

--- a/src/migration/project-bundle.ts
+++ b/src/migration/project-bundle.ts
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import {
+  projectSkillEvidenceUnchanged,
+  verifyProjectSkillInstallation,
+} from "../commands/project-skill-ownership";
+import { projectSkillInstallTargetsForProviders } from "../commands/skill";
+import { providerUsesProjectInstructions } from "../setup/project-instructions";
+import {
+  isExactProjectCodexProxy,
+  isExactProjectJsonProxy,
+  type ProjectProxyExpectation,
+} from "./planners";
+import { assertProjectProof, type ProjectProof } from "./project-proof";
+import type { ProviderId } from "./targets";
+
+const projectBundleBrand: unique symbol = Symbol("DosuProjectBundleProof");
+const projectBundleEvidence: unique symbol = Symbol("DosuProjectBundleEvidence");
+
+const AGENTS_START = "<!-- dosu:mcp:start v2 -->";
+const AGENTS_END = "<!-- dosu:mcp:end -->";
+const ADAPTER_START = "<!-- dosu:project-instructions:start v1 -->";
+const ADAPTER_END = "<!-- dosu:project-instructions:end -->";
+
+type SupportedProjectProvider =
+  | "claude"
+  | "cursor"
+  | "vscode"
+  | "gemini"
+  | "codex"
+  | "zed"
+  | "copilot"
+  | "opencode"
+  | "antigravity"
+  | "mcporter"
+  | "factory";
+
+interface ProviderBundleSpec {
+  mcpPath(root: string): string;
+  topKey?: string;
+  adapter?: "claude" | "gemini" | "antigravity";
+}
+
+const PROJECT_BUNDLE_SPECS: Readonly<Record<SupportedProjectProvider, ProviderBundleSpec>> = {
+  claude: {
+    mcpPath: (root) => join(root, ".mcp.json"),
+    topKey: "mcpServers",
+    adapter: "claude",
+  },
+  cursor: {
+    mcpPath: (root) => join(root, ".cursor", "mcp.json"),
+    topKey: "mcpServers",
+  },
+  vscode: {
+    mcpPath: (root) => join(root, ".vscode", "mcp.json"),
+    topKey: "servers",
+  },
+  gemini: {
+    mcpPath: (root) => join(root, ".gemini", "settings.json"),
+    topKey: "mcpServers",
+    adapter: "gemini",
+  },
+  codex: {
+    mcpPath: (root) => join(root, ".codex", "config.toml"),
+  },
+  zed: {
+    mcpPath: (root) => join(root, ".zed", "settings.json"),
+    topKey: "context_servers",
+  },
+  copilot: {
+    mcpPath: (root) => join(root, ".mcp.json"),
+    topKey: "mcpServers",
+  },
+  opencode: {
+    mcpPath: (root) => join(root, "opencode.json"),
+    topKey: "mcp",
+  },
+  antigravity: {
+    mcpPath: (root) => join(root, ".agents", "mcp_config.json"),
+    topKey: "mcpServers",
+    adapter: "antigravity",
+  },
+  mcporter: {
+    mcpPath: (root) => join(root, "config", "mcporter.json"),
+    topKey: "mcpServers",
+  },
+  factory: {
+    mcpPath: (root) => join(root, ".factory", "mcp.json"),
+    topKey: "mcpServers",
+  },
+};
+
+type BundleEvidence =
+  | { kind: "file"; path: string; realPath: string; hash: string }
+  | { kind: "directory"; path: string; realPath: string; hash: string }
+  | { kind: "symlink"; path: string; realPath: string };
+
+export interface ProjectBundleProof {
+  readonly root: string;
+  readonly providers: readonly SupportedProjectProvider[];
+  readonly [projectBundleBrand]: true;
+  readonly [projectBundleEvidence]: readonly BundleEvidence[];
+}
+
+export type ProjectBundleFailureReason =
+  | "no_selected_provider"
+  | "unsupported_provider"
+  | "invalid_proxy_expectation"
+  | "project_mcp_mismatch"
+  | "project_instructions_mismatch"
+  | "project_skill_mismatch";
+
+export type ProjectBundleVerification =
+  | { ok: true; proof: ProjectBundleProof }
+  | { ok: false; reason: ProjectBundleFailureReason; provider?: ProviderId; path?: string };
+
+export type ProjectBundleStatus = "valid" | "unauthorized_provider" | "changed";
+
+function isSupportedProvider(provider: ProviderId): provider is SupportedProjectProvider {
+  return Object.hasOwn(PROJECT_BUNDLE_SPECS, provider);
+}
+
+function containsPath(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return (
+    path === "" ||
+    (path !== ".." &&
+      !path.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) &&
+      !isAbsolute(path))
+  );
+}
+
+function contentHash(content: string | Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function readRegularFile(
+  path: string,
+  realRoot: string,
+): { content: string; evidence: BundleEvidence } | null {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) return null;
+    const realPath = realpathSync(path);
+    if (!containsPath(realRoot, realPath)) return null;
+    const content = readFileSync(path, "utf8");
+    return { content, evidence: { kind: "file", path, realPath, hash: contentHash(content) } };
+  } catch {
+    return null;
+  }
+}
+
+function exactOwnedBlock(content: string, start: string, body: string, end: string): boolean {
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end);
+  if (startIndex < 0 || endIndex < startIndex) return false;
+  if (content.indexOf(start, startIndex + start.length) !== -1) return false;
+  if (content.indexOf(end, endIndex + end.length) !== -1) return false;
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const expected = `${start}${eol}${body.trim().replace(/\r?\n/g, eol)}${eol}${end}`;
+  return content.slice(startIndex, endIndex + end.length) === expected;
+}
+
+function adapterPath(root: string, adapter: NonNullable<ProviderBundleSpec["adapter"]>): string {
+  switch (adapter) {
+    case "claude":
+      return join(root, "CLAUDE.md");
+    case "gemini":
+      return join(root, "GEMINI.md");
+    case "antigravity":
+      return join(root, ".agents", "rules", "dosu.md");
+  }
+}
+
+function verifyAdapter(
+  root: string,
+  realRoot: string,
+  adapter: NonNullable<ProviderBundleSpec["adapter"]>,
+  instructionContent: string,
+): BundleEvidence | null {
+  const path = adapterPath(root, adapter);
+  try {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      if (adapter === "antigravity") return null;
+      const realPath = realpathSync(path);
+      if (realPath !== realpathSync(join(root, "AGENTS.md"))) return null;
+      return { kind: "symlink", path, realPath };
+    }
+  } catch {
+    return null;
+  }
+
+  const file = readRegularFile(path, realRoot);
+  if (!file) return null;
+  const body = adapter === "antigravity" ? instructionContent : "@AGENTS.md";
+  return exactOwnedBlock(file.content, ADAPTER_START, body, ADAPTER_END) ? file.evidence : null;
+}
+
+function verifyProjectSkill(
+  root: string,
+  providers: readonly SupportedProjectProvider[],
+): BundleEvidence[] | null {
+  const targets = projectSkillInstallTargetsForProviders(providers, root);
+  const verification = verifyProjectSkillInstallation({ projectRoot: root, targets });
+  return verification.ok ? verification.evidence : null;
+}
+
+function deduplicateEvidence(evidence: readonly BundleEvidence[]): BundleEvidence[] {
+  const seen = new Set<string>();
+  return evidence.filter((item) => {
+    const key = `${item.kind}\0${item.path}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function validProxyExpectation(expectation: ProjectProxyExpectation): boolean {
+  const value = expectation as unknown;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proxy = value as Record<string, unknown>;
+  if (
+    typeof proxy.packageVersion !== "string" ||
+    !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(proxy.packageVersion)
+  ) {
+    return false;
+  }
+  const keys = Object.keys(proxy).sort();
+  if (proxy.oss === true) {
+    return keys.length === 2 && keys[0] === "oss" && keys[1] === "packageVersion";
+  }
+  const expectedKeys =
+    proxy.oss === false
+      ? ["deploymentID", "oss", "packageVersion"]
+      : ["deploymentID", "packageVersion"];
+  return (
+    keys.length === expectedKeys.length &&
+    keys.every((key, index) => key === expectedKeys[index]) &&
+    typeof proxy.deploymentID === "string" &&
+    proxy.deploymentID.length > 0
+  );
+}
+
+export function verifyProjectBundle(input: {
+  project: ProjectProof;
+  providerIDs: readonly ProviderId[];
+  proxy: ProjectProxyExpectation;
+  instructionContent: string;
+}): ProjectBundleVerification {
+  assertProjectProof(input.project);
+  const providers = [...new Set(input.providerIDs)];
+  if (providers.length === 0) return { ok: false, reason: "no_selected_provider" };
+  const unsupported = providers.find((provider) => !isSupportedProvider(provider));
+  if (unsupported) return { ok: false, reason: "unsupported_provider", provider: unsupported };
+  if (!validProxyExpectation(input.proxy)) {
+    return { ok: false, reason: "invalid_proxy_expectation" };
+  }
+
+  const supported = providers as SupportedProjectProvider[];
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(input.project.root);
+  } catch {
+    return { ok: false, reason: "project_mcp_mismatch" };
+  }
+  const evidence: BundleEvidence[] = [];
+
+  for (const provider of supported) {
+    const spec = PROJECT_BUNDLE_SPECS[provider];
+    const path = spec.mcpPath(input.project.root);
+    const file = readRegularFile(path, realRoot);
+    if (!file) return { ok: false, reason: "project_mcp_mismatch", provider, path };
+    const valid =
+      provider === "codex"
+        ? isExactProjectCodexProxy(file.content, input.proxy)
+        : isExactProjectJsonProxy({
+            content: file.content,
+            provider,
+            topKey: spec.topKey ?? "",
+            expectation: input.proxy,
+          });
+    if (!valid) return { ok: false, reason: "project_mcp_mismatch", provider, path };
+    evidence.push(file.evidence);
+  }
+
+  if (supported.some(providerUsesProjectInstructions)) {
+    const path = join(input.project.root, "AGENTS.md");
+    const agents = readRegularFile(path, realRoot);
+    if (
+      !agents ||
+      !exactOwnedBlock(agents.content, AGENTS_START, input.instructionContent, AGENTS_END)
+    ) {
+      return { ok: false, reason: "project_instructions_mismatch", path };
+    }
+    evidence.push(agents.evidence);
+
+    for (const provider of supported) {
+      const adapter = PROJECT_BUNDLE_SPECS[provider].adapter;
+      if (!adapter) continue;
+      const adapterEvidence = verifyAdapter(
+        input.project.root,
+        realRoot,
+        adapter,
+        input.instructionContent,
+      );
+      if (!adapterEvidence) {
+        return {
+          ok: false,
+          reason: "project_instructions_mismatch",
+          provider,
+          path: adapterPath(input.project.root, adapter),
+        };
+      }
+      evidence.push(adapterEvidence);
+    }
+  }
+
+  const skillProviders = supported.filter(
+    (provider) => projectSkillInstallTargetsForProviders([provider], input.project.root).length > 0,
+  );
+  if (skillProviders.length > 0) {
+    const skillEvidence = verifyProjectSkill(input.project.root, skillProviders);
+    if (!skillEvidence) return { ok: false, reason: "project_skill_mismatch" };
+    evidence.push(...skillEvidence);
+  }
+
+  const frozenProviders = Object.freeze([...supported]);
+  const frozenEvidence = Object.freeze(deduplicateEvidence(evidence));
+  const proof: ProjectBundleProof = {
+    root: resolve(input.project.root),
+    providers: frozenProviders,
+    [projectBundleBrand]: true,
+    [projectBundleEvidence]: frozenEvidence,
+  };
+  return {
+    ok: true,
+    proof: Object.freeze(proof),
+  };
+}
+
+function evidenceUnchanged(evidence: BundleEvidence, realRoot: string): boolean {
+  try {
+    const stat = lstatSync(evidence.path);
+    if (evidence.kind === "symlink") {
+      return stat.isSymbolicLink() && realpathSync(evidence.path) === evidence.realPath;
+    }
+    if (stat.isSymbolicLink() || realpathSync(evidence.path) !== evidence.realPath) return false;
+    if (evidence.kind === "file") {
+      return stat.isFile() && contentHash(readFileSync(evidence.path)) === evidence.hash;
+    }
+    return stat.isDirectory() && projectSkillEvidenceUnchanged(evidence, realRoot);
+  } catch {
+    return false;
+  }
+}
+
+export function projectBundleStatus(
+  proof: ProjectBundleProof,
+  provider: ProviderId,
+): ProjectBundleStatus {
+  if (proof?.[projectBundleBrand] !== true) return "changed";
+  if (!proof.providers.includes(provider as SupportedProjectProvider))
+    return "unauthorized_provider";
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(proof.root);
+  } catch {
+    return "changed";
+  }
+  return proof[projectBundleEvidence].every((evidence) => evidenceUnchanged(evidence, realRoot))
+    ? "valid"
+    : "changed";
+}
+
+export function assertProjectBundleProof(proof: ProjectBundleProof): void {
+  if (proof?.[projectBundleBrand] !== true) {
+    throw new Error("A verified project bundle proof is required for legacy migration");
+  }
+}


### PR DESCRIPTION
<!-- Is this PR related to a Linear issue? -->
<!-- Example: Fixes [ENG-123](https://linear.app/dosu/issue/ENG-123) -->

### Description

Stack 4/8, based on #159. Adds a branded, file-backed proof that every selected provider has the exact secretless MCP entry, canonical instructions, adapters, and owned skill content before legacy cleanup can be authorized.

This layer only verifies project state; it cannot delete or migrate global configuration.

Validated locally with `bun run typecheck`, `bun run check`, all 1,966 tests, 32 focused bundle-proof tests, `git diff --check`, and `bun run build:npm`.

Stack review order:

1. #157 feat(mcp): add safe project file foundation
2. #158 feat(mcp): add secretless project proxy runtime
3. #159 feat(setup): add project agent assets
4. #160 feat(migration): prove complete project bundles
5. #161 feat(migration): add proof-gated global cleanup
6. #162 feat(mcp): enable project-scoped providers
7. #163 feat(setup): scope setup to the current project
8. #164 docs(setup): document project-scoped agent setup

Because this repository is squash-only, land by collapsing leaf into base: #164 -> #163 -> #162 -> #161 -> #160 -> #159 -> #158 -> #157 -> main.

### Review Tasks - Only request review after completing these.

* [ ] I self-reviewed this PR
* [ ] Testing is adequate for this change
* [ ] I reviewed AI-generated code and resolved suggestions

### Details (for context) - Not tasks; tooling uses tasks to determine review readiness

- Generated with AI: (N/Claude/Codex/Other)
- Manual testing: (Y/N/NA)
- Tests updated: (Y/N/NA)

<!-- Describe any manual testing or special testing approach -->
