### PR TITLE
feat(migration): add proof-gated global cleanup (5/8)

### DIFF
--- a/src/migration/global-intent.test.ts
+++ b/src/migration/global-intent.test.ts
@@ -1,0 +1,272 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  finalizeGlobalMcpIntent,
+  globalMcpIntentMarkerPath,
+  inspectGlobalMcpIntent,
+  prepareGlobalMcpIntent,
+  releaseGlobalMcpIntent,
+} from "./global-intent";
+import { acquireTargetOperationLock, releaseTargetOperationLock } from "./orchestrator";
+
+let tempDir: string;
+let intentRoot: string;
+let targetPath: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-global-intent-"));
+  intentRoot = join(tempDir, "private", "migrations", "global-mcp-intent-v1");
+  targetPath = join(tempDir, "home", ".cursor", "mcp.json");
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("explicit global MCP intent", () => {
+  it("rejects invalid identities, relative paths, and a non-file marker before writing", () => {
+    expect(() => globalMcpIntentMarkerPath({ provider: "Cursor", targetPath, intentRoot })).toThrow(
+      "Invalid global MCP provider ID",
+    );
+    expect(() =>
+      globalMcpIntentMarkerPath({ provider: "cursor", targetPath: "relative", intentRoot }),
+    ).toThrow("Global MCP target path must be absolute");
+    expect(() =>
+      globalMcpIntentMarkerPath({ provider: "cursor", targetPath, intentRoot: "relative" }),
+    ).toThrow("Global MCP intent root must be absolute");
+
+    mkdirSync(intentRoot, { recursive: true });
+    const markerPath = globalMcpIntentMarkerPath({ provider: "cursor", targetPath, intentRoot });
+    mkdirSync(markerPath);
+
+    expect(() => prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toThrow(
+      "Unsafe global MCP intent marker",
+    );
+    expect(lstatSync(markerPath).isDirectory()).toBe(true);
+  });
+
+  it("durably records pending intent before the target changes, then binds installed content", () => {
+    const pending = prepareGlobalMcpIntent({
+      provider: "cursor",
+      targetPath,
+      intentRoot,
+    });
+    const pendingMarker = JSON.parse(readFileSync(pending.markerPath, "utf8"));
+    expect(pendingMarker).toMatchObject({
+      version: 1,
+      state: "pending",
+      provider: "cursor",
+      targetPath,
+    });
+    expect(existsSync(`${targetPath}.dosu-migration.lock`)).toBe(true);
+
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    finalizeGlobalMcpIntent(pending);
+
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "explicit_global_intent",
+    });
+    expect(existsSync(`${targetPath}.dosu-migration.lock`)).toBe(false);
+  });
+
+  it("shares target exclusion with migration and releases it while retaining failed intent", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    const migrationLock = acquireTargetOperationLock(targetPath, join(tempDir, "receipts"));
+    expect(() => prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toThrow(
+      "Global MCP target is locked",
+    );
+    expect(
+      existsSync(globalMcpIntentMarkerPath({ provider: "cursor", targetPath, intentRoot })),
+    ).toBe(false);
+    releaseTargetOperationLock(migrationLock);
+
+    const pending = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    expect(existsSync(pending.operationLock.path)).toBe(true);
+    releaseGlobalMcpIntent(pending);
+    expect(existsSync(pending.operationLock.path)).toBe(false);
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "global_intent_pending",
+    });
+  });
+
+  it("updates the content binding on an explicit reinstall", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    const first = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    finalizeGlobalMcpIntent(first);
+    const markerPath = globalMcpIntentMarkerPath({ provider: "cursor", targetPath, intentRoot });
+    const firstHash = JSON.parse(readFileSync(markerPath, "utf8")).contentHash;
+
+    const second = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"two"}}}\n');
+    finalizeGlobalMcpIntent(second);
+    const secondHash = JSON.parse(readFileSync(markerPath, "utf8")).contentHash;
+
+    expect(secondHash).not.toBe(firstHash);
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "explicit_global_intent",
+    });
+  });
+
+  it("prefers an exact marker and recognizes canonical intent shared across providers", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"shared"}}}\n');
+    for (const provider of ["claude", "copilot", "cursor"]) {
+      const pending = prepareGlobalMcpIntent({ provider, targetPath, intentRoot });
+      finalizeGlobalMcpIntent(pending);
+    }
+
+    for (const provider of ["claude", "copilot", "cursor", "gemini"]) {
+      expect(inspectGlobalMcpIntent({ provider, targetPath, intentRoot })).toEqual({
+        status: "preserve",
+        reason: "explicit_global_intent",
+      });
+    }
+  });
+
+  it("refuses to finalize a marker or target that changed after prepare", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    const changedMarker = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    const marker = JSON.parse(readFileSync(changedMarker.markerPath, "utf8"));
+    writeFileSync(changedMarker.markerPath, `${JSON.stringify({ ...marker, unexpected: true })}\n`);
+
+    expect(() => finalizeGlobalMcpIntent(changedMarker)).toThrow(
+      "Global MCP intent marker changed during install",
+    );
+    expect(readFileSync(targetPath, "utf8")).toContain('"url":"one"');
+
+    const directoryTarget = join(tempDir, "home", ".claude", "config.json");
+    const nonRegularTarget = prepareGlobalMcpIntent({
+      provider: "claude",
+      targetPath: directoryTarget,
+      intentRoot,
+    });
+    mkdirSync(directoryTarget, { recursive: true });
+
+    expect(() => finalizeGlobalMcpIntent(nonRegularTarget)).toThrow(
+      "Global MCP install target is not a regular file",
+    );
+    expect(lstatSync(directoryTarget).isDirectory()).toBe(true);
+  });
+
+  it("fails closed for invalid inputs, unsafe roots, and an empty marker inventory", () => {
+    expect(inspectGlobalMcpIntent({ provider: "Cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "global_intent_unsafe",
+    });
+
+    const unsafeRoot = join(tempDir, "intent-root-file");
+    writeFileSync(unsafeRoot, "do not replace");
+    expect(
+      inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot: unsafeRoot }),
+    ).toEqual({ status: "preserve", reason: "global_intent_unsafe" });
+    expect(readFileSync(unsafeRoot, "utf8")).toBe("do not replace");
+
+    mkdirSync(intentRoot, { recursive: true });
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "absent",
+    });
+  });
+
+  it("fails closed for invalid installed markers and missing or non-regular targets", () => {
+    mkdirSync(intentRoot, { recursive: true });
+    const hash = "0".repeat(64);
+    const writeInstalledMarker = (
+      provider: string,
+      target: string,
+      extra: Record<string, unknown> = {},
+    ) => {
+      const markerPath = globalMcpIntentMarkerPath({ provider, targetPath: target, intentRoot });
+      writeFileSync(
+        markerPath,
+        `${JSON.stringify({
+          version: 1,
+          state: "installed",
+          provider,
+          targetPath: target,
+          contentHash: hash,
+          ...extra,
+        })}\n`,
+      );
+    };
+
+    const invalidTarget = join(tempDir, "invalid-target.json");
+    writeInstalledMarker("cursor", invalidTarget, { unexpected: true });
+    expect(
+      inspectGlobalMcpIntent({ provider: "cursor", targetPath: invalidTarget, intentRoot }),
+    ).toEqual({ status: "preserve", reason: "global_intent_invalid" });
+
+    const directoryTarget = join(tempDir, "directory-target");
+    mkdirSync(directoryTarget);
+    writeInstalledMarker("claude", directoryTarget);
+    expect(
+      inspectGlobalMcpIntent({ provider: "claude", targetPath: directoryTarget, intentRoot }),
+    ).toEqual({ status: "preserve", reason: "global_intent_content_changed" });
+
+    const missingTarget = join(tempDir, "missing-target.json");
+    writeInstalledMarker("gemini", missingTarget);
+    expect(
+      inspectGlobalMcpIntent({ provider: "gemini", targetPath: missingTarget, intentRoot }),
+    ).toEqual({ status: "preserve", reason: "global_intent_content_changed" });
+  });
+
+  it("rejects a marker replaced by a symlink between prepare and finalize", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    const pending = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    const pendingContent = readFileSync(pending.markerPath, "utf8");
+    const foreignMarker = join(tempDir, "foreign-pending-marker");
+    writeFileSync(foreignMarker, pendingContent);
+    rmSync(pending.markerPath);
+    symlinkSync(foreignMarker, pending.markerPath);
+
+    expect(() => finalizeGlobalMcpIntent(pending)).toThrow(/regular|unsafe/i);
+    expect(readFileSync(foreignMarker, "utf8")).toBe(pendingContent);
+  });
+
+  it("fails closed for pending, damaged, symlinked, and content-mismatched markers", () => {
+    mkdirSync(join(targetPath, ".."), { recursive: true });
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"one"}}}\n');
+    const pending = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toMatchObject({
+      status: "preserve",
+    });
+
+    writeFileSync(pending.markerPath, "not-json");
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toMatchObject({
+      status: "preserve",
+    });
+
+    rmSync(pending.markerPath);
+    symlinkSync(join(tempDir, "foreign-marker"), pending.markerPath);
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toMatchObject({
+      status: "preserve",
+    });
+
+    rmSync(pending.markerPath);
+    releaseGlobalMcpIntent(pending);
+    const installed = prepareGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot });
+    finalizeGlobalMcpIntent(installed);
+    writeFileSync(targetPath, '{"mcpServers":{"dosu":{"url":"changed"}}}\n');
+    expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath, intentRoot })).toEqual({
+      status: "preserve",
+      reason: "global_intent_content_changed",
+    });
+  });
+});

--- a/src/migration/global-intent.ts
+++ b/src/migration/global-intent.ts
@@ -1,0 +1,367 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import {
+  getNodeValue,
+  type Node as JsonNode,
+  type ParseError,
+  parseTree,
+} from "jsonc-parser/lib/esm/main.js";
+import { getConfigDir } from "../config/config";
+import {
+  acquireTargetOperationLock,
+  releaseTargetOperationLock,
+  type TargetOperationLock,
+} from "./orchestrator";
+
+const VERSION = 1;
+const DIRECTORY_NAME = "global-mcp-intent-v1";
+
+export interface GlobalMcpIntentInput {
+  provider: string;
+  targetPath: string;
+  /** Test override. Production intent lives under Dosu's private config directory. */
+  intentRoot?: string;
+}
+
+export interface PendingGlobalMcpIntent {
+  provider: string;
+  targetPath: string;
+  intentRoot: string;
+  markerPath: string;
+  nonce: string;
+  operationLock: TargetOperationLock;
+}
+
+export type GlobalMcpIntentInspection =
+  | { status: "absent" }
+  | {
+      status: "preserve";
+      reason:
+        | "explicit_global_intent"
+        | "global_intent_pending"
+        | "global_intent_invalid"
+        | "global_intent_unsafe"
+        | "global_intent_content_changed";
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function duplicateJsonKey(node: JsonNode): boolean {
+  if (node.type === "object") {
+    const seen = new Set<string>();
+    for (const property of node.children ?? []) {
+      const keyNode = property.children?.[0];
+      const key = keyNode ? getNodeValue(keyNode) : undefined;
+      if (typeof key !== "string") continue;
+      if (seen.has(key)) return true;
+      seen.add(key);
+    }
+  }
+  return (node.children ?? []).some(duplicateJsonKey);
+}
+
+function parseStrictObject(content: string): Record<string, unknown> | null {
+  const errors: ParseError[] = [];
+  const root = parseTree(content, errors, { allowTrailingComma: false, disallowComments: true });
+  if (root?.type !== "object" || errors.length > 0 || duplicateJsonKey(root)) return null;
+  const value: unknown = getNodeValue(root);
+  return isRecord(value) ? value : null;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+}
+
+function canonicalInput(input: GlobalMcpIntentInput): {
+  provider: string;
+  targetPath: string;
+  intentRoot: string;
+} {
+  if (!/^[a-z0-9-]+$/.test(input.provider)) throw new Error("Invalid global MCP provider ID");
+  if (!isAbsolute(input.targetPath)) throw new Error("Global MCP target path must be absolute");
+  const intentRoot = input.intentRoot ?? join(getConfigDir(), "migrations", DIRECTORY_NAME);
+  if (!isAbsolute(intentRoot)) throw new Error("Global MCP intent root must be absolute");
+  return {
+    provider: input.provider,
+    targetPath: resolve(input.targetPath),
+    intentRoot: resolve(intentRoot),
+  };
+}
+
+export function globalMcpIntentMarkerPath(input: GlobalMcpIntentInput): string {
+  const canonical = canonicalInput(input);
+  const pathHash = targetPathHash(canonical.targetPath);
+  return join(canonical.intentRoot, `${canonical.provider}-${pathHash}.json`);
+}
+
+function targetPathHash(path: string): string {
+  return createHash("sha256").update(path).digest("hex").slice(0, 24);
+}
+
+function contentHash(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function fsyncParent(path: string): void {
+  try {
+    const fd = openSync(dirname(path), "r");
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    // Some supported platforms do not expose directory fsync.
+  }
+}
+
+function atomicWrite(path: string, content: string): void {
+  const temporary = `${path}.candidate-${process.pid}-${randomBytes(6).toString("hex")}`;
+  let exists = false;
+  try {
+    const fd = openSync(temporary, "wx", 0o600);
+    exists = true;
+    try {
+      writeFileSync(fd, content, "utf8");
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(temporary, path);
+    chmodSync(path, 0o600);
+    fsyncParent(path);
+    exists = false;
+  } finally {
+    if (exists) {
+      try {
+        unlinkSync(temporary);
+      } catch {
+        // A never-published candidate is not authoritative.
+      }
+    }
+  }
+}
+
+function prepareRoot(path: string): void {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error("Unsafe global MCP intent root");
+    }
+  } catch (error: unknown) {
+    const code = isRecord(error) && "code" in error ? error.code : undefined;
+    if (code !== "ENOENT") throw error;
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+  }
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe global MCP intent root");
+  }
+  chmodSync(path, 0o700);
+}
+
+function assertReplaceableMarker(path: string): void {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error("Unsafe global MCP intent marker");
+    }
+  } catch (error: unknown) {
+    const code = isRecord(error) && "code" in error ? error.code : undefined;
+    if (code !== "ENOENT") throw error;
+  }
+}
+
+/** Persist a fail-closed pending marker before any global provider file is changed. */
+export function prepareGlobalMcpIntent(input: GlobalMcpIntentInput): PendingGlobalMcpIntent {
+  const canonical = canonicalInput(input);
+  prepareRoot(canonical.intentRoot);
+  mkdirSync(dirname(canonical.targetPath), { recursive: true, mode: 0o700 });
+  const targetParent = lstatSync(dirname(canonical.targetPath));
+  if (!targetParent.isDirectory() || targetParent.isSymbolicLink()) {
+    throw new Error("Unsafe global MCP target directory");
+  }
+  const operationLock = acquireTargetOperationLock(canonical.targetPath, canonical.intentRoot);
+  try {
+    const markerPath = globalMcpIntentMarkerPath(canonical);
+    assertReplaceableMarker(markerPath);
+    const nonce = randomBytes(16).toString("hex");
+    atomicWrite(
+      markerPath,
+      `${JSON.stringify({
+        version: VERSION,
+        state: "pending",
+        provider: canonical.provider,
+        targetPath: canonical.targetPath,
+        nonce,
+      })}\n`,
+    );
+    return { ...canonical, markerPath, nonce, operationLock };
+  } catch (error) {
+    releaseTargetOperationLock(operationLock);
+    throw error;
+  }
+}
+
+/** Bind the marker to the exact complete config contents produced by install. */
+export function finalizeGlobalMcpIntent(pending: PendingGlobalMcpIntent): void {
+  try {
+    const markerStat = lstatSync(pending.markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
+      throw new Error("Global MCP intent marker is not a regular file");
+    }
+    const marker = parseStrictObject(readFileSync(pending.markerPath, "utf8"));
+    if (
+      !marker ||
+      !exactKeys(marker, ["version", "state", "provider", "targetPath", "nonce"]) ||
+      marker.version !== VERSION ||
+      marker.state !== "pending" ||
+      marker.provider !== pending.provider ||
+      marker.targetPath !== pending.targetPath ||
+      marker.nonce !== pending.nonce
+    ) {
+      throw new Error("Global MCP intent marker changed during install");
+    }
+    const targetStat = lstatSync(pending.targetPath);
+    if (!targetStat.isFile() || targetStat.isSymbolicLink()) {
+      throw new Error("Global MCP install target is not a regular file");
+    }
+    const installedHash = contentHash(pending.targetPath);
+    atomicWrite(
+      pending.markerPath,
+      `${JSON.stringify({
+        version: VERSION,
+        state: "installed",
+        provider: pending.provider,
+        targetPath: pending.targetPath,
+        contentHash: installedHash,
+      })}\n`,
+    );
+  } finally {
+    releaseTargetOperationLock(pending.operationLock);
+  }
+}
+
+/** Keep the pending marker as fail-closed evidence, but release the operation lock after failure. */
+export function releaseGlobalMcpIntent(pending: PendingGlobalMcpIntent): void {
+  releaseTargetOperationLock(pending.operationLock);
+}
+
+/** Read-only migration guard. Every non-absent unknown state preserves config. */
+export function inspectGlobalMcpIntent(input: GlobalMcpIntentInput): GlobalMcpIntentInspection {
+  let canonical: ReturnType<typeof canonicalInput>;
+  try {
+    canonical = canonicalInput(input);
+  } catch {
+    return { status: "preserve", reason: "global_intent_unsafe" };
+  }
+
+  try {
+    const rootStat = lstatSync(canonical.intentRoot);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+      return { status: "preserve", reason: "global_intent_unsafe" };
+    }
+  } catch (error: unknown) {
+    const code = isRecord(error) && "code" in error ? error.code : undefined;
+    return code === "ENOENT"
+      ? { status: "absent" }
+      : { status: "preserve", reason: "global_intent_unsafe" };
+  }
+
+  const exactMarkerPath = globalMcpIntentMarkerPath(canonical);
+  let candidatePaths: string[];
+  try {
+    const hash = targetPathHash(canonical.targetPath);
+    const pattern = new RegExp(`^.+-${hash}\\.json$`);
+    candidatePaths = readdirSync(canonical.intentRoot)
+      .filter((name) => pattern.test(name))
+      .map((name) => join(canonical.intentRoot, name))
+      .sort((left, right) => {
+        if (left === exactMarkerPath) return -1;
+        if (right === exactMarkerPath) return 1;
+        return left.localeCompare(right);
+      });
+  } catch {
+    return { status: "preserve", reason: "global_intent_unsafe" };
+  }
+  if (candidatePaths.length === 0) return { status: "absent" };
+  const markerPath = candidatePaths[0];
+  let markerContent: string;
+  try {
+    const markerStat = lstatSync(markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
+      return { status: "preserve", reason: "global_intent_unsafe" };
+    }
+    markerContent = readFileSync(markerPath, "utf8");
+  } catch {
+    return { status: "preserve", reason: "global_intent_unsafe" };
+  }
+
+  const marker = parseStrictObject(markerContent);
+  if (!marker) return { status: "preserve", reason: "global_intent_invalid" };
+  if (
+    exactKeys(marker, ["version", "state", "provider", "targetPath", "nonce"]) &&
+    marker.version === VERSION &&
+    marker.state === "pending" &&
+    typeof marker.provider === "string" &&
+    /^[a-z0-9-]+$/.test(marker.provider) &&
+    marker.targetPath === canonical.targetPath &&
+    typeof marker.nonce === "string" &&
+    /^[a-f0-9]{32}$/.test(marker.nonce) &&
+    markerPath ===
+      globalMcpIntentMarkerPath({
+        provider: marker.provider,
+        targetPath: canonical.targetPath,
+        intentRoot: canonical.intentRoot,
+      })
+  ) {
+    return { status: "preserve", reason: "global_intent_pending" };
+  }
+  if (
+    !exactKeys(marker, ["version", "state", "provider", "targetPath", "contentHash"]) ||
+    marker.version !== VERSION ||
+    marker.state !== "installed" ||
+    typeof marker.provider !== "string" ||
+    !/^[a-z0-9-]+$/.test(marker.provider) ||
+    marker.targetPath !== canonical.targetPath ||
+    typeof marker.contentHash !== "string" ||
+    !/^[a-f0-9]{64}$/.test(marker.contentHash) ||
+    markerPath !==
+      globalMcpIntentMarkerPath({
+        provider: marker.provider,
+        targetPath: canonical.targetPath,
+        intentRoot: canonical.intentRoot,
+      })
+  ) {
+    return { status: "preserve", reason: "global_intent_invalid" };
+  }
+
+  try {
+    const targetStat = lstatSync(canonical.targetPath);
+    if (!targetStat.isFile() || targetStat.isSymbolicLink()) {
+      return { status: "preserve", reason: "global_intent_content_changed" };
+    }
+    return contentHash(canonical.targetPath) === marker.contentHash
+      ? { status: "preserve", reason: "explicit_global_intent" }
+      : { status: "preserve", reason: "global_intent_content_changed" };
+  } catch {
+    return { status: "preserve", reason: "global_intent_content_changed" };
+  }
+}

--- a/src/migration/index.ts
+++ b/src/migration/index.ts
@@ -1,0 +1,45 @@
+export {
+  applyContentPlan,
+  inspectLegacyTarget,
+  type LegacyTargetInspection,
+  legacyTargetsNeedCleanup,
+  type MigrationOutcome,
+  type MigrationReceipt,
+  migrateLegacyTargets,
+} from "./orchestrator";
+export {
+  type ContentPlan,
+  isExactProjectCodexProxy,
+  isExactProjectJsonProxy,
+  type ProjectProxyExpectation,
+  planCodexDosuMcp,
+  planLegacyCodexMcp,
+  planLegacyJsonMcp,
+  planLegacyRuleSection,
+  planLegacyStandaloneRule,
+  planProjectCodexMcp,
+  removeJsonObjectPropertyRaw,
+} from "./planners";
+export {
+  assertProjectBundleProof,
+  type ProjectBundleFailureReason,
+  type ProjectBundleProof,
+  type ProjectBundleStatus,
+  type ProjectBundleVerification,
+  projectBundleStatus,
+  verifyProjectBundle,
+} from "./project-bundle";
+export {
+  type ProjectFacts,
+  type ProjectProof,
+  type ProjectProofResult,
+  proveProjectScope,
+  resolveProjectProof,
+} from "./project-proof";
+export {
+  type LegacyTarget,
+  type LegacyTargetEnvironment,
+  type LegacyTargetResolution,
+  type ProviderId,
+  resolveLegacyTargets,
+} from "./targets";

--- a/src/migration/orchestrator.test.ts
+++ b/src/migration/orchestrator.test.ts
@@ -1,0 +1,2050 @@
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyContentPlan,
+  ensureBackup,
+  inspectLegacyTarget,
+  legacyTargetsNeedCleanup,
+  type MigrationReceipt,
+  migrateLegacyTargets,
+} from "./orchestrator";
+import { hashContent, planLegacyJsonMcp, planLegacyStandaloneRule } from "./planners";
+import { type ProjectBundleProof, verifyProjectBundle } from "./project-bundle";
+import { proveProjectScope } from "./project-proof";
+import type { LegacyTarget } from "./targets";
+
+let tempDir: string;
+let backupRoot: string;
+const RELEASED_RULE = readFileSync(join(process.cwd(), "rules", "dosu.md"), "utf8");
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-legacy-migration-"));
+  backupRoot = join(tempDir, "backups");
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function proof(): ProjectBundleProof {
+  const root = join(tempDir, "project");
+  mkdirSync(join(root, ".agents", "skills", "dosu"), { recursive: true });
+  mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+  const skill = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+  writeFileSync(join(root, ".agents", "skills", "dosu", "SKILL.md"), skill);
+  const skillHash = createHash("sha256").update("SKILL.md").update(skill).digest("hex");
+  writeFileSync(
+    join(root, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash: skillHash,
+        },
+      },
+    }),
+  );
+  const claudeSkill = join(root, ".claude", "skills", "dosu");
+  mkdirSync(claudeSkill, { recursive: true });
+  writeFileSync(join(claudeSkill, "SKILL.md"), skill);
+  writeFileSync(
+    join(root, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"],
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, "AGENTS.md"),
+    "<!-- dosu:mcp:start v2 -->\nUse Dosu.\n<!-- dosu:mcp:end -->\n",
+  );
+  writeFileSync(
+    join(root, "CLAUDE.md"),
+    "<!-- dosu:project-instructions:start v1 -->\n@AGENTS.md\n<!-- dosu:project-instructions:end -->\n",
+  );
+  const result = proveProjectScope({
+    cwd: root,
+    gitTopLevel: root,
+    insideWorkTree: true,
+    bareRepository: false,
+  });
+  if (!result.ok) throw new Error(result.reason);
+  const bundle = verifyProjectBundle({
+    project: result.proof,
+    providerIDs: ["claude"],
+    proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+    instructionContent: "Use Dosu.",
+  });
+  if (!bundle.ok) throw new Error(bundle.reason);
+  return bundle.proof;
+}
+
+function jsonTarget(path: string): LegacyTarget {
+  return {
+    id: "claude:mcp",
+    provider: "claude",
+    kind: "json_mcp",
+    path,
+    topKey: "mcpServers",
+  };
+}
+
+function crashedWriteCapture(name: string): {
+  path: string;
+  original: string;
+  plan: ReturnType<typeof planLegacyJsonMcp>;
+  pending: MigrationReceipt;
+} {
+  const path = join(tempDir, `${name}.json`);
+  const original = JSON.stringify({
+    mcpServers: {
+      dosu: {
+        type: "http",
+        url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+        headers: { "X-Dosu-API-Key": "legacy-secret" },
+      },
+      user: { url: "https://example.com" },
+    },
+  });
+  writeFileSync(path, original);
+  const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+  expect(
+    applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: () => {
+          throw new Error("simulated crash");
+        },
+      },
+    }),
+  ).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+  const receiptName = readdirSync(backupRoot).find((entry) => entry.endsWith(".receipt.json"));
+  if (!receiptName) throw new Error("expected pending receipt");
+  const pending = JSON.parse(readFileSync(join(backupRoot, receiptName), "utf8"));
+  return { path, original, plan, pending };
+}
+
+describe("backup, receipt, concurrent hash, and idempotence orchestration", () => {
+  it("rejects and removes a newly copied backup whose bytes do not match the preimage", () => {
+    const source = join(tempDir, "source.json");
+    const backup = join(tempDir, "corrupted.bak");
+    const content = '{"secret":"original"}';
+    writeFileSync(source, content);
+    const expectedHash = createHash("sha256").update(content).digest("hex");
+
+    expect(() =>
+      ensureBackup(source, backup, expectedHash, (from, to, flags) => {
+        copyFileSync(from, to, flags);
+        writeFileSync(to, "corrupted during copy");
+      }),
+    ).toThrow("New migration backup does not match the planned content");
+    expect(existsSync(backup)).toBe(false);
+  });
+
+  it("rejects an existing backup symlink even when it resolves to the exact preimage", () => {
+    const source = join(tempDir, "source.json");
+    const backup = join(tempDir, "linked.bak");
+    const content = '{"secret":"original"}';
+    writeFileSync(source, content);
+    symlinkSync(source, backup);
+
+    expect(() => ensureBackup(source, backup, hashContent(content))).toThrow(
+      "Existing migration backup is not a regular file",
+    );
+    expect(readFileSync(source, "utf8")).toBe(content);
+    expect(lstatSync(backup).isSymbolicLink()).toBe(true);
+  });
+
+  it("inspects strict current plans without mutating and requests runtime verification only for removal", () => {
+    const owned = join(tempDir, "owned.json");
+    const foreign = join(tempDir, "foreign-inspection.json");
+    writeFileSync(
+      owned,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": "secret" },
+          },
+        },
+      }),
+    );
+    writeFileSync(foreign, '{"mcpServers":{"dosu":{"url":"https://example.com"}}}');
+
+    expect(legacyTargetsNeedCleanup([jsonTarget(owned)])).toBe(true);
+    expect(legacyTargetsNeedCleanup([jsonTarget(foreign)])).toBe(false);
+    expect(inspectLegacyTarget(jsonTarget(owned))).toMatchObject({ disposition: "remove" });
+    expect(inspectLegacyTarget(jsonTarget(foreign))).toMatchObject({
+      disposition: "ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+    expect(inspectLegacyTarget(jsonTarget(join(tempDir, "absent.json")))).toEqual({
+      disposition: "not_found",
+      reason: "target_absent",
+    });
+    expect(existsSync(backupRoot)).toBe(false);
+  });
+
+  it("inspects every historical target kind and deduplicates repeated paths", () => {
+    const codexPath = join(tempDir, "config.toml");
+    writeFileSync(
+      codexPath,
+      '[mcp_servers.dosu]\ntype = "http"\nurl = "https://api.dosu.dev/v1/mcp/deployments/dep"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "secret"\n',
+    );
+    const claudeRule = join(tempDir, "dosu.md");
+    writeFileSync(claudeRule, RELEASED_RULE);
+    const cursorRule = join(tempDir, "dosu.mdc");
+    writeFileSync(cursorRule, `---\nalwaysApply: true\n---\n\n${RELEASED_RULE}`);
+    const targets: LegacyTarget[] = [
+      { id: "codex:mcp", provider: "codex", kind: "codex_toml", path: codexPath },
+      {
+        id: "claude:rule",
+        provider: "claude",
+        kind: "rule_file",
+        path: claudeRule,
+        ruleKind: "claude",
+      },
+      {
+        id: "cursor:rule",
+        provider: "cursor",
+        kind: "rule_file",
+        path: cursorRule,
+        ruleKind: "cursor",
+      },
+    ];
+    for (const target of targets) {
+      expect(inspectLegacyTarget(target)).toMatchObject({ disposition: "remove" });
+    }
+    expect(legacyTargetsNeedCleanup([targets[0], targets[0]])).toBe(true);
+  });
+
+  it("treats directories and symlinks as ambiguous without following them", () => {
+    const directory = join(tempDir, "directory-target");
+    const linked = join(tempDir, "linked-target.json");
+    const foreign = join(tempDir, "foreign.json");
+    mkdirSync(directory);
+    writeFileSync(foreign, '{"mcpServers":{}}');
+    symlinkSync(foreign, linked);
+
+    expect(inspectLegacyTarget(jsonTarget(directory))).toEqual({
+      disposition: "ambiguous",
+      reason: "non_regular_target",
+    });
+    expect(inspectLegacyTarget(jsonTarget(linked))).toEqual({
+      disposition: "ambiguous",
+      reason: "non_regular_target",
+    });
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [jsonTarget(directory), jsonTarget(linked)],
+        backupRoot,
+        allowRemoval: true,
+      }).map((receipt) => receipt.reason),
+    ).toEqual(["non_regular_target", "non_regular_target"]);
+    expect(lstatSync(linked).isSymbolicLink()).toBe(true);
+  });
+
+  it("fails closed when even a not-found receipt cannot be written", () => {
+    const unsafeBackupRoot = join(tempDir, "backup-file");
+    writeFileSync(unsafeBackupRoot, "not a directory");
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [jsonTarget(join(tempDir, "missing.json"))],
+        backupRoot: unsafeBackupRoot,
+        allowRemoval: true,
+      }),
+    ).toEqual([expect.objectContaining({ outcome: "failed", reason: "receipt_write_failed" })]);
+  });
+
+  it("does not mutate or tombstone a removable target without runtime verification", () => {
+    const path = join(tempDir, "runtime-gated.json");
+    const content = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    writeFileSync(path, content);
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: false,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "runtime_not_verified",
+    });
+    expect(readFileSync(path, "utf8")).toBe(content);
+    expect(existsSync(backupRoot)).toBe(false);
+  });
+
+  it("backs up before mutation, writes a secret-free receipt, and is idempotent", () => {
+    const path = join(tempDir, "home", ".claude.json");
+    mkdirSync(join(tempDir, "home"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": "super-secret" },
+          },
+          user: { url: "https://example.com" },
+        },
+      }),
+      { mode: 0o600 },
+    );
+
+    const first = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(first).toHaveLength(1);
+    expect(first[0]).toMatchObject({ outcome: "removed", targetId: "claude:mcp" });
+    expect(readFileSync(path, "utf8")).toContain("https://example.com");
+    expect(readFileSync(path, "utf8")).not.toContain("super-secret");
+    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+
+    const backupFiles = readdirSync(backupRoot).filter((name) => name.endsWith(".bak"));
+    const receiptFiles = readdirSync(backupRoot).filter((name) => name.endsWith(".receipt.json"));
+    expect(backupFiles).toHaveLength(1);
+    expect(receiptFiles).toHaveLength(1);
+    expect(readFileSync(join(backupRoot, backupFiles[0]), "utf8")).toContain("super-secret");
+    const receiptText = readFileSync(join(backupRoot, receiptFiles[0]), "utf8");
+    expect(receiptText).not.toContain("super-secret");
+    expect(JSON.parse(receiptText)).toMatchObject({ outcome: "removed" });
+    expect(JSON.parse(receiptText)).toMatchObject({
+      plannedMutation: "write",
+      plannedAfterHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+
+    const second = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(second[0]).toMatchObject({ outcome: "not_found" });
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".bak"))).toHaveLength(1);
+  });
+
+  it("refuses to apply a stale plan after a concurrent content change", async () => {
+    const path = join(tempDir, "config.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    writeFileSync(path, original);
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    writeFileSync(path, `${original}\n// concurrent edit\n`);
+
+    const { applyContentPlan } = await import("./orchestrator");
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+    });
+
+    expect(receipt).toMatchObject({ outcome: "concurrent_conflict" });
+    expect(readFileSync(path, "utf8")).toContain("concurrent edit");
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".receipt.json"))).toHaveLength(
+      1,
+    );
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".bak"))).toHaveLength(0);
+  });
+
+  it("rechecks the source and project bundle at every pre-capture boundary", () => {
+    const phases = [
+      "afterLockAcquired",
+      "afterBackupCreated",
+      "beforeFinalBundleCheck",
+      "beforeFinalSourceCheck",
+    ] as const;
+
+    for (const phase of phases) {
+      const phaseBackupRoot = join(backupRoot, phase);
+      const path = join(tempDir, `${phase}.json`);
+      const original = JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": "legacy-secret" },
+          },
+          user: { url: "https://example.com" },
+        },
+      });
+      writeFileSync(path, original);
+      const bundle = proof();
+      const mutate = () => {
+        if (phase === "beforeFinalBundleCheck") {
+          writeFileSync(join(bundle.root, ".mcp.json"), '{"mcpServers":{}}');
+        } else {
+          writeFileSync(path, `${original}\nuser concurrent edit`);
+        }
+      };
+      const testHooks =
+        phase === "afterLockAcquired"
+          ? { afterLockAcquired: mutate }
+          : phase === "afterBackupCreated"
+            ? { afterBackupCreated: mutate }
+            : phase === "beforeFinalBundleCheck"
+              ? { beforeFinalBundleCheck: mutate }
+              : { beforeFinalSourceCheck: mutate };
+
+      const receipt = applyContentPlan({
+        bundle,
+        target: jsonTarget(path),
+        plan: planLegacyJsonMcp({
+          content: original,
+          provider: "claude",
+          topKey: "mcpServers",
+        }),
+        backupRoot: phaseBackupRoot,
+        allowRemoval: true,
+        _testHooks: testHooks,
+      });
+
+      expect(receipt).toMatchObject({
+        outcome: phase === "beforeFinalBundleCheck" ? "preserved_ambiguous" : "concurrent_conflict",
+        reason:
+          phase === "beforeFinalBundleCheck" ? "project_bundle_changed" : "content_hash_changed",
+      });
+    }
+  });
+
+  it("applies authorization and not-found plans without touching the target", () => {
+    const path = join(tempDir, "direct-not-found.json");
+    const content = '{"mcpServers":{"user":{"url":"https://example.com"}}}';
+    writeFileSync(path, content);
+    const plan = planLegacyJsonMcp({ content, provider: "claude", topKey: "mcpServers" });
+    expect(plan.disposition).toBe("not_found");
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: jsonTarget(path),
+        plan,
+        backupRoot: join(backupRoot, "not-found"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "not_found" });
+
+    const unauthorized: LegacyTarget = {
+      ...jsonTarget(path),
+      id: "shared:mcp",
+      requiredProviders: ["claude", "gemini"],
+    };
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: unauthorized,
+        plan,
+        backupRoot: join(backupRoot, "unauthorized"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "shared_target_not_fully_authorized",
+    });
+    expect(readFileSync(path, "utf8")).toBe(content);
+  });
+
+  it("restores a replacement captured after the final delete check instead of deleting it", () => {
+    const path = join(tempDir, "delete-capture-race.md");
+    const displaced = join(tempDir, "delete-capture-race.displaced.md");
+    const original = RELEASED_RULE;
+    const replacement = "# User-owned replacement\n";
+    writeFileSync(path, original);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+    const plan = planLegacyStandaloneRule(original, "claude");
+    expect(plan.mutation).toBe("delete");
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeCapture: () => {
+          renameSync(path, displaced);
+          writeFileSync(path, replacement);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "captured_source_mismatch",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+    expect(readFileSync(displaced, "utf8")).toBe(original);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("restores a symlink captured after the final delete check without following it", () => {
+    const path = join(tempDir, "delete-capture-symlink-race.md");
+    const displaced = join(tempDir, "delete-capture-symlink-race.displaced.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeCapture: () => {
+          renameSync(path, displaced);
+          symlinkSync(displaced, path);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "captured_source_mismatch",
+    });
+    expect(lstatSync(path).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(path)).toBe(displaced);
+    expect(readFileSync(displaced, "utf8")).toBe(RELEASED_RULE);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("keeps a captured directory in a durable pending journal and reports it again on recovery", () => {
+    const path = join(tempDir, "delete-capture-directory-race.md");
+    const displaced = join(tempDir, "delete-capture-directory-race.displaced.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeCapture: () => {
+          renameSync(path, displaced);
+          mkdirSync(path);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "pending", reason: "captured_source_mismatch" });
+    const receiptName = readdirSync(backupRoot).find((name) => name.endsWith(".receipt.json"));
+    if (!receiptName) throw new Error("expected pending receipt");
+    const persisted = JSON.parse(readFileSync(join(backupRoot, receiptName), "utf8"));
+    expect(persisted).toMatchObject({ outcome: "pending", reason: "mutation_prepared" });
+    expect(lstatSync(persisted.capturePath).isDirectory()).toBe(true);
+    expect(existsSync(path)).toBe(false);
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [target],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(retried).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_capture_invalid",
+    });
+    expect(JSON.parse(readFileSync(join(backupRoot, receiptName), "utf8"))).toMatchObject({
+      outcome: "pending",
+    });
+    expect(lstatSync(persisted.capturePath).isDirectory()).toBe(true);
+  });
+
+  it("never overwrites a target created after an exact source was captured for a write", () => {
+    const path = join(tempDir, "write-publish-race.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const replacement = '{"userOwned":"created after capture"}';
+    writeFileSync(path, original);
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    expect(plan.mutation).toBe("write");
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: () => writeFileSync(path, replacement),
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "target_recreated_during_migration",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("retries a pending write after a crash immediately after atomic capture", () => {
+    const path = join(tempDir, "write-capture-crash.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: jsonTarget(path),
+        plan,
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterCapture: () => {
+            throw new Error("simulated crash");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(existsSync(path)).toBe(false);
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(retried.outcome).toBe("removed");
+    expect(readFileSync(path, "utf8")).toBe(plan.nextContent);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("finalizes a pending delete without leaking the exact captured legacy file", () => {
+    const path = join(tempDir, "delete-capture-crash.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+    const plan = planLegacyStandaloneRule(RELEASED_RULE, "claude");
+
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target,
+        plan,
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterCapture: () => {
+            throw new Error("simulated crash");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(existsSync(path)).toBe(false);
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [target],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(retried).toMatchObject({ outcome: "removed", reason: "recovered_pending_mutation" });
+    expect(existsSync(path)).toBe(false);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("does not delete a target recreated after an exact delete capture", () => {
+    const path = join(tempDir, "delete-target-recreated.md");
+    const replacement = "# New user rule\n";
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: { afterCapture: () => writeFileSync(path, replacement) },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "target_recreated_during_migration",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+  });
+
+  it("does not overwrite a target replacement installed immediately after publish", () => {
+    const path = join(tempDir, "write-after-publish-race.json");
+    const publishedAside = join(tempDir, "write-after-publish-race.published.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const replacement = '{"userOwned":"after publish"}';
+    writeFileSync(path, original);
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({
+        content: original,
+        provider: "claude",
+        topKey: "mcpServers",
+      }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterPublish: () => {
+          renameSync(path, publishedAside);
+          writeFileSync(path, replacement);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "concurrent_conflict",
+      reason: "target_changed_after_publish",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+    expect(readFileSync(publishedAside, "utf8")).toContain("https://example.com");
+  });
+
+  it("cleans an unjournaled private stage when preparation fails", () => {
+    const path = join(tempDir, "stage-preparation-failure.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: jsonTarget(path),
+        plan: planLegacyJsonMcp({
+          content: original,
+          provider: "claude",
+          topKey: "mcpServers",
+        }),
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterStagePrepared: () => {
+            throw new Error("simulated preparation failure");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(readFileSync(path, "utf8")).toBe(original);
+    expect(
+      readdirSync(tempDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("fails closed when staged write bytes change after capture", () => {
+    const path = join(tempDir, "changed-staged-write.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: (stage) => writeFileSync(stage.nextPath as string, "tampered next bytes"),
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("keeps a recreated delete target when an unknown stage artifact blocks cleanup", () => {
+    const path = join(tempDir, "delete-cleanup-failure.md");
+    const replacement = "# User rule created during migration\n";
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target,
+      plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: (stage) => {
+          writeFileSync(path, replacement);
+          writeFileSync(join(stage.capturePath, "..", "unknown"), "do not remove blindly");
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+  });
+
+  it("keeps a recreated write target when an unknown stage artifact blocks conflict cleanup", () => {
+    const path = join(tempDir, "write-cleanup-failure.json");
+    const replacement = '{"userOwned":"publish conflict"}';
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterCapture: (stage) => {
+          writeFileSync(path, replacement);
+          writeFileSync(join(stage.capturePath, "..", "unknown"), "do not remove blindly");
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+  });
+
+  it("leaves a valid published target when an unknown stage artifact blocks final cleanup", () => {
+    const path = join(tempDir, "write-final-cleanup-failure.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "legacy-secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, original);
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        afterPublish: (stage) =>
+          writeFileSync(join(stage.capturePath, "..", "unknown"), "do not remove blindly"),
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "failed", reason: "migration_io_failed" });
+    expect(readFileSync(path, "utf8")).toBe(plan.nextContent);
+  });
+
+  it("preserves a pending capture when an unknown artifact prevents recovery cleanup", () => {
+    const path = join(tempDir, "pending-cleanup-failure.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target,
+        plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterCapture: (stage) => {
+            writeFileSync(join(stage.capturePath, "..", "unknown"), "do not remove blindly");
+            throw new Error("simulated crash");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed" });
+
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [target],
+        backupRoot,
+        allowRemoval: true,
+      })[0],
+    ).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_capture_cleanup_failed",
+    });
+  });
+
+  it.each([
+    [
+      "outside path",
+      (receipt: MigrationReceipt) => ({
+        ...receipt,
+        capturePath: join(tempDir, "outside", "captured"),
+      }),
+    ],
+    ["non-number device", (receipt: MigrationReceipt) => ({ ...receipt, sourceDev: "x" })],
+    ["negative device", (receipt: MigrationReceipt) => ({ ...receipt, sourceDev: -1 })],
+    ["non-number inode", (receipt: MigrationReceipt) => ({ ...receipt, sourceIno: "x" })],
+    ["negative inode", (receipt: MigrationReceipt) => ({ ...receipt, sourceIno: -1 })],
+  ])("preserves a pending capture with invalid %s authority", (_variant, mutate) => {
+    const { path, pending } = crashedWriteCapture(`invalid-capture-${_variant}`);
+    writeFileSync(pending.receiptPath as string, JSON.stringify(mutate(pending)));
+
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      })[0],
+    ).toMatchObject({ outcome: "preserved_ambiguous", reason: "invalid_pending_receipt" });
+  });
+
+  it("keeps a changed captured object and its pending recovery journal", () => {
+    const { path, pending } = crashedWriteCapture("changed-pending-capture");
+    writeFileSync(pending.capturePath as string, "changed captured object");
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_capture_invalid",
+    });
+    expect(readFileSync(pending.receiptPath as string, "utf8")).toContain('"outcome": "pending"');
+  });
+
+  it("keeps an exact capture when a conflicting target appears during recovery", () => {
+    const { path, pending } = crashedWriteCapture("conflicted-pending-capture");
+    const replacement = '{"userOwned":"during recovery"}';
+    writeFileSync(path, replacement);
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_recovery_conflict",
+    });
+    expect(readFileSync(path, "utf8")).toBe(replacement);
+    expect(readFileSync(pending.capturePath as string, "utf8")).toContain("legacy-secret");
+  });
+
+  it("preserves a captured delete when its recovery backup changed", () => {
+    const path = join(tempDir, "invalid-pending-backup.md");
+    writeFileSync(path, RELEASED_RULE);
+    const target: LegacyTarget = {
+      id: "claude:rule",
+      provider: "claude",
+      kind: "rule_file",
+      path,
+      ruleKind: "claude",
+    };
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target,
+        plan: planLegacyStandaloneRule(RELEASED_RULE, "claude"),
+        backupRoot,
+        allowRemoval: true,
+        _testHooks: {
+          afterCapture: () => {
+            throw new Error("simulated crash");
+          },
+        },
+      }),
+    ).toMatchObject({ outcome: "failed" });
+    const receiptName = readdirSync(backupRoot).find((entry) => entry.endsWith(".receipt.json"));
+    if (!receiptName) throw new Error("expected pending receipt");
+    const pending: MigrationReceipt = JSON.parse(
+      readFileSync(join(backupRoot, receiptName), "utf8"),
+    );
+    writeFileSync(pending.backupPath as string, "changed backup");
+
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [target],
+        backupRoot,
+        allowRemoval: true,
+      })[0],
+    ).toMatchObject({ outcome: "preserved_ambiguous", reason: "pending_backup_invalid" });
+  });
+
+  it("retries a pre-mutation conflict after the exact source preimage returns", () => {
+    const path = join(tempDir, "retry-conflict.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    writeFileSync(path, `${original}\nchanged concurrently`);
+
+    expect(
+      applyContentPlan({
+        bundle: proof(),
+        target: jsonTarget(path),
+        plan,
+        backupRoot,
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "concurrent_conflict" });
+
+    writeFileSync(path, original);
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+
+    expect(retried.outcome).toBe("removed");
+    expect(JSON.parse(readFileSync(path, "utf8")).mcpServers.dosu).toBeUndefined();
+  });
+
+  it("retries a terminal pre-mutation I/O failure from the exact source preimage", () => {
+    const path = join(tempDir, "retry-io-failure.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    writeFileSync(
+      receiptPath,
+      JSON.stringify({
+        targetId: "claude:mcp",
+        provider: "claude",
+        path,
+        targetPathHash: targetHash,
+        outcome: "failed",
+        reason: "migration_io_failed",
+        beforeHash: hashContent(original),
+        plannedMutation: "delete",
+        receiptPath,
+      }),
+    );
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+
+    expect(retried.outcome).toBe("removed");
+    expect(JSON.parse(readFileSync(path, "utf8")).mcpServers.dosu).toBeUndefined();
+  });
+
+  it("never mutates ambiguous content and records the reason", () => {
+    const path = join(tempDir, "foreign.json");
+    const content = JSON.stringify({ mcpServers: { dosu: { url: "https://example.com" } } });
+    writeFileSync(path, content);
+    const receipts = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(receipts[0]).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "foreign_dosu_entry",
+    });
+    expect(readFileSync(path, "utf8")).toBe(content);
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".receipt.json"))).toHaveLength(
+      1,
+    );
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".bak"))).toHaveLength(0);
+  });
+
+  it("deduplicates a shared target and returns one per-target receipt", () => {
+    const path = join(tempDir, "GEMINI.md");
+    writeFileSync(
+      path,
+      `<!-- dosu:rules:start v1 -->\n${RELEASED_RULE.trimEnd()}\n<!-- dosu:rules:end -->\n`,
+    );
+    const shared: LegacyTarget = {
+      id: "claude:rule-alias-a",
+      provider: "claude",
+      kind: "rule_section",
+      path,
+    };
+    const duplicate: LegacyTarget = { ...shared, id: "claude:rule-alias-b" };
+    const receipts: MigrationReceipt[] = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [shared, duplicate],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].outcome).toBe("removed");
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("preserves a shared target unless every historical consumer has a project proof", () => {
+    const path = join(tempDir, "shared-rule.md");
+    const content = `<!-- dosu:rules:start v1 -->\n${RELEASED_RULE.trimEnd()}\n<!-- dosu:rules:end -->\n`;
+    writeFileSync(path, content);
+    const target: LegacyTarget = {
+      id: "claude:shared-rule",
+      provider: "claude",
+      requiredProviders: ["claude", "gemini"],
+      kind: "rule_section",
+      path,
+    };
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [target],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "shared_target_not_fully_authorized",
+    });
+    expect(readFileSync(path, "utf8")).toBe(content);
+  });
+
+  it("treats a terminal receipt as a tombstone and never deletes a later global re-creation", () => {
+    const path = join(tempDir, "recreated.json");
+    const globalEntry = (key: string) =>
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": key },
+          },
+        },
+      });
+    writeFileSync(path, globalEntry("old-secret"));
+    expect(
+      migrateLegacyTargets({
+        bundle: proof(),
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      })[0].outcome,
+    ).toBe("removed");
+
+    writeFileSync(path, globalEntry("explicit-new-secret"));
+    const second = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(second[0]).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "already_migrated",
+    });
+    expect(readFileSync(path, "utf8")).toContain("explicit-new-secret");
+  });
+
+  it("persists an absent target tombstone so a later user-created global entry is preserved", () => {
+    const path = join(tempDir, "absent-then-created.json");
+    const first = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(first[0]).toMatchObject({ outcome: "not_found", reason: "target_absent" });
+    expect(readdirSync(backupRoot).filter((name) => name.endsWith(".receipt.json"))).toHaveLength(
+      1,
+    );
+
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/new",
+            headers: { "X-Dosu-API-Key": "new-user-choice" },
+          },
+        },
+      }),
+    );
+    const second = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(second[0]).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "already_migrated",
+    });
+    expect(readFileSync(path, "utf8")).toContain("new-user-choice");
+  });
+
+  it("recovers a pending journal when mutation already reached the planned after-state", () => {
+    const path = join(tempDir, "pending-after.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        other: { url: "https://example.com" },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, plan.nextContent);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const backupPath = join(backupRoot, "pending.bak");
+    writeFileSync(backupPath, original);
+    writeFileSync(
+      receiptPath,
+      JSON.stringify({
+        targetId: "claude:mcp",
+        provider: "claude",
+        path,
+        targetPathHash: targetHash,
+        outcome: "pending",
+        reason: "mutation_prepared",
+        beforeHash: plan.expectedHash,
+        plannedMutation: "write",
+        plannedAfterHash: createHash("sha256").update(plan.nextContent).digest("hex"),
+        backupPath,
+        receiptPath,
+      }),
+    );
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({ outcome: "removed", reason: "recovered_pending_mutation" });
+    expect(JSON.parse(readFileSync(receiptPath, "utf8"))).toMatchObject({ outcome: "removed" });
+  });
+
+  it("retries a pending journal from the exact before-state and terminalizes conflicts", () => {
+    const path = join(tempDir, "pending-before.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const backupPath = join(backupRoot, "pending-before.bak");
+    writeFileSync(backupPath, original);
+    const pending = {
+      targetId: "claude:mcp",
+      provider: "claude",
+      path,
+      targetPathHash: targetHash,
+      outcome: "pending",
+      reason: "mutation_prepared",
+      beforeHash: plan.expectedHash,
+      plannedMutation: "write",
+      plannedAfterHash: createHash("sha256").update(plan.nextContent).digest("hex"),
+      backupPath,
+      receiptPath,
+    };
+    writeFileSync(receiptPath, JSON.stringify(pending));
+
+    const retried = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(retried.outcome).toBe("removed");
+
+    const conflictPath = join(tempDir, "pending-conflict.json");
+    writeFileSync(conflictPath, `${original}\n// user changed it`);
+    const conflictHash = createHash("sha256").update(conflictPath).digest("hex").slice(0, 12);
+    const conflictReceiptPath = join(backupRoot, `target-${conflictHash}.receipt.json`);
+    const conflictBackupPath = join(backupRoot, "pending-conflict.bak");
+    writeFileSync(conflictBackupPath, original);
+    writeFileSync(
+      conflictReceiptPath,
+      JSON.stringify({
+        ...pending,
+        path: conflictPath,
+        targetPathHash: conflictHash,
+        receiptPath: conflictReceiptPath,
+        backupPath: conflictBackupPath,
+      }),
+    );
+    const conflict = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(conflictPath)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(conflict).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "pending_recovery_conflict",
+    });
+    expect(JSON.parse(readFileSync(conflictReceiptPath, "utf8"))).toMatchObject({
+      outcome: "preserved_ambiguous",
+    });
+  });
+
+  it("recovers an old lock owned by a process that is definitely gone", () => {
+    const path = join(tempDir, "stale-lock.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const pendingBackup = join(backupRoot, "stale-lock-pending.bak");
+    writeFileSync(pendingBackup, original);
+    writeFileSync(
+      receiptPath,
+      JSON.stringify({
+        targetId: "claude:mcp",
+        provider: "claude",
+        path,
+        targetPathHash: targetHash,
+        outcome: "pending",
+        reason: "mutation_prepared",
+        beforeHash: plan.expectedHash,
+        plannedMutation: "write",
+        plannedAfterHash: hashContent(plan.nextContent),
+        backupPath: pendingBackup,
+        receiptPath,
+      }),
+    );
+    const lockPath = `${path}.dosu-migration.lock`;
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        version: 1,
+        pid: 2_147_483_647,
+        createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+        targetPath: path,
+        backupRoot,
+        nonce: "a".repeat(32),
+      })}\n`,
+    );
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({ outcome: "removed" });
+    expect(readFileSync(path, "utf8")).toContain("https://example.com");
+    expect(existsSync(lockPath)).toBe(false);
+    expect(JSON.parse(readFileSync(receiptPath, "utf8"))).toMatchObject({ outcome: "removed" });
+  });
+
+  it("never unlinks a replacement raced into a stale lock path", () => {
+    const path = join(tempDir, "stale-lock-race.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const lockPath = `${path}.dosu-migration.lock`;
+    const displaced = `${lockPath}.displaced`;
+    const replacement = "user-owned lock replacement\n";
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        version: 1,
+        pid: 2_147_483_647,
+        createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+        targetPath: path,
+        backupRoot,
+        nonce: "c".repeat(32),
+      })}\n`,
+    );
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeLockCapture: (kind) => {
+          if (kind !== "stale") return;
+          renameSync(lockPath, displaced);
+          writeFileSync(lockPath, replacement);
+        },
+      },
+    });
+
+    expect(receipt).toMatchObject({ outcome: "preserved_ambiguous", reason: "target_locked" });
+    expect(readFileSync(path, "utf8")).toBe(original);
+    expect(readFileSync(lockPath, "utf8")).toBe(replacement);
+    expect(readFileSync(displaced, "utf8")).toContain('"version":1');
+  });
+
+  it.each([
+    "symlink",
+    "directory",
+  ] as const)("restores or durably reports a %s raced into a stale lock capture", (replacementKind) => {
+    const path = join(tempDir, `stale-lock-${replacementKind}.json`);
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const lockPath = `${path}.dosu-migration.lock`;
+    const displaced = `${lockPath}.displaced`;
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        version: 1,
+        pid: 2_147_483_647,
+        createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+        targetPath: path,
+        backupRoot,
+        nonce: "d".repeat(32),
+      })}\n`,
+    );
+
+    const first = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeLockCapture: (kind) => {
+          if (kind !== "stale") return;
+          renameSync(lockPath, displaced);
+          if (replacementKind === "symlink") symlinkSync(displaced, lockPath);
+          else mkdirSync(lockPath);
+        },
+      },
+    });
+
+    expect(first).toMatchObject({ outcome: "preserved_ambiguous", reason: "target_locked" });
+    expect(readFileSync(path, "utf8")).toBe(original);
+    if (replacementKind === "symlink") {
+      expect(lstatSync(lockPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(lockPath)).toBe(displaced);
+    } else {
+      expect(existsSync(lockPath)).toBe(false);
+      expect(
+        readdirSync(tempDir).filter((name) => name.startsWith(".dosu-public-capture-")),
+      ).toHaveLength(1);
+    }
+
+    const retried = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(retried).toMatchObject(
+      replacementKind === "directory"
+        ? { outcome: "preserved_ambiguous", reason: "pending_lock_capture_recovery" }
+        : { outcome: "preserved_ambiguous", reason: "invalid_target_lock" },
+    );
+    if (replacementKind === "directory") {
+      expect(
+        readdirSync(tempDir).filter((name) => name.startsWith(".dosu-public-capture-")),
+      ).toHaveLength(1);
+    }
+  });
+
+  it("never unlinks a replacement raced into the acquired lock during release", () => {
+    const path = join(tempDir, "release-lock-race.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const lockPath = `${path}.dosu-migration.lock`;
+    const displaced = `${lockPath}.displaced`;
+    const replacement = "user-owned release replacement\n";
+
+    const receipt = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan: planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" }),
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeLockCapture: (kind) => {
+          if (kind !== "release") return;
+          renameSync(lockPath, displaced);
+          writeFileSync(lockPath, replacement);
+        },
+      },
+    });
+
+    expect(receipt.outcome).toBe("removed");
+    expect(readFileSync(path, "utf8")).toContain("https://example.com");
+    expect(readFileSync(lockPath, "utf8")).toBe(replacement);
+    expect(readFileSync(displaced, "utf8")).toContain('"version":1');
+  });
+
+  it.each([
+    "symlink",
+    "directory",
+  ] as const)("restores or durably reports a %s raced into an acquired lock during release", (replacementKind) => {
+    const path = join(tempDir, `release-lock-${replacementKind}.json`);
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const lockPath = `${path}.dosu-migration.lock`;
+    const displaced = `${lockPath}.displaced`;
+    const plan = planLegacyJsonMcp({
+      content: original,
+      provider: "claude",
+      topKey: "mcpServers",
+    });
+
+    const first = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+      _testHooks: {
+        beforeLockCapture: (kind) => {
+          if (kind !== "release") return;
+          renameSync(lockPath, displaced);
+          if (replacementKind === "symlink") symlinkSync(displaced, lockPath);
+          else mkdirSync(lockPath);
+        },
+      },
+    });
+
+    expect(first.outcome).toBe("removed");
+    expect(readFileSync(path, "utf8")).toContain("https://example.com");
+    if (replacementKind === "symlink") {
+      expect(lstatSync(lockPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(lockPath)).toBe(displaced);
+    } else {
+      expect(existsSync(lockPath)).toBe(false);
+      expect(
+        readdirSync(tempDir).filter((name) => name.startsWith(".dosu-public-capture-")),
+      ).toHaveLength(1);
+    }
+
+    const retried = applyContentPlan({
+      bundle: proof(),
+      target: jsonTarget(path),
+      plan,
+      backupRoot,
+      allowRemoval: true,
+    });
+    expect(retried).toMatchObject(
+      replacementKind === "directory"
+        ? { outcome: "preserved_ambiguous", reason: "pending_lock_capture_recovery" }
+        : { outcome: "not_found", reason: "terminal_receipt_unchanged" },
+    );
+    if (replacementKind === "directory") {
+      expect(
+        readdirSync(tempDir).filter((name) => name.startsWith(".dosu-public-capture-")),
+      ).toHaveLength(1);
+    }
+  });
+
+  it("does not overwrite a pending journal while a recognized active lock exists", () => {
+    const path = join(tempDir, "active-lock.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    if (!plan.nextContent) throw new Error("expected write plan");
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const pendingText = `${JSON.stringify({
+      targetId: "claude:mcp",
+      provider: "claude",
+      path,
+      targetPathHash: targetHash,
+      outcome: "pending",
+      reason: "mutation_prepared",
+      beforeHash: plan.expectedHash,
+      plannedMutation: "write",
+      plannedAfterHash: hashContent(plan.nextContent),
+      backupPath: join(backupRoot, "active-lock-pending.bak"),
+      receiptPath,
+    })}\n`;
+    writeFileSync(receiptPath, pendingText);
+    const lockPath = `${path}.dosu-migration.lock`;
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        version: 1,
+        pid: process.pid,
+        createdAt: new Date().toISOString(),
+        targetPath: path,
+        backupRoot,
+        nonce: "b".repeat(32),
+      })}\n`,
+    );
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({ outcome: "preserved_ambiguous", reason: "target_locked" });
+    expect(readFileSync(receiptPath, "utf8")).toBe(pendingText);
+    expect(readFileSync(path, "utf8")).toBe(original);
+    expect(existsSync(lockPath)).toBe(true);
+  });
+
+  it("preserves a pending journal and target behind an unrecognized lock", () => {
+    const path = join(tempDir, "invalid-lock.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    writeFileSync(path, original);
+    mkdirSync(backupRoot, { recursive: true });
+    const targetHash = createHash("sha256").update(path).digest("hex").slice(0, 12);
+    const receiptPath = join(backupRoot, `target-${targetHash}.receipt.json`);
+    const pendingText = `${JSON.stringify({
+      targetId: "claude:mcp",
+      provider: "claude",
+      path,
+      targetPathHash: targetHash,
+      outcome: "pending",
+      reason: "mutation_prepared",
+      beforeHash: plan.expectedHash,
+      plannedMutation: plan.mutation,
+      backupPath: join(backupRoot, "invalid-lock-pending.bak"),
+      receiptPath,
+    })}\n`;
+    writeFileSync(receiptPath, pendingText);
+    writeFileSync(`${path}.dosu-migration.lock`, "user data");
+
+    const receipt = migrateLegacyTargets({
+      bundle: proof(),
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "invalid_target_lock",
+    });
+    expect(readFileSync(receiptPath, "utf8")).toBe(pendingText);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it.each([
+    "directory",
+    "array",
+    "wrong target",
+    "malformed JSON",
+  ])("preserves the target behind a tampered %s receipt", (variant) => {
+    const path = join(tempDir, `receipt-${variant.replaceAll(" ", "-")}.json`);
+    const bundle = proof();
+    const first = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    if (!first.receiptPath) throw new Error("expected receipt path");
+    rmSync(first.receiptPath);
+    if (variant === "directory") mkdirSync(first.receiptPath);
+    if (variant === "array") writeFileSync(first.receiptPath, "[]");
+    if (variant === "wrong target") {
+      writeFileSync(
+        first.receiptPath,
+        JSON.stringify({
+          path: "/other",
+          targetPathHash: "wrong",
+          outcome: "removed",
+          reason: "x",
+        }),
+      );
+    }
+    if (variant === "malformed JSON") writeFileSync(first.receiptPath, "{");
+
+    expect(
+      migrateLegacyTargets({
+        bundle,
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        outcome: "preserved_ambiguous",
+        reason: "invalid_migration_receipt",
+      }),
+    ]);
+  });
+
+  it("returns an unchanged terminal ambiguity without reinterpreting edited content", () => {
+    const path = join(tempDir, "foreign-repeat.json");
+    writeFileSync(path, '{"mcpServers":{"dosu":{"url":"https://example.com/user"}}}');
+    const bundle = proof();
+    const first = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(first).toMatchObject({ outcome: "preserved_ambiguous", reason: "foreign_dosu_entry" });
+    const second = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    expect(second).toMatchObject({ outcome: "preserved_ambiguous", reason: "foreign_dosu_entry" });
+  });
+
+  it("rejects a pending receipt missing its recovery authority", () => {
+    const path = join(tempDir, "invalid-pending.json");
+    const bundle = proof();
+    const first = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    if (!first.receiptPath) throw new Error("expected receipt path");
+    writeFileSync(
+      first.receiptPath,
+      JSON.stringify({ ...first, outcome: "pending", reason: "mutation_prepared" }),
+    );
+    expect(
+      migrateLegacyTargets({
+        bundle,
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        outcome: "preserved_ambiguous",
+        reason: "invalid_pending_receipt",
+      }),
+    ]);
+  });
+
+  it("does not finalize a pending after-state when its immutable backup is gone", () => {
+    const path = join(tempDir, "pending-missing-backup.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+        user: { url: "https://example.com" },
+      },
+    });
+    writeFileSync(path, original);
+    const bundle = proof();
+    const removed = migrateLegacyTargets({
+      bundle,
+      targets: [jsonTarget(path)],
+      backupRoot,
+      allowRemoval: true,
+    })[0];
+    if (!removed.receiptPath || !removed.backupPath) throw new Error("expected recovery journal");
+    writeFileSync(
+      removed.receiptPath,
+      JSON.stringify({ ...removed, outcome: "pending", reason: "mutation_prepared" }),
+    );
+    rmSync(removed.backupPath);
+
+    expect(
+      migrateLegacyTargets({
+        bundle,
+        targets: [jsonTarget(path)],
+        backupRoot,
+        allowRemoval: true,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        outcome: "preserved_ambiguous",
+        reason: "pending_backup_invalid",
+      }),
+    ]);
+  });
+
+  it("rejects invalid plans and source replacement before creating a backup", () => {
+    const original = JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+          headers: { "X-Dosu-API-Key": "secret" },
+        },
+      },
+    });
+    const plan = planLegacyJsonMcp({ content: original, provider: "claude", topKey: "mcpServers" });
+    const bundle = proof();
+
+    const invalidPath = join(tempDir, "invalid-plan.json");
+    writeFileSync(invalidPath, original);
+    expect(
+      applyContentPlan({
+        bundle,
+        target: jsonTarget(invalidPath),
+        plan: { ...plan, mutation: "write", nextContent: undefined },
+        backupRoot: join(tempDir, "invalid-plan-backups"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "preserved_ambiguous", reason: "invalid_migration_plan" });
+
+    const directoryPath = join(tempDir, "replaced-by-directory.json");
+    writeFileSync(directoryPath, original);
+    rmSync(directoryPath);
+    mkdirSync(directoryPath);
+    expect(
+      applyContentPlan({
+        bundle,
+        target: jsonTarget(directoryPath),
+        plan,
+        backupRoot: join(tempDir, "directory-backups"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "concurrent_conflict", reason: "non_regular_target" });
+
+    const missingPath = join(tempDir, "removed-before-apply.json");
+    expect(
+      applyContentPlan({
+        bundle,
+        target: jsonTarget(missingPath),
+        plan,
+        backupRoot: join(tempDir, "missing-backups"),
+        allowRemoval: true,
+      }),
+    ).toMatchObject({ outcome: "concurrent_conflict", reason: "target_changed_or_missing" });
+  });
+});

--- a/src/migration/orchestrator.ts
+++ b/src/migration/orchestrator.ts
@@ -1,0 +1,2009 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmdirSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+  type ContentPlan,
+  hashContent,
+  planLegacyCodexMcp,
+  planLegacyJsonMcp,
+  planLegacyRuleSection,
+  planLegacyStandaloneRule,
+} from "./planners";
+import {
+  assertProjectBundleProof,
+  type ProjectBundleProof,
+  projectBundleStatus,
+} from "./project-bundle";
+import type { LegacyTarget } from "./targets";
+
+export type MigrationOutcome =
+  | "pending"
+  | "removed"
+  | "not_found"
+  | "preserved_ambiguous"
+  | "concurrent_conflict"
+  | "failed";
+
+export interface MigrationReceipt {
+  targetId: string;
+  provider: LegacyTarget["provider"];
+  path: string;
+  outcome: MigrationOutcome;
+  reason: string;
+  beforeHash?: string;
+  afterHash?: string;
+  backupPath?: string;
+  receiptPath?: string;
+  targetPathHash?: string;
+  plannedMutation?: ContentPlan["mutation"];
+  plannedAfterHash?: string;
+  capturePath?: string;
+  sourceDev?: number;
+  sourceIno?: number;
+}
+
+export type LegacyTargetInspection =
+  | { disposition: "remove"; reason: string }
+  | { disposition: "not_found"; reason: string }
+  | { disposition: "ambiguous"; reason: string };
+
+function pathHash(path: string): string {
+  return createHash("sha256").update(resolve(path)).digest("hex").slice(0, 12);
+}
+
+function safeId(id: string): string {
+  return id.replace(/[^A-Za-z0-9_.-]+/g, "_");
+}
+
+function baseReceipt(
+  target: LegacyTarget,
+  outcome: MigrationOutcome,
+  reason: string,
+): MigrationReceipt {
+  return { targetId: target.id, provider: target.provider, path: target.path, outcome, reason };
+}
+
+function planForTarget(target: LegacyTarget, content: string): ContentPlan {
+  switch (target.kind) {
+    case "json_mcp":
+      return planLegacyJsonMcp({
+        content,
+        provider: target.provider,
+        topKey: target.topKey,
+      });
+    case "codex_toml":
+      return planLegacyCodexMcp(content);
+    case "rule_file":
+      return planLegacyStandaloneRule(content, target.ruleKind);
+    case "rule_section":
+      return planLegacyRuleSection(content);
+  }
+}
+
+/** Strict read-only ownership inspection; it never creates receipts, locks, or backups. */
+export function inspectLegacyTarget(target: LegacyTarget): LegacyTargetInspection {
+  try {
+    const stat = lstatSync(target.path);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return { disposition: "ambiguous", reason: "non_regular_target" };
+    }
+    const plan = planForTarget(target, readFileSync(target.path, "utf8"));
+    if (plan.disposition === "remove") {
+      return { disposition: "remove", reason: plan.reason };
+    }
+    if (plan.disposition === "not_found") {
+      return { disposition: "not_found", reason: plan.reason };
+    }
+    return { disposition: "ambiguous", reason: plan.reason };
+  } catch (error: unknown) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+    return code === "ENOENT"
+      ? { disposition: "not_found", reason: "target_absent" }
+      : { disposition: "ambiguous", reason: "target_read_failed" };
+  }
+}
+
+/** Read-only strict inspection used to decide whether runtime verification is necessary. */
+export function legacyTargetsNeedCleanup(targets: readonly LegacyTarget[]): boolean {
+  const seenPaths = new Set<string>();
+  for (const target of targets) {
+    const key = resolve(target.path);
+    if (seenPaths.has(key)) continue;
+    seenPaths.add(key);
+    if (inspectLegacyTarget(target).disposition === "remove") return true;
+  }
+  return false;
+}
+
+function prepareBackupRoot(backupRoot: string): void {
+  mkdirSync(backupRoot, { recursive: true, mode: 0o700 });
+  const stat = lstatSync(backupRoot);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe migration backup root");
+  }
+  chmodSync(backupRoot, 0o700);
+}
+
+function fsyncPath(path: string): void {
+  const fd = openSync(path, "r");
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function fsyncParent(path: string): void {
+  try {
+    fsyncPath(dirname(path));
+  } catch {
+    // Directory fsync is unavailable on some supported platforms.
+  }
+}
+
+function atomicWrite(path: string, content: string, mode: number): void {
+  const temporary = `${path}.dosu-migration-${process.pid}-${randomBytes(6).toString("hex")}.tmp`;
+  let created = false;
+  try {
+    const file = openSync(temporary, "wx", mode);
+    created = true;
+    try {
+      writeFileSync(file, content, "utf8");
+      fsyncSync(file);
+    } finally {
+      closeSync(file);
+    }
+    renameSync(temporary, path);
+    chmodSync(path, mode);
+    fsyncParent(path);
+    created = false;
+  } finally {
+    if (created) {
+      try {
+        unlinkSync(temporary);
+      } catch {
+        // Best effort cleanup of a never-published temporary file.
+      }
+    }
+  }
+}
+
+function writePersistedReceipt(path: string, receipt: MigrationReceipt): void {
+  atomicWrite(path, `${JSON.stringify(receipt, null, 2)}\n`, 0o600);
+}
+
+function backupPathFor(target: LegacyTarget, expectedHash: string, backupRoot: string): string {
+  return join(
+    backupRoot,
+    `${safeId(target.id)}-${pathHash(target.path)}-${expectedHash.slice(0, 12)}.bak`,
+  );
+}
+
+function receiptPathFor(target: LegacyTarget, backupRoot: string): string {
+  return join(backupRoot, `target-${pathHash(target.path)}.receipt.json`);
+}
+
+type BackupCopy = (source: string, destination: string, mode: number) => void;
+
+export function ensureBackup(
+  targetPath: string,
+  backupPath: string,
+  expectedHash: string,
+  copy: BackupCopy = copyFileSync,
+): void {
+  if (existsSync(backupPath)) {
+    secureBackup(backupPath, expectedHash, "Existing");
+    return;
+  }
+  let created = false;
+  try {
+    copy(targetPath, backupPath, constants.COPYFILE_EXCL);
+    created = true;
+    secureBackup(backupPath, expectedHash, "New");
+  } catch (error) {
+    if (created) {
+      try {
+        unlinkSync(backupPath);
+      } catch {
+        // A corrupt backup is never trusted; a failed cleanup still aborts mutation.
+      }
+    }
+    throw error;
+  }
+}
+
+function secureBackup(path: string, expectedHash: string, label = "Migration"): void {
+  const before = lstatSync(path);
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw new Error(`${label} migration backup is not a regular file`);
+  }
+  const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(path, constants.O_RDONLY | noFollow);
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error(`${label} migration backup changed while it was verified`);
+    }
+    if (hashContent(readFileSync(fd, "utf8")) !== expectedHash) {
+      throw new Error(`${label} migration backup does not match the planned content`);
+    }
+    fchmodSync(fd, 0o600);
+    fsyncSync(fd);
+    const after = lstatSync(path);
+    if (
+      !after.isFile() ||
+      after.isSymbolicLink() ||
+      after.dev !== opened.dev ||
+      after.ino !== opened.ino
+    ) {
+      throw new Error(`${label} migration backup changed while it was verified`);
+    }
+  } finally {
+    closeSync(fd);
+  }
+}
+
+const STALE_LOCK_MINIMUM_AGE_MS = 5 * 60 * 1000;
+
+type MigrationLockResult =
+  | { ok: true; content: string; dev: number; ino: number }
+  | { ok: false; reason: "target_locked" | "invalid_target_lock" };
+
+interface MigrationTestHooks {
+  afterStagePrepared?: (stage: { capturePath: string; nextPath?: string }) => void;
+  beforeCapture?: (target: LegacyTarget) => void;
+  afterCapture?: (stage: { capturePath: string; nextPath?: string }) => void;
+  afterPublish?: (stage: { capturePath: string; nextPath?: string }) => void;
+  beforeLockCapture?: (kind: "stale" | "release", path: string) => void;
+  afterLockAcquired?: () => void;
+  afterBackupCreated?: () => void;
+  beforeFinalBundleCheck?: () => void;
+  beforeFinalSourceCheck?: () => void;
+  beforeFinalMutationAuthorization?: () => void;
+}
+
+type FinalMutationAuthorization = (target: LegacyTarget) => string | null;
+
+function mutationAuthorizationFailure(
+  authorize: FinalMutationAuthorization | undefined,
+  target: LegacyTarget,
+): string | null {
+  try {
+    return authorize?.(target) ?? null;
+  } catch {
+    return "mutation_authorization_failed";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(record: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(record).sort();
+  const sortedExpected = [...expected].sort();
+  return (
+    actual.length === sortedExpected.length &&
+    actual.every((key, index) => key === sortedExpected[index])
+  );
+}
+
+function validIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+}
+
+function migrationLockContent(targetPath: string, backupRoot: string): string {
+  return `${JSON.stringify({
+    version: 1,
+    pid: process.pid,
+    createdAt: new Date().toISOString(),
+    targetPath: resolve(targetPath),
+    backupRoot: resolve(backupRoot),
+    nonce: randomBytes(16).toString("hex"),
+  })}\n`;
+}
+
+function publishMigrationLock(path: string, content: string): { dev: number; ino: number } {
+  const candidate = `${path}.candidate-${process.pid}-${randomBytes(6).toString("hex")}`;
+  let candidateExists = false;
+  try {
+    const fd = openSync(candidate, "wx", 0o600);
+    candidateExists = true;
+    let identity: { dev: number; ino: number };
+    try {
+      writeFileSync(fd, content, "utf8");
+      fsyncSync(fd);
+      const stat = fstatSync(fd);
+      identity = { dev: stat.dev, ino: stat.ino };
+    } finally {
+      closeSync(fd);
+    }
+    // Publishing a fully-written inode avoids crash-created empty lock files.
+    linkSync(candidate, path);
+    fsyncParent(path);
+    return identity;
+  } finally {
+    if (candidateExists) {
+      try {
+        unlinkSync(candidate);
+      } catch {
+        // The fixed path, when present, is the only authoritative lock.
+      }
+    }
+  }
+}
+
+function processIsDefinitelyGone(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error: unknown) {
+    return isRecord(error) && error.code === "ESRCH";
+  }
+}
+
+function recognizedLock(
+  parsed: unknown,
+  targetPath: string,
+  backupRoot: string,
+): parsed is Record<string, unknown> {
+  return (
+    isRecord(parsed) &&
+    exactKeys(parsed, ["version", "pid", "createdAt", "targetPath", "backupRoot", "nonce"]) &&
+    parsed.version === 1 &&
+    typeof parsed.pid === "number" &&
+    Number.isSafeInteger(parsed.pid) &&
+    parsed.pid > 0 &&
+    validIsoTimestamp(parsed.createdAt) &&
+    parsed.targetPath === resolve(targetPath) &&
+    parsed.backupRoot === resolve(backupRoot) &&
+    typeof parsed.nonce === "string" &&
+    /^[a-f0-9]{32}$/.test(parsed.nonce)
+  );
+}
+
+function staleMigrationLockContent(
+  path: string,
+  targetPath: string,
+  backupRoot: string,
+): { content: string; dev: number; ino: number } | null {
+  try {
+    const snapshot = readStableRegularFile(path);
+    if (!snapshot.ok) return null;
+    const content = snapshot.file.content;
+    const parsed: unknown = JSON.parse(content);
+    if (
+      !recognizedLock(parsed, targetPath, backupRoot) ||
+      Date.now() - new Date(parsed.createdAt as string).getTime() < STALE_LOCK_MINIMUM_AGE_MS ||
+      !processIsDefinitelyGone(parsed.pid as number)
+    ) {
+      return null;
+    }
+    return { content, dev: snapshot.file.dev, ino: snapshot.file.ino };
+  } catch {
+    return null;
+  }
+}
+
+function acquireMigrationLock(
+  path: string,
+  targetPath: string,
+  backupRoot: string,
+  testHooks?: MigrationTestHooks,
+): MigrationLockResult {
+  if (!recoverPublicCaptures(path)) {
+    return { ok: false, reason: "invalid_target_lock" };
+  }
+  const content = migrationLockContent(targetPath, backupRoot);
+  try {
+    const identity = publishMigrationLock(path, content);
+    return { ok: true, content, ...identity };
+  } catch (error: unknown) {
+    if (!isRecord(error) || error.code !== "EEXIST") {
+      return { ok: false, reason: "invalid_target_lock" };
+    }
+  }
+
+  const stale = staleMigrationLockContent(path, targetPath, backupRoot);
+  if (!stale) {
+    try {
+      const stat = lstatSync(path);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        return { ok: false, reason: "invalid_target_lock" };
+      }
+      const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+      return {
+        ok: false,
+        reason: recognizedLock(parsed, targetPath, backupRoot)
+          ? "target_locked"
+          : "invalid_target_lock",
+      };
+    } catch {
+      return { ok: false, reason: "invalid_target_lock" };
+    }
+  }
+
+  try {
+    if (
+      !atomicCaptureAndRemovePublicFile(
+        path,
+        stale.content,
+        { dev: stale.dev, ino: stale.ino },
+        () => testHooks?.beforeLockCapture?.("stale", path),
+      )
+    ) {
+      return { ok: false, reason: "target_locked" };
+    }
+    const identity = publishMigrationLock(path, content);
+    return { ok: true, content, ...identity };
+  } catch {
+    return { ok: false, reason: "target_locked" };
+  }
+}
+
+function releaseMigrationLock(
+  path: string,
+  expectedContent: string,
+  expectedIdentity: { dev: number; ino: number },
+  testHooks?: MigrationTestHooks,
+): void {
+  atomicCaptureAndRemovePublicFile(path, expectedContent, expectedIdentity, () =>
+    testHooks?.beforeLockCapture?.("release", path),
+  );
+}
+
+export interface TargetOperationLock {
+  path: string;
+  content: string;
+  dev: number;
+  ino: number;
+}
+
+/**
+ * Acquire the same atomic exclusion used by migration before another command
+ * starts a target-wide operation. Sharing this lock removes authorization
+ * TOCTOU windows between explicit global installs and legacy cleanup.
+ */
+export function acquireTargetOperationLock(
+  targetPath: string,
+  authorityRoot: string,
+): TargetOperationLock {
+  const path = `${resolve(targetPath)}.dosu-migration.lock`;
+  const acquired = acquireMigrationLock(path, targetPath, authorityRoot);
+  if (!acquired.ok) throw new Error(`Global MCP target is locked (${acquired.reason})`);
+  return { path, content: acquired.content, dev: acquired.dev, ino: acquired.ino };
+}
+
+/** Release only the exact lock inode/content acquired by this operation. */
+export function releaseTargetOperationLock(lock: TargetOperationLock): void {
+  releaseMigrationLock(lock.path, lock.content, { dev: lock.dev, ino: lock.ino });
+}
+
+function bundleFailure(bundle: ProjectBundleProof, target: LegacyTarget): string | null {
+  const required = target.requiredProviders ?? [target.provider];
+  for (const provider of required) {
+    const status = projectBundleStatus(bundle, provider);
+    if (status === "changed") return "project_bundle_changed";
+    if (status === "unauthorized_provider") {
+      return target.requiredProviders
+        ? "shared_target_not_fully_authorized"
+        : "project_bundle_not_authorized";
+    }
+  }
+  return null;
+}
+
+type PriorReceiptRead =
+  | { status: "absent" }
+  | { status: "invalid" }
+  | { status: "valid"; receipt: MigrationReceipt };
+
+function readPriorReceipt(target: LegacyTarget, receiptPath: string): PriorReceiptRead {
+  if (!existsSync(receiptPath)) return { status: "absent" };
+  try {
+    const stat = lstatSync(receiptPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) return { status: "invalid" };
+    const parsed: unknown = JSON.parse(readFileSync(receiptPath, "utf8"));
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return { status: "invalid" };
+    }
+    const receipt = parsed as Record<string, unknown>;
+    if (
+      receipt.path !== target.path ||
+      receipt.targetPathHash !== pathHash(target.path) ||
+      typeof receipt.outcome !== "string" ||
+      typeof receipt.reason !== "string"
+    ) {
+      return { status: "invalid" };
+    }
+    return { status: "valid", receipt: receipt as unknown as MigrationReceipt };
+  } catch {
+    return { status: "invalid" };
+  }
+}
+
+function receiptWithJournalFields(
+  target: LegacyTarget,
+  outcome: MigrationOutcome,
+  reason: string,
+  beforeHash: string,
+  backupPath: string,
+  receiptPath: string,
+  afterHash?: string,
+  plannedMutation?: ContentPlan["mutation"],
+  plannedAfterHash?: string,
+  capture?: CaptureAuthority,
+): MigrationReceipt {
+  return {
+    ...baseReceipt(target, outcome, reason),
+    beforeHash,
+    ...(afterHash ? { afterHash } : {}),
+    backupPath,
+    receiptPath,
+    targetPathHash: pathHash(target.path),
+    ...(plannedMutation ? { plannedMutation } : {}),
+    ...(plannedAfterHash ? { plannedAfterHash } : {}),
+    ...(capture
+      ? {
+          capturePath: capture.capturePath,
+          sourceDev: capture.sourceDev,
+          sourceIno: capture.sourceIno,
+        }
+      : {}),
+  };
+}
+
+function persistTerminal(
+  target: LegacyTarget,
+  backupRoot: string,
+  outcome: Exclude<MigrationOutcome, "pending">,
+  reason: string,
+  options: {
+    beforeHash?: string;
+    afterHash?: string;
+    backupPath?: string;
+    plannedMutation?: ContentPlan["mutation"];
+    plannedAfterHash?: string;
+  } = {},
+): MigrationReceipt {
+  try {
+    prepareBackupRoot(backupRoot);
+    const receiptPath = receiptPathFor(target, backupRoot);
+    const receipt: MigrationReceipt = {
+      ...baseReceipt(target, outcome, reason),
+      ...(options.beforeHash ? { beforeHash: options.beforeHash } : {}),
+      ...(options.afterHash ? { afterHash: options.afterHash } : {}),
+      ...(options.backupPath ? { backupPath: options.backupPath } : {}),
+      ...(options.plannedMutation ? { plannedMutation: options.plannedMutation } : {}),
+      ...(options.plannedAfterHash ? { plannedAfterHash: options.plannedAfterHash } : {}),
+      receiptPath,
+      targetPathHash: pathHash(target.path),
+    };
+    writePersistedReceipt(receiptPath, receipt);
+    return receipt;
+  } catch {
+    return baseReceipt(target, "failed", "receipt_write_failed");
+  }
+}
+
+type TargetState = { kind: "absent" } | { kind: "file"; hash: string } | { kind: "unsafe" };
+
+function targetState(path: string): TargetState {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) return { kind: "unsafe" };
+    return { kind: "file", hash: hashContent(readFileSync(path, "utf8")) };
+  } catch (error: unknown) {
+    const code = typeof error === "object" && error !== null && "code" in error ? error.code : null;
+    return code === "ENOENT" ? { kind: "absent" } : { kind: "unsafe" };
+  }
+}
+
+type PriorReceiptDecision =
+  | { action: "continue" }
+  | { action: "return"; receipt: MigrationReceipt };
+
+function decidePriorReceipt(target: LegacyTarget, backupRoot: string): PriorReceiptDecision {
+  if (!recoverPublicCaptures(`${target.path}.dosu-migration.lock`)) {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "pending_lock_capture_recovery"),
+    };
+  }
+  const receiptPath = receiptPathFor(target, backupRoot);
+  const prior = readPriorReceipt(target, receiptPath);
+  if (prior.status === "absent") return { action: "continue" };
+  if (prior.status === "invalid") {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "invalid_migration_receipt"),
+    };
+  }
+
+  const receipt = prior.receipt;
+  const state = targetState(target.path);
+  if (receipt.outcome !== "pending") {
+    // A terminal pre-mutation failure is not a tombstone when the exact
+    // planned preimage is present again. Retrying from that byte-for-byte
+    // state is safe; any changed or unknown state remains preserved.
+    const retryablePreMutationFailure =
+      (receipt.outcome === "failed" || receipt.outcome === "concurrent_conflict") &&
+      state.kind === "file" &&
+      typeof receipt.beforeHash === "string" &&
+      state.hash === receipt.beforeHash;
+    if (retryablePreMutationFailure) return { action: "continue" };
+
+    const unchangedAfterWrite =
+      receipt.outcome === "removed" &&
+      receipt.plannedMutation === "write" &&
+      state.kind === "file" &&
+      typeof receipt.afterHash === "string" &&
+      state.hash === receipt.afterHash;
+    const unchangedAfterDelete =
+      receipt.outcome === "removed" &&
+      receipt.plannedMutation === "delete" &&
+      state.kind === "absent";
+    const stillAbsent = receipt.outcome === "not_found" && state.kind === "absent";
+    if (unchangedAfterWrite || unchangedAfterDelete || stillAbsent) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "not_found", "terminal_receipt_unchanged"),
+      };
+    }
+    if (
+      receipt.outcome === "preserved_ambiguous" &&
+      state.kind === "file" &&
+      receipt.beforeHash === state.hash
+    ) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "preserved_ambiguous", receipt.reason),
+      };
+    }
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "already_migrated"),
+    };
+  }
+
+  if (
+    typeof receipt.beforeHash !== "string" ||
+    (receipt.plannedMutation !== "write" && receipt.plannedMutation !== "delete") ||
+    typeof receipt.backupPath !== "string"
+  ) {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "invalid_pending_receipt"),
+    };
+  }
+
+  const capturedPendingDecision = decideCapturedPendingReceipt(target, backupRoot, receipt, state);
+  if (capturedPendingDecision) return capturedPendingDecision;
+
+  if (state.kind === "file" && state.hash === receipt.beforeHash) {
+    return { action: "continue" };
+  }
+
+  const reachedAfter =
+    (receipt.plannedMutation === "delete" && state.kind === "absent") ||
+    (receipt.plannedMutation === "write" &&
+      state.kind === "file" &&
+      typeof receipt.plannedAfterHash === "string" &&
+      state.hash === receipt.plannedAfterHash);
+  if (reachedAfter) {
+    try {
+      const backupStat = lstatSync(receipt.backupPath);
+      if (
+        !backupStat.isFile() ||
+        backupStat.isSymbolicLink() ||
+        hashContent(readFileSync(receipt.backupPath, "utf8")) !== receipt.beforeHash
+      ) {
+        throw new Error("invalid backup");
+      }
+    } catch {
+      return {
+        action: "return",
+        receipt: persistTerminal(
+          target,
+          backupRoot,
+          "preserved_ambiguous",
+          "pending_backup_invalid",
+          { beforeHash: receipt.beforeHash },
+        ),
+      };
+    }
+    return {
+      action: "return",
+      receipt: persistTerminal(target, backupRoot, "removed", "recovered_pending_mutation", {
+        beforeHash: receipt.beforeHash,
+        afterHash: receipt.plannedAfterHash,
+        backupPath: receipt.backupPath,
+        plannedMutation: receipt.plannedMutation,
+        plannedAfterHash: receipt.plannedAfterHash,
+      }),
+    };
+  }
+
+  return {
+    action: "return",
+    receipt: persistTerminal(
+      target,
+      backupRoot,
+      "preserved_ambiguous",
+      "pending_recovery_conflict",
+      { beforeHash: receipt.beforeHash, backupPath: receipt.backupPath },
+    ),
+  };
+}
+
+type StableRegularFile = {
+  mode: number;
+  dev: number;
+  ino: number;
+  hash: string;
+  content: string;
+};
+
+type StableRegularFileResult =
+  | { ok: true; file: StableRegularFile }
+  | { ok: false; reason: "non_regular_target" | "target_changed_or_missing" };
+
+function readStableRegularFile(path: string): StableRegularFileResult {
+  try {
+    const before = lstatSync(path);
+    if (!before.isFile() || before.isSymbolicLink()) {
+      return { ok: false, reason: "non_regular_target" };
+    }
+    const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+    const fd = openSync(path, constants.O_RDONLY | noFollow);
+    try {
+      const opened = fstatSync(fd);
+      if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+        return { ok: false, reason: "target_changed_or_missing" };
+      }
+      const content = readFileSync(fd, "utf8");
+      const hash = hashContent(content);
+      const after = lstatSync(path);
+      if (
+        !after.isFile() ||
+        after.isSymbolicLink() ||
+        after.dev !== opened.dev ||
+        after.ino !== opened.ino
+      ) {
+        return { ok: false, reason: "target_changed_or_missing" };
+      }
+      return {
+        ok: true,
+        file: {
+          mode: opened.mode & 0o777,
+          dev: opened.dev,
+          ino: opened.ino,
+          hash,
+          content,
+        },
+      };
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return { ok: false, reason: "target_changed_or_missing" };
+  }
+}
+
+function recheckSource(
+  target: LegacyTarget,
+  expectedHash: string,
+): { ok: true; mode: number; dev: number; ino: number } | { ok: false; reason: string } {
+  const snapshot = readStableRegularFile(target.path);
+  if (!snapshot.ok) return snapshot;
+  if (snapshot.file.hash !== expectedHash) {
+    return { ok: false, reason: "content_hash_changed" };
+  }
+  return {
+    ok: true,
+    mode: snapshot.file.mode,
+    dev: snapshot.file.dev,
+    ino: snapshot.file.ino,
+  };
+}
+
+interface CaptureAuthority {
+  capturePath: string;
+  sourceDev: number;
+  sourceIno: number;
+}
+
+interface CaptureStage extends CaptureAuthority {
+  directory: string;
+  nextPath?: string;
+}
+
+function createCaptureStage(
+  targetPath: string,
+  source: { mode: number; dev: number; ino: number },
+  nextContent?: string,
+): CaptureStage {
+  const directory = mkdtempSync(join(dirname(resolve(targetPath)), ".dosu-migration-capture-"));
+  chmodSync(directory, 0o700);
+  const directoryStat = lstatSync(directory);
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+    throw new Error("Unsafe migration capture directory");
+  }
+  const capturePath = join(directory, "captured");
+  let nextPath: string | undefined;
+  try {
+    if (nextContent !== undefined) {
+      nextPath = join(directory, "next");
+      const fd = openSync(nextPath, "wx", 0o600);
+      try {
+        writeFileSync(fd, nextContent, "utf8");
+        fchmodSync(fd, source.mode);
+        fsyncSync(fd);
+      } finally {
+        closeSync(fd);
+      }
+    }
+    try {
+      fsyncPath(directory);
+    } catch {
+      // Directory fsync is unavailable on some supported platforms.
+    }
+    return {
+      directory,
+      capturePath,
+      sourceDev: source.dev,
+      sourceIno: source.ino,
+      ...(nextPath ? { nextPath } : {}),
+    };
+  } catch (error) {
+    if (nextPath) {
+      try {
+        unlinkSync(nextPath);
+      } catch {
+        // Best effort cleanup before this private stage is journaled.
+      }
+    }
+    try {
+      rmdirSync(directory);
+    } catch {
+      // Best effort cleanup before this private stage is journaled.
+    }
+    throw error;
+  }
+}
+
+function captureDirectoryFor(targetPath: string, capturePath: string): string | null {
+  const resolvedCapture = resolve(capturePath);
+  const directory = dirname(resolvedCapture);
+  if (
+    basename(resolvedCapture) !== "captured" ||
+    dirname(directory) !== dirname(resolve(targetPath)) ||
+    !basename(directory).startsWith(".dosu-migration-capture-")
+  ) {
+    return null;
+  }
+  return directory;
+}
+
+// This helper is deliberately restricted to files inside a random 0700
+// capture directory. Public target and lock paths are always renamed into a
+// private capture first and are never passed here directly.
+function removeExactPrivateStageFile(
+  path: string,
+  expectedHash: string,
+  expectedIdentity?: { dev: number; ino: number },
+): boolean {
+  try {
+    const snapshot = readStableRegularFile(path);
+    if (
+      !snapshot.ok ||
+      snapshot.file.hash !== expectedHash ||
+      (expectedIdentity !== undefined &&
+        (snapshot.file.dev !== expectedIdentity.dev || snapshot.file.ino !== expectedIdentity.ino))
+    ) {
+      return false;
+    }
+    unlinkSync(path);
+    fsyncParent(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathIsAbsent(path: string): boolean {
+  try {
+    lstatSync(path);
+    return false;
+  } catch (error: unknown) {
+    return isRecord(error) && error.code === "ENOENT";
+  }
+}
+
+function removeStageDirectoryIfEmpty(targetPath: string, capturePath: string): boolean {
+  const directory = captureDirectoryFor(targetPath, capturePath);
+  if (!directory) return false;
+  if (pathIsAbsent(directory)) return true;
+  try {
+    rmdirSync(directory);
+    fsyncParent(directory);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function cleanupStagedNext(
+  targetPath: string,
+  capturePath: string,
+  plannedAfterHash: string | undefined,
+): boolean {
+  const directory = captureDirectoryFor(targetPath, capturePath);
+  if (!directory) return false;
+  const nextPath = join(directory, "next");
+  if (pathIsAbsent(nextPath)) return true;
+  return plannedAfterHash !== undefined && removeExactPrivateStageFile(nextPath, plannedAfterHash);
+}
+
+function exactCapturedSource(capture: CaptureAuthority, expectedHash: string): boolean {
+  const snapshot = readStableRegularFile(capture.capturePath);
+  return (
+    snapshot.ok &&
+    snapshot.file.hash === expectedHash &&
+    snapshot.file.dev === capture.sourceDev &&
+    snapshot.file.ino === capture.sourceIno
+  );
+}
+
+function cleanupVerifiedCapture(
+  targetPath: string,
+  capture: CaptureAuthority,
+  expectedHash: string,
+  plannedAfterHash: string | undefined,
+): boolean {
+  if (
+    !cleanupStagedNext(targetPath, capture.capturePath, plannedAfterHash) ||
+    !removeExactPrivateStageFile(capture.capturePath, expectedHash, {
+      dev: capture.sourceDev,
+      ino: capture.sourceIno,
+    })
+  ) {
+    return false;
+  }
+  return removeStageDirectoryIfEmpty(targetPath, capture.capturePath);
+}
+
+function restoreCapturedReplacement(
+  targetPath: string,
+  capturePath: string,
+  plannedAfterHash: string | undefined,
+): boolean {
+  try {
+    const capturedStat = lstatSync(capturePath);
+    if (capturedStat.isSymbolicLink()) {
+      const linkTarget = readlinkSync(capturePath);
+      // symlinkSync is no-clobber: a concurrently recreated public path makes
+      // restoration fail and leaves the private capture untouched.
+      symlinkSync(linkTarget, targetPath);
+      fsyncParent(targetPath);
+      const restored = lstatSync(targetPath);
+      if (!restored.isSymbolicLink() || readlinkSync(targetPath) !== linkTarget) return false;
+      unlinkSync(capturePath);
+      fsyncParent(capturePath);
+      cleanupStagedNext(targetPath, capturePath, plannedAfterHash);
+      removeStageDirectoryIfEmpty(targetPath, capturePath);
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  const captured = readStableRegularFile(capturePath);
+  if (!captured.ok) return false;
+  try {
+    linkSync(capturePath, targetPath);
+    fsyncParent(targetPath);
+  } catch {
+    return false;
+  }
+
+  const restored = readStableRegularFile(targetPath);
+  if (
+    !restored.ok ||
+    restored.file.dev !== captured.file.dev ||
+    restored.file.ino !== captured.file.ino ||
+    restored.file.hash !== captured.file.hash
+  ) {
+    return false;
+  }
+
+  // The user object is now back at its original path. Only unlink the private
+  // duplicate after proving it is still the same inode we restored.
+  if (
+    !removeExactPrivateStageFile(capturePath, captured.file.hash, {
+      dev: captured.file.dev,
+      ino: captured.file.ino,
+    })
+  ) {
+    return true;
+  }
+  cleanupStagedNext(targetPath, capturePath, plannedAfterHash);
+  removeStageDirectoryIfEmpty(targetPath, capturePath);
+  return true;
+}
+
+type CapturedPublicNode =
+  | { kind: "regular"; dev: number; ino: number; hash: string }
+  | { kind: "symlink"; dev: number; ino: number; linkTarget: string }
+  | { kind: "directory"; dev: number; ino: number };
+
+type PublicCaptureJournal = {
+  version: 1;
+  state: "prepared" | "captured";
+  publicPath: string;
+  capturePath: string;
+  expectedHash: string;
+  expectedDev: number;
+  expectedIno: number;
+  captured?: CapturedPublicNode;
+};
+
+interface PublicCaptureStage {
+  directory: string;
+  capturePath: string;
+  journalPath: string;
+  journalContent: string;
+  journal: PublicCaptureJournal;
+}
+
+function publicCapturePrefix(publicPath: string): string {
+  return `.dosu-public-capture-${pathHash(publicPath)}-`;
+}
+
+function capturedPublicNode(path: string): CapturedPublicNode | null {
+  try {
+    const before = lstatSync(path);
+    if (before.isFile() && !before.isSymbolicLink()) {
+      const snapshot = readStableRegularFile(path);
+      return snapshot.ok
+        ? {
+            kind: "regular",
+            dev: snapshot.file.dev,
+            ino: snapshot.file.ino,
+            hash: snapshot.file.hash,
+          }
+        : null;
+    }
+    if (before.isSymbolicLink()) {
+      const linkTarget = readlinkSync(path);
+      const after = lstatSync(path);
+      return after.isSymbolicLink() && after.dev === before.dev && after.ino === before.ino
+        ? { kind: "symlink", dev: before.dev, ino: before.ino, linkTarget }
+        : null;
+    }
+    if (before.isDirectory()) {
+      const after = lstatSync(path);
+      return after.isDirectory() &&
+        !after.isSymbolicLink() &&
+        after.dev === before.dev &&
+        after.ino === before.ino
+        ? { kind: "directory", dev: before.dev, ino: before.ino }
+        : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function sameCapturedPublicNode(left: CapturedPublicNode, right: CapturedPublicNode): boolean {
+  if (left.kind !== right.kind || left.dev !== right.dev || left.ino !== right.ino) return false;
+  if (left.kind === "regular" && right.kind === "regular") return left.hash === right.hash;
+  if (left.kind === "symlink" && right.kind === "symlink") {
+    return left.linkTarget === right.linkTarget;
+  }
+  return left.kind === "directory" && right.kind === "directory";
+}
+
+function serializePublicCaptureJournal(journal: PublicCaptureJournal): string {
+  return `${JSON.stringify(journal)}\n`;
+}
+
+function writePublicCaptureJournal(
+  stage: PublicCaptureStage,
+  journal: PublicCaptureJournal,
+): PublicCaptureStage {
+  const content = serializePublicCaptureJournal(journal);
+  atomicWrite(stage.journalPath, content, 0o600);
+  return { ...stage, journal, journalContent: content };
+}
+
+function createPublicCaptureStage(
+  publicPath: string,
+  source: StableRegularFile,
+): PublicCaptureStage {
+  const canonicalPath = resolve(publicPath);
+  const directory = mkdtempSync(join(dirname(canonicalPath), publicCapturePrefix(canonicalPath)));
+  chmodSync(directory, 0o700);
+  const directoryStat = lstatSync(directory);
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+    throw new Error("Unsafe public capture directory");
+  }
+  const stage: PublicCaptureStage = {
+    directory,
+    capturePath: join(directory, "captured"),
+    journalPath: join(directory, "journal.json"),
+    journalContent: "",
+    journal: {
+      version: 1,
+      state: "prepared",
+      publicPath: canonicalPath,
+      capturePath: join(directory, "captured"),
+      expectedHash: source.hash,
+      expectedDev: source.dev,
+      expectedIno: source.ino,
+    },
+  };
+  try {
+    return writePublicCaptureJournal(stage, stage.journal);
+  } catch (error) {
+    try {
+      rmdirSync(directory);
+    } catch {
+      // A failed journal publication leaves no authority to mutate publicPath.
+    }
+    throw error;
+  }
+}
+
+function validPublicCaptureJournal(
+  value: unknown,
+  publicPath: string,
+  directory: string,
+): value is PublicCaptureJournal {
+  if (!isRecord(value)) return false;
+  const preparedKeys = [
+    "version",
+    "state",
+    "publicPath",
+    "capturePath",
+    "expectedHash",
+    "expectedDev",
+    "expectedIno",
+  ];
+  const capturedKeys = [...preparedKeys, "captured"];
+  if (!exactKeys(value, value.state === "captured" ? capturedKeys : preparedKeys)) return false;
+  if (
+    value.version !== 1 ||
+    (value.state !== "prepared" && value.state !== "captured") ||
+    value.publicPath !== resolve(publicPath) ||
+    value.capturePath !== join(directory, "captured") ||
+    typeof value.expectedHash !== "string" ||
+    !/^[a-f0-9]{64}$/.test(value.expectedHash) ||
+    typeof value.expectedDev !== "number" ||
+    !Number.isSafeInteger(value.expectedDev) ||
+    value.expectedDev < 0 ||
+    typeof value.expectedIno !== "number" ||
+    !Number.isSafeInteger(value.expectedIno) ||
+    value.expectedIno < 0
+  ) {
+    return false;
+  }
+  if (value.state === "prepared") return true;
+  if (!isRecord(value.captured)) return false;
+  const captured = value.captured;
+  const commonValid =
+    typeof captured.kind === "string" &&
+    typeof captured.dev === "number" &&
+    Number.isSafeInteger(captured.dev) &&
+    captured.dev >= 0 &&
+    typeof captured.ino === "number" &&
+    Number.isSafeInteger(captured.ino) &&
+    captured.ino >= 0;
+  if (!commonValid) return false;
+  if (captured.kind === "regular") {
+    return (
+      exactKeys(captured, ["kind", "dev", "ino", "hash"]) &&
+      typeof captured.hash === "string" &&
+      /^[a-f0-9]{64}$/.test(captured.hash)
+    );
+  }
+  if (captured.kind === "symlink") {
+    return (
+      exactKeys(captured, ["kind", "dev", "ino", "linkTarget"]) &&
+      typeof captured.linkTarget === "string"
+    );
+  }
+  return captured.kind === "directory" && exactKeys(captured, ["kind", "dev", "ino"]);
+}
+
+function readPublicCaptureStage(publicPath: string, directory: string): PublicCaptureStage | null {
+  try {
+    const directoryStat = lstatSync(directory);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) return null;
+    const journalPath = join(directory, "journal.json");
+    const snapshot = readStableRegularFile(journalPath);
+    if (!snapshot.ok) return null;
+    const parsed: unknown = JSON.parse(snapshot.file.content);
+    if (!validPublicCaptureJournal(parsed, publicPath, directory)) return null;
+    return {
+      directory,
+      capturePath: join(directory, "captured"),
+      journalPath,
+      journalContent: snapshot.file.content,
+      journal: parsed,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function removeExactPublicCaptureJournal(stage: PublicCaptureStage): boolean {
+  const snapshot = readStableRegularFile(stage.journalPath);
+  if (!snapshot.ok || snapshot.file.content !== stage.journalContent) return false;
+  try {
+    unlinkSync(stage.journalPath);
+    fsyncParent(stage.journalPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function finishPublicCaptureStage(stage: PublicCaptureStage): boolean {
+  if (!pathIsAbsent(stage.capturePath)) return false;
+  if (!removeExactPublicCaptureJournal(stage)) return false;
+  try {
+    rmdirSync(stage.directory);
+    fsyncParent(stage.directory);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removeExactCapturedPublicNode(
+  stage: PublicCaptureStage,
+  expected: CapturedPublicNode,
+): boolean {
+  const current = capturedPublicNode(stage.capturePath);
+  if (!current || !sameCapturedPublicNode(current, expected)) return false;
+  if (current.kind === "directory") return false;
+  try {
+    unlinkSync(stage.capturePath);
+    fsyncParent(stage.capturePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function restoreCapturedPublicNode(
+  stage: PublicCaptureStage,
+  captured: CapturedPublicNode,
+): boolean {
+  if (captured.kind === "directory" || !pathIsAbsent(stage.journal.publicPath)) return false;
+  try {
+    if (captured.kind === "regular") {
+      linkSync(stage.capturePath, stage.journal.publicPath);
+      fsyncParent(stage.journal.publicPath);
+      const restored = capturedPublicNode(stage.journal.publicPath);
+      if (!restored || !sameCapturedPublicNode(restored, captured)) return false;
+    } else {
+      symlinkSync(captured.linkTarget, stage.journal.publicPath);
+      fsyncParent(stage.journal.publicPath);
+      const restored = capturedPublicNode(stage.journal.publicPath);
+      if (restored?.kind !== "symlink" || restored.linkTarget !== captured.linkTarget) {
+        return false;
+      }
+    }
+    return removeExactCapturedPublicNode(stage, captured);
+  } catch {
+    return false;
+  }
+}
+
+function recoverPublicCaptureStage(stage: PublicCaptureStage): boolean {
+  const captured = capturedPublicNode(stage.capturePath);
+  if (!captured) {
+    return pathIsAbsent(stage.capturePath) && finishPublicCaptureStage(stage);
+  }
+
+  const expected: CapturedPublicNode = {
+    kind: "regular",
+    dev: stage.journal.expectedDev,
+    ino: stage.journal.expectedIno,
+    hash: stage.journal.expectedHash,
+  };
+  if (sameCapturedPublicNode(captured, expected)) {
+    return removeExactCapturedPublicNode(stage, expected) && finishPublicCaptureStage(stage);
+  }
+
+  if (
+    stage.journal.state !== "captured" ||
+    !stage.journal.captured ||
+    !sameCapturedPublicNode(captured, stage.journal.captured)
+  ) {
+    return false;
+  }
+
+  if (pathIsAbsent(stage.journal.publicPath)) {
+    return restoreCapturedPublicNode(stage, captured) && finishPublicCaptureStage(stage);
+  }
+
+  const publicNode = capturedPublicNode(stage.journal.publicPath);
+  if (
+    captured.kind === "regular" &&
+    publicNode?.kind === "regular" &&
+    sameCapturedPublicNode(publicNode, captured)
+  ) {
+    return removeExactCapturedPublicNode(stage, captured) && finishPublicCaptureStage(stage);
+  }
+  return false;
+}
+
+/** Recover or explicitly retain every durable sidecar capture for one lock path. */
+function recoverPublicCaptures(publicPath: string): boolean {
+  const canonicalPath = resolve(publicPath);
+  const prefix = publicCapturePrefix(canonicalPath);
+  let names: string[];
+  try {
+    names = readdirSync(dirname(canonicalPath))
+      .filter((name) => name.startsWith(prefix))
+      .sort();
+  } catch (error: unknown) {
+    return isRecord(error) && error.code === "ENOENT";
+  }
+  for (const name of names) {
+    const directory = join(dirname(canonicalPath), name);
+    const stage = readPublicCaptureStage(canonicalPath, directory);
+    if (!stage || !recoverPublicCaptureStage(stage)) return false;
+  }
+  return true;
+}
+
+function atomicCaptureAndRemovePublicFile(
+  path: string,
+  expectedContent: string,
+  expectedIdentity: { dev: number; ino: number },
+  beforeCapture?: () => void,
+): boolean {
+  const snapshot = readStableRegularFile(path);
+  if (
+    !snapshot.ok ||
+    snapshot.file.content !== expectedContent ||
+    snapshot.file.dev !== expectedIdentity.dev ||
+    snapshot.file.ino !== expectedIdentity.ino
+  ) {
+    return false;
+  }
+
+  let stage: PublicCaptureStage | undefined;
+  try {
+    stage = createPublicCaptureStage(path, snapshot.file);
+    beforeCapture?.();
+    renameSync(path, stage.capturePath);
+    fsyncParent(path);
+    const captured = capturedPublicNode(stage.capturePath);
+    if (!captured) return false;
+    const expected: CapturedPublicNode = {
+      kind: "regular",
+      dev: snapshot.file.dev,
+      ino: snapshot.file.ino,
+      hash: snapshot.file.hash,
+    };
+    if (!sameCapturedPublicNode(captured, expected)) {
+      stage = writePublicCaptureJournal(stage, {
+        ...stage.journal,
+        state: "captured",
+        captured,
+      });
+      if (
+        (captured.kind === "regular" || captured.kind === "symlink") &&
+        restoreCapturedPublicNode(stage, captured)
+      ) {
+        finishPublicCaptureStage(stage);
+      }
+      return false;
+    }
+    if (!removeExactCapturedPublicNode(stage, expected)) return false;
+    return finishPublicCaptureStage(stage);
+  } catch {
+    // The prepared/captured journal remains authoritative. The next migration
+    // pass either completes a proven cleanup/restoration or reports it.
+    return false;
+  }
+}
+
+function pendingCaptureAuthority(
+  target: LegacyTarget,
+  receipt: MigrationReceipt,
+): CaptureAuthority | "invalid" | null {
+  const fields = [receipt.capturePath, receipt.sourceDev, receipt.sourceIno];
+  if (fields.every((value) => value === undefined)) return null;
+  if (
+    typeof receipt.capturePath !== "string" ||
+    typeof receipt.sourceDev !== "number" ||
+    !Number.isSafeInteger(receipt.sourceDev) ||
+    receipt.sourceDev < 0 ||
+    typeof receipt.sourceIno !== "number" ||
+    !Number.isSafeInteger(receipt.sourceIno) ||
+    receipt.sourceIno < 0 ||
+    !captureDirectoryFor(target.path, receipt.capturePath)
+  ) {
+    return "invalid";
+  }
+  return {
+    capturePath: receipt.capturePath,
+    sourceDev: receipt.sourceDev,
+    sourceIno: receipt.sourceIno,
+  };
+}
+
+function cleanupPendingStageWithoutCapture(
+  targetPath: string,
+  capturePath: string,
+  plannedAfterHash: string | undefined,
+): boolean {
+  return (
+    cleanupStagedNext(targetPath, capturePath, plannedAfterHash) &&
+    removeStageDirectoryIfEmpty(targetPath, capturePath)
+  );
+}
+
+function pendingBackupIsValid(receipt: MigrationReceipt): boolean {
+  if (typeof receipt.backupPath !== "string" || typeof receipt.beforeHash !== "string") {
+    return false;
+  }
+  try {
+    secureBackup(receipt.backupPath, receipt.beforeHash);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Recover journals written by the atomic-capture implementation. `null`
+ * delegates to the pre-capture recovery path for old receipts.
+ */
+function decideCapturedPendingReceipt(
+  target: LegacyTarget,
+  backupRoot: string,
+  receipt: MigrationReceipt,
+  state: TargetState,
+): PriorReceiptDecision | null {
+  const capture = pendingCaptureAuthority(target, receipt);
+  if (capture === null) return null;
+  if (capture === "invalid") {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "invalid_pending_receipt"),
+    };
+  }
+  if (typeof receipt.beforeHash !== "string") {
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "invalid_pending_receipt"),
+    };
+  }
+
+  const captureAbsent = pathIsAbsent(capture.capturePath);
+  const captureExact = !captureAbsent && exactCapturedSource(capture, receipt.beforeHash);
+  if (!captureAbsent && !captureExact) {
+    // Keep the pending journal and unexpected object as recovery evidence.
+    return {
+      action: "return",
+      receipt: baseReceipt(target, "preserved_ambiguous", "pending_capture_invalid"),
+    };
+  }
+
+  const cleanupCapture = (): boolean =>
+    captureExact
+      ? cleanupVerifiedCapture(
+          target.path,
+          capture,
+          receipt.beforeHash as string,
+          receipt.plannedAfterHash,
+        )
+      : cleanupPendingStageWithoutCapture(
+          target.path,
+          capture.capturePath,
+          receipt.plannedAfterHash,
+        );
+
+  if (state.kind === "file" && state.hash === receipt.beforeHash) {
+    if (!cleanupCapture()) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "preserved_ambiguous", "pending_capture_cleanup_failed"),
+      };
+    }
+    return { action: "continue" };
+  }
+
+  const reachedAfter =
+    (receipt.plannedMutation === "delete" && state.kind === "absent") ||
+    (receipt.plannedMutation === "write" &&
+      state.kind === "file" &&
+      typeof receipt.plannedAfterHash === "string" &&
+      state.hash === receipt.plannedAfterHash);
+  if (reachedAfter) {
+    if (!pendingBackupIsValid(receipt)) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "preserved_ambiguous", "pending_backup_invalid"),
+      };
+    }
+    if (!cleanupCapture()) {
+      return {
+        action: "return",
+        receipt: baseReceipt(target, "preserved_ambiguous", "pending_capture_cleanup_failed"),
+      };
+    }
+    return {
+      action: "return",
+      receipt: persistTerminal(target, backupRoot, "removed", "recovered_pending_mutation", {
+        beforeHash: receipt.beforeHash,
+        afterHash: receipt.plannedAfterHash,
+        backupPath: receipt.backupPath,
+        plannedMutation: receipt.plannedMutation,
+        plannedAfterHash: receipt.plannedAfterHash,
+      }),
+    };
+  }
+
+  if (
+    receipt.plannedMutation === "write" &&
+    state.kind === "absent" &&
+    captureExact &&
+    restoreCapturedReplacement(target.path, capture.capturePath, receipt.plannedAfterHash)
+  ) {
+    return { action: "continue" };
+  }
+
+  // Leave both the pending journal and capture untouched when another object
+  // now owns the target path or recovery cannot be proven.
+  return {
+    action: "return",
+    receipt: baseReceipt(target, "preserved_ambiguous", "pending_recovery_conflict"),
+  };
+}
+
+export function applyContentPlan(input: {
+  bundle: ProjectBundleProof;
+  target: LegacyTarget;
+  plan: ContentPlan;
+  backupRoot: string;
+  allowRemoval: boolean;
+  /**
+   * Final fail-closed authorization evaluated under the per-target lock both
+   * immediately before and immediately after capture. A non-null reason keeps
+   * the public target intact (or restores its exact captured preimage).
+   */
+  finalMutationAuthorization?: FinalMutationAuthorization;
+  /** @internal Deterministic fault injection for filesystem race tests only. */
+  _testHooks?: MigrationTestHooks;
+}): MigrationReceipt {
+  assertProjectBundleProof(input.bundle);
+  const { target, plan, backupRoot } = input;
+  const authorizationFailure = bundleFailure(input.bundle, target);
+  if (authorizationFailure) {
+    return baseReceipt(target, "preserved_ambiguous", authorizationFailure);
+  }
+  if (plan.disposition === "remove" && !input.allowRemoval) {
+    return baseReceipt(target, "preserved_ambiguous", "runtime_not_verified");
+  }
+  const priorDecision = decidePriorReceipt(target, backupRoot);
+  if (priorDecision.action === "return") return priorDecision.receipt;
+  if (plan.disposition === "not_found") {
+    return persistTerminal(target, backupRoot, "not_found", plan.reason, {
+      beforeHash: plan.expectedHash,
+    });
+  }
+  if (plan.disposition === "preserved_ambiguous") {
+    return persistTerminal(target, backupRoot, "preserved_ambiguous", plan.reason, {
+      beforeHash: plan.expectedHash,
+    });
+  }
+  if (!plan.mutation || (plan.mutation === "write" && plan.nextContent === undefined)) {
+    return persistTerminal(target, backupRoot, "preserved_ambiguous", "invalid_migration_plan", {
+      beforeHash: plan.expectedHash,
+    });
+  }
+
+  // This early guard gives a newly published intent a descriptive preserve
+  // result before lock acquisition. The shared target lock and the two final
+  // checks below remain the actual race-free mutation authorization.
+  const earlyAuthorizationFailure = mutationAuthorizationFailure(
+    input.finalMutationAuthorization,
+    target,
+  );
+  if (earlyAuthorizationFailure) {
+    return baseReceipt(target, "preserved_ambiguous", earlyAuthorizationFailure);
+  }
+
+  const firstCheck = recheckSource(target, plan.expectedHash);
+  if (!firstCheck.ok) {
+    return persistTerminal(target, backupRoot, "concurrent_conflict", firstCheck.reason, {
+      beforeHash: plan.expectedHash,
+    });
+  }
+
+  const receiptPath = receiptPathFor(target, backupRoot);
+  const lockPath = `${target.path}.dosu-migration.lock`;
+  const lock = acquireMigrationLock(lockPath, target.path, backupRoot, input._testHooks);
+  if (!lock.ok) {
+    // Do not overwrite a pending journal: another process (or an untrusted
+    // sidecar) may be the only evidence needed for safe crash recovery.
+    return baseReceipt(target, "preserved_ambiguous", lock.reason);
+  }
+
+  let journalWritten = false;
+  let stage: CaptureStage | undefined;
+  const plannedAfterHash =
+    plan.mutation === "write" ? hashContent(plan.nextContent ?? "") : undefined;
+  try {
+    input._testHooks?.afterLockAcquired?.();
+    const lockedCheck = recheckSource(target, plan.expectedHash);
+    if (!lockedCheck.ok) {
+      return persistTerminal(target, backupRoot, "concurrent_conflict", lockedCheck.reason, {
+        beforeHash: plan.expectedHash,
+      });
+    }
+    prepareBackupRoot(backupRoot);
+    const backupPath = backupPathFor(target, plan.expectedHash, backupRoot);
+    ensureBackup(target.path, backupPath, plan.expectedHash);
+
+    input._testHooks?.afterBackupCreated?.();
+    const afterBackupCheck = recheckSource(target, plan.expectedHash);
+    if (!afterBackupCheck.ok) {
+      return persistTerminal(target, backupRoot, "concurrent_conflict", afterBackupCheck.reason, {
+        beforeHash: plan.expectedHash,
+        backupPath,
+      });
+    }
+
+    input._testHooks?.beforeFinalBundleCheck?.();
+    const finalBundleFailure = bundleFailure(input.bundle, target);
+    if (finalBundleFailure) {
+      const receipt = receiptWithJournalFields(
+        target,
+        "preserved_ambiguous",
+        finalBundleFailure,
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+
+    input._testHooks?.beforeFinalSourceCheck?.();
+    const finalCheck = recheckSource(target, plan.expectedHash);
+    if (!finalCheck.ok) {
+      const receipt = receiptWithJournalFields(
+        target,
+        "concurrent_conflict",
+        finalCheck.reason,
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+    input._testHooks?.beforeFinalMutationAuthorization?.();
+    const finalAuthorizationFailure = mutationAuthorizationFailure(
+      input.finalMutationAuthorization,
+      target,
+    );
+    if (finalAuthorizationFailure) {
+      const receipt = receiptWithJournalFields(
+        target,
+        "preserved_ambiguous",
+        finalAuthorizationFailure,
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+    // Re-prove the immutable preimage backup before preparing a durable
+    // capture journal. A replaced symlink is never trusted.
+    secureBackup(backupPath, plan.expectedHash);
+
+    stage = createCaptureStage(
+      target.path,
+      finalCheck,
+      plan.mutation === "write" ? (plan.nextContent ?? "") : undefined,
+    );
+    input._testHooks?.afterStagePrepared?.(stage);
+    const pending = receiptWithJournalFields(
+      target,
+      "pending",
+      "mutation_prepared",
+      plan.expectedHash,
+      backupPath,
+      receiptPath,
+      undefined,
+      plan.mutation,
+      plannedAfterHash,
+      stage,
+    );
+    writePersistedReceipt(receiptPath, pending);
+    journalWritten = true;
+
+    input._testHooks?.beforeCapture?.(target);
+    renameSync(target.path, stage.capturePath);
+    fsyncParent(target.path);
+    input._testHooks?.afterCapture?.(stage);
+
+    if (!exactCapturedSource(stage, plan.expectedHash)) {
+      const restored = restoreCapturedReplacement(target.path, stage.capturePath, plannedAfterHash);
+      if (!restored || !pathIsAbsent(stage.capturePath)) {
+        // The durable pending journal is the recovery authority for a captured
+        // directory or any object that cannot be restored without clobbering.
+        // Never replace it with a terminal tombstone while capturePath exists.
+        return baseReceipt(target, "pending", "captured_source_mismatch");
+      }
+      const receipt = receiptWithJournalFields(
+        target,
+        "concurrent_conflict",
+        "captured_source_mismatch",
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+        undefined,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+
+    // A concurrent explicit-global install publishes its intent marker before
+    // it touches the provider file. Rechecking after capture closes the final
+    // authorization-to-rename window. If authorization changed, restore the
+    // exact legacy preimage with no-clobber semantics; when another writer has
+    // already recreated the target, retain the durable pending journal and
+    // capture for the next recovery pass.
+    const capturedAuthorizationFailure = mutationAuthorizationFailure(
+      input.finalMutationAuthorization,
+      target,
+    );
+    if (capturedAuthorizationFailure) {
+      if (
+        !restoreCapturedReplacement(target.path, stage.capturePath, plannedAfterHash) ||
+        !pathIsAbsent(stage.capturePath)
+      ) {
+        return baseReceipt(target, "pending", capturedAuthorizationFailure);
+      }
+      const receipt = receiptWithJournalFields(
+        target,
+        "preserved_ambiguous",
+        capturedAuthorizationFailure,
+        plan.expectedHash,
+        backupPath,
+        receiptPath,
+        undefined,
+        plan.mutation,
+        plannedAfterHash,
+      );
+      writePersistedReceipt(receiptPath, receipt);
+      return receipt;
+    }
+
+    if (plan.mutation === "delete") {
+      if (!pathIsAbsent(target.path)) {
+        if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+          throw new Error("Could not safely clean the captured legacy source");
+        }
+        const receipt = receiptWithJournalFields(
+          target,
+          "concurrent_conflict",
+          "target_recreated_during_migration",
+          plan.expectedHash,
+          backupPath,
+          receiptPath,
+          undefined,
+          plan.mutation,
+          plannedAfterHash,
+        );
+        writePersistedReceipt(receiptPath, receipt);
+        return receipt;
+      }
+      if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+        throw new Error("Could not safely remove the captured legacy source");
+      }
+    } else {
+      if (!stage.nextPath || plannedAfterHash === undefined) {
+        throw new Error("Missing staged migration content");
+      }
+      const stagedWrite = readStableRegularFile(stage.nextPath);
+      if (!stagedWrite.ok || stagedWrite.file.hash !== plannedAfterHash) {
+        throw new Error("Staged migration content changed");
+      }
+      try {
+        // A hard link is an atomic no-replace publish on the same filesystem.
+        // Unlike rename(), it fails when any process has recreated target.path.
+        linkSync(stage.nextPath, target.path);
+        fsyncParent(target.path);
+      } catch (error: unknown) {
+        if (!isRecord(error) || error.code !== "EEXIST") throw error;
+        if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+          throw new Error("Could not safely clean a conflicted capture");
+        }
+        const receipt = receiptWithJournalFields(
+          target,
+          "concurrent_conflict",
+          "target_recreated_during_migration",
+          plan.expectedHash,
+          backupPath,
+          receiptPath,
+          undefined,
+          plan.mutation,
+          plannedAfterHash,
+        );
+        writePersistedReceipt(receiptPath, receipt);
+        return receipt;
+      }
+      input._testHooks?.afterPublish?.(stage);
+
+      const published = readStableRegularFile(target.path);
+      if (
+        !published.ok ||
+        published.file.hash !== plannedAfterHash ||
+        published.file.dev !== stagedWrite.file.dev ||
+        published.file.ino !== stagedWrite.file.ino
+      ) {
+        if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+          throw new Error("Could not safely clean a raced publish");
+        }
+        const receipt = receiptWithJournalFields(
+          target,
+          "concurrent_conflict",
+          "target_changed_after_publish",
+          plan.expectedHash,
+          backupPath,
+          receiptPath,
+          undefined,
+          plan.mutation,
+          plannedAfterHash,
+        );
+        writePersistedReceipt(receiptPath, receipt);
+        return receipt;
+      }
+      if (!cleanupVerifiedCapture(target.path, stage, plan.expectedHash, plannedAfterHash)) {
+        throw new Error("Could not safely finalize the captured legacy source");
+      }
+    }
+    const afterHash = plan.mutation === "delete" ? undefined : hashContent(plan.nextContent ?? "");
+    const receipt = receiptWithJournalFields(
+      target,
+      "removed",
+      plan.reason,
+      plan.expectedHash,
+      backupPath,
+      receiptPath,
+      afterHash,
+      plan.mutation,
+      plannedAfterHash,
+    );
+    writePersistedReceipt(receiptPath, receipt);
+    return receipt;
+  } catch {
+    // Once pending is durable, leave it intact. The next run can distinguish
+    // before/after/conflict and recover safely instead of guessing here.
+    if (journalWritten) return baseReceipt(target, "failed", "migration_io_failed");
+    if (stage) {
+      cleanupStagedNext(target.path, stage.capturePath, plannedAfterHash);
+      removeStageDirectoryIfEmpty(target.path, stage.capturePath);
+    }
+    return persistTerminal(target, backupRoot, "failed", "migration_io_failed", {
+      beforeHash: plan.expectedHash,
+      plannedMutation: plan.mutation,
+      plannedAfterHash,
+    });
+  } finally {
+    releaseMigrationLock(
+      lockPath,
+      lock.content,
+      { dev: lock.dev, ino: lock.ino },
+      input._testHooks,
+    );
+  }
+}
+
+export function migrateLegacyTargets(input: {
+  bundle: ProjectBundleProof;
+  targets: readonly LegacyTarget[];
+  backupRoot: string;
+  allowRemoval: boolean;
+  finalMutationAuthorization?: FinalMutationAuthorization;
+  /** @internal Deterministic fault injection for filesystem race tests only. */
+  _testHooks?: MigrationTestHooks;
+}): MigrationReceipt[] {
+  assertProjectBundleProof(input.bundle);
+  const receipts: MigrationReceipt[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const target of input.targets) {
+    const key = resolve(target.path);
+    if (seenPaths.has(key)) continue;
+    seenPaths.add(key);
+
+    const authorizationFailure = bundleFailure(input.bundle, target);
+    if (authorizationFailure) {
+      receipts.push(baseReceipt(target, "preserved_ambiguous", authorizationFailure));
+      continue;
+    }
+
+    const priorDecision = decidePriorReceipt(target, input.backupRoot);
+    if (priorDecision.action === "return") {
+      receipts.push(priorDecision.receipt);
+      continue;
+    }
+
+    let content: string;
+    try {
+      const stat = lstatSync(target.path);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        receipts.push(
+          persistTerminal(target, input.backupRoot, "preserved_ambiguous", "non_regular_target"),
+        );
+        continue;
+      }
+      content = readFileSync(target.path, "utf8");
+    } catch (error: unknown) {
+      const code =
+        typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+      receipts.push(
+        code === "ENOENT"
+          ? persistTerminal(target, input.backupRoot, "not_found", "target_absent")
+          : baseReceipt(target, "failed", "target_read_failed"),
+      );
+      continue;
+    }
+
+    const plan = planForTarget(target, content);
+    receipts.push(applyContentPlan({ ...input, target, plan }));
+  }
+  return receipts;
+}

--- a/src/migration/project-bundle.test.ts
+++ b/src/migration/project-bundle.test.ts
@@ -3,12 +3,14 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { migrateLegacyTargets } from "./orchestrator";
 import {
   assertProjectBundleProof,
   projectBundleStatus,
   verifyProjectBundle,
 } from "./project-bundle";
 import { proveProjectScope } from "./project-proof";
+import type { LegacyTarget } from "./targets";
 
 let root: string;
 
@@ -221,6 +223,45 @@ describe("file-backed project bundle proof", () => {
     writeClaudeBundle();
     writeFileSync(join(root, ".claude", "skills", "dosu", "SKILL.md"), "user replacement");
     expect(verifyClaude()).toMatchObject({ ok: false, reason: "project_skill_mismatch" });
+  });
+
+  it("revalidates proof evidence immediately before cleanup", () => {
+    writeClaudeBundle();
+    const verified = verifyClaude();
+    if (!verified.ok) throw new Error(verified.reason);
+
+    writeFileSync(join(root, ".mcp.json"), '{"mcpServers":{}}');
+    const globalPath = join(root, "legacy-global.json");
+    writeFileSync(
+      globalPath,
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "http",
+            url: "https://api.dosu.dev/v1/mcp/deployments/dep",
+            headers: { "X-Dosu-API-Key": "secret" },
+          },
+        },
+      }),
+    );
+    const target: LegacyTarget = {
+      id: "claude:mcp",
+      provider: "claude",
+      kind: "json_mcp",
+      path: globalPath,
+      topKey: "mcpServers",
+    };
+    const receipt = migrateLegacyTargets({
+      bundle: verified.proof,
+      targets: [target],
+      backupRoot: join(root, "backups"),
+      allowRemoval: true,
+    })[0];
+    expect(receipt).toMatchObject({
+      outcome: "preserved_ambiguous",
+      reason: "project_bundle_changed",
+    });
+    expect(readFileSync(globalPath, "utf8")).toContain("secret");
   });
 
   it("requires at least one selected project-capable provider", () => {

--- a/src/setup/project-scope-migration.test.ts
+++ b/src/setup/project-scope-migration.test.ts
@@ -1,0 +1,557 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type ProjectProof, type ProviderId, proveProjectScope } from "../migration";
+import {
+  finalizeGlobalMcpIntent,
+  globalMcpIntentMarkerPath,
+  prepareGlobalMcpIntent,
+  releaseGlobalMcpIntent,
+} from "../migration/global-intent";
+import {
+  inspectProjectScopeMigration,
+  type ProjectScopeMigrationInput,
+  runProjectScopeMigration,
+} from "./project-scope-migration";
+
+const INSTRUCTIONS = "Use Dosu.";
+const SKILL = "---\nname: dosu\ndescription: Dosu knowledge\n---\nUse Dosu.\n";
+const RELEASED_RULE = readFileSync(join(process.cwd(), "rules", "dosu.md"), "utf8");
+const PROXY_ARGS = ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep-project"];
+
+let tempDir: string;
+let homeDir: string;
+let projectRoot: string;
+let backupRoot: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-project-scope-runner-"));
+  homeDir = join(tempDir, "home");
+  projectRoot = join(tempDir, "project");
+  backupRoot = join(tempDir, "config", "migrations", "project-scope-v1");
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(projectRoot, { recursive: true });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function projectProof(): ProjectProof {
+  const result = proveProjectScope({
+    cwd: projectRoot,
+    gitTopLevel: projectRoot,
+    insideWorkTree: true,
+    bareRepository: false,
+  });
+  if (!result.ok) throw new Error(result.reason);
+  return result.proof;
+}
+
+function writeProjectSkill(path: string): void {
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, "SKILL.md"), SKILL);
+  const computedHash = createHash("sha256").update("SKILL.md").update(SKILL).digest("hex");
+  writeFileSync(
+    join(projectRoot, "skills-lock.json"),
+    JSON.stringify({
+      version: 1,
+      skills: {
+        dosu: {
+          source: "dosu-ai/dosu-skill",
+          sourceType: "github",
+          skillPath: "skills/dosu/SKILL.md",
+          computedHash,
+        },
+      },
+    }),
+  );
+}
+
+function writeProjectBundle(provider: "claude" | "gemini" | "antigravity" | "factory"): void {
+  const proxy = { command: "npx", args: PROXY_ARGS };
+  writeFileSync(
+    join(projectRoot, "AGENTS.md"),
+    `<!-- dosu:mcp:start v2 -->\n${INSTRUCTIONS}\n<!-- dosu:mcp:end -->\n`,
+  );
+
+  if (provider === "claude") {
+    writeFileSync(
+      join(projectRoot, ".mcp.json"),
+      JSON.stringify({ mcpServers: { dosu: { type: "stdio", ...proxy } } }),
+    );
+    writeFileSync(
+      join(projectRoot, "CLAUDE.md"),
+      "<!-- dosu:project-instructions:start v1 -->\n@AGENTS.md\n<!-- dosu:project-instructions:end -->\n",
+    );
+    writeProjectSkill(join(projectRoot, ".claude", "skills", "dosu"));
+    return;
+  }
+
+  if (provider === "gemini") {
+    mkdirSync(join(projectRoot, ".gemini"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".gemini", "settings.json"),
+      JSON.stringify({ mcpServers: { dosu: proxy } }),
+    );
+    writeFileSync(
+      join(projectRoot, "GEMINI.md"),
+      "<!-- dosu:project-instructions:start v1 -->\n@AGENTS.md\n<!-- dosu:project-instructions:end -->\n",
+    );
+  } else if (provider === "antigravity") {
+    mkdirSync(join(projectRoot, ".agents", "rules"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".agents", "mcp_config.json"),
+      JSON.stringify({ mcpServers: { dosu: proxy } }),
+    );
+    writeFileSync(
+      join(projectRoot, ".agents", "rules", "dosu.md"),
+      `<!-- dosu:project-instructions:start v1 -->\n${INSTRUCTIONS}\n<!-- dosu:project-instructions:end -->\n`,
+    );
+  } else {
+    mkdirSync(join(projectRoot, ".factory"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".factory", "mcp.json"),
+      JSON.stringify({ mcpServers: { dosu: { type: "stdio", ...proxy } } }),
+    );
+    writeProjectSkill(join(projectRoot, ".factory", "skills", "dosu"));
+    return;
+  }
+  writeProjectSkill(join(projectRoot, ".agents", "skills", "dosu"));
+}
+
+function input(
+  provider: "claude" | "gemini" | "antigravity" | "factory" = "claude",
+): ProjectScopeMigrationInput {
+  writeProjectBundle(provider);
+  return {
+    project: projectProof(),
+    providerIDs: [provider],
+    proxy: { packageVersion: "0.43.0", deploymentID: "dep-project" },
+    instructionContent: INSTRUCTIONS,
+    environment: { platform: "linux", homeDir, env: {} },
+    backupRoot,
+    globalIntentRoot: join(tempDir, "config", "migrations", "global-mcp-intent-v1"),
+  };
+}
+
+function writeOwnedGlobalMcp(provider: ProviderId, path: string): string {
+  const secret = "global-secret-must-never-appear-in-summary";
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      mcpServers: {
+        dosu: {
+          type: "http",
+          url: "https://api.dosu.dev/v1/mcp/deployments/dep-old",
+          headers: { "X-Dosu-API-Key": secret },
+        },
+        user: { url: `https://example.com/${provider}` },
+      },
+    }),
+  );
+  return secret;
+}
+
+describe("project-scope migration runner", () => {
+  it("creates durable not-found tombstones for a new user and is idempotent", () => {
+    const migration = input();
+    const inspection = inspectProjectScopeMigration(migration);
+    expect(inspection).toMatchObject({ ok: true, needsRuntimeVerification: false });
+    expect(existsSync(backupRoot)).toBe(false);
+
+    const first = runProjectScopeMigration({ ...migration, runtimeVerified: false });
+    expect(first).toMatchObject({
+      ok: true,
+      cleanupAttempted: true,
+      counts: { removed: 0, not_found: 2, preserved: 0, failed: 0, total: 2 },
+    });
+    expect(existsSync(backupRoot)).toBe(true);
+
+    const second = runProjectScopeMigration({ ...migration, runtimeVerified: false });
+    expect(second).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 2, preserved: 0, failed: 0, total: 2 },
+    });
+  });
+
+  it("keeps an exact legacy target when runtime was not verified", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+    const before = readFileSync(globalPath, "utf8");
+
+    expect(inspectProjectScopeMigration(migration)).toMatchObject({
+      ok: true,
+      needsRuntimeVerification: true,
+    });
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: false });
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 1, preserved: 1, failed: 0, total: 2 },
+    });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("removes a markerless v0.43 legacy global entry after runtime verification", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 1, not_found: 1, preserved: 0, failed: 0, total: 2 },
+      receiptRoot: backupRoot,
+    });
+    const remaining = readFileSync(globalPath, "utf8");
+    expect(remaining).toContain("https://example.com/claude");
+    expect(remaining).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain(secret);
+
+    const second = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(second).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 2, preserved: 0, failed: 0, total: 2 },
+    });
+  });
+
+  it("preserves the first explicit global opt-in on later project setup", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const pending = prepareGlobalMcpIntent({
+      provider: "claude",
+      targetPath: globalPath,
+      intentRoot: migration.globalIntentRoot,
+    });
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+    finalizeGlobalMcpIntent(pending);
+
+    expect(inspectProjectScopeMigration(migration)).toMatchObject({
+      ok: true,
+      needsRuntimeVerification: false,
+    });
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({ ok: true, counts: { removed: 0, preserved: 1, total: 2 } });
+    expect(readFileSync(globalPath, "utf8")).toContain(secret);
+    expect(result.warnings.join("\n")).toContain("explicit global MCP");
+  });
+
+  it.each([
+    "pending",
+    "installed",
+    "tampered",
+  ] as const)("preserves a concurrent %s explicit-global intent created after the initial partition", (markerState) => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+    const before = readFileSync(globalPath, "utf8");
+    let injected = false;
+    let pendingIntent: ReturnType<typeof prepareGlobalMcpIntent> | undefined;
+
+    const result = runProjectScopeMigration({
+      ...migration,
+      runtimeVerified: true,
+      _testHooks: {
+        afterExplicitGlobalIntentPartition: () => {
+          if (injected) return;
+          injected = true;
+          const pending = prepareGlobalMcpIntent({
+            provider: "claude",
+            targetPath: globalPath,
+            intentRoot: migration.globalIntentRoot,
+          });
+          pendingIntent = pending;
+          if (markerState === "installed") finalizeGlobalMcpIntent(pending);
+          if (markerState === "tampered") {
+            writeFileSync(pending.markerPath, "not-json");
+            releaseGlobalMcpIntent(pending);
+          }
+        },
+      },
+    });
+
+    expect(injected).toBe(true);
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 1, preserved: 1, failed: 0, total: 2 },
+    });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+    expect(readFileSync(globalPath, "utf8")).toContain(secret);
+    expect(result.warnings.join("\n")).toContain("explicit global MCP");
+    if (markerState === "pending" && pendingIntent) releaseGlobalMcpIntent(pendingIntent);
+  });
+
+  it("restores the target when a pending marker appears after final authorization but before capture", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    const secret = writeOwnedGlobalMcp("claude", globalPath);
+    const before = readFileSync(globalPath, "utf8");
+
+    const result = runProjectScopeMigration({
+      ...migration,
+      runtimeVerified: true,
+      _testHooks: {
+        beforeLegacyTargetCapture: () => {
+          mkdirSync(migration.globalIntentRoot as string, { recursive: true });
+          const markerPath = globalMcpIntentMarkerPath({
+            provider: "claude",
+            targetPath: globalPath,
+            intentRoot: migration.globalIntentRoot,
+          });
+          writeFileSync(
+            markerPath,
+            `${JSON.stringify({
+              version: 1,
+              state: "pending",
+              provider: "claude",
+              targetPath: globalPath,
+              nonce: "a".repeat(32),
+            })}\n`,
+          );
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 1, preserved: 1, failed: 0, total: 2 },
+    });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+    expect(readFileSync(globalPath, "utf8")).toContain(secret);
+    expect(result.warnings.join("\n")).toContain("global_intent_pending");
+    expect(
+      readdirSync(homeDir).filter((name) => name.startsWith(".dosu-migration-capture-")),
+    ).toHaveLength(0);
+  });
+
+  it("preserves a shared canonical target when another provider recorded the opt-in", () => {
+    const migration = input();
+    const sharedGlobalPath = join(homeDir, ".claude.json");
+    const pending = prepareGlobalMcpIntent({
+      provider: "copilot",
+      targetPath: sharedGlobalPath,
+      intentRoot: migration.globalIntentRoot,
+    });
+    writeOwnedGlobalMcp("claude", sharedGlobalPath);
+    finalizeGlobalMcpIntent(pending);
+
+    const before = readFileSync(sharedGlobalPath, "utf8");
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({ ok: true, counts: { removed: 0, preserved: 1, total: 2 } });
+    expect(readFileSync(sharedGlobalPath, "utf8")).toBe(before);
+  });
+
+  it.each([
+    "damaged",
+    "symlinked",
+  ])("fails closed when the explicit global intent marker is %s", (markerState) => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    writeOwnedGlobalMcp("claude", globalPath);
+    const pending = prepareGlobalMcpIntent({
+      provider: "claude",
+      targetPath: globalPath,
+      intentRoot: migration.globalIntentRoot,
+    });
+    if (markerState === "damaged") {
+      writeFileSync(pending.markerPath, "not-json");
+    } else {
+      rmSync(pending.markerPath);
+      symlinkSync(join(tempDir, "foreign-marker"), pending.markerPath);
+    }
+
+    const before = readFileSync(globalPath, "utf8");
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({ ok: true, counts: { removed: 0, preserved: 1, total: 2 } });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+  });
+
+  it("fails closed when global config changed after explicit intent was recorded", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    writeOwnedGlobalMcp("claude", globalPath);
+    const pending = prepareGlobalMcpIntent({
+      provider: "claude",
+      targetPath: globalPath,
+      intentRoot: migration.globalIntentRoot,
+    });
+    finalizeGlobalMcpIntent(pending);
+    const changed = JSON.parse(readFileSync(globalPath, "utf8"));
+    changed.userChangedAfterInstall = true;
+    writeFileSync(globalPath, JSON.stringify(changed));
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({ ok: true, counts: { removed: 0, preserved: 1, total: 2 } });
+    expect(JSON.parse(readFileSync(globalPath, "utf8")).userChangedAfterInstall).toBe(true);
+    expect(result.warnings.join("\n")).toContain("global_intent_content_changed");
+  });
+
+  it("migrates Factory MCP", () => {
+    const migration = input("factory");
+    const globalMcpPath = join(homeDir, ".factory", "mcp.json");
+    const secret = writeOwnedGlobalMcp("factory", globalMcpPath);
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 1, not_found: 0, preserved: 0, failed: 0, total: 1 },
+    });
+    expect(readFileSync(globalMcpPath, "utf8")).not.toContain(secret);
+  });
+
+  it("never touches an indistinguishable legacy global skill", () => {
+    const migration = input();
+    const skillPath = join(homeDir, ".agents", "skills", "dosu", "SKILL.md");
+    const lockPath = join(homeDir, ".agents", ".skill-lock.json");
+    mkdirSync(join(skillPath, ".."), { recursive: true });
+    writeFileSync(skillPath, "user explicitly requested this global Dosu skill\n");
+    writeFileSync(lockPath, '{"version":3,"skills":{"dosu":{"source":"dosu-ai/dosu-skill"}}}\n');
+    const skillBefore = readFileSync(skillPath, "utf8");
+    const lockBefore = readFileSync(lockPath, "utf8");
+
+    runProjectScopeMigration({ ...migration, runtimeVerified: true });
+
+    expect(readFileSync(skillPath, "utf8")).toBe(skillBefore);
+    expect(readFileSync(lockPath, "utf8")).toBe(lockBefore);
+  });
+
+  it("fails before any cleanup when the project bundle no longer matches", () => {
+    const migration = input();
+    const globalPath = join(homeDir, ".claude.json");
+    writeOwnedGlobalMcp("claude", globalPath);
+    const before = readFileSync(globalPath, "utf8");
+    writeFileSync(join(projectRoot, ".mcp.json"), '{"mcpServers":{}}');
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({
+      ok: false,
+      cleanupAttempted: false,
+      reason: "project_mcp_mismatch",
+      counts: { total: 0 },
+    });
+    expect(readFileSync(globalPath, "utf8")).toBe(before);
+    expect(existsSync(backupRoot)).toBe(false);
+  });
+
+  it("preserves the shared Gemini rule when an unselected Antigravity target is ambiguous", () => {
+    const migration = input("gemini");
+    const antigravityPath = join(homeDir, ".gemini", "antigravity", "mcp_config.json");
+    mkdirSync(join(antigravityPath, ".."), { recursive: true });
+    writeFileSync(
+      antigravityPath,
+      '{"mcpServers":{"dosu":{"url":"https://example.com/user-owned"}}}',
+    );
+    const sharedRulePath = join(homeDir, ".gemini", "GEMINI.md");
+    writeFileSync(sharedRulePath, "<!-- dosu:rules:start v1 -->\nowned\n<!-- dosu:rules:end -->\n");
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 0, not_found: 1, preserved: 2, failed: 0, total: 3 },
+    });
+    expect(readFileSync(sharedRulePath, "utf8")).toContain("dosu:rules:start");
+    expect(readFileSync(antigravityPath, "utf8")).toContain("user-owned");
+  });
+
+  it("removes the shared Gemini rule when the counterpart MCP target is strictly absent", () => {
+    const migration = input("gemini");
+    const sharedRulePath = join(homeDir, ".gemini", "GEMINI.md");
+    mkdirSync(join(sharedRulePath, ".."), { recursive: true });
+    writeFileSync(
+      sharedRulePath,
+      `<!-- dosu:rules:start v1 -->\n${RELEASED_RULE.trimEnd()}\n<!-- dosu:rules:end -->\n`,
+    );
+
+    expect(inspectProjectScopeMigration(migration)).toMatchObject({
+      ok: true,
+      needsRuntimeVerification: true,
+    });
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({
+      ok: true,
+      counts: { removed: 1, not_found: 1, preserved: 0, failed: 0, total: 2 },
+    });
+    expect(existsSync(sharedRulePath)).toBe(false);
+  });
+
+  it("uses the versioned private config receipt root by default and rejects relative overrides", () => {
+    const migration = input();
+    delete migration.backupRoot;
+    const xdgConfig = join(tempDir, "xdg-config");
+    vi.stubEnv("XDG_CONFIG_HOME", xdgConfig);
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: false });
+    expect(result).toMatchObject({
+      ok: true,
+      receiptRoot: join(xdgConfig, "dosu-cli", "migrations", "project-scope-v1"),
+    });
+
+    const unsafe = runProjectScopeMigration({
+      ...migration,
+      backupRoot: "relative-receipts",
+      runtimeVerified: true,
+    });
+    expect(unsafe).toMatchObject({
+      ok: false,
+      cleanupAttempted: false,
+      reason: "unsafe_backup_root",
+    });
+    expect(
+      inspectProjectScopeMigration({ ...migration, backupRoot: "relative-receipts" }),
+    ).toMatchObject({ ok: false, reason: "unsafe_backup_root" });
+  });
+
+  it("fails closed on an unsupported runtime platform when no environment was injected", () => {
+    const migration = input();
+    delete migration.environment;
+    vi.spyOn(process, "platform", "get").mockReturnValue("freebsd" as NodeJS.Platform);
+
+    expect(inspectProjectScopeMigration(migration)).toMatchObject({
+      ok: false,
+      reason: "unsupported_platform",
+    });
+    expect(runProjectScopeMigration({ ...migration, runtimeVerified: true })).toMatchObject({
+      ok: false,
+      cleanupAttempted: false,
+      reason: "unsupported_platform",
+    });
+  });
+
+  it("preserves the shared Gemini rule for an unselected Gemini target seen by Antigravity setup", () => {
+    const migration = input("antigravity");
+    const geminiPath = join(homeDir, ".gemini", "settings.json");
+    mkdirSync(join(geminiPath, ".."), { recursive: true });
+    writeFileSync(geminiPath, '{"mcpServers":{"dosu":{"url":"https://example.com/user"}}}');
+    const sharedRulePath = join(homeDir, ".gemini", "GEMINI.md");
+    writeFileSync(
+      sharedRulePath,
+      "<!-- dosu:rules:start v1 -->\nuser edit\n<!-- dosu:rules:end -->\n",
+    );
+
+    const result = runProjectScopeMigration({ ...migration, runtimeVerified: true });
+    expect(result).toMatchObject({ ok: true, counts: { preserved: 2 } });
+    expect(readFileSync(sharedRulePath, "utf8")).toContain("user edit");
+    expect(readFileSync(geminiPath, "utf8")).toContain("example.com/user");
+  });
+});

--- a/src/setup/project-scope-migration.ts
+++ b/src/setup/project-scope-migration.ts
@@ -1,0 +1,389 @@
+import { lstatSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { getConfigDir } from "../config/config";
+import {
+  inspectLegacyTarget,
+  type LegacyTarget,
+  type LegacyTargetEnvironment,
+  legacyTargetsNeedCleanup,
+  type MigrationOutcome,
+  migrateLegacyTargets,
+  type ProjectBundleFailureReason,
+  type ProjectBundleProof,
+  type ProjectProof,
+  type ProjectProxyExpectation,
+  type ProviderId,
+  resolveLegacyTargets,
+  verifyProjectBundle,
+} from "../migration";
+import { inspectGlobalMcpIntent } from "../migration/global-intent";
+
+export interface ProjectScopeMigrationEnvironment extends LegacyTargetEnvironment {}
+
+export interface ProjectScopeMigrationInput {
+  /** Opaque proof returned by resolveProjectProof/proveProjectScope. */
+  project: ProjectProof;
+  /** Providers whose complete project bundle was successfully installed. */
+  providerIDs: readonly ProviderId[];
+  /** Exact secretless proxy command expected in every selected project config. */
+  proxy: ProjectProxyExpectation;
+  instructionContent: string;
+  environment?: ProjectScopeMigrationEnvironment;
+  /** Test override. Production receipts live under getConfigDir(). */
+  backupRoot?: string;
+  /** Test override. Production global intent lives under getConfigDir(). */
+  globalIntentRoot?: string;
+  /** @internal Deterministic race injection for migration tests only. */
+  _testHooks?: {
+    afterExplicitGlobalIntentPartition?: () => void;
+    beforeLegacyTargetCapture?: (target: LegacyTarget) => void;
+  };
+}
+
+export interface ProjectScopeMigrationCounts {
+  removed: number;
+  not_found: number;
+  preserved: number;
+  failed: number;
+  total: number;
+}
+
+type ProjectScopeMigrationFailureReason =
+  | ProjectBundleFailureReason
+  | "unsupported_platform"
+  | "unsafe_backup_root"
+  | "migration_failed";
+
+export type ProjectScopeMigrationInspection =
+  | {
+      ok: true;
+      needsRuntimeVerification: boolean;
+      receiptRoot: string;
+      warnings: string[];
+    }
+  | {
+      ok: false;
+      reason: Exclude<ProjectScopeMigrationFailureReason, "migration_failed">;
+      receiptRoot: string;
+      warnings: string[];
+    };
+
+export type ProjectScopeMigrationResult =
+  | {
+      ok: true;
+      cleanupAttempted: true;
+      runtimeVerified: boolean;
+      receiptRoot: string;
+      counts: ProjectScopeMigrationCounts;
+      warnings: string[];
+    }
+  | {
+      ok: false;
+      cleanupAttempted: boolean;
+      runtimeVerified: boolean;
+      reason: ProjectScopeMigrationFailureReason;
+      receiptRoot: string;
+      counts: ProjectScopeMigrationCounts;
+      warnings: string[];
+    };
+
+interface ResolvedMigration {
+  bundle: ProjectBundleProof;
+  providerIDs: ProviderId[];
+  targets: LegacyTarget[];
+  environment: ProjectScopeMigrationEnvironment;
+  receiptRoot: string;
+  globalIntentRoot: string;
+  warnings: string[];
+}
+
+type Resolution =
+  | { ok: true; value: ResolvedMigration }
+  | {
+      ok: false;
+      reason: Exclude<ProjectScopeMigrationFailureReason, "migration_failed">;
+      receiptRoot: string;
+      warnings: string[];
+    };
+
+const EMPTY_COUNTS: ProjectScopeMigrationCounts = Object.freeze({
+  removed: 0,
+  not_found: 0,
+  preserved: 0,
+  failed: 0,
+  total: 0,
+});
+
+function runtimeEnvironment(): ProjectScopeMigrationEnvironment | null {
+  const platform = process.platform;
+  if (platform !== "darwin" && platform !== "linux" && platform !== "win32") return null;
+  return { platform, homeDir: homedir(), env: process.env };
+}
+
+function receiptRoot(input: ProjectScopeMigrationInput): string {
+  return input.backupRoot ?? join(getConfigDir(), "migrations", "project-scope-v1");
+}
+
+function globalIntentRoot(input: ProjectScopeMigrationInput): string {
+  return input.globalIntentRoot ?? join(getConfigDir(), "migrations", "global-mcp-intent-v1");
+}
+
+function safeExistingReceiptRoot(path: string): boolean {
+  if (!isAbsolute(path)) return false;
+  try {
+    const stat = lstatSync(path);
+    return stat.isDirectory() && !stat.isSymbolicLink();
+  } catch (error: unknown) {
+    return (
+      typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"
+    );
+  }
+}
+
+function counterpart(provider: ProviderId): ProviderId | null {
+  if (provider === "gemini") return "antigravity";
+  if (provider === "antigravity") return "gemini";
+  return null;
+}
+
+/**
+ * Old Gemini and Antigravity setup shared one global GEMINI.md section. If an
+ * unselected counterpart MCP target is anything except strictly absent, keep
+ * that provider in the authorization set so the shared rule cannot be removed.
+ */
+function effectiveProviderIDs(
+  selected: readonly ProviderId[],
+  environment: ProjectScopeMigrationEnvironment,
+): { providerIDs: ProviderId[]; warnings: string[] } {
+  const effective = new Set(selected);
+  const warnings: string[] = [];
+
+  for (const provider of selected) {
+    const other = counterpart(provider);
+    if (!other || effective.has(other)) continue;
+    const resolution = resolveLegacyTargets([other], environment);
+    warnings.push(...resolution.warnings);
+    const mcpTarget = resolution.targets.find(
+      (target) => target.provider === other && target.id === `${other}:mcp`,
+    );
+    if (!mcpTarget || inspectLegacyTarget(mcpTarget).disposition !== "not_found") {
+      effective.add(other);
+    }
+  }
+
+  return { providerIDs: [...effective], warnings };
+}
+
+function resolveMigration(input: ProjectScopeMigrationInput): Resolution {
+  const root = receiptRoot(input);
+  const verified = verifyProjectBundle({
+    project: input.project,
+    providerIDs: input.providerIDs,
+    proxy: input.proxy,
+    instructionContent: input.instructionContent,
+  });
+  if (!verified.ok) {
+    return { ok: false, reason: verified.reason, receiptRoot: root, warnings: [] };
+  }
+
+  const environment = input.environment ?? runtimeEnvironment();
+  if (!environment) {
+    return { ok: false, reason: "unsupported_platform", receiptRoot: root, warnings: [] };
+  }
+  if (!safeExistingReceiptRoot(root)) {
+    return { ok: false, reason: "unsafe_backup_root", receiptRoot: root, warnings: [] };
+  }
+
+  const selected = [...new Set(input.providerIDs)];
+  const effective = effectiveProviderIDs(selected, environment);
+  const legacy = resolveLegacyTargets(effective.providerIDs, environment);
+  return {
+    ok: true,
+    value: {
+      bundle: verified.proof,
+      providerIDs: effective.providerIDs,
+      targets: legacy.targets,
+      environment,
+      receiptRoot: root,
+      globalIntentRoot: globalIntentRoot(input),
+      warnings: [...new Set([...effective.warnings, ...legacy.warnings])],
+    },
+  };
+}
+
+function partitionExplicitGlobalIntent(
+  targets: readonly LegacyTarget[],
+  intentRoot: string,
+): { migratable: LegacyTarget[]; preserved: LegacyTarget[]; warnings: string[] } {
+  const migratable: LegacyTarget[] = [];
+  const preserved: LegacyTarget[] = [];
+  const warnings: string[] = [];
+  for (const target of targets) {
+    if (target.kind !== "json_mcp" && target.kind !== "codex_toml") {
+      migratable.push(target);
+      continue;
+    }
+    const intent = inspectGlobalMcpIntent({
+      provider: target.provider,
+      targetPath: target.path,
+      intentRoot,
+    });
+    if (intent.status === "absent") {
+      migratable.push(target);
+      continue;
+    }
+    preserved.push(target);
+    warnings.push(
+      `Preserved explicit global MCP configuration for ${target.provider} (${intent.reason})`,
+    );
+  }
+  return { migratable, preserved, warnings };
+}
+
+function finalGlobalMcpAuthorization(target: LegacyTarget, intentRoot: string): string | null {
+  if (target.kind !== "json_mcp" && target.kind !== "codex_toml") return null;
+  const intent = inspectGlobalMcpIntent({
+    provider: target.provider,
+    targetPath: target.path,
+    intentRoot,
+  });
+  return intent.status === "absent" ? null : intent.reason;
+}
+
+/**
+ * Read-only ownership inspection. Callers may use this to avoid a cleanup-only
+ * runtime check when no removable legacy target exists.
+ */
+export function inspectProjectScopeMigration(
+  input: ProjectScopeMigrationInput,
+): ProjectScopeMigrationInspection {
+  const resolved = resolveMigration(input);
+  if (!resolved.ok) return resolved;
+  const { globalIntentRoot: intentRoot, receiptRoot: root, targets, warnings } = resolved.value;
+  const explicitIntent = partitionExplicitGlobalIntent(targets, intentRoot);
+  return {
+    ok: true,
+    needsRuntimeVerification: legacyTargetsNeedCleanup(explicitIntent.migratable),
+    receiptRoot: root,
+    warnings: [...new Set([...warnings, ...explicitIntent.warnings])],
+  };
+}
+
+function summarizeOutcomes(outcomes: readonly MigrationOutcome[]): ProjectScopeMigrationCounts {
+  const counts: ProjectScopeMigrationCounts = { ...EMPTY_COUNTS };
+  for (const outcome of outcomes) {
+    counts.total += 1;
+    switch (outcome) {
+      case "removed":
+        counts.removed += 1;
+        break;
+      case "not_found":
+        counts.not_found += 1;
+        break;
+      case "preserved_ambiguous":
+      case "concurrent_conflict":
+        counts.preserved += 1;
+        break;
+      case "pending":
+      case "failed":
+        counts.failed += 1;
+        break;
+    }
+  }
+  return counts;
+}
+
+/**
+ * Re-verifies the complete project bundle, then performs only strict,
+ * recoverable legacy cleanup. This function never starts the MCP runtime.
+ */
+export function runProjectScopeMigration(
+  input: ProjectScopeMigrationInput & { runtimeVerified: boolean },
+): ProjectScopeMigrationResult {
+  const resolved = resolveMigration(input);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      cleanupAttempted: false,
+      runtimeVerified: input.runtimeVerified,
+      reason: resolved.reason,
+      receiptRoot: resolved.receiptRoot,
+      counts: { ...EMPTY_COUNTS },
+      warnings: resolved.warnings,
+    };
+  }
+
+  const {
+    bundle,
+    globalIntentRoot: intentRoot,
+    receiptRoot: root,
+    targets,
+    warnings,
+  } = resolved.value;
+  const resultWarnings = [...warnings];
+  const outcomes: MigrationOutcome[] = [];
+  try {
+    const explicitIntent = partitionExplicitGlobalIntent(targets, intentRoot);
+    input._testHooks?.afterExplicitGlobalIntentPartition?.();
+    resultWarnings.push(...explicitIntent.warnings);
+    outcomes.push(...explicitIntent.preserved.map(() => "preserved_ambiguous" as const));
+    const targetReceipts = migrateLegacyTargets({
+      bundle,
+      targets: explicitIntent.migratable,
+      backupRoot: root,
+      allowRemoval: input.runtimeVerified,
+      finalMutationAuthorization: (target) => finalGlobalMcpAuthorization(target, intentRoot),
+      ...(input._testHooks?.beforeLegacyTargetCapture
+        ? {
+            _testHooks: {
+              beforeCapture: input._testHooks.beforeLegacyTargetCapture,
+            },
+          }
+        : {}),
+    });
+    outcomes.push(...targetReceipts.map((receipt) => receipt.outcome));
+    for (const receipt of targetReceipts) {
+      if (
+        !receipt.reason.startsWith("global_intent_") &&
+        receipt.reason !== "explicit_global_intent"
+      ) {
+        continue;
+      }
+      resultWarnings.push(
+        `Preserved explicit global MCP configuration for ${receipt.provider} (${receipt.reason})`,
+      );
+    }
+  } catch {
+    return {
+      ok: false,
+      cleanupAttempted: true,
+      runtimeVerified: input.runtimeVerified,
+      reason: "migration_failed",
+      receiptRoot: root,
+      counts: summarizeOutcomes([...outcomes, "failed"]),
+      warnings: [...new Set(resultWarnings)],
+    };
+  }
+
+  const counts = summarizeOutcomes(outcomes);
+  if (counts.failed > 0) {
+    return {
+      ok: false,
+      cleanupAttempted: true,
+      runtimeVerified: input.runtimeVerified,
+      reason: "migration_failed",
+      receiptRoot: root,
+      counts,
+      warnings: [...new Set(resultWarnings)],
+    };
+  }
+  return {
+    ok: true,
+    cleanupAttempted: true,
+    runtimeVerified: input.runtimeVerified,
+    receiptRoot: root,
+    counts,
+    warnings: [...new Set(resultWarnings)],
+  };
+}


### PR DESCRIPTION
<!-- Is this PR related to a Linear issue? -->
<!-- Example: Fixes [ENG-123](https://linear.app/dosu/issue/ENG-123) -->

### Description

Stack 5/8, based on #160. Adds the proof-gated migration transaction: exact legacy ownership checks, explicit-global-intent preservation, per-target locks, backups, receipts, crash recovery, and fail-closed conflict handling.

The migration remains unwired in this layer. Nothing invokes cleanup until the later setup integration succeeds and re-verifies the complete project bundle.

Validated locally with `bun run typecheck`, `bun run check`, all 2,056 tests, 122 focused migration tests, `git diff --check`, and `bun run build:npm`.

Stack review order:

1. #157 feat(mcp): add safe project file foundation
2. #158 feat(mcp): add secretless project proxy runtime
3. #159 feat(setup): add project agent assets
4. #160 feat(migration): prove complete project bundles
5. #161 feat(migration): add proof-gated global cleanup
6. #162 feat(mcp): enable project-scoped providers
7. #163 feat(setup): scope setup to the current project
8. #164 docs(setup): document project-scoped agent setup

Because this repository is squash-only, land by collapsing leaf into base: #164 -> #163 -> #162 -> #161 -> #160 -> #159 -> #158 -> #157 -> main.

### Review Tasks - Only request review after completing these.

* [ ] I self-reviewed this PR
* [ ] Testing is adequate for this change
* [ ] I reviewed AI-generated code and resolved suggestions

### Details (for context) - Not tasks; tooling uses tasks to determine review readiness

- Generated with AI: (N/Claude/Codex/Other)
- Manual testing: (Y/N/NA)
- Tests updated: (Y/N/NA)

<!-- Describe any manual testing or special testing approach -->
