### PR TITLE
feat(mcp): enable project-scoped providers (6/8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,182 @@ jobs:
           $pkg = Get-ChildItem -Filter "dosu-cli-*.tgz" | Select-Object -First 1 -ExpandProperty Name
           npm exec --yes --package "./$pkg" dosu -- --version
 
+      - name: Exercise project proxy from a spaced Windows PATH
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $smokeRoot = Join-Path $env:RUNNER_TEMP "dosu proxy smoke"
+          $fakeBin = Join-Path $smokeRoot "node tools"
+          $configRoot = Join-Path $smokeRoot "config"
+          $dosuConfig = Join-Path $configRoot "dosu-cli"
+          $credentialStore = Join-Path $dosuConfig "project-mcp-credentials.v1"
+          $packageRoot = Join-Path $smokeRoot "installed package"
+          New-Item -ItemType Directory -Force -Path @($fakeBin, $credentialStore, $packageRoot) | Out-Null
+
+          $env:XDG_CONFIG_HOME = $configRoot
+          $env:DOSU_PROXY_CAPTURE = Join-Path $smokeRoot "proxy-capture.txt"
+          $env:DOSU_PROXY_DESCENDANT_PID = Join-Path $smokeRoot "descendant.pid"
+          $env:DOSU_FAKE_NPX_PID = Join-Path $smokeRoot "fake-npx.pid"
+          $env:DOSU_FAKE_NPX_SCRIPT = Join-Path $smokeRoot "fake-npx.mjs"
+          $env:DOSU_SIGNAL_INJECTOR = Join-Path $smokeRoot "signal-packed-proxy.mjs"
+          $env:DOSU_NODE_EXE = (Get-Command node).Source
+          $env:PATH = "$fakeBin;$env:PATH"
+
+          @'
+          import { spawn } from "node:child_process";
+          import { writeFileSync } from "node:fs";
+
+          writeFileSync(
+            process.env.DOSU_PROXY_CAPTURE,
+            `${process.argv.slice(2).join(" ")}\n${process.env.X_DOSU_API_KEY ?? ""}\n`,
+          );
+          writeFileSync(process.env.DOSU_FAKE_NPX_PID, String(process.pid));
+          const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+            detached: true,
+            stdio: "ignore",
+            windowsHide: true,
+          });
+          if (!descendant.pid) process.exit(92);
+          writeFileSync(process.env.DOSU_PROXY_DESCENDANT_PID, String(descendant.pid));
+          descendant.unref();
+          setInterval(() => {}, 1_000);
+          '@ | Set-Content -Encoding utf8 $env:DOSU_FAKE_NPX_SCRIPT
+
+          @'
+          import { existsSync } from "node:fs";
+
+          // GitHub's Windows shell is non-interactive, so inject the same Node
+          // SIGINT event only after the packed proxy owns its signal listener.
+          const deadline = Date.now() + 15_000;
+          let descendantReadyAt;
+          const timer = setInterval(() => {
+            if (existsSync(process.env.DOSU_PROXY_DESCENDANT_PID)) {
+              descendantReadyAt ??= Date.now();
+            }
+            if (
+              descendantReadyAt &&
+              Date.now() - descendantReadyAt >= 100 &&
+              process.listenerCount("SIGINT") > 0
+            ) {
+              clearInterval(timer);
+              process.emit("SIGINT");
+              return;
+            }
+            if (Date.now() >= deadline) {
+              clearInterval(timer);
+              console.error("packed proxy never became ready for the shutdown signal");
+              process.exit(91);
+            }
+          }, 25);
+          '@ | Set-Content -Encoding utf8 $env:DOSU_SIGNAL_INJECTOR
+
+          @'
+          @echo off
+          "%DOSU_NODE_EXE%" "%DOSU_FAKE_NPX_SCRIPT%" %*
+          '@ | Set-Content -Encoding ascii (Join-Path $fakeBin "npx.cmd")
+
+          $userID = "windows-smoke-user"
+          $targetKey = "deployment:windows-smoke-dep"
+          @{
+            schema_version = 2
+            active_account = @{
+              user_id = $userID
+              session = @{
+                access_token = "smoke-token"
+                refresh_token = "smoke-refresh"
+                expires_at = 4102444800
+              }
+            }
+          } | ConvertTo-Json -Depth 6 | Set-Content -Encoding utf8 (Join-Path $dosuConfig "config.json")
+
+          $identity = [Text.Encoding]::UTF8.GetBytes("$userID`0$targetKey")
+          $recordName = "$([Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($identity)).ToLower()).json"
+          @{
+            schema_version = 1
+            user_id = $userID
+            target_key = $targetKey
+            credential = @{
+              endpoint = "https://api.dosu.dev/v1/mcp/deployments/windows-smoke-dep"
+              api_key = "windows-smoke-secret"
+            }
+          } | ConvertTo-Json -Depth 6 | Set-Content -Encoding utf8 (Join-Path $credentialStore $recordName)
+
+          $pkg = Get-ChildItem -Filter "dosu-cli-*.tgz" | Select-Object -First 1 -ExpandProperty FullName
+          npm install --ignore-scripts --no-audit --no-fund --prefix "$packageRoot" "$pkg"
+          if ($LASTEXITCODE -ne 0) { throw "could not install packed CLI" }
+          $dosuBin = Join-Path $packageRoot "node_modules/@dosu/cli/bin/dosu.js"
+          $signalInjectorURL = [Uri]::new($env:DOSU_SIGNAL_INJECTOR).AbsoluteUri
+          if (-not $signalInjectorURL.StartsWith("file:")) {
+            throw "could not convert the signal injector to a file URL"
+          }
+
+          $outer = $null
+          try {
+            $startInfo = [Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $env:DOSU_NODE_EXE
+            $startInfo.UseShellExecute = $false
+            foreach ($argument in @(
+              "--import",
+              $signalInjectorURL,
+              $dosuBin,
+              "mcp",
+              "proxy",
+              "--deployment",
+              "windows-smoke-dep"
+            )) {
+              $startInfo.ArgumentList.Add($argument)
+            }
+            $outer = [Diagnostics.Process]::Start($startInfo)
+            if (-not $outer.WaitForExit(30000)) {
+              throw "packed project proxy did not settle after SIGINT"
+            }
+            if ($outer.ExitCode -ne 0) { throw "project proxy exited $($outer.ExitCode)" }
+
+            if (-not (Test-Path $env:DOSU_PROXY_DESCENDANT_PID)) {
+              throw "fake npx did not launch its persistent descendant"
+            }
+            $descendantPID = [int](Get-Content $env:DOSU_PROXY_DESCENDANT_PID -Raw)
+            $descendantGone = $false
+            for ($attempt = 0; $attempt -lt 50; $attempt++) {
+              if (-not (Get-Process -Id $descendantPID -ErrorAction SilentlyContinue)) {
+                $descendantGone = $true
+                break
+              }
+              Start-Sleep -Milliseconds 100
+            }
+            if (-not $descendantGone) {
+              throw "taskkill returned but descendant PID $descendantPID survived"
+            }
+
+            $capture = Get-Content $env:DOSU_PROXY_CAPTURE
+            if ($capture.Count -lt 2) { throw "fake npx did not capture argv and env" }
+            if ($capture[0] -notmatch "mcp-remote@0\.1\.38") { throw "proxy did not invoke pinned mcp-remote" }
+            if ($capture[0] -match "windows-smoke-secret") { throw "proxy exposed its key in argv" }
+            if ($capture[1].Trim() -ne "windows-smoke-secret") { throw "proxy did not pass its key through env" }
+
+            # A save interrupted after fsync leaves this exact temporary shape.
+            # Exercise the packed CLI against Windows/libuv's real stat mode.
+            $crashTemporary = Join-Path $credentialStore "$recordName.4321.abcdef012345.tmp"
+            Copy-Item (Join-Path $credentialStore $recordName) $crashTemporary
+            & $env:DOSU_NODE_EXE $dosuBin logout | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "packed logout rejected its own crash temporary" }
+            if (Test-Path $credentialStore) {
+              throw "packed logout left the proven crash credential temporary behind"
+            }
+          } finally {
+            if ($outer -and -not $outer.HasExited) { $outer.Kill($true) }
+            if (Test-Path $env:DOSU_FAKE_NPX_PID) {
+              $fakeNpxPID = [int](Get-Content $env:DOSU_FAKE_NPX_PID -Raw)
+              if (Get-Process -Id $fakeNpxPID -ErrorAction SilentlyContinue) {
+                & taskkill.exe /PID $fakeNpxPID /T /F 2>&1 | Out-Null
+              }
+            }
+            if (Test-Path $env:DOSU_PROXY_DESCENDANT_PID) {
+              $cleanupPID = [int](Get-Content $env:DOSU_PROXY_DESCENDANT_PID -Raw)
+              Stop-Process -Id $cleanupPID -Force -ErrorAction SilentlyContinue
+            }
+          }
+
   release:
     needs:
       - lint

--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -111,6 +111,8 @@ function makeProvider(id: string, opts: Partial<SetupProvider> = {}): SetupProvi
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => `/tmp/${id}/mcp.json`,
+    projectConfigPath: (root) => `${root}/.${id}/mcp.json`,
+    isProjectConfigured: () => false,
     priority: () => 0,
     ...opts,
   };

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -1,4 +1,13 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,7 +15,13 @@ import { OAuthCallbackError } from "../auth/errors";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
 import { makeTestConfig, testSession, testTarget } from "../config/config.test-utils";
+import {
+  getProjectMcpCredentialStorePath,
+  readProjectMcpCredential,
+  saveProjectMcpCredential,
+} from "../mcp/project-credential-store";
 import { allProviders } from "../mcp/providers";
+import { globalMcpIntentMarkerPath, inspectGlobalMcpIntent } from "../migration/global-intent";
 import { createProgram } from "./cli";
 
 // ── Mocks (true external boundaries only) ───────────────────────────────────
@@ -65,6 +80,12 @@ vi.mock("../setup/flow", () => ({
   runSetup: (...args: unknown[]) => mockRunSetup(...args),
 }));
 
+const mockRunAgentSetup = vi.fn();
+vi.mock("../agent/flow", () => ({
+  runAgentSetup: (...args: unknown[]) => mockRunAgentSetup(...args),
+  listAgentSupportedToolIDs: () => ["claude", "codex"],
+}));
+
 const { mockLoggerGetLogPath } = vi.hoisted(() => ({
   mockLoggerGetLogPath: vi.fn(),
 }));
@@ -85,14 +106,36 @@ vi.mock("../debug/logger", () => ({
 let tempDir: string;
 let origXDG: string | undefined;
 let origHome: string | undefined;
+let origDosuDev: string | undefined;
+let origCwd: string;
+let origExitCode: typeof process.exitCode;
 let logSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "dosu-cli-test-"));
   origXDG = process.env.XDG_CONFIG_HOME;
   origHome = process.env.HOME;
+  origDosuDev = process.env.DOSU_DEV;
+  origCwd = process.cwd();
+  origExitCode = process.exitCode;
+  process.exitCode = undefined;
   process.env.XDG_CONFIG_HOME = tempDir;
   process.env.HOME = tempDir;
+  delete process.env.DOSU_DEV;
+
+  // Keep every CLI action offline: fresh caches prevent the fire-and-forget
+  // npm/GitHub update checks from starting real network requests.
+  const configDir = join(tempDir, "dosu-cli");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(
+    join(configDir, "update-check.json"),
+    JSON.stringify({ lastCheck: Date.now(), latestVersion: "0.0.0" }),
+  );
+  writeFileSync(
+    join(configDir, "skill-update-check.json"),
+    JSON.stringify({ lastCheck: Date.now(), latestSha: "same", installedSha: "same" }),
+  );
+  writeFileSync(join(configDir, "pending-tasks.json"), JSON.stringify({ tasks: [] }));
 
   vi.clearAllMocks();
   mockIsHeadless.mockReturnValue(false);
@@ -101,10 +144,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  process.chdir(origCwd);
+  process.exitCode = origExitCode;
   if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
   else delete process.env.XDG_CONFIG_HOME;
   if (origHome !== undefined) process.env.HOME = origHome;
   else delete process.env.HOME;
+  if (origDosuDev !== undefined) process.env.DOSU_DEV = origDosuDev;
+  else delete process.env.DOSU_DEV;
   rmSync(tempDir, { recursive: true, force: true });
   logSpy.mockRestore();
 });
@@ -464,6 +511,11 @@ describe("CLI actions", () => {
   describe("logout", () => {
     it("clears credentials in real config file", async () => {
       saveConfig(authenticatedConfig());
+      saveProjectMcpCredential({
+        userID: "user-1",
+        targetKey: "deployment-1",
+        credential: { endpoint: "https://api.dosu.dev/mcp", api_key: "secret" },
+      });
 
       await run("logout");
 
@@ -472,13 +524,21 @@ describe("CLI actions", () => {
       // Read back the real config file and verify credentials are cleared
       const cfg = loadConfig();
       expect(cfg.active_account).toBeUndefined();
+      expect(existsSync(getProjectMcpCredentialStorePath())).toBe(false);
     });
 
     it("prints not-logged-in when config has no credentials", async () => {
       // No config file on disk = empty config
+      saveProjectMcpCredential({
+        userID: "user-1",
+        targetKey: "deployment-1",
+        credential: { endpoint: "https://api.dosu.dev/mcp", api_key: "secret" },
+      });
+
       await run("logout");
 
       expect(logSpy).toHaveBeenCalledWith("You are not logged in.");
+      expect(existsSync(getProjectMcpCredentialStorePath())).toBe(false);
     });
   });
 
@@ -675,16 +735,16 @@ describe("CLI actions", () => {
       for (const p of providers) {
         if (p.id() === "manual") {
           // Manual provider should have NO scope label
-          // Check that the line with "manual" does not include "(global only)" or "(local + global)"
+          // Check that the line with "manual" does not include a scope label.
           const lines = output.split("\n");
           const manualLine = lines.find((l: string) => l.includes("manual"));
           expect(manualLine).toBeDefined();
           expect(manualLine).not.toContain("(global only)");
-          expect(manualLine).not.toContain("(local + global)");
+          expect(manualLine).not.toContain("(project + global)");
         } else if (!p.supportsLocal()) {
           expect(output).toContain("(global only)");
         } else {
-          expect(output).toContain("(local + global)");
+          expect(output).toContain("(project + global)");
         }
       }
 
@@ -695,6 +755,70 @@ describe("CLI actions", () => {
   // ── mcp add ─────────────────────────────────────────────────────────────
 
   describe("mcp add", () => {
+    it("installs a secretless proxy only in the current Git project by default", async () => {
+      const projectRoot = join(tempDir, "project");
+      mkdirSync(projectRoot);
+      execFileSync("git", ["init", "--quiet"], { cwd: projectRoot, stdio: "ignore" });
+      process.chdir(projectRoot);
+      saveConfig(authenticatedConfig());
+
+      await run("mcp", "add", "cursor");
+
+      const projectConfigPath = join(projectRoot, ".cursor", "mcp.json");
+      const projectConfig = readFileSync(projectConfigPath, "utf8");
+      expect(projectConfig).toContain("@dosu/cli@");
+      expect(projectConfig).toContain("dep_123");
+      expect(projectConfig).not.toContain("key_abc");
+      expect(projectConfig).not.toContain("/v1/mcp/deployments/");
+      expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
+      expect(
+        readProjectMcpCredential({
+          userID: "test-user-id",
+          targetKey: "deployment:dep_123",
+        }),
+      ).toMatchObject({ api_key: "key_abc" });
+      expect(allLogOutput()).toContain("current project");
+    });
+
+    it("refuses to create split-brain project targets across agents", async () => {
+      const projectRoot = join(tempDir, "project");
+      mkdirSync(projectRoot);
+      execFileSync("git", ["init", "--quiet"], { cwd: projectRoot, stdio: "ignore" });
+      process.chdir(projectRoot);
+      const cfg = authenticatedConfig();
+      saveConfig(cfg);
+      await run("mcp", "add", "codex");
+
+      testTarget(cfg).deployment_id = "dep_456";
+      testTarget(cfg).api_key = "key_updated";
+      saveConfig(cfg);
+
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow(/pinned to a different/i);
+      expect(existsSync(join(projectRoot, ".cursor", "mcp.json"))).toBe(false);
+      expect(readFileSync(join(projectRoot, ".codex", "config.toml"), "utf8")).toContain("dep_123");
+    });
+
+    it("retargets one existing project agent only with explicit authorization", async () => {
+      const projectRoot = join(tempDir, "project");
+      mkdirSync(projectRoot);
+      execFileSync("git", ["init", "--quiet"], { cwd: projectRoot, stdio: "ignore" });
+      process.chdir(projectRoot);
+      const cfg = authenticatedConfig();
+      saveConfig(cfg);
+      await run("mcp", "add", "cursor");
+
+      testTarget(cfg).deployment_id = "dep_456";
+      testTarget(cfg).api_key = "key_updated";
+      saveConfig(cfg);
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow(/pinned to a different/i);
+
+      await run("mcp", "add", "cursor", "--retarget");
+
+      const content = readFileSync(join(projectRoot, ".cursor", "mcp.json"), "utf8");
+      expect(content).toContain("dep_456");
+      expect(content).not.toContain("dep_123");
+    });
+
     it("creates real cursor config file with --global", async () => {
       const cfg = authenticatedConfig();
       saveConfig(cfg);
@@ -709,10 +833,67 @@ describe("CLI actions", () => {
       expect(cursorConfig.mcpServers.dosu.url).toContain("dep_123");
       expect(cursorConfig.mcpServers.dosu.headers).toBeDefined();
       expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key_abc");
+      expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath: cursorConfigPath })).toEqual({
+        status: "preserve",
+        reason: "explicit_global_intent",
+      });
 
       expect(logSpy).toHaveBeenCalledWith(
         expect.stringContaining("Successfully added Dosu MCP to Cursor"),
       );
+    });
+
+    it("updates explicit global intent when the user reinstalls a different target", async () => {
+      const cfg = authenticatedConfig();
+      saveConfig(cfg);
+      await run("mcp", "add", "cursor", "--global");
+      const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+      const markerPath = globalMcpIntentMarkerPath({
+        provider: "cursor",
+        targetPath: cursorConfigPath,
+      });
+      const firstHash = JSON.parse(readFileSync(markerPath, "utf8")).contentHash;
+
+      testTarget(cfg).deployment_id = "dep_456";
+      testTarget(cfg).api_key = "key_updated";
+      saveConfig(cfg);
+      await run("mcp", "add", "cursor", "--global");
+
+      const secondHash = JSON.parse(readFileSync(markerPath, "utf8")).contentHash;
+      expect(secondHash).not.toBe(firstHash);
+      expect(readFileSync(cursorConfigPath, "utf8")).toContain("dep_456");
+      expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath: cursorConfigPath })).toEqual({
+        status: "preserve",
+        reason: "explicit_global_intent",
+      });
+    });
+
+    it("does not modify global config when pending intent cannot be written safely", async () => {
+      saveConfig(authenticatedConfig());
+      const intentRoot = join(tempDir, "dosu-cli", "migrations", "global-mcp-intent-v1");
+      const foreign = join(tempDir, "foreign-intent-root");
+      mkdirSync(join(intentRoot, ".."), { recursive: true });
+      mkdirSync(foreign);
+      symlinkSync(foreign, intentRoot, "dir");
+
+      await expect(run("mcp", "add", "cursor", "--global")).rejects.toThrow(/unsafe/i);
+
+      expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
+    });
+
+    it("releases shared migration exclusion but keeps pending intent when global install fails", async () => {
+      saveConfig(authenticatedConfig());
+      const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+      mkdirSync(cursorConfigPath, { recursive: true });
+
+      await expect(run("mcp", "add", "cursor", "--global")).rejects.toThrow();
+
+      expect(existsSync(`${cursorConfigPath}.dosu-migration.lock`)).toBe(false);
+      expect(existsSync(cursorConfigPath)).toBe(true);
+      expect(inspectGlobalMcpIntent({ provider: "cursor", targetPath: cursorConfigPath })).toEqual({
+        status: "preserve",
+        reason: "global_intent_pending",
+      });
     });
 
     it("throws error for unknown tool", async () => {
@@ -801,15 +982,28 @@ describe("CLI actions", () => {
       expect(allLogOutput()).toContain("key_abc");
     });
 
-    it("auto-sets global when provider does not support local", async () => {
+    it("rejects an untrackable manual global install", async () => {
       saveConfig(authenticatedConfig());
 
-      // Windsurf only supports global installation
-      await run("mcp", "add", "windsurf");
+      await expect(run("mcp", "add", "manual", "--global")).rejects.toThrow(
+        /cannot be recorded safely/i,
+      );
+      expect(allLogOutput()).not.toContain("api.dosu.dev");
+    });
 
-      const output = allLogOutput();
-      expect(output).toContain("only supports global installation");
-      expect(output).toContain("Successfully added Dosu MCP to Windsurf");
+    it("refuses to silently fall back to global when project scope is unsupported", async () => {
+      saveConfig(authenticatedConfig());
+
+      await expect(run("mcp", "add", "windsurf")).rejects.toThrow(/will not silently fall back/i);
+      expect(allLogOutput()).not.toContain("Successfully added Dosu MCP to Windsurf");
+    });
+
+    it("still allows an explicit global install for an unsupported project client", async () => {
+      saveConfig(authenticatedConfig());
+
+      await run("mcp", "add", "windsurf", "--global");
+
+      expect(allLogOutput()).toContain("Successfully added Dosu MCP to Windsurf");
     });
 
     it("installs globally when --global flag is passed", async () => {
@@ -825,7 +1019,43 @@ describe("CLI actions", () => {
 
   // ── setup ───────────────────────────────────────────────────────────────
 
+  describe("mcp proxy", () => {
+    it("rejects both missing and conflicting target selectors before starting the proxy", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        await run("mcp", "proxy");
+        expect(process.exitCode).toBe(2);
+
+        process.exitCode = undefined;
+        await run("mcp", "proxy", "--deployment", "dep_123", "--oss");
+        expect(process.exitCode).toBe(2);
+        expect(errorSpy).toHaveBeenCalledTimes(2);
+        expect(errorSpy).toHaveBeenCalledWith("Exactly one of --deployment or --oss is required.");
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+  });
+
   describe("setup", () => {
+    it("emits a structured error when agent setup omits --tool", async () => {
+      await run("setup", "--agent");
+
+      expect(process.exitCode).toBe(2);
+      expect(allLogOutput()).toContain('"reason":"missing_tool"');
+      expect(allLogOutput()).toContain("Supported ids: claude, codex");
+      expect(mockRunAgentSetup).not.toHaveBeenCalled();
+    });
+
+    it("rejects agent-only flags outside agent setup", async () => {
+      await expect(run("setup", "--tool", "codex")).rejects.toThrow(
+        "--tool and --login-ticket require --agent",
+      );
+
+      expect(mockRunSetup).not.toHaveBeenCalled();
+      expect(mockRunAgentSetup).not.toHaveBeenCalled();
+    });
+
     it("runs setup flow", async () => {
       mockRunSetup.mockResolvedValue(undefined);
 

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -64,6 +64,17 @@ describe("CLI", () => {
     expect(mcpCmd?.commands.find((c) => c.name() === "list")).toBeDefined();
   });
 
+  it("registers the internal project proxy without advertising it in help", () => {
+    const program = createProgram();
+    const mcpCmd = program.commands.find((c) => c.name() === "mcp");
+    const proxy = mcpCmd?.commands.find((c) => c.name() === "proxy");
+
+    expect(proxy).toBeDefined();
+    expect(proxy?.options.find((o) => o.long === "--deployment")).toBeDefined();
+    expect(proxy?.options.find((o) => o.long === "--oss")).toBeDefined();
+    expect(mcpCmd?.helpInformation()).not.toContain("proxy");
+  });
+
   it("has setup command with --deployment option", () => {
     const program = createProgram();
     const cmd = program.commands.find((c) => c.name() === "setup");

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -34,7 +34,20 @@ import {
   saveConfig,
 } from "../config/config";
 import { logger } from "../debug/logger";
-import { allProviders, getProvider, type Provider } from "../mcp/providers";
+import { clearProjectMcpCredentials } from "../mcp/project-credential-store";
+import {
+  recordProjectProxyEndpoint,
+  runProjectProxy,
+  sameProjectProxyTarget,
+} from "../mcp/project-proxy";
+import { allProviders, allSetupProviders, getProvider, type Provider } from "../mcp/providers";
+import {
+  finalizeGlobalMcpIntent,
+  prepareGlobalMcpIntent,
+  releaseGlobalMcpIntent,
+} from "../migration/global-intent";
+import { requireProjectRoot } from "../setup/project-root";
+import { resolveProjectPinnedTarget } from "../setup/project-target";
 import { browserFallbackHint } from "../setup/styles";
 import { checkForReadyTasks } from "../version/pending-tasks-check";
 import { checkForSkillUpdates } from "../version/skill-update-check";
@@ -47,9 +60,11 @@ import { getVersionString } from "../version/version";
  * are noise on the hot path and the background fetch can delay process exit).
  */
 const HOOK_ENTRYPOINTS = new Set(["user-prompt-submit", "post-tool-use", "stop"]);
-function isHookEntrypointInvocation(argv: string[]): boolean {
+function isHotPathInvocation(argv: string[]): boolean {
   const i = argv.indexOf("hooks");
-  return i >= 0 && HOOK_ENTRYPOINTS.has(argv[i + 1] ?? "");
+  if (i >= 0 && HOOK_ENTRYPOINTS.has(argv[i + 1] ?? "")) return true;
+  const mcpIndex = argv.indexOf("mcp");
+  return mcpIndex >= 0 && argv[mcpIndex + 1] === "proxy";
 }
 
 /** Suggest the closest registered command name for a mistyped one, if any is close enough. */
@@ -94,7 +109,7 @@ export function createProgram(): Command {
     .hook("preAction", (thisCommand) => {
       const opts = thisCommand.optsWithGlobals();
       logger.init({ debug: opts.debug });
-      if (!isHookEntrypointInvocation(process.argv)) {
+      if (!isHotPathInvocation(process.argv)) {
         checkForUpdates();
         checkForSkillUpdates();
         checkForReadyTasks();
@@ -235,11 +250,13 @@ export function createProgram(): Command {
     .action(() => {
       const cfg = loadConfig();
       if (!isAuthenticated(cfg)) {
+        clearProjectMcpCredentials();
         console.log("You are not logged in.");
         return;
       }
       clearConfigInPlace(cfg);
       saveConfig(cfg);
+      clearProjectMcpCredentials();
       console.log("Successfully logged out.");
     });
 
@@ -333,52 +350,145 @@ export function createProgram(): Command {
     .command("add <agent>")
     .description("Add Dosu MCP to an AI tool")
     .option("-g, --global", "Add globally (all projects) instead of project-local", false)
+    .option("--retarget", "Replace this agent's existing project Dosu target", false)
     .option("--show-secret", "Print full manual configuration secrets", false)
-    .action(async (toolId: string, opts: { global: boolean; showSecret: boolean }) => {
-      let provider: Provider;
-      try {
-        provider = getProvider(toolId.toLowerCase());
-      } catch {
-        throw new Error(`unknown tool '${toolId}'. Use 'dosu mcp list' to see available tools`);
-      }
-      const cfg = loadConfig();
+    .action(
+      async (toolId: string, opts: { global: boolean; retarget: boolean; showSecret: boolean }) => {
+        let provider: Provider;
+        try {
+          provider = getProvider(toolId.toLowerCase());
+        } catch {
+          throw new Error(`unknown tool '${toolId}'. Use 'dosu mcp list' to see available tools`);
+        }
+        const cfg = loadConfig();
 
-      if (!isAuthenticated(cfg)) {
-        throw new Error("not logged in. Run 'dosu login' first");
-      }
-      if (isTokenExpired(cfg) && !(await ensureFreshSession(cfg))) {
-        throw new Error("session expired. Run 'dosu login' to re-authenticate");
-      }
-      if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id) {
-        throw new Error("no MCP selected. Run 'dosu' to open the TUI and select an MCP");
-      }
-      if (!cfg.active_account?.target?.api_key) {
-        throw new Error("no API key available. Run 'dosu setup' to create one");
-      }
+        if (!isAuthenticated(cfg)) {
+          throw new Error("not logged in. Run 'dosu login' first");
+        }
+        if (isTokenExpired(cfg) && !(await ensureFreshSession(cfg))) {
+          throw new Error("session expired. Run 'dosu login' to re-authenticate");
+        }
+        if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id) {
+          throw new Error("no MCP selected. Run 'dosu' to open the TUI and select an MCP");
+        }
+        if (!cfg.active_account?.target?.api_key) {
+          throw new Error("no API key available. Run 'dosu setup' to create one");
+        }
 
-      if (provider.id() === "manual") {
-        provider.install(cfg, false, { showSecret: opts.showSecret });
+        if (opts.retarget && (opts.global || provider.id() === "manual")) {
+          throw new Error("--retarget is only valid for a project-scoped agent configuration");
+        }
+
+        if (provider.id() === "manual") {
+          if (opts.global) {
+            throw new Error(
+              "--global cannot be recorded safely for manual configuration; choose a supported agent ID instead",
+            );
+          }
+          provider.install(cfg, false, { showSecret: opts.showSecret });
+          return;
+        }
+
+        if (!provider.supportsLocal() && !opts.global) {
+          throw new Error(
+            `${provider.name()} has no official project-scoped MCP config. ` +
+              "Dosu will not silently fall back to a global install; use --global explicitly if you accept that scope.",
+          );
+        }
+
+        let projectRoot: string | undefined;
+        if (!opts.global) {
+          projectRoot = requireProjectRoot();
+          const configuredTarget =
+            cfg.mode === MODE_OSS
+              ? ({ oss: true } as const)
+              : { deploymentID: cfg.active_account?.target?.deployment_id as string };
+          const projectTarget = opts.retarget
+            ? resolveProjectPinnedTarget(
+                allSetupProviders(),
+                projectRoot,
+                cfg.mode === MODE_OSS
+                  ? { mode: "oss" }
+                  : {
+                      mode: "cloud",
+                      deploymentID: cfg.active_account?.target?.deployment_id,
+                    },
+                [provider.id()],
+              )
+            : resolveProjectPinnedTarget(allSetupProviders(), projectRoot);
+          if (!projectTarget.ok) {
+            const locations = projectTarget.paths.join(", ");
+            throw new Error(
+              `Cannot safely update this project's Dosu MCP (${projectTarget.reason}): ${locations}. ` +
+                "Run `dosu setup` to reconcile every project agent together.",
+            );
+          }
+          if (
+            !opts.retarget &&
+            projectTarget.target &&
+            !sameProjectProxyTarget(projectTarget.target, configuredTarget)
+          ) {
+            throw new Error(
+              "This project is pinned to a different Dosu target. Run `dosu setup` to add this agent " +
+                "without splitting the project's MCP target, or pass --retarget only when no other project agent must stay on the old target.",
+            );
+          }
+          recordProjectProxyEndpoint(cfg);
+          saveConfig(cfg);
+        }
+
+        const global = opts.global;
+        const scope = global ? "global (all projects)" : "current project";
+        console.log(`Adding Dosu MCP to ${provider.name()} (${scope})...`);
+
+        if (global && !("globalConfigPath" in provider)) {
+          throw new Error(`${provider.name()} does not expose a canonical global config path`);
+        }
+        const globalIntent = global
+          ? prepareGlobalMcpIntent({
+              provider: provider.id(),
+              targetPath: (
+                provider as Provider & { globalConfigPath(): string }
+              ).globalConfigPath(),
+            })
+          : null;
+        try {
+          provider.install(cfg, global, {
+            showSecret: opts.showSecret,
+            projectRoot,
+            allowProjectRetarget: opts.retarget,
+          });
+        } catch (error) {
+          if (globalIntent) releaseGlobalMcpIntent(globalIntent);
+          throw error;
+        }
+        if (globalIntent) finalizeGlobalMcpIntent(globalIntent);
+
+        console.log(`\n✓ Successfully added Dosu MCP to ${provider.name()}!`);
+        if (global) {
+          console.log(`\nStart ${provider.name()} in any project to use the Dosu MCP.`);
+        } else {
+          console.log(`\nStart ${provider.name()} in this project directory to use the Dosu MCP.`);
+        }
+      },
+    );
+
+  const proxyCommand = new Command("proxy")
+    .description("Internal project MCP credential bridge")
+    .option("--deployment <id>", "Expected project deployment")
+    .option("--oss", "Use the configured public-libraries endpoint", false)
+    .action(async (opts: { deployment?: string; oss: boolean }) => {
+      if (Boolean(opts.deployment) === opts.oss) {
+        console.error("Exactly one of --deployment or --oss is required.");
+        process.exitCode = 2;
         return;
       }
-
-      let global = opts.global;
-      if (!provider.supportsLocal() && !global) {
-        console.log(`Note: ${provider.name()} only supports global installation.\n`);
-        global = true;
-      }
-
-      const scope = global ? "global (all projects)" : "project-local";
-      console.log(`Adding Dosu MCP to ${provider.name()} (${scope})...`);
-
-      provider.install(cfg, global, { showSecret: opts.showSecret });
-
-      console.log(`\n✓ Successfully added Dosu MCP to ${provider.name()}!`);
-      if (global) {
-        console.log(`\nStart ${provider.name()} in any project to use the Dosu MCP.`);
-      } else {
-        console.log(`\nStart ${provider.name()} in this project directory to use the Dosu MCP.`);
-      }
+      process.exitCode = await runProjectProxy({
+        deploymentID: opts.deployment,
+        oss: opts.oss,
+      });
     });
+  mcp.addCommand(proxyCommand, { hidden: true });
 
   mcp
     .command("list")
@@ -386,7 +496,7 @@ export function createProgram(): Command {
     .action(() => {
       console.log("Available AI tools:\n");
       for (const p of allProviders()) {
-        let scope = "(local + global)";
+        let scope = "(project + global)";
         if (!p.supportsLocal()) scope = "(global only)";
         if (p.id() === "manual") scope = "";
         console.log(`  ${p.id().padEnd(10)} ${p.name()} ${scope}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,22 @@
  */
 
 import { execute } from "./cli/cli";
+import {
+  CLI_SIGNALS,
+  dispatchCliSignal,
+  installsImmediateSigintHandler,
+} from "./cli/signal-policy";
 
-// Ensure Ctrl+C always exits immediately, even when @clack/prompts
-// intercepts SIGINT and swallows it as a cancel symbol.
-process.on("SIGINT", () => process.exit(0));
+// Ordinary prompt cancellation remains immediate. Short-lived guarded work
+// (currently the project MCP preflight) can delay exit only until its detached
+// process tree has been shut down.
+if (installsImmediateSigintHandler(process.argv)) {
+  for (const signal of CLI_SIGNALS) {
+    process.on(signal, () => {
+      void dispatchCliSignal(signal);
+    });
+  }
+}
 
 execute().catch((err) => {
   console.error(err.message ?? err);

--- a/src/mcp/providers.test.ts
+++ b/src/mcp/providers.test.ts
@@ -61,7 +61,7 @@ describe("provider registry", () => {
       { id: "cline-cli", name: "Cline CLI", local: false },
       { id: "copilot", name: "GitHub Copilot CLI", local: true },
       { id: "opencode", name: "OpenCode", local: true },
-      { id: "antigravity", name: "Antigravity", local: false },
+      { id: "antigravity", name: "Antigravity", local: true },
       { id: "mcporter", name: "MCPorter", local: true },
       { id: "manual", name: "Manual Configuration", local: false },
     ];

--- a/src/mcp/providers.ts
+++ b/src/mcp/providers.ts
@@ -3,20 +3,29 @@
  */
 
 import type { Config } from "../config/config";
+import type { ProjectFileMutationReceipt } from "./config-helpers";
 
 /**
  * Provider is the base interface for MCP tool providers.
  */
 export interface ProviderInstallOptions {
   showSecret?: boolean;
+  /** Canonical Git worktree root for project-scoped configuration. */
+  projectRoot?: string;
+  /** Explicit user authorization to replace an owned project entry with a different target. */
+  allowProjectRetarget?: boolean;
 }
 
 export interface Provider {
   name(): string;
   id(): string;
   supportsLocal(): boolean;
-  install(cfg: Config, global: boolean, opts?: ProviderInstallOptions): void;
-  remove(global: boolean): void;
+  install(
+    cfg: Config,
+    global: boolean,
+    opts?: ProviderInstallOptions,
+  ): ProjectFileMutationReceipt | undefined;
+  remove(global: boolean, opts?: ProviderInstallOptions): ProjectFileMutationReceipt | undefined;
 }
 
 /**
@@ -27,6 +36,8 @@ export interface SetupProvider extends Provider {
   isInstalled(): boolean;
   isConfigured(): boolean;
   globalConfigPath(): string;
+  projectConfigPath(projectRoot: string): string | null;
+  isProjectConfigured(projectRoot: string): boolean;
   priority(): number;
 }
 

--- a/src/mcp/providers/antigravity.ts
+++ b/src/mcp/providers/antigravity.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { mcpHeaders, mcpURL } from "../config-helpers";
 import { createJSONProvider } from "./base";
 
@@ -5,10 +6,11 @@ export const AntigravityProvider = () =>
   createJSONProvider({
     providerName: "Antigravity",
     providerID: "antigravity",
-    local: false,
+    local: true,
     priorityValue: 15,
     paths: ["~/.gemini"],
-    globalPath: "~/.gemini/antigravity/mcp_config.json",
+    globalPath: "~/.gemini/config/mcp_config.json",
+    configuredGlobalPaths: ["~/.gemini/antigravity/mcp_config.json"],
     topKey: "mcpServers",
     buildServer: (cfg) => ({
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
@@ -16,4 +18,6 @@ export const AntigravityProvider = () =>
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
+    buildProjectServer: (command) => ({ command: command.command, args: command.args }),
+    localConfigPath: (cwd) => join(cwd, ".agents", "mcp_config.json"),
   });

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -4,15 +4,24 @@
  */
 
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-path";
 import {
   installJSONServer,
-  isJSONKeyConfigured,
+  installProjectJSONServer,
+  isProjectJSONServerConfigured,
   mcpBaseURL,
   mcpHeaders,
   mcpURL,
   removeJSONServer,
+  removeProjectJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import {
+  buildProjectProxyCommand,
+  isDosuMcpEntryForProvider,
+  ownedProjectProxyOptionsForProvider,
+  sameProjectProxyTarget,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 export interface BaseProviderConfig {
@@ -22,10 +31,16 @@ export interface BaseProviderConfig {
   priorityValue: number;
   paths: string[];
   globalPath: string;
+  /** Historical global paths used only for detection, never for new writes. */
+  configuredGlobalPaths?: string[];
   topKey: string;
   /** Override the server entry shape if needed */
   // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
   buildServer?: (cfg: Config) => Record<string, any>;
+  /** Exact provider-specific stdio shape for a secretless project entry. */
+  buildProjectServer?: (
+    command: ReturnType<typeof buildProjectProxyCommand>,
+  ) => Record<string, unknown>;
   /** For providers that use a different local config path pattern */
   localConfigPath?: (cwd: string) => string;
 }
@@ -47,6 +62,26 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
   });
 
   const buildServer = opts.buildServer ?? defaultBuildServer;
+  const buildProjectServer =
+    opts.buildProjectServer ??
+    ((command: ReturnType<typeof buildProjectProxyCommand>) => ({
+      type: "stdio",
+      command: command.command,
+      args: command.args,
+    }));
+
+  const projectConfigPath = (projectRoot: string): string | null =>
+    opts.localConfigPath ? opts.localConfigPath(projectRoot) : null;
+  const isOwned = (entry: unknown): boolean => isDosuMcpEntryForProvider(opts.providerID, entry);
+  const isCurrentProjectEntry = (entry: unknown): boolean =>
+    ownedProjectProxyOptionsForProvider(opts.providerID, entry) !== null;
+
+  const requireProjectRoot = (projectRoot: string | undefined): string => {
+    if (!projectRoot) {
+      throw new Error(`${opts.providerName} project installation requires a verified project root`);
+    }
+    return projectRoot;
+  };
 
   return {
     name: () => opts.providerName,
@@ -56,33 +91,71 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     detectPaths: () => opts.paths,
     isInstalled: () => isInstalled(opts.paths),
     globalConfigPath: () => expandHome(opts.globalPath),
-    isConfigured: () => isJSONKeyConfigured(expandHome(opts.globalPath), opts.topKey),
+    isConfigured: () =>
+      [opts.globalPath, ...(opts.configuredGlobalPaths ?? [])].some((path) =>
+        isProjectJSONServerConfigured(expandHome(path), opts.topKey, isOwned),
+      ),
+    projectConfigPath,
+    isProjectConfigured: (projectRoot: string) => {
+      const path = projectConfigPath(projectRoot);
+      return path ? isProjectJSONServerConfigured(path, opts.topKey, isCurrentProjectEntry) : false;
+    },
 
-    install(cfg: Config, global: boolean): void {
+    install(cfg: Config, global: boolean, installOpts = {}) {
       if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
         throw new Error("deployment ID is required");
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
       } else if (opts.localConfigPath) {
-        configPath = opts.localConfigPath(process.cwd());
+        const projectRoot = requireProjectRoot(installOpts.projectRoot);
+        configPath = opts.localConfigPath(projectRoot);
+        assertSafeProjectPath(projectRoot, configPath);
       } else {
-        throw new Error(`${opts.providerName} does not support local installation`);
+        throw new Error(`${opts.providerName} does not support project installation`);
       }
-      const serverBuilder = cfg.mode === MODE_OSS ? defaultBuildOSSServer : buildServer;
-      installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
+      if (global) {
+        const serverBuilder = cfg.mode === MODE_OSS ? defaultBuildOSSServer : buildServer;
+        installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
+      } else {
+        const desiredTarget =
+          cfg.mode === MODE_OSS
+            ? ({ oss: true } as const)
+            : { deploymentID: cfg.active_account?.target?.deployment_id as string };
+        return installProjectJSONServer(
+          configPath,
+          opts.topKey,
+          buildProjectServer(buildProjectProxyCommand(cfg)),
+          isOwned,
+          (current) => {
+            const currentTarget = ownedProjectProxyOptionsForProvider(opts.providerID, current);
+            if (
+              !installOpts.allowProjectRetarget &&
+              (!currentTarget || !sameProjectProxyTarget(currentTarget, desiredTarget))
+            ) {
+              throw new Error(
+                `Existing ${opts.providerName} project MCP targets something else; refusing to retarget. ` +
+                  "pass an explicit deployment to retarget it",
+              );
+            }
+          },
+        );
+      }
     },
 
-    remove(global: boolean): void {
+    remove(global: boolean, removeOpts = {}) {
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
       } else if (opts.localConfigPath) {
-        configPath = opts.localConfigPath(process.cwd());
+        const projectRoot = requireProjectRoot(removeOpts.projectRoot);
+        configPath = opts.localConfigPath(projectRoot);
+        assertSafeProjectPath(projectRoot, configPath);
       } else {
-        throw new Error(`${opts.providerName} does not support local removal`);
+        throw new Error(`${opts.providerName} does not support project removal`);
       }
-      removeJSONServer(configPath, opts.topKey);
+      if (global) removeJSONServer(configPath, opts.topKey);
+      else return removeProjectJSONServer(configPath, opts.topKey, isOwned);
     },
   };
 }

--- a/src/mcp/providers/claude-desktop.ts
+++ b/src/mcp/providers/claude-desktop.ts
@@ -24,9 +24,11 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
   isInstalled: () => isInstalled([join(appSupportDir(), "Claude")]),
   globalConfigPath: () => configPath(),
   isConfigured: () => isJSONKeyConfigured(configPath(), "mcpServers"),
+  projectConfigPath: () => null,
+  isProjectConfigured: () => false,
 
-  install(cfg: Config, global: boolean): void {
-    if (!global) throw new Error("Claude Desktop does not support local installation");
+  install(cfg: Config, global: boolean) {
+    if (!global) throw new Error("Claude Desktop does not support project installation");
     if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
       throw new Error("deployment ID is required");
     const url =
@@ -48,10 +50,12 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
       args: remote.args,
       env: { PATH: npxPathEnv(npx), ...remote.env },
     });
+    return undefined;
   },
 
-  remove(global: boolean): void {
-    if (!global) throw new Error("Claude Desktop does not support local removal");
+  remove(global: boolean) {
+    if (!global) throw new Error("Claude Desktop does not support project removal");
     removeJSONServer(configPath(), "mcpServers");
+    return undefined;
   },
 });

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -6,18 +6,39 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { parse as parseToml } from "smol-toml";
 import { type Config, MODE_OSS } from "../../config/config";
-import { mcpBaseURL, mcpRemoteServer, mcpURL, writeSecureFile } from "../config-helpers";
+import {
+  isExactProjectCodexProxy,
+  type ProjectProxyExpectation,
+  planCodexDosuMcp,
+} from "../../migration/planners";
+import { assertSafeProjectPath } from "../../setup/project-path";
+import { VERSION } from "../../version/version";
+import {
+  mcpBaseURL,
+  mcpRemoteServer,
+  mcpURL,
+  type ProjectFileMutationReceipt,
+  writeProjectFile,
+  writeSecureFile,
+} from "../config-helpers";
 import { expandHome, findNpx, isInstalled, npxPathEnv } from "../detect";
+import {
+  buildProjectProxyCommand,
+  ownedProjectProxyOptionsFromEntry,
+  sameProjectProxyTarget,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function codexHome(): string {
   return process.env.CODEX_HOME ?? expandHome("~/.codex");
 }
 
-function getConfigPath(global: boolean): string {
+function getConfigPath(global: boolean, projectRoot?: string): string {
   if (global) return join(codexHome(), "config.toml");
-  return join(process.cwd(), ".codex", "config.toml");
+  if (!projectRoot) throw new Error("Codex project installation requires a verified project root");
+  return join(projectRoot, ".codex", "config.toml");
 }
 
 /**
@@ -29,8 +50,14 @@ function readTOML(path: string): string {
   return readFileSync(path, "utf-8");
 }
 
-function writeTOML(path: string, content: string): void {
-  writeSecureFile(path, content);
+function writeTOML(
+  path: string,
+  content: string,
+  global: boolean,
+  expectedProjectContent?: string | null,
+): ProjectFileMutationReceipt | undefined {
+  if (global) writeSecureFile(path, content);
+  else return writeProjectFile(path, content, expectedProjectContent);
 }
 
 function mcpEndpoint(cfg: Config): string {
@@ -43,11 +70,75 @@ function tomlString(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function installDosuToTOML(path: string, cfg: Config): void {
+function projectExpectation(cfg: Config): ProjectProxyExpectation {
+  if (cfg.mode === MODE_OSS) return { packageVersion: VERSION, oss: true };
+  const deploymentID = cfg.active_account?.target?.deployment_id;
+  if (!deploymentID) throw new Error("deployment ID is required");
+  return { packageVersion: VERSION, deploymentID };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function existingProjectTarget(content: string): {
+  present: boolean;
+  target: ReturnType<typeof ownedProjectProxyOptionsFromEntry>;
+} {
+  if (!content.trim()) return { present: false, target: null };
+  try {
+    const parsed: unknown = parseToml(content);
+    if (!isRecord(parsed) || !isRecord(parsed.mcp_servers)) {
+      return { present: false, target: null };
+    }
+    if (!Object.hasOwn(parsed.mcp_servers, "dosu")) return { present: false, target: null };
+    return {
+      present: true,
+      target: ownedProjectProxyOptionsFromEntry(parsed.mcp_servers.dosu),
+    };
+  } catch {
+    return { present: true, target: null };
+  }
+}
+
+function removeOwnedDosuFromTOML(content: string): string {
+  const plan = planCodexDosuMcp(content, {
+    projectProxy: "any",
+    allowLegacyGlobal: true,
+  });
+  if (plan.disposition === "preserved_ambiguous") {
+    throw new Error("Found a non-Dosu or ambiguous Codex server named dosu; refusing to modify it");
+  }
+  return plan.disposition === "remove" ? (plan.nextContent ?? content) : content;
+}
+
+function installDosuToTOML(
+  path: string,
+  cfg: Config,
+  global: boolean,
+  allowProjectRetarget = false,
+): ProjectFileMutationReceipt | undefined {
+  const projectFileExisted = !global && existsSync(path);
   let content = readTOML(path);
-  // Remove existing [mcp_servers.dosu] section if present (including the
-  // legacy [mcp_servers.dosu.http_headers] subtable from the remote-HTTP form)
-  content = removeDosuFromTOML(content);
+  const originalContent = content;
+  if (!global) {
+    const current = existingProjectTarget(content);
+    const expectation = projectExpectation(cfg);
+    const desired = expectation.oss
+      ? ({ oss: true } as const)
+      : { deploymentID: expectation.deploymentID };
+    if (
+      current.present &&
+      !allowProjectRetarget &&
+      (!current.target || !sameProjectProxyTarget(current.target, desired))
+    ) {
+      throw new Error(
+        "Existing Codex project MCP targets something else; refusing to retarget. " +
+          "Pass an explicit deployment to retarget it",
+      );
+    }
+  }
+  content = removeOwnedDosuFromTOML(content);
   // Codex desktop only renders MCP Apps (the Session Knowledge card) for
   // locally spawned stdio servers — a remote-HTTP entry serves tools fine
   // but never shows the card — so proxy the endpoint through `npx
@@ -58,40 +149,29 @@ function installDosuToTOML(path: string, cfg: Config): void {
   // with an explicit PATH because this config is shared with Codex desktop,
   // which launches from the Dock with the minimal launchd PATH — the same
   // pitfall as Claude Desktop.
-  const npx = findNpx();
-  const remote = mcpRemoteServer(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
-  const env: Record<string, string> = { PATH: npxPathEnv(npx), ...remote.env };
-  const envEntries = Object.entries(env)
-    .map(([key, value]) => `${key} = ${tomlString(value)}`)
-    .join("\n");
-  const args = remote.args.map(tomlString).join(", ");
-  const section =
-    `\n[mcp_servers.dosu]\ncommand = ${tomlString(npx)}\nargs = [${args}]\n` +
-    `\n[mcp_servers.dosu.env]\n${envEntries}\n`;
-  content += section;
-  writeTOML(path, content);
-}
-
-function removeDosuFromTOML(content: string): string {
-  // Remove [mcp_servers.dosu] and [mcp_servers.dosu.*] sections
-  const lines = content.split("\n");
-  const result: string[] = [];
-  let inDosuSection = false;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed.match(/^\[mcp_servers\.dosu(\..*)?]$/)) {
-      inDosuSection = true;
-      continue;
-    }
-    if (inDosuSection && trimmed.startsWith("[")) {
-      inDosuSection = false;
-    }
-    if (!inDosuSection) {
-      result.push(line);
+  let section: string;
+  if (global) {
+    const npx = findNpx();
+    const remote = mcpRemoteServer(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
+    const env: Record<string, string> = { PATH: npxPathEnv(npx), ...remote.env };
+    const envEntries = Object.entries(env)
+      .map(([key, value]) => `${key} = ${tomlString(value)}`)
+      .join("\n");
+    const args = remote.args.map(tomlString).join(", ");
+    section =
+      `\n[mcp_servers.dosu]\ncommand = ${tomlString(npx)}\nargs = [${args}]\n` +
+      `\n[mcp_servers.dosu.env]\n${envEntries}\n`;
+  } else {
+    const expectation = projectExpectation(cfg);
+    const command = buildProjectProxyCommand(cfg);
+    const args = command.args.map(tomlString).join(", ");
+    section = `\n[mcp_servers.dosu]\ncommand = ${tomlString(command.command)}\nargs = [${args}]\n`;
+    if (command.args[1] !== `@dosu/cli@${expectation.packageVersion}`) {
+      throw new Error("Project proxy version mismatch");
     }
   }
-  return result.join("\n");
+  content += section;
+  return writeTOML(path, content, global, projectFileExisted ? originalContent : null);
 }
 
 export const CodexProvider = (): SetupProvider => ({
@@ -104,16 +184,24 @@ export const CodexProvider = (): SetupProvider => ({
   globalConfigPath: () => join(codexHome(), "config.toml"),
   isConfigured: () => {
     const content = readTOML(join(codexHome(), "config.toml"));
-    return content.includes("[mcp_servers.dosu]");
+    return planCodexDosuMcp(content).disposition === "remove";
   },
-  install(cfg: Config, global: boolean): void {
+  projectConfigPath: (projectRoot) => join(projectRoot, ".codex", "config.toml"),
+  isProjectConfigured: (projectRoot) => {
+    const content = readTOML(join(projectRoot, ".codex", "config.toml"));
+    return isExactProjectCodexProxy(content);
+  },
+  install(cfg: Config, global: boolean, opts = {}) {
     if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
       throw new Error("deployment ID is required");
-    installDosuToTOML(getConfigPath(global), cfg);
+    const path = getConfigPath(global, opts.projectRoot);
+    if (!global) assertSafeProjectPath(opts.projectRoot as string, path);
+    return installDosuToTOML(path, cfg, global, opts.allowProjectRetarget);
   },
-  remove(global: boolean): void {
-    const path = getConfigPath(global);
+  remove(global: boolean, opts = {}) {
+    const path = getConfigPath(global, opts.projectRoot);
+    if (!global) assertSafeProjectPath(opts.projectRoot as string, path);
     const content = readTOML(path);
-    if (content) writeTOML(path, removeDosuFromTOML(content));
+    if (content) return writeTOML(path, removeOwnedDosuFromTOML(content), global, content);
   },
 });

--- a/src/mcp/providers/copilot.ts
+++ b/src/mcp/providers/copilot.ts
@@ -1,14 +1,23 @@
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-path";
 import {
   installJSONServer,
-  isJSONKeyConfigured,
+  installProjectJSONServer,
+  isProjectJSONServerConfigured,
   mcpBaseURL,
   mcpHeaders,
   mcpURL,
   removeJSONServer,
+  removeProjectJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import {
+  buildProjectProxyCommand,
+  isDosuMcpEntryForProvider,
+  ownedProjectProxyOptionsForProvider,
+  sameProjectProxyTarget,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function globalPath(): string {
@@ -24,6 +33,12 @@ function mcpEndpoint(cfg: Config): string {
   return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
+function requireProjectRoot(projectRoot: string | undefined): string {
+  if (!projectRoot)
+    throw new Error("Copilot project installation requires a verified project root");
+  return projectRoot;
+}
+
 export const CopilotProvider = (): SetupProvider => ({
   name: () => "GitHub Copilot CLI",
   id: () => "copilot",
@@ -32,9 +47,17 @@ export const CopilotProvider = (): SetupProvider => ({
   detectPaths: () => [expandHome("~/.copilot")],
   isInstalled: () => isInstalled([expandHome("~/.copilot")]),
   globalConfigPath: () => globalPath(),
-  isConfigured: () => isJSONKeyConfigured(globalPath(), "mcpServers"),
+  isConfigured: () =>
+    isProjectJSONServerConfigured(globalPath(), "mcpServers", (entry) =>
+      isDosuMcpEntryForProvider("copilot", entry),
+    ),
+  projectConfigPath: (projectRoot) => join(projectRoot, ".mcp.json"),
+  isProjectConfigured: (projectRoot) =>
+    isProjectJSONServerConfigured(join(projectRoot, ".mcp.json"), "mcpServers", (entry) =>
+      Boolean(ownedProjectProxyOptionsForProvider("copilot", entry)),
+    ),
 
-  install(cfg: Config, global: boolean): void {
+  install(cfg: Config, global: boolean, opts = {}) {
     const url = mcpEndpoint(cfg);
 
     if (global) {
@@ -47,23 +70,50 @@ export const CopilotProvider = (): SetupProvider => ({
       };
       installJSONServer(globalPath(), "mcpServers", server);
     } else {
-      const configPath = join(process.cwd(), ".vscode", "mcp.json");
+      const projectRoot = requireProjectRoot(opts.projectRoot);
+      const configPath = join(projectRoot, ".mcp.json");
+      assertSafeProjectPath(projectRoot, configPath);
+      const command = buildProjectProxyCommand(cfg);
+      const desiredTarget =
+        cfg.mode === MODE_OSS
+          ? ({ oss: true } as const)
+          : { deploymentID: cfg.active_account?.target?.deployment_id as string };
       const server = {
-        type: "http",
-        url,
-        // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-        headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+        type: "stdio",
+        command: command.command,
+        args: command.args,
       };
-      installJSONServer(configPath, "servers", server);
+      return installProjectJSONServer(
+        configPath,
+        "mcpServers",
+        server,
+        (entry) => isDosuMcpEntryForProvider("copilot", entry),
+        (current) => {
+          const currentTarget = ownedProjectProxyOptionsForProvider("copilot", current);
+          if (
+            !opts.allowProjectRetarget &&
+            (!currentTarget || !sameProjectProxyTarget(currentTarget, desiredTarget))
+          ) {
+            throw new Error(
+              "Existing GitHub Copilot CLI project MCP targets something else; refusing to retarget. " +
+                "Pass an explicit deployment to retarget it",
+            );
+          }
+        },
+      );
     }
   },
 
-  remove(global: boolean): void {
+  remove(global: boolean, opts = {}) {
     if (global) {
       removeJSONServer(globalPath(), "mcpServers");
     } else {
-      const configPath = join(process.cwd(), ".vscode", "mcp.json");
-      removeJSONServer(configPath, "servers");
+      const projectRoot = requireProjectRoot(opts.projectRoot);
+      const configPath = join(projectRoot, ".mcp.json");
+      assertSafeProjectPath(projectRoot, configPath);
+      return removeProjectJSONServer(configPath, "mcpServers", (entry) =>
+        isDosuMcpEntryForProvider("copilot", entry),
+      );
     }
   },
 });

--- a/src/mcp/providers/gemini.ts
+++ b/src/mcp/providers/gemini.ts
@@ -10,5 +10,6 @@ export const GeminiProvider = () =>
     paths: ["~/.gemini"],
     globalPath: "~/.gemini/settings.json",
     topKey: "mcpServers",
+    buildProjectServer: (command) => ({ command: command.command, args: command.args }),
     localConfigPath: (cwd) => join(cwd, ".gemini", "settings.json"),
   });

--- a/src/mcp/providers/manual.ts
+++ b/src/mcp/providers/manual.ts
@@ -19,7 +19,7 @@ export const ManualProvider = (): Provider => ({
   id: () => "manual",
   supportsLocal: () => false,
 
-  install(cfg: Config, _global: boolean, opts: ProviderInstallOptions = {}): void {
+  install(cfg: Config, _global: boolean, opts: ProviderInstallOptions = {}) {
     const url = mcpEndpoint(cfg);
     const apiKey = mcpHeaders(cfg.active_account?.target?.api_key)["X-Dosu-API-Key"];
     const headerValue = opts.showSecret ? apiKey : maskSecret(apiKey);
@@ -33,11 +33,13 @@ export const ManualProvider = (): Provider => ({
       console.log("  Secret hidden. Re-run with --show-secret to print the full API key.");
     }
     console.log();
+    return undefined;
   },
 
-  remove(): void {
+  remove() {
     console.log(
       "\nTo remove the Dosu MCP server, manually delete the configuration from your client.",
     );
+    return undefined;
   },
 });

--- a/src/mcp/providers/mcporter.ts
+++ b/src/mcp/providers/mcporter.ts
@@ -1,15 +1,24 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-path";
 import {
   installJSONServer,
-  isJSONKeyConfigured,
+  installProjectJSONServer,
+  isProjectJSONServerConfigured,
   mcpBaseURL,
   mcpHeaders,
   mcpURL,
   removeJSONServer,
+  removeProjectJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import {
+  buildProjectProxyCommand,
+  isDosuMcpEntryForProvider,
+  ownedProjectProxyOptionsForProvider,
+  sameProjectProxyTarget,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function resolveGlobalConfigPath(): string {
@@ -26,6 +35,12 @@ function mcpEndpoint(cfg: Config): string {
   return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
+function requireProjectRoot(projectRoot: string | undefined): string {
+  if (!projectRoot)
+    throw new Error("MCPorter project installation requires a verified project root");
+  return projectRoot;
+}
+
 export const MCPorterProvider = (): SetupProvider => ({
   name: () => "MCPorter",
   id: () => "mcporter",
@@ -34,25 +49,69 @@ export const MCPorterProvider = (): SetupProvider => ({
   detectPaths: () => ["~/.mcporter"],
   isInstalled: () => isInstalled(["~/.mcporter"]),
   globalConfigPath: () => resolveGlobalConfigPath(),
-  isConfigured: () => isJSONKeyConfigured(resolveGlobalConfigPath(), "mcpServers"),
+  isConfigured: () =>
+    isProjectJSONServerConfigured(resolveGlobalConfigPath(), "mcpServers", (entry) =>
+      isDosuMcpEntryForProvider("mcporter", entry),
+    ),
+  projectConfigPath: (projectRoot) => join(projectRoot, "config", "mcporter.json"),
+  isProjectConfigured: (projectRoot) =>
+    isProjectJSONServerConfigured(
+      join(projectRoot, "config", "mcporter.json"),
+      "mcpServers",
+      (entry) => Boolean(ownedProjectProxyOptionsForProvider("mcporter", entry)),
+    ),
 
-  install(cfg: Config, global: boolean): void {
+  install(cfg: Config, global: boolean, opts = {}) {
+    const projectRoot = global ? undefined : requireProjectRoot(opts.projectRoot);
     const configPath = global
       ? resolveGlobalConfigPath()
-      : join(process.cwd(), "config", "mcporter.json");
-    const server = {
-      type: "http",
-      url: mcpEndpoint(cfg),
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
-    };
-    installJSONServer(configPath, "mcpServers", server);
+      : join(projectRoot as string, "config", "mcporter.json");
+    if (projectRoot) assertSafeProjectPath(projectRoot, configPath);
+    if (global) {
+      const server = {
+        type: "http",
+        url: mcpEndpoint(cfg),
+        // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
+        headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+      };
+      installJSONServer(configPath, "mcpServers", server);
+    } else {
+      const command = buildProjectProxyCommand(cfg);
+      const desiredTarget =
+        cfg.mode === MODE_OSS
+          ? ({ oss: true } as const)
+          : { deploymentID: cfg.active_account?.target?.deployment_id as string };
+      return installProjectJSONServer(
+        configPath,
+        "mcpServers",
+        { command: command.command, args: command.args },
+        (entry) => isDosuMcpEntryForProvider("mcporter", entry),
+        (current) => {
+          const currentTarget = ownedProjectProxyOptionsForProvider("mcporter", current);
+          if (
+            !opts.allowProjectRetarget &&
+            (!currentTarget || !sameProjectProxyTarget(currentTarget, desiredTarget))
+          ) {
+            throw new Error(
+              "Existing MCPorter project MCP targets something else; refusing to retarget. " +
+                "Pass an explicit deployment to retarget it",
+            );
+          }
+        },
+      );
+    }
   },
 
-  remove(global: boolean): void {
+  remove(global: boolean, opts = {}) {
+    const projectRoot = global ? undefined : requireProjectRoot(opts.projectRoot);
     const configPath = global
       ? resolveGlobalConfigPath()
-      : join(process.cwd(), "config", "mcporter.json");
-    removeJSONServer(configPath, "mcpServers");
+      : join(projectRoot as string, "config", "mcporter.json");
+    if (projectRoot) assertSafeProjectPath(projectRoot, configPath);
+    if (global) removeJSONServer(configPath, "mcpServers");
+    else
+      return removeProjectJSONServer(configPath, "mcpServers", (entry) =>
+        isDosuMcpEntryForProvider("mcporter", entry),
+      );
   },
 });

--- a/src/mcp/providers/opencode.ts
+++ b/src/mcp/providers/opencode.ts
@@ -19,5 +19,10 @@ export const OpenCodeProvider = () =>
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
+    buildProjectServer: (command) => ({
+      type: "local",
+      command: [command.command, ...command.args],
+      enabled: true,
+    }),
     localConfigPath: (cwd) => join(cwd, "opencode.json"),
   });

--- a/src/mcp/providers/project-install.test.ts
+++ b/src/mcp/providers/project-install.test.ts
@@ -1,0 +1,325 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Config } from "../../config/config";
+import { makeTestConfig } from "../../config/config.test-utils";
+import { loadJSONConfig } from "../config-helpers";
+import { allSetupProviders } from "../providers";
+
+const SECRET = "project-config-must-not-contain-this-key";
+
+function config(): Config {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 60_000,
+    deployment_id: "dep-project",
+    deployment_name: "Project brain",
+    api_key: SECRET,
+    mcp_endpoint: "https://api.dosu.dev/v1/mcp/deployments/dep-project",
+  });
+}
+
+interface JSONExpectation {
+  provider: string;
+  relativePath: string;
+  topKey: string;
+  type?: string;
+  commandArray?: boolean;
+}
+
+const JSON_PROJECT_PROVIDERS: JSONExpectation[] = [
+  { provider: "claude", relativePath: ".mcp.json", topKey: "mcpServers", type: "stdio" },
+  { provider: "cursor", relativePath: ".cursor/mcp.json", topKey: "mcpServers", type: "stdio" },
+  { provider: "vscode", relativePath: ".vscode/mcp.json", topKey: "servers", type: "stdio" },
+  { provider: "gemini", relativePath: ".gemini/settings.json", topKey: "mcpServers" },
+  { provider: "zed", relativePath: ".zed/settings.json", topKey: "context_servers" },
+  // Claude and Copilot intentionally share the cross-client .mcp.json contract.
+  { provider: "copilot", relativePath: ".mcp.json", topKey: "mcpServers", type: "stdio" },
+  {
+    provider: "opencode",
+    relativePath: "opencode.json",
+    topKey: "mcp",
+    type: "local",
+    commandArray: true,
+  },
+  { provider: "antigravity", relativePath: ".agents/mcp_config.json", topKey: "mcpServers" },
+  { provider: "mcporter", relativePath: "config/mcporter.json", topKey: "mcpServers" },
+  { provider: "factory", relativePath: ".factory/mcp.json", topKey: "mcpServers", type: "stdio" },
+];
+
+let tempDir: string;
+let projectRoot: string;
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-project-providers-"));
+  projectRoot = join(tempDir, "repo");
+  mkdirSync(projectRoot, { recursive: true });
+  originalEnv = { ...process.env };
+  process.env.HOME = join(tempDir, "home");
+  process.env.XDG_CONFIG_HOME = join(tempDir, "xdg");
+  process.env.APPDATA = join(tempDir, "appdata");
+  process.env.CODEX_HOME = join(tempDir, "codex-home");
+  const binDir = join(tempDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(binDir, process.platform === "win32" ? "npx.cmd" : "npx"), "", {
+    mode: 0o755,
+  });
+  process.env.PATH = binDir;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("project-scoped MCP provider entries", () => {
+  it("never falls back to an arbitrary current working directory", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false)).toThrow(/verified project root/i);
+  });
+
+  it.each(
+    JSON_PROJECT_PROVIDERS,
+  )("$provider writes the official project schema without credentials", ({
+    provider: id,
+    relativePath,
+    topKey,
+    type,
+    commandArray,
+  }) => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === id);
+    expect(provider).toBeDefined();
+
+    const receipt = provider?.install(config(), false, { projectRoot });
+
+    const path = join(projectRoot, relativePath);
+    expect(provider?.projectConfigPath(projectRoot)).toBe(path);
+    const entry = loadJSONConfig(path)[topKey].dosu;
+    if (type) expect(entry.type).toBe(type);
+    if (commandArray) {
+      expect(entry.command).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-project"]));
+    } else {
+      expect(entry.command).toBe("npx");
+      expect(entry.args).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-project"]));
+    }
+    const raw = readFileSync(path, "utf8");
+    expect(receipt).toMatchObject({
+      path,
+      beforeContent: null,
+      beforeMode: null,
+      afterContent: raw,
+      afterMode: 0o644,
+    });
+    expect(statSync(path).mode & 0o777).toBe(0o644);
+    expect(raw).not.toContain(SECRET);
+    expect(raw).not.toContain("X-Dosu-API-Key");
+    expect(raw).not.toContain("api.dosu.dev");
+    expect(provider?.isProjectConfigured(projectRoot)).toBe(true);
+  });
+
+  it("Codex writes a secretless project TOML entry", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "codex");
+    const receipt = provider?.install(config(), false, { projectRoot });
+
+    const path = join(projectRoot, ".codex", "config.toml");
+    const raw = readFileSync(path, "utf8");
+    expect(receipt).toMatchObject({
+      path,
+      beforeContent: null,
+      beforeMode: null,
+      afterContent: raw,
+      afterMode: 0o644,
+    });
+    expect(statSync(path).mode & 0o777).toBe(0o644);
+    expect(raw).toContain("[mcp_servers.dosu]");
+    expect(raw).toContain('command = "npx"');
+    expect(raw).toContain('"mcp", "proxy"');
+    expect(raw).not.toContain(SECRET);
+    expect(raw).not.toContain("X-Dosu-API-Key");
+    expect(raw).not.toContain("api.dosu.dev");
+    expect(provider?.projectConfigPath(projectRoot)).toBe(path);
+    expect(provider?.isProjectConfigured(projectRoot)).toBe(true);
+  });
+
+  it("Codex refuses to overwrite or remove a foreign server named dosu", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "codex");
+    const path = join(projectRoot, ".codex", "config.toml");
+    mkdirSync(join(projectRoot, ".codex"), { recursive: true });
+    const foreign = '[mcp_servers.dosu]\ncommand = "my-company-server"\nargs = []\n';
+    writeFileSync(path, foreign);
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/refusing/i);
+    expect(() => provider?.remove(false, { projectRoot })).toThrow(/refusing/i);
+    expect(readFileSync(path, "utf8")).toBe(foreign);
+  });
+
+  it("Codex refuses an invalid TOML document even when it contains an exact proxy table", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "codex");
+    provider?.install(config(), false, { projectRoot });
+    const path = join(projectRoot, ".codex", "config.toml");
+    const invalid = `not valid toml !!!\n${readFileSync(path, "utf8")}`;
+    writeFileSync(path, invalid);
+
+    expect(provider?.isProjectConfigured(projectRoot)).toBe(false);
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/refusing/i);
+    expect(readFileSync(path, "utf8")).toBe(invalid);
+  });
+
+  it("uses the explicit Git root instead of process.cwd()", () => {
+    const nested = join(projectRoot, "packages", "api");
+    mkdirSync(nested, { recursive: true });
+    const originalCwd = process.cwd();
+    process.chdir(nested);
+    try {
+      const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+      provider?.install(config(), false, { projectRoot });
+      expect(existsSync(join(projectRoot, ".cursor", "mcp.json"))).toBe(true);
+      expect(existsSync(join(nested, ".cursor", "mcp.json"))).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it.each([
+    "claude-desktop",
+    "windsurf",
+    "cline",
+    "cline-cli",
+  ])("%s remains unsupported instead of silently falling back to global", (id) => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === id);
+    expect(provider?.supportsLocal()).toBe(false);
+    expect(provider?.projectConfigPath(projectRoot)).toBeNull();
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(
+      /does not support project/i,
+    );
+  });
+
+  it("refuses to overwrite a non-Dosu server that happens to use the dosu name", () => {
+    const path = join(projectRoot, ".cursor", "mcp.json");
+    mkdirSync(join(projectRoot, ".cursor"), { recursive: true });
+    writeFileSync(path, JSON.stringify({ mcpServers: { dosu: { command: "my-company-server" } } }));
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(
+      /non-Dosu server named "dosu"/i,
+    );
+    expect(readFileSync(path, "utf8")).toContain("my-company-server");
+  });
+
+  it.each(
+    JSON_PROJECT_PROVIDERS,
+  )("$provider preserves a same-shaped server on a foreign origin during removal", ({
+    provider: id,
+    relativePath,
+    topKey,
+  }) => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === id);
+    const path = join(projectRoot, relativePath);
+    mkdirSync(join(path, ".."), { recursive: true });
+    const url = "https://foreign.example/v1/mcp/deployments/dep-project";
+    const headers = { "X-Dosu-API-Key": "foreign-key" };
+    const entry =
+      id === "cursor"
+        ? { url, headers }
+        : id === "opencode"
+          ? { type: "remote", enabled: true, url, headers }
+          : id === "zed"
+            ? { source: "custom", type: "http", url, headers }
+            : id === "antigravity"
+              ? { serverUrl: url, headers }
+              : id === "copilot"
+                ? { type: "http", url, tools: ["*"], headers }
+                : { type: "http", url, headers };
+    const original = JSON.stringify({ [topKey]: { dosu: entry, user: { command: "keep" } } });
+    writeFileSync(path, original);
+
+    expect(() => provider?.remove(false, { projectRoot })).toThrow(/refusing/i);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it("Codex preserves a same-shaped HTTP server on a foreign origin during removal", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "codex");
+    const path = join(projectRoot, ".codex", "config.toml");
+    mkdirSync(join(projectRoot, ".codex"), { recursive: true });
+    const original = `[mcp_servers.dosu]\ntype = "http"\nurl = "https://foreign.example/v1/mcp/deployments/dep-project"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "foreign-key"\n`;
+    writeFileSync(path, original);
+
+    expect(() => provider?.remove(false, { projectRoot })).toThrow(/refusing/i);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  it("refuses a project MCP config symlink that could escape the repository", () => {
+    const outside = join(tempDir, "outside.json");
+    writeFileSync(outside, JSON.stringify({ mcpServers: {} }));
+    mkdirSync(join(projectRoot, ".cursor"), { recursive: true });
+    symlinkSync(outside, join(projectRoot, ".cursor", "mcp.json"));
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/symbolic link/i);
+    expect(readFileSync(outside, "utf8")).toBe(JSON.stringify({ mcpServers: {} }));
+  });
+
+  it("refuses a symlinked project config directory", () => {
+    const outside = join(tempDir, "outside-dir");
+    mkdirSync(outside);
+    symlinkSync(outside, join(projectRoot, ".cursor"));
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/symbolic link/i);
+    expect(existsSync(join(outside, "mcp.json"))).toBe(false);
+  });
+
+  it("refuses duplicate JSON properties instead of guessing which value owns the file", () => {
+    const path = join(projectRoot, ".cursor", "mcp.json");
+    mkdirSync(join(projectRoot, ".cursor"), { recursive: true });
+    writeFileSync(
+      path,
+      '{"mcpServers":{"dosu":{"command":"foreign"},"dosu":{"command":"foreign-2"}}}',
+    );
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+
+    expect(() => provider?.install(config(), false, { projectRoot })).toThrow(/duplicate/i);
+  });
+
+  it("removes a project entry without rewriting sibling JSONC bytes", () => {
+    const provider = allSetupProviders().find((candidate) => candidate.id() === "cursor");
+    provider?.install(config(), false, { projectRoot });
+    const path = join(projectRoot, ".cursor", "mcp.json");
+    const owned = loadJSONConfig(path).mcpServers.dosu;
+    const before = `{
+  // keep this root comment
+  "mcpServers": {
+    "user": {"url":"x"}, // keep this user comment
+    "dosu": ${JSON.stringify(owned)}
+  },
+  "other": [1,2,3]
+}
+`;
+    writeFileSync(path, before);
+
+    provider?.remove(false, { projectRoot });
+
+    expect(readFileSync(path, "utf8")).toBe(`{
+  // keep this root comment
+  "mcpServers": {
+    "user": {"url":"x"} // keep this user comment
+${"    "}
+  },
+  "other": [1,2,3]
+}
+`);
+  });
+});

--- a/src/mcp/providers/project-retarget.test.ts
+++ b/src/mcp/providers/project-retarget.test.ts
@@ -1,0 +1,222 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { parse as parseJSONC } from "jsonc-parser/lib/esm/main.js";
+import { parse as parseToml } from "smol-toml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Config } from "../../config/config";
+import { makeTestConfig } from "../../config/config.test-utils";
+import { VERSION } from "../../version/version";
+import { ownedProjectProxyOptionsFromEntry, type ProjectProxyOptions } from "../project-proxy";
+import type { SetupProvider } from "../providers";
+import { CodexProvider } from "./codex";
+import { CopilotProvider } from "./copilot";
+import { CursorProvider } from "./cursor";
+import { MCPorterProvider } from "./mcporter";
+
+const HISTORICAL_VERSION = "0.42.0";
+
+type ProjectProviderCase = {
+  id: "cursor" | "codex" | "copilot" | "mcporter";
+  create: () => SetupProvider;
+  relativePath: string;
+};
+
+const PROJECT_PROVIDERS: ProjectProviderCase[] = [
+  { id: "cursor", create: CursorProvider, relativePath: ".cursor/mcp.json" },
+  { id: "codex", create: CodexProvider, relativePath: ".codex/config.toml" },
+  { id: "copilot", create: CopilotProvider, relativePath: ".mcp.json" },
+  { id: "mcporter", create: MCPorterProvider, relativePath: "config/mcporter.json" },
+];
+
+function cloudConfig(deploymentID: string): Config {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 60_000,
+    deployment_id: deploymentID,
+    deployment_name: deploymentID,
+    api_key: `key-for-${deploymentID}`,
+    mcp_endpoint: `https://api.dosu.dev/v1/mcp/deployments/${deploymentID}`,
+  });
+}
+
+function ossConfig(): Config {
+  return makeTestConfig({
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 60_000,
+    mode: "oss",
+    api_key: "key-for-oss",
+    mcp_endpoint: "https://api.dosu.dev/v1/mcp",
+  });
+}
+
+function proxyArgs(target: ProjectProxyOptions, packageVersion = HISTORICAL_VERSION): string[] {
+  const prefix = ["-y", `@dosu/cli@${packageVersion}`, "mcp", "proxy"];
+  return target.oss
+    ? [...prefix, "--oss"]
+    : [...prefix, "--deployment", target.deploymentID as string];
+}
+
+function historicalFixture(id: ProjectProviderCase["id"], target: ProjectProxyOptions): string {
+  const args = proxyArgs(target);
+  if (id !== "codex") {
+    const entry = {
+      ...(id === "cursor" || id === "copilot" ? { type: "stdio" } : {}),
+      command: "npx",
+      args,
+    };
+    return `{
+  // unrelated project setting: preserve this comment
+  "mcpServers": {
+    "other": { "command": "other-server", "args": [] },
+    "dosu": ${JSON.stringify(entry)}
+  },
+  "userSetting": "preserve-me"
+}
+`;
+  }
+
+  return `# unrelated project setting: preserve this comment
+model = "preserve-me"
+
+[mcp_servers.other]
+command = "other-server"
+args = []
+
+[mcp_servers.dosu]
+command = "npx"
+args = ${JSON.stringify(args)}
+`;
+}
+
+function writeHistoricalFixture(
+  providerCase: ProjectProviderCase,
+  projectRoot: string,
+  target: ProjectProxyOptions,
+): string {
+  const path = join(projectRoot, providerCase.relativePath);
+  mkdirSync(dirname(path), { recursive: true });
+  const content = historicalFixture(providerCase.id, target);
+  writeFileSync(path, content);
+  return content;
+}
+
+function readEntry(providerCase: ProjectProviderCase, projectRoot: string): unknown {
+  const path = join(projectRoot, providerCase.relativePath);
+  if (providerCase.id !== "codex") {
+    const parsed = parseJSONC(readFileSync(path, "utf8")) as {
+      mcpServers?: { dosu?: unknown };
+    };
+    return parsed.mcpServers?.dosu;
+  }
+  const parsed = parseToml(readFileSync(path, "utf8")) as {
+    mcp_servers?: { dosu?: unknown };
+  };
+  return parsed.mcp_servers?.dosu;
+}
+
+function expectCurrentTarget(
+  providerCase: ProjectProviderCase,
+  projectRoot: string,
+  expected: ProjectProxyOptions,
+): void {
+  const path = join(projectRoot, providerCase.relativePath);
+  const raw = readFileSync(path, "utf8");
+  expect(raw).toContain(`@dosu/cli@${VERSION}`);
+  expect(raw).toContain("unrelated project setting: preserve this comment");
+  expect(raw).toContain("preserve-me");
+  expect(ownedProjectProxyOptionsFromEntry(readEntry(providerCase, projectRoot))).toEqual(expected);
+}
+
+let tempDir: string;
+let projectRoot: string;
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-project-retarget-"));
+  projectRoot = join(tempDir, "repo");
+  mkdirSync(projectRoot, { recursive: true });
+  originalEnv = { ...process.env };
+  process.env.HOME = join(tempDir, "home");
+  process.env.XDG_CONFIG_HOME = join(tempDir, "xdg");
+  process.env.CODEX_HOME = join(tempDir, "codex-home");
+  const binDir = join(tempDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(binDir, process.platform === "win32" ? "npx.cmd" : "npx"), "", {
+    mode: 0o755,
+  });
+  process.env.PATH = binDir;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe.each(PROJECT_PROVIDERS)("$id project target safety", (providerCase) => {
+  it("recognizes an exact project proxy emitted by a historical CLI version", () => {
+    const provider = providerCase.create();
+    writeHistoricalFixture(providerCase, projectRoot, { deploymentID: "deployment-a" });
+
+    expect(provider.isProjectConfigured(projectRoot)).toBe(true);
+  });
+
+  it("refreshes a historical proxy for the same deployment without retarget permission", () => {
+    const provider = providerCase.create();
+    writeHistoricalFixture(providerCase, projectRoot, { deploymentID: "deployment-a" });
+
+    provider.install(cloudConfig("deployment-a"), false, { projectRoot });
+
+    expectCurrentTarget(providerCase, projectRoot, { deploymentID: "deployment-a" });
+  });
+
+  it("preserves every byte when a different deployment is not explicitly authorized", () => {
+    const provider = providerCase.create();
+    const original = writeHistoricalFixture(providerCase, projectRoot, {
+      deploymentID: "deployment-a",
+    });
+    const path = join(projectRoot, providerCase.relativePath);
+
+    expect(() => provider.install(cloudConfig("deployment-b"), false, { projectRoot })).toThrow(
+      /retarget/i,
+    );
+    expect(readFileSync(path, "utf8")).toBe(original);
+
+    provider.install(cloudConfig("deployment-b"), false, {
+      projectRoot,
+      allowProjectRetarget: true,
+    });
+    expectCurrentTarget(providerCase, projectRoot, { deploymentID: "deployment-b" });
+  });
+
+  it.each([
+    {
+      label: "cloud to OSS",
+      existing: { deploymentID: "deployment-a" } as ProjectProxyOptions,
+      desiredConfig: ossConfig,
+      expected: { oss: true } as ProjectProxyOptions,
+    },
+    {
+      label: "OSS to cloud",
+      existing: { oss: true } as ProjectProxyOptions,
+      desiredConfig: () => cloudConfig("deployment-a"),
+      expected: { deploymentID: "deployment-a" } as ProjectProxyOptions,
+    },
+  ])("requires explicit retarget permission for $label", ({
+    existing,
+    desiredConfig,
+    expected,
+  }) => {
+    const provider = providerCase.create();
+    const original = writeHistoricalFixture(providerCase, projectRoot, existing);
+    const path = join(projectRoot, providerCase.relativePath);
+
+    expect(() => provider.install(desiredConfig(), false, { projectRoot })).toThrow(/retarget/i);
+    expect(readFileSync(path, "utf8")).toBe(original);
+
+    provider.install(desiredConfig(), false, { projectRoot, allowProjectRetarget: true });
+    expectCurrentTarget(providerCase, projectRoot, expected);
+  });
+});

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -124,7 +124,9 @@ describe("createJSONProvider (base)", () => {
       topKey: "mcpServers",
     });
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support project installation",
+    );
   });
 
   it("local install writes to localConfigPath when provided", async () => {
@@ -141,11 +143,13 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: () => localPath,
     });
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const cfg = loadJSONConfig(localPath);
     expect(cfg.mcpServers.dosu).toBeDefined();
-    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.args).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-123"]));
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
   it("global remove deletes dosu entry from JSON config", async () => {
@@ -187,15 +191,12 @@ describe("createJSONProvider (base)", () => {
       topKey: "mcpServers",
     });
 
-    expect(() => provider.remove(false)).toThrow("does not support local removal");
+    expect(() => provider.remove(false)).toThrow("does not support project removal");
   });
 
   it("local remove deletes dosu entry when localConfigPath is provided", async () => {
     const { createJSONProvider } = await import("./base");
     const localPath = join(tempDir, "local-rm", "mcp.json");
-    mkdirSync(join(tempDir, "local-rm"), { recursive: true });
-    writeFileSync(localPath, JSON.stringify({ mcpServers: { dosu: { url: "x" } } }));
-
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
@@ -207,7 +208,8 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: () => localPath,
     });
 
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const cfg = loadJSONConfig(localPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
@@ -246,6 +248,7 @@ describe("CodexProvider", () => {
   let origCodexHome: string | undefined;
   let origCwd: string;
   let origPath: string | undefined;
+  let origBackendOverride: string | undefined;
   let npxPath: string;
 
   beforeEach(() => {
@@ -255,6 +258,8 @@ describe("CodexProvider", () => {
     origCwd = process.cwd();
     process.chdir(tempDir);
     origPath = process.env.PATH;
+    origBackendOverride = process.env.DOSU_BACKEND_URL_OVERRIDE;
+    process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api.dosu.dev";
     const binDir = join(tempDir, "fake-bin");
     mkdirSync(binDir, { recursive: true });
     npxPath = join(binDir, "npx");
@@ -270,6 +275,8 @@ describe("CodexProvider", () => {
       delete process.env.CODEX_HOME;
     }
     process.env.PATH = origPath;
+    if (origBackendOverride === undefined) delete process.env.DOSU_BACKEND_URL_OVERRIDE;
+    else process.env.DOSU_BACKEND_URL_OVERRIDE = origBackendOverride;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -303,11 +310,11 @@ describe("CodexProvider", () => {
     expect(content).not.toContain("http_headers");
   });
 
-  it("local install writes TOML config to .codex/config.toml in cwd", async () => {
+  it("project install writes TOML config to the explicit project root", async () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".codex", "config.toml");
     expect(existsSync(configPath)).toBe(true);
@@ -372,7 +379,7 @@ describe("CodexProvider", () => {
     mkdirSync(join(tempDir, "codex-home"), { recursive: true });
     writeFileSync(
       configPath,
-      '[mcp_servers.dosu]\ntype = "http"\nurl = "https://old.example"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "old-key"\n',
+      '[mcp_servers.dosu]\ntype = "http"\nurl = "https://api.dosu.dev/v1/mcp/deployments/old-dep"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "old-key"\n',
     );
 
     provider.install(makeCfg(), true);
@@ -399,6 +406,20 @@ describe("CodexProvider", () => {
     expect(content).toContain("[other_section]");
     expect(content).toContain('key = "value"');
     expect(content).toContain("[mcp_servers.dosu]");
+  });
+
+  it("refuses to install over or remove a semantically equivalent quoted Dosu table", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+    const configPath = join(tempDir, "codex-home", "config.toml");
+    const original = '[mcp_servers."dosu"]\ncommand = "foreign"\nargs = []\n';
+    mkdirSync(join(tempDir, "codex-home"), { recursive: true });
+    writeFileSync(configPath, original);
+
+    expect(() => provider.install(makeCfg(), true)).toThrow(/ambiguous|refus/i);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(() => provider.remove(true)).toThrow(/ambiguous|refus/i);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
   });
 
   it("global install replaces loose-permission TOML config with owner-only permissions", async () => {
@@ -431,8 +452,8 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".codex", "config.toml");
     const content = readFileSync(configPath, "utf-8");
@@ -515,37 +536,38 @@ describe("CopilotProvider", () => {
     expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
-  it("local install writes to cwd/.vscode/mcp.json with servers key", async () => {
+  it("project install writes the shared .mcp.json Copilot CLI schema", async () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
-    const configPath = join(tempDir, ".vscode", "mcp.json");
+    const configPath = join(tempDir, ".mcp.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.servers).toBeDefined();
-    expect(cfg.servers.dosu).toBeDefined();
-    expect(cfg.servers.dosu.type).toBe("http");
-    expect(cfg.servers.dosu.url).toContain("dep-123");
-    // local config should not have tools key
-    expect(cfg.servers.dosu.tools).toBeUndefined();
+    expect(cfg.mcpServers).toBeDefined();
+    expect(cfg.mcpServers.dosu.type).toBe("stdio");
+    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.args).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-123"]));
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
-  it("OSS mode install writes base MCP URL for global and local Copilot configs", async () => {
+  it("OSS mode keeps the global URL but writes a secretless project proxy", async () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
     provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), false);
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), false, {
+      projectRoot: tempDir,
+    });
 
     const globalCfg = loadJSONConfig(join(tempDir, "xdg-config", "mcp-config.json"));
     expect(globalCfg.mcpServers.dosu.url).toContain("/v1/mcp");
     expect(globalCfg.mcpServers.dosu.url).not.toContain("/deployments/");
 
-    const localCfg = loadJSONConfig(join(tempDir, ".vscode", "mcp.json"));
-    expect(localCfg.servers.dosu.url).toContain("/v1/mcp");
-    expect(localCfg.servers.dosu.url).not.toContain("/deployments/");
+    const localCfg = loadJSONConfig(join(tempDir, ".mcp.json"));
+    expect(localCfg.mcpServers.dosu.args).toContain("--oss");
+    expect(localCfg.mcpServers.dosu.url).toBeUndefined();
   });
 
   it("install throws when deployment_id is missing", async () => {
@@ -569,16 +591,16 @@ describe("CopilotProvider", () => {
     expect(cfg.mcpServers.dosu).toBeUndefined();
   });
 
-  it("local remove deletes dosu entry from servers", async () => {
+  it("project remove deletes the owned dosu entry", async () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
-    const configPath = join(tempDir, ".vscode", "mcp.json");
+    const configPath = join(tempDir, ".mcp.json");
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.servers.dosu).toBeUndefined();
+    expect(cfg.mcpServers.dosu).toBeUndefined();
   });
 
   it("install preserves existing entries", async () => {
@@ -665,11 +687,11 @@ describe("MCPorterProvider", () => {
     expect(cfg.mcpServers.dosu).toBeDefined();
   });
 
-  it("local install writes to cwd/config/mcporter.json", async () => {
+  it("project install writes to the explicit project config/mcporter.json", async () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "config", "mcporter.json");
     expect(existsSync(configPath)).toBe(true);
@@ -714,8 +736,8 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "config", "mcporter.json");
     const cfg = loadJSONConfig(configPath);
@@ -915,7 +937,9 @@ describe("ClaudeDesktopProvider", () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support project installation",
+    );
   });
 
   it("remove deletes the dosu entry", async () => {
@@ -933,7 +957,7 @@ describe("ClaudeDesktopProvider", () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.remove(false)).toThrow("does not support local removal");
+    expect(() => provider.remove(false)).toThrow("does not support project removal");
   });
 
   it("install skips empty PATH segments when resolving npx", async () => {
@@ -999,11 +1023,11 @@ describe("CursorProvider", () => {
     expect(cfg.mcpServers.dosu.type).toBeUndefined();
   });
 
-  it("local install writes to cwd/.cursor/mcp.json", async () => {
+  it("project install writes to the explicit project .cursor/mcp.json", async () => {
     const { CursorProvider } = await import("./cursor");
     const provider = CursorProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".cursor", "mcp.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1058,11 +1082,11 @@ describe("OpenCodeProvider", () => {
     expect(cfg.mcp.dosu.url).toContain("dep-123");
   });
 
-  it("local install writes to cwd/opencode.json", async () => {
+  it("project install writes to the explicit project opencode.json", async () => {
     const { OpenCodeProvider } = await import("./opencode");
     const provider = OpenCodeProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "opencode.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1142,7 +1166,9 @@ describe("ClineCliProvider", () => {
     const { ClineCliProvider } = await import("./cline-cli");
     const provider = ClineCliProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), false)).toThrow(
+      "does not support project installation",
+    );
   });
 });
 
@@ -1161,13 +1187,13 @@ describe("AntigravityProvider", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("global install writes to ~/.gemini/antigravity/mcp_config.json with mcpServers key", async () => {
+  it("global install writes to ~/.gemini/config/mcp_config.json with mcpServers key", async () => {
     const { AntigravityProvider } = await import("./antigravity");
     const provider = AntigravityProvider();
 
     provider.install(makeCfg(), true);
 
-    const configPath = join(tempDir, ".gemini", "antigravity", "mcp_config.json");
+    const configPath = join(tempDir, ".gemini", "config", "mcp_config.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
     expect(cfg.mcpServers.dosu).toBeDefined();
@@ -1176,11 +1202,17 @@ describe("AntigravityProvider", () => {
     expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
-  it("local install throws because Antigravity does not support local", async () => {
+  it("project install writes .agents/mcp_config.json without a secret", async () => {
     const { AntigravityProvider } = await import("./antigravity");
     const provider = AntigravityProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+
+    const configPath = join(tempDir, ".agents", "mcp_config.json");
+    const cfg = loadJSONConfig(configPath);
+    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.args).toEqual(expect.arrayContaining(["mcp", "proxy", "dep-123"]));
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
   it("remove deletes dosu entry", async () => {
@@ -1190,7 +1222,7 @@ describe("AntigravityProvider", () => {
     provider.install(makeCfg(), true);
     provider.remove(true);
 
-    const configPath = join(tempDir, ".gemini", "antigravity", "mcp_config.json");
+    const configPath = join(tempDir, ".gemini", "config", "mcp_config.json");
     const cfg = loadJSONConfig(configPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
   });
@@ -1230,11 +1262,11 @@ describe("ZedProvider", () => {
     expect(cfg.context_servers.dosu.url).toContain("dep-123");
   });
 
-  it("local install writes to cwd/.zed/settings.json", async () => {
+  it("project install writes to the explicit project .zed/settings.json", async () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".zed", "settings.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1258,8 +1290,8 @@ describe("ZedProvider", () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".zed", "settings.json");
     const cfg = loadJSONConfig(configPath);

--- a/src/mcp/providers/zed.ts
+++ b/src/mcp/providers/zed.ts
@@ -29,5 +29,10 @@ export const ZedProvider = () =>
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
+    buildProjectServer: (command) => ({
+      command: command.command,
+      args: command.args,
+      env: {},
+    }),
     localConfigPath: (cwd) => join(cwd, ".zed", "settings.json"),
   });

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -248,6 +248,8 @@ function throwingProvider(): providersModule.SetupProvider {
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => join(tempDir, "broken.json"),
+    projectConfigPath: (root) => join(root, ".broken", "mcp.json"),
+    isProjectConfigured: () => false,
     install() {
       throw new Error("boom: provider failure");
     },
@@ -1380,9 +1382,17 @@ describe("runSetup integration", () => {
       OpenCodeProvider(),
     ]);
 
-    // Pre-configure both providers so isConfigured() returns true
-    CursorProvider().install(cfg, true);
-    OpenCodeProvider().install(cfg, true);
+    // Pre-configure both providers with the production-shaped absolute URL
+    // required by the stricter ownership check introduced in this stack layer.
+    const previousBackendOverride = process.env.DOSU_BACKEND_URL_OVERRIDE;
+    try {
+      process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api.dosu.dev";
+      CursorProvider().install(cfg, true);
+      OpenCodeProvider().install(cfg, true);
+    } finally {
+      if (previousBackendOverride === undefined) delete process.env.DOSU_BACKEND_URL_OVERRIDE;
+      else process.env.DOSU_BACKEND_URL_OVERRIDE = previousBackendOverride;
+    }
 
     // User deselects opencode but keeps cursor
     mockToolSelection(["cursor"]);

--- a/src/setup/project-target.test.ts
+++ b/src/setup/project-target.test.ts
@@ -1,0 +1,385 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTestConfig } from "../config/config.test-utils";
+import { allSetupProviders } from "../mcp/providers";
+import { ClaudeProvider } from "../mcp/providers/claude";
+import { ClaudeDesktopProvider } from "../mcp/providers/claude-desktop";
+import { CodexProvider } from "../mcp/providers/codex";
+import { CopilotProvider } from "../mcp/providers/copilot";
+import { CursorProvider } from "../mcp/providers/cursor";
+import { inspectProviderProjectTarget, resolveProjectPinnedTarget } from "./project-target";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "dosu-project-target-"));
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+function args(target: string): string[] {
+  return ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--deployment", target];
+}
+
+function writeCursor(target: string): void {
+  const path = join(root, ".cursor", "mcp.json");
+  mkdirSync(join(root, ".cursor"), { recursive: true });
+  writeFileSync(
+    path,
+    `{// preserved\n  "mcpServers": {"dosu": ${JSON.stringify({
+      type: "stdio",
+      command: "npx",
+      args: args(target),
+    })}}\n}`,
+  );
+}
+
+function writeCodex(target: string): void {
+  mkdirSync(join(root, ".codex"), { recursive: true });
+  writeFileSync(
+    join(root, ".codex", "config.toml"),
+    `[mcp_servers.dosu]\ncommand = "npx"\nargs = ${JSON.stringify(args(target))}\n`,
+  );
+}
+
+describe("project MCP target recovery", () => {
+  it("resolves pins from every provider with an official project config", () => {
+    const providers = allSetupProviders().filter(
+      (provider) => provider.projectConfigPath(root) !== null,
+    );
+    const expectedProviderIDs = [
+      "claude",
+      "cursor",
+      "vscode",
+      "gemini",
+      "codex",
+      "zed",
+      "copilot",
+      "opencode",
+      "antigravity",
+      "mcporter",
+      "factory",
+    ];
+    expect(providers.map((provider) => provider.id())).toEqual(expectedProviderIDs);
+
+    const cfg = makeTestConfig({
+      access_token: "access",
+      refresh_token: "refresh",
+      expires_at: Date.now() + 60_000,
+      deployment_id: "dep-all-providers",
+      deployment_name: "Project",
+      api_key: "private-key",
+    });
+    for (const provider of providers) provider.install(cfg, false, { projectRoot: root });
+
+    expect(resolveProjectPinnedTarget(providers, root)).toEqual({
+      ok: true,
+      target: { deploymentID: "dep-all-providers" },
+      providers: expectedProviderIDs,
+    });
+  });
+
+  it("recovers an exact historical-version JSON or Codex project pin", () => {
+    writeCursor("dep-a");
+    writeCodex("dep-a");
+
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "owned",
+      target: { deploymentID: "dep-a" },
+    });
+    expect(inspectProviderProjectTarget(CodexProvider(), root)).toMatchObject({
+      disposition: "owned",
+      target: { deploymentID: "dep-a" },
+    });
+    expect(resolveProjectPinnedTarget([CursorProvider(), CodexProvider()], root)).toMatchObject({
+      ok: true,
+      target: { deploymentID: "dep-a" },
+    });
+  });
+
+  it("fails closed when exact project configs pin different deployments", () => {
+    writeCursor("dep-a");
+    writeCodex("dep-b");
+
+    expect(resolveProjectPinnedTarget([CursorProvider(), CodexProvider()], root)).toEqual({
+      ok: false,
+      reason: "conflicting_project_targets",
+      providers: ["cursor", "codex"],
+      paths: [join(root, ".cursor", "mcp.json"), join(root, ".codex", "config.toml")],
+    });
+  });
+
+  it("fails closed with the provider and path for a foreign server named dosu", () => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    const path = join(root, ".cursor", "mcp.json");
+    writeFileSync(path, JSON.stringify({ mcpServers: { dosu: { command: "foreign", args: [] } } }));
+
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+    });
+    expect(resolveProjectPinnedTarget([CursorProvider()], root)).toEqual({
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ["cursor"],
+      paths: [path],
+    });
+  });
+
+  it("fails closed with the provider and path for ambiguous Codex TOML", () => {
+    const path = join(root, ".codex", "config.toml");
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(path, "[[unterminated");
+
+    expect(resolveProjectPinnedTarget([CursorProvider(), CodexProvider()], root)).toEqual({
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ["codex"],
+      paths: [path],
+    });
+  });
+
+  it("rejects an explicit deployment that would split an undetected client's exact pin", () => {
+    writeCursor("dep-a");
+
+    expect(
+      resolveProjectPinnedTarget([CursorProvider()], root, {
+        mode: "cloud",
+        deploymentID: "dep-b",
+      }),
+    ).toEqual({
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: ["cursor"],
+      paths: [join(root, ".cursor", "mcp.json")],
+    });
+  });
+
+  it("allows an explicit rerun when every exact project pin already has that target", () => {
+    writeCursor("dep-a");
+    writeCodex("dep-a");
+
+    expect(
+      resolveProjectPinnedTarget([CursorProvider(), CodexProvider()], root, {
+        mode: "cloud",
+        deploymentID: "dep-a",
+      }),
+    ).toMatchObject({
+      ok: true,
+      target: { deploymentID: "dep-a" },
+      providers: ["cursor", "codex"],
+    });
+  });
+
+  it("allows an explicitly selected client to retarget its own exact pin", () => {
+    writeCursor("dep-a");
+
+    expect(
+      resolveProjectPinnedTarget(
+        [CursorProvider()],
+        root,
+        { mode: "cloud", deploymentID: "dep-b" },
+        ["cursor"],
+      ),
+    ).toEqual({
+      ok: true,
+      target: { deploymentID: "dep-b" },
+      providers: ["cursor"],
+    });
+  });
+
+  it("does not recover an OSS pin as the target of an explicit Cloud request", () => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(
+      join(root, ".cursor", "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "stdio",
+            command: "npx",
+            args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--oss"],
+          },
+        },
+      }),
+    );
+
+    expect(
+      resolveProjectPinnedTarget([CursorProvider()], root, { mode: "cloud" }, ["cursor"]),
+    ).toEqual({ ok: true, providers: ["cursor"] });
+  });
+
+  it("still rejects an unselected client's pin when the selected client can retarget", () => {
+    writeCursor("dep-a");
+    writeCodex("dep-a");
+
+    expect(
+      resolveProjectPinnedTarget(
+        [CursorProvider(), CodexProvider()],
+        root,
+        { mode: "cloud", deploymentID: "dep-b" },
+        ["cursor"],
+      ),
+    ).toEqual({
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: ["codex"],
+      paths: [join(root, ".codex", "config.toml")],
+    });
+  });
+
+  it("treats every client sharing a selected project file as mutable", () => {
+    writeFileSync(
+      join(root, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "stdio",
+            command: "npx",
+            args: args("dep-a"),
+          },
+        },
+      }),
+    );
+
+    expect(
+      resolveProjectPinnedTarget(
+        [ClaudeProvider(), CopilotProvider()],
+        root,
+        { mode: "cloud", deploymentID: "dep-b" },
+        ["claude"],
+      ),
+    ).toEqual({
+      ok: true,
+      target: { deploymentID: "dep-b" },
+      providers: ["claude", "copilot"],
+    });
+  });
+
+  it.each([
+    ["OSS over Cloud", { mode: "oss" } as const, "dep-a"],
+    ["Cloud over OSS", { mode: "cloud" } as const, null],
+  ])("rejects an explicit %s mode that conflicts with the repository", (_name, request, cloud) => {
+    if (cloud) {
+      writeCursor(cloud);
+    } else {
+      mkdirSync(join(root, ".cursor"), { recursive: true });
+      writeFileSync(
+        join(root, ".cursor", "mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            dosu: {
+              type: "stdio",
+              command: "npx",
+              args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--oss"],
+            },
+          },
+        }),
+      );
+    }
+
+    expect(resolveProjectPinnedTarget([CursorProvider()], root, request)).toMatchObject({
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: ["cursor"],
+      paths: [join(root, ".cursor", "mcp.json")],
+    });
+  });
+
+  it("treats unsupported, missing, and Dosu-free project files as unpinned", () => {
+    expect(inspectProviderProjectTarget(ClaudeDesktopProvider(), root)).toEqual({
+      disposition: "not_found",
+      providerID: "claude-desktop",
+    });
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "not_found",
+      providerID: "cursor",
+    });
+
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(join(root, ".cursor", "mcp.json"), '{"mcpServers":{"other":{}}}');
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "not_found",
+      providerID: "cursor",
+    });
+
+    writeFileSync(join(root, ".cursor", "mcp.json"), "{}");
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "not_found",
+      providerID: "cursor",
+    });
+  });
+
+  it.each([
+    ["invalid JSON", "{"],
+    ["duplicate top-level key", '{"mcpServers":{},"mcpServers":{}}'],
+    ["duplicate Dosu key", '{"mcpServers":{"dosu":{},"dosu":{}}}'],
+    ["array root", "[]"],
+    ["non-object MCP section", '{"mcpServers":[]}'],
+  ])("fails closed for %s", (_name, content) => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(join(root, ".cursor", "mcp.json"), content);
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+      providerID: "cursor",
+    });
+  });
+
+  it("fails closed for a symlink or directory at the project config path", () => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(join(root, "foreign.json"), '{"mcpServers":{}}');
+    symlinkSync(join(root, "foreign.json"), join(root, ".cursor", "mcp.json"));
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+    });
+
+    rmSync(join(root, ".cursor", "mcp.json"));
+    mkdirSync(join(root, ".cursor", "mcp.json"));
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+    });
+  });
+
+  it("recognizes an exact OSS pin and rejects malformed Codex TOML", () => {
+    mkdirSync(join(root, ".cursor"), { recursive: true });
+    writeFileSync(
+      join(root, ".cursor", "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          dosu: {
+            type: "stdio",
+            command: "npx",
+            args: ["-y", "@dosu/cli@0.42.0", "mcp", "proxy", "--oss"],
+          },
+        },
+      }),
+    );
+    expect(inspectProviderProjectTarget(CursorProvider(), root)).toMatchObject({
+      disposition: "owned",
+      target: { oss: true },
+    });
+
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(join(root, ".codex", "config.toml"), "[[unterminated");
+    expect(inspectProviderProjectTarget(CodexProvider(), root)).toMatchObject({
+      disposition: "ambiguous",
+      providerID: "codex",
+    });
+  });
+
+  it("treats valid Codex TOML without a Dosu table as unpinned", () => {
+    mkdirSync(join(root, ".codex"), { recursive: true });
+    writeFileSync(join(root, ".codex", "config.toml"), '[model]\nname = "gpt"\n');
+    expect(inspectProviderProjectTarget(CodexProvider(), root)).toMatchObject({
+      disposition: "not_found",
+      providerID: "codex",
+    });
+  });
+
+  it("returns no pin when no selected provider has an owned entry", () => {
+    expect(resolveProjectPinnedTarget([ClaudeDesktopProvider(), CursorProvider()], root)).toEqual({
+      ok: true,
+      providers: [],
+    });
+  });
+});

--- a/src/setup/project-target.ts
+++ b/src/setup/project-target.ts
@@ -1,0 +1,237 @@
+import { lstatSync, readFileSync } from "node:fs";
+import {
+  getNodeValue,
+  type Node as JsonNode,
+  type ParseError,
+  parseTree,
+} from "jsonc-parser/lib/esm/main.js";
+import { parse as parseToml } from "smol-toml";
+import {
+  ownedProjectProxyOptionsForProvider,
+  type ProjectProxyOptions,
+  sameProjectProxyTarget,
+} from "../mcp/project-proxy";
+import type { SetupProvider } from "../mcp/providers";
+
+export type ProviderProjectTargetInspection =
+  | { disposition: "owned"; providerID: string; path: string; target: ProjectProxyOptions }
+  | { disposition: "not_found"; providerID: string; path?: string }
+  | { disposition: "ambiguous"; providerID: string; path: string };
+
+export type ProjectPinnedTargetResolution =
+  | { ok: true; target?: ProjectProxyOptions; providers: string[] }
+  | {
+      ok: false;
+      reason:
+        | "ambiguous_project_config"
+        | "conflicting_project_targets"
+        | "requested_project_target_conflict";
+      providers: string[];
+      paths: string[];
+    };
+
+export type RequestedProjectTarget = { mode: "oss" } | { mode: "cloud"; deploymentID?: string };
+
+function entryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function duplicateJsonKey(node: JsonNode): boolean {
+  if (node.type === "object") {
+    const seen = new Set<string>();
+    for (const property of node.children ?? []) {
+      const key = property.children?.[0] ? getNodeValue(property.children[0]) : undefined;
+      if (typeof key !== "string") continue;
+      if (seen.has(key)) return true;
+      seen.add(key);
+    }
+  }
+  return (node.children ?? []).some(duplicateJsonKey);
+}
+
+function jsonTopKey(providerID: string): string {
+  switch (providerID) {
+    case "vscode":
+      return "servers";
+    case "zed":
+      return "context_servers";
+    case "opencode":
+      return "mcp";
+    default:
+      return "mcpServers";
+  }
+}
+
+function projectEntryFromJson(content: string, providerID: string): unknown {
+  const errors: ParseError[] = [];
+  const root = parseTree(content, errors, { allowTrailingComma: true, disallowComments: false });
+  if (!root || errors.length > 0 || root.type !== "object" || duplicateJsonKey(root)) {
+    throw new Error("invalid project JSON");
+  }
+  const parsed: unknown = getNodeValue(root);
+  if (!isRecord(parsed)) throw new Error("invalid project JSON");
+  const section = parsed[jsonTopKey(providerID)];
+  if (section === undefined) return undefined;
+  if (!isRecord(section)) throw new Error("invalid project MCP section");
+  return section.dosu;
+}
+
+function projectEntryFromToml(content: string): unknown {
+  const parsed: unknown = parseToml(content);
+  if (!isRecord(parsed) || !isRecord(parsed.mcp_servers)) return undefined;
+  return parsed.mcp_servers.dosu;
+}
+
+/** Read a project pin only from an exact, secretless Dosu proxy emitted by a released CLI. */
+export function inspectProviderProjectTarget(
+  provider: SetupProvider,
+  projectRoot: string,
+): ProviderProjectTargetInspection {
+  const providerID = provider.id();
+  const path = provider.projectConfigPath(projectRoot);
+  if (!path) return { disposition: "not_found", providerID };
+  try {
+    if (!entryExists(path)) return { disposition: "not_found", providerID, path };
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return { disposition: "ambiguous", providerID, path };
+    }
+    const content = readFileSync(path, "utf8");
+    const entry =
+      providerID === "codex"
+        ? projectEntryFromToml(content)
+        : projectEntryFromJson(content, providerID);
+    if (entry === undefined) return { disposition: "not_found", providerID, path };
+    const target = ownedProjectProxyOptionsForProvider(providerID, entry);
+    return target
+      ? { disposition: "owned", providerID, path, target }
+      : { disposition: "ambiguous", providerID, path };
+  } catch {
+    return { disposition: "ambiguous", providerID, path };
+  }
+}
+
+export function resolveProjectPinnedTarget(
+  providers: readonly SetupProvider[],
+  projectRoot: string,
+  requested?: RequestedProjectTarget,
+  retargetProviderIDs: readonly string[] = [],
+): ProjectPinnedTargetResolution {
+  const inspections = providers.map((provider) =>
+    inspectProviderProjectTarget(provider, projectRoot),
+  );
+  const ambiguous = inspections.filter(
+    (
+      inspection,
+    ): inspection is Extract<ProviderProjectTargetInspection, { disposition: "ambiguous" }> =>
+      inspection.disposition === "ambiguous",
+  );
+  if (ambiguous.length > 0) {
+    return {
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ambiguous.map((inspection) => inspection.providerID),
+      paths: uniqueStrings(ambiguous.map((inspection) => inspection.path)),
+    };
+  }
+  const owned = inspections.filter(
+    (
+      inspection,
+    ): inspection is Extract<ProviderProjectTargetInspection, { disposition: "owned" }> =>
+      inspection.disposition === "owned",
+  );
+  if (owned.length === 0) return { ok: true, providers: [] };
+  const mutableProviders = new Set(retargetProviderIDs);
+  const mutablePaths = new Set(
+    owned
+      .filter((inspection) => mutableProviders.has(inspection.providerID))
+      .map((inspection) => inspection.path),
+  );
+  const fixed = requested
+    ? owned.filter(
+        (inspection) =>
+          !mutableProviders.has(inspection.providerID) && !mutablePaths.has(inspection.path),
+      )
+    : owned;
+  const firstFixed = fixed[0]?.target;
+  if (
+    firstFixed &&
+    fixed.some((inspection) => !sameProjectProxyTarget(firstFixed, inspection.target))
+  ) {
+    return {
+      ok: false,
+      reason: "conflicting_project_targets",
+      providers: fixed.map((inspection) => inspection.providerID),
+      paths: uniqueStrings(fixed.map((inspection) => inspection.path)),
+    };
+  }
+  const requestedConflicts =
+    requested?.mode === "oss"
+      ? fixed.some((inspection) => inspection.target.oss !== true)
+      : requested?.mode === "cloud"
+        ? fixed.some(
+            (inspection) =>
+              inspection.target.oss === true ||
+              (requested.deploymentID !== undefined &&
+                inspection.target.deploymentID !== requested.deploymentID),
+          )
+        : false;
+  if (requestedConflicts) {
+    return {
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: fixed.map((inspection) => inspection.providerID),
+      paths: uniqueStrings(fixed.map((inspection) => inspection.path)),
+    };
+  }
+  let resolvedTarget: ProjectProxyOptions | undefined;
+  if (requested?.mode === "oss") {
+    resolvedTarget = { oss: true };
+  } else if (requested?.mode === "cloud" && requested.deploymentID) {
+    resolvedTarget = { deploymentID: requested.deploymentID };
+  } else if (firstFixed) {
+    resolvedTarget = firstFixed;
+  } else if (requested?.mode === "cloud") {
+    const firstOwned = owned[0].target;
+    const allOwnedShareOneCloudTarget =
+      firstOwned.oss !== true &&
+      owned.every(
+        (inspection) =>
+          inspection.target.oss !== true && sameProjectProxyTarget(firstOwned, inspection.target),
+      );
+    resolvedTarget = allOwnedShareOneCloudTarget ? firstOwned : undefined;
+  } else {
+    const firstOwned = owned[0].target;
+    if (owned.some((inspection) => !sameProjectProxyTarget(firstOwned, inspection.target))) {
+      return {
+        ok: false,
+        reason: "conflicting_project_targets",
+        providers: owned.map((inspection) => inspection.providerID),
+        paths: uniqueStrings(owned.map((inspection) => inspection.path)),
+      };
+    }
+    resolvedTarget = firstOwned;
+  }
+  const result: ProjectPinnedTargetResolution = {
+    ok: true,
+    providers: owned.map((inspection) => inspection.providerID),
+  };
+  if (resolvedTarget) result.target = resolvedTarget;
+  return result;
+}

--- a/src/setup/rules-step.test.ts
+++ b/src/setup/rules-step.test.ts
@@ -51,6 +51,8 @@ function makeProvider(id: string): SetupProvider {
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => `/config/${id}`,
+    projectConfigPath: (root) => `${root}/.${id}/mcp.json`,
+    isProjectConfigured: () => false,
     priority: () => 0,
   };
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -15,6 +15,7 @@ import {
   replaceLoginSession,
   saveConfig,
 } from "../config/config";
+import { clearProjectMcpCredentials } from "../mcp/project-credential-store";
 import { runSetup } from "../setup/flow";
 import { browserFallbackHint } from "../setup/styles";
 
@@ -160,10 +161,12 @@ async function handleAuthenticate(cfg: ReturnType<typeof loadConfig>): Promise<v
 
 export function handleLogout(cfg: ReturnType<typeof loadConfig>): void {
   if (!isAuthenticated(cfg)) {
+    clearProjectMcpCredentials();
     p.log.warn("You are not logged in.");
     return;
   }
   clearConfigInPlace(cfg);
   saveConfig(cfg);
+  clearProjectMcpCredentials();
   p.log.success("Credentials cleared.");
 }


### PR DESCRIPTION
<!-- Is this PR related to a Linear issue? -->
<!-- Example: Fixes [ENG-123](https://linear.app/dosu/issue/ENG-123) -->

### Description

Stack 6/8, based on #161. Enables strict project-scoped provider writers and makes direct `dosu mcp add` use the verified Git root, secretless proxy, private credential store, target-conflict checks, explicit `--retarget`, and explicit-only global fallback.

It also wires the hidden proxy command, logout cleanup, signal forwarding, and a Windows packed-CLI smoke job. Interactive and agent setup still keep their existing behavior until the next PR.

Validated locally with `bun run typecheck`, `bun run check`, all 2,147 tests, 326 focused provider/CLI tests, `git diff --check`, and `bun run build:npm`.

Stack review order:

1. #157 feat(mcp): add safe project file foundation
2. #158 feat(mcp): add secretless project proxy runtime
3. #159 feat(setup): add project agent assets
4. #160 feat(migration): prove complete project bundles
5. #161 feat(migration): add proof-gated global cleanup
6. #162 feat(mcp): enable project-scoped providers
7. #163 feat(setup): scope setup to the current project
8. #164 docs(setup): document project-scoped agent setup

Because this repository is squash-only, land by collapsing leaf into base: #164 -> #163 -> #162 -> #161 -> #160 -> #159 -> #158 -> #157 -> main.

### Review Tasks - Only request review after completing these.

* [ ] I self-reviewed this PR
* [ ] Testing is adequate for this change
* [ ] I reviewed AI-generated code and resolved suggestions

### Details (for context) - Not tasks; tooling uses tasks to determine review readiness

- Generated with AI: (N/Claude/Codex/Other)
- Manual testing: (Y/N/NA)
- Tests updated: (Y/N/NA)

<!-- Describe any manual testing or special testing approach -->
