### PR TITLE
feat(setup): scope setup to the current project (7/8)

### DIFF
--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -8,6 +8,7 @@ import {
   testTarget,
 } from "../config/config.test-utils";
 import type { SetupProvider } from "../mcp/providers";
+import { VERSION } from "../version/version";
 
 const {
   mockMintTicket,
@@ -24,6 +25,10 @@ const {
   mockSkillAgentIDsForProviders,
   mockInGitWorkTree,
   mockUpsertDosuAgentsSection,
+  mockRequireProjectRoot,
+  mockInstallProjectInstructions,
+  mockResolveProjectProof,
+  mockRunProjectScopeMigration,
 } = vi.hoisted(() => {
   return {
     mockMintTicket: vi.fn(),
@@ -46,12 +51,39 @@ const {
     mockSkillAgentIDsForProviders: vi.fn(),
     mockInGitWorkTree: vi.fn(),
     mockUpsertDosuAgentsSection: vi.fn(),
+    mockRequireProjectRoot: vi.fn(),
+    mockInstallProjectInstructions: vi.fn(),
+    mockResolveProjectProof: vi.fn(),
+    mockRunProjectScopeMigration: vi.fn(),
   };
 });
 
 vi.mock("../auth/ticket", () => ({
   mintTicket: mockMintTicket,
   exchangeTicket: mockExchangeTicket,
+}));
+
+vi.mock("../mcp/project-credential-store", () => ({
+  saveProjectMcpCredential: vi.fn(),
+  readProjectMcpCredential: vi.fn(),
+}));
+
+const { mockPreflightProjectProxy } = vi.hoisted(() => ({
+  mockPreflightProjectProxy: vi.fn(),
+}));
+vi.mock("../mcp/project-proxy-preflight", () => ({
+  preflightProjectProxy: (...args: unknown[]) => mockPreflightProjectProxy(...args),
+}));
+
+vi.mock("../migration", () => ({
+  resolveProjectProof: (...args: unknown[]) => mockResolveProjectProof(...args),
+}));
+
+const { mockResolveProjectPinnedTarget } = vi.hoisted(() => ({
+  mockResolveProjectPinnedTarget: vi.fn(),
+}));
+vi.mock("../setup/project-target", () => ({
+  resolveProjectPinnedTarget: (...args: unknown[]) => mockResolveProjectPinnedTarget(...args),
 }));
 
 vi.mock("../config/config", async (importOriginal) => ({
@@ -78,6 +110,19 @@ vi.mock("../commands/skill", () => ({
 vi.mock("../setup/agents-md-step", () => ({
   inGitWorkTree: mockInGitWorkTree,
   upsertDosuAgentsSection: mockUpsertDosuAgentsSection,
+}));
+
+vi.mock("../setup/project-root", () => ({
+  requireProjectRoot: mockRequireProjectRoot,
+}));
+
+vi.mock("../setup/project-scope-migration", () => ({
+  runProjectScopeMigration: (...args: unknown[]) => mockRunProjectScopeMigration(...args),
+}));
+
+vi.mock("../setup/project-instructions", () => ({
+  installProjectInstructions: mockInstallProjectInstructions,
+  providerUsesProjectInstructions: (providerID: string) => providerID !== "mcporter",
 }));
 
 vi.mock("../client/client", () => ({
@@ -139,17 +184,24 @@ describe("buildResumeCommand", () => {
       "npx @dosu/cli@latest setup --agent --tool cursor --login-ticket tkt-2 --deployment dep-9",
     );
   });
+
+  it("preserves an explicit mode in the resume command", () => {
+    const cmd = buildResumeCommand("codex", "tkt-3", undefined, "oss");
+    expect(cmd).toBe(
+      "npx @dosu/cli@latest setup --agent --tool codex --login-ticket tkt-3 --mode oss",
+    );
+  });
 });
 
 describe("listAgentSupportedToolIDs", () => {
-  it("lists every setup provider id, including Claude Desktop", () => {
+  it("lists only providers with an official project MCP scope", () => {
     mockAllSetupProviders.mockReturnValue([
       makeProvider("claude"),
-      makeProvider("claude-desktop"),
+      makeProvider("claude-desktop", { supportsLocal: () => false }),
       makeProvider("cursor"),
     ]);
 
-    expect(listAgentSupportedToolIDs()).toEqual(["claude", "claude-desktop", "cursor"]);
+    expect(listAgentSupportedToolIDs()).toEqual(["claude", "cursor"]);
   });
 });
 
@@ -177,10 +229,19 @@ describe("runAgentSetup", () => {
     mockSkillAgentIDsForProviders.mockReset();
     mockInGitWorkTree.mockReset();
     mockUpsertDosuAgentsSection.mockReset();
+    mockRequireProjectRoot.mockReset();
+    mockInstallProjectInstructions.mockReset();
+    mockResolveProjectProof.mockReset();
+    mockRunProjectScopeMigration.mockReset();
+    mockPreflightProjectProxy.mockReset();
+    mockResolveProjectPinnedTarget.mockReset();
     for (const fn of Object.values(mockClient)) fn.mockReset();
 
     claudeProvider = makeProvider("claude", { name: () => "Claude Code" });
-    desktopProvider = makeProvider("claude-desktop", { name: () => "Claude Desktop" });
+    desktopProvider = makeProvider("claude-desktop", {
+      name: () => "Claude Desktop",
+      supportsLocal: () => false,
+    });
 
     mockAllSetupProviders.mockReturnValue([claudeProvider, desktopProvider]);
     mockLoadConfig.mockReturnValue(makeBaseConfig());
@@ -200,6 +261,25 @@ describe("runAgentSetup", () => {
       action: "created",
       path: "/tmp/repo/AGENTS.md",
     });
+    mockRequireProjectRoot.mockReturnValue("/tmp/repo");
+    mockInstallProjectInstructions.mockReturnValue({
+      agentsMd: { action: "created", path: "/tmp/repo/AGENTS.md" },
+      adapters: [{ provider: "claude", action: "created", path: "/tmp/repo/CLAUDE.md" }],
+    });
+    mockResolveProjectProof.mockReturnValue({
+      ok: true,
+      proof: { root: "/tmp/repo", cwd: "/tmp/repo" },
+    });
+    mockRunProjectScopeMigration.mockReturnValue({
+      ok: true,
+      cleanupAttempted: true,
+      runtimeVerified: true,
+      receiptRoot: "/tmp/dosu-migration-receipts",
+      counts: { removed: 0, not_found: 3, preserved: 0, failed: 0, total: 3 },
+      warnings: [],
+    });
+    mockPreflightProjectProxy.mockResolvedValue({ ok: true, reason: "initialize_ok" });
+    mockResolveProjectPinnedTarget.mockReturnValue({ ok: true, providers: [] });
   });
 
   afterEach(() => {
@@ -281,7 +361,7 @@ describe("runAgentSetup", () => {
       "mcp_install",
       "rule_install",
       "skill_install",
-      "agents_md_install",
+      "legacy_migration",
       "done",
     ]);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
@@ -295,9 +375,40 @@ describe("runAgentSetup", () => {
       status: "ok",
       agent_next_steps: expect.stringMatching(/Claude Code.*dosu status --json/),
     });
-    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n");
-    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
-    expect(mockUpsertDosuAgentsSection).toHaveBeenCalledWith(process.cwd(), "canonical rule\n");
+    expect(events.at(-2)).toMatchObject({
+      step: "legacy_migration",
+      status: "ok",
+      receipt_root: "/tmp/dosu-migration-receipts",
+      counts: { removed: 0, not_found: 3, preserved: 0, failed: 0, total: 3 },
+    });
+    expect(JSON.stringify(events)).not.toContain("sk_user_x");
+    expect(mockInstallProjectInstructions).toHaveBeenCalledWith({
+      projectRoot: "/tmp/repo",
+      providerIDs: ["claude"],
+      content: "canonical rule\n",
+    });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], {
+      quiet: true,
+      projectRoot: "/tmp/repo",
+    });
+    expect(mockResolveProjectProof).toHaveBeenCalledWith("/tmp/repo");
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith({
+      project: { root: "/tmp/repo", cwd: "/tmp/repo" },
+      providerIDs: ["claude"],
+      proxy: { packageVersion: VERSION, deploymentID: "dep-1" },
+      instructionContent: "canonical rule\n",
+      runtimeVerified: true,
+    });
+    const preflightOrder = mockPreflightProjectProxy.mock.invocationCallOrder[0];
+    const mcpOrder = (claudeProvider.install as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    const instructionOrder = mockInstallProjectInstructions.mock.invocationCallOrder[0];
+    const skillOrder = mockInstallSkill.mock.invocationCallOrder[0];
+    const migrationOrder = mockRunProjectScopeMigration.mock.invocationCallOrder[0];
+    expect(preflightOrder).toBeLessThan(mcpOrder);
+    expect(mcpOrder).toBeLessThan(instructionOrder);
+    expect(instructionOrder).toBeLessThan(skillOrder);
+    expect(skillOrder).toBeLessThan(migrationOrder);
   });
 
   it("errors with multiple_deployments when the user has more than one dosu_mcp", async () => {
@@ -521,6 +632,12 @@ describe("runAgentSetup", () => {
     const code = await runAgentSetup({ tool: "claude", deploymentID: "dep-B" });
 
     expect(code).toBe(0);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, desktopProvider],
+      "/tmp/repo",
+      { mode: "cloud", deploymentID: "dep-B" },
+      ["claude"],
+    );
     const events = emittedEvents();
     const depEvent = events.find((e) => e.step === "deployment");
     expect(depEvent).toMatchObject({
@@ -663,6 +780,305 @@ describe("runAgentSetup", () => {
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
   });
 
+  it("prefers the exact project-pinned deployment over another globally active target", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-global-b",
+        deployment_name: "acme/global-b",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.getDeployments.mockResolvedValue([
+      {
+        deployment_id: "dep-project-a",
+        name: "acme/project-a",
+        provider_slug: "dosu_mcp",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-1",
+      },
+    ]);
+    mockClient.validateAPIKey.mockResolvedValue(false);
+    mockClient.createAPIKey.mockResolvedValue({ api_key: "key-a" });
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["claude"],
+      target: { deploymentID: "dep-project-a" },
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(0);
+    expect(emittedEvents().find((event) => event.step === "deployment")).toMatchObject({
+      deployment_id: "dep-project-a",
+    });
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.objectContaining({
+        active_account: expect.objectContaining({
+          target: expect.objectContaining({ deployment_id: "dep-project-a" }),
+        }),
+      }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: false },
+    );
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerIDs: ["claude"],
+        proxy: { packageVersion: VERSION, deploymentID: "dep-project-a" },
+        runtimeVerified: true,
+      }),
+    );
+  });
+
+  it("fails closed on conflicting pins from any project-supported provider", async () => {
+    const undetectedCodex = makeProvider("codex", { isInstalled: () => false });
+    mockAllSetupProviders.mockReturnValue([claudeProvider, undetectedCodex, desktopProvider]);
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-global",
+        deployment_name: "acme/global",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "conflicting_project_targets",
+      providers: ["claude", "codex"],
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, undetectedCodex, desktopProvider],
+      "/tmp/repo",
+    );
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "project_target",
+      status: "error",
+      reason: "conflicting_project_targets",
+      providers: ["claude", "codex"],
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+  });
+
+  it("fails on an ambiguous project entry before ticket redemption or session verification", async () => {
+    mockLoadConfig.mockReturnValue(makeBaseConfig());
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ["claude"],
+      paths: ["/tmp/repo/.mcp.json"],
+    });
+
+    const code = await runAgentSetup({
+      tool: "claude",
+      loginTicket: "ticket-must-not-be-redeemed",
+    });
+
+    expect(code).toBe(1);
+    expect(mockExchangeTicket).not.toHaveBeenCalled();
+    expect(mockClient.doRequestRaw).not.toHaveBeenCalled();
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "project_target",
+      status: "error",
+      reason: "ambiguous_project_config",
+      providers: ["claude"],
+      paths: ["/tmp/repo/.mcp.json"],
+    });
+  });
+
+  it("rejects an explicit OSS split-brain in an undetected client before authentication", async () => {
+    const undetectedCodex = makeProvider("codex", { isInstalled: () => false });
+    mockAllSetupProviders.mockReturnValue([claudeProvider, undetectedCodex, desktopProvider]);
+    mockLoadConfig.mockReturnValue(makeBaseConfig());
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "requested_project_target_conflict",
+      providers: ["codex"],
+      paths: ["/tmp/repo/.codex/config.toml"],
+    });
+
+    const code = await runAgentSetup({ tool: "claude", mode: "oss" });
+
+    expect(code).toBe(1);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, undetectedCodex, desktopProvider],
+      "/tmp/repo",
+      { mode: "oss" },
+      ["claude"],
+    );
+    expect(mockMintTicket).not.toHaveBeenCalled();
+    expect(mockClient.doRequestRaw).not.toHaveBeenCalled();
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  it("passes the exact OSS project proxy expectation to legacy migration", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-global",
+        deployment_name: "acme/global",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["claude"],
+      target: { oss: true },
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(0);
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "oss" }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: false },
+    );
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: { packageVersion: VERSION, oss: true },
+        runtimeVerified: true,
+      }),
+    );
+  });
+
+  it("honors an explicit OSS mode and authorizes that project retarget", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-cloud",
+        deployment_name: "acme/cloud",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+
+    const code = await runAgentSetup({ tool: "claude", mode: "oss" });
+
+    expect(code).toBe(0);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, desktopProvider],
+      "/tmp/repo",
+      { mode: "oss" },
+      ["claude"],
+    );
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "oss" }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: true },
+    );
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: { packageVersion: VERSION, oss: true },
+        runtimeVerified: true,
+      }),
+    );
+  });
+
+  it("honors an explicit cloud mode when the saved mode is OSS", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-cloud",
+        deployment_name: "acme/cloud",
+        api_key: "sk_existing",
+        mode: "oss",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+
+    const code = await runAgentSetup({ tool: "claude", mode: "cloud" });
+
+    expect(code).toBe(0);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, desktopProvider],
+      "/tmp/repo",
+      { mode: "cloud", deploymentID: "dep-cloud" },
+      ["claude"],
+    );
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.not.objectContaining({ mode: "oss" }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: true },
+    );
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: { packageVersion: VERSION, deploymentID: "dep-cloud" },
+        runtimeVerified: true,
+      }),
+    );
+  });
+
+  it("uses the Cloud picker instead of recovering a selected client's old OSS pin", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        api_key: "sk_existing",
+        mode: "oss",
+      }),
+    );
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["claude"],
+    });
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.getDeployments.mockResolvedValue([
+      {
+        deployment_id: "dep-cloud-picked",
+        name: "acme/cloud-picked",
+        provider_slug: "dosu_mcp",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-1",
+      },
+    ]);
+    mockClient.validateAPIKey.mockResolvedValue(true);
+
+    const code = await runAgentSetup({ tool: "claude", mode: "cloud" });
+
+    expect(code).toBe(0);
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [claudeProvider, desktopProvider],
+      "/tmp/repo",
+      { mode: "cloud", deploymentID: undefined },
+      ["claude"],
+    );
+    expect(mockClient.getDeployments).toHaveBeenCalled();
+    expect(claudeProvider.install).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: undefined,
+        active_account: expect.objectContaining({
+          target: expect.objectContaining({ deployment_id: "dep-cloud-picked" }),
+        }),
+      }),
+      false,
+      { projectRoot: "/tmp/repo", allowProjectRetarget: true },
+    );
+  });
+
   it("reuses a still-valid API key without minting a new one", async () => {
     mockLoadConfig.mockReturnValue(
       makeBaseConfig({
@@ -714,6 +1130,35 @@ describe("runAgentSetup", () => {
     expect(claudeProvider.install).not.toHaveBeenCalled();
   });
 
+  it("fails before project writes when the exact proxy cannot initialize", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockPreflightProjectProxy.mockResolvedValue({ ok: false, reason: "timeout" });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "mcp_preflight",
+      status: "error",
+      reason: "timeout",
+      agent_next_steps: expect.stringContaining("no project files"),
+    });
+    expect(claudeProvider.install).not.toHaveBeenCalled();
+    expect(mockInstallProjectInstructions).not.toHaveBeenCalled();
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+  });
+
   it("emits install_failed when the provider install throws", async () => {
     mockLoadConfig.mockReturnValue(
       makeBaseConfig({
@@ -758,7 +1203,7 @@ describe("runAgentSetup", () => {
     );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.validateAPIKey.mockResolvedValue(true);
-    mockInstallRuleForAgent.mockImplementation(() => {
+    mockInstallProjectInstructions.mockImplementation(() => {
       throw new Error("rule directory is read-only");
     });
 
@@ -794,16 +1239,17 @@ describe("runAgentSetup", () => {
 
     expect(code).toBe(1);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
-    expect(mockInstallRuleForAgent).toHaveBeenCalledTimes(1);
+    expect(mockInstallProjectInstructions).toHaveBeenCalledTimes(1);
     expect(emittedEvents().at(-1)).toMatchObject({
       step: "skill_install",
       status: "error",
       reason: "install_failed",
       agent_next_steps: expect.stringContaining("idempotent"),
     });
+    expect(mockRunProjectScopeMigration).not.toHaveBeenCalled();
   });
 
-  it("reports an AGENTS.md failure after preserving the other bundled installs", async () => {
+  it("fails closed and reports receipt counts when safe legacy migration cannot finish", async () => {
     mockLoadConfig.mockReturnValue(
       makeBaseConfig({
         access_token: ticketAccessToken,
@@ -816,8 +1262,78 @@ describe("runAgentSetup", () => {
     );
     mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
     mockClient.validateAPIKey.mockResolvedValue(true);
-    mockInGitWorkTree.mockReturnValue(true);
-    mockUpsertDosuAgentsSection.mockImplementation(() => {
+    mockRunProjectScopeMigration.mockReturnValue({
+      ok: false,
+      cleanupAttempted: true,
+      runtimeVerified: true,
+      reason: "migration_failed",
+      receiptRoot: "/tmp/dosu-migration-receipts/run-1",
+      counts: { removed: 1, not_found: 2, preserved: 1, failed: 1, total: 5 },
+      warnings: ["ambiguous legacy entry preserved"],
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+    expect(mockInstallProjectInstructions).toHaveBeenCalledTimes(1);
+    expect(mockInstallSkill).toHaveBeenCalledTimes(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "legacy_migration",
+      status: "error",
+      reason: "migration_failed",
+      receipt_root: "/tmp/dosu-migration-receipts/run-1",
+      counts: { removed: 1, not_found: 2, preserved: 1, failed: 1, total: 5 },
+      agent_next_steps: expect.stringContaining("1 proven global item(s) were already backed up"),
+    });
+    expect(emittedEvents().some((event) => event.step === "done")).toBe(false);
+    expect(JSON.stringify(emittedEvents())).not.toContain("sk_existing");
+  });
+
+  it("preserves globals when the project cannot be re-proven after bundle installation", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockResolveProjectProof.mockReturnValue({ ok: false, reason: "git_probe_failed" });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(1);
+    expect(mockRunProjectScopeMigration).not.toHaveBeenCalled();
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "legacy_migration",
+      status: "error",
+      reason: "project_reverification_failed",
+      project_reason: "git_probe_failed",
+      receipt_root: null,
+      counts: { removed: 0, not_found: 0, preserved: 0, failed: 0, total: 0 },
+    });
+    expect(emittedEvents().some((event) => event.step === "done")).toBe(false);
+  });
+
+  it("reports a project instruction failure before attempting the skill", async () => {
+    mockLoadConfig.mockReturnValue(
+      makeBaseConfig({
+        access_token: ticketAccessToken,
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        deployment_id: "dep-locked",
+        deployment_name: "acme/locked",
+        api_key: "sk_existing",
+      }),
+    );
+    mockClient.doRequestRaw.mockResolvedValue(new Response(null, { status: 200 }));
+    mockClient.validateAPIKey.mockResolvedValue(true);
+    mockInstallProjectInstructions.mockImplementation(() => {
       throw new Error("AGENTS.md is read-only");
     });
 
@@ -825,10 +1341,10 @@ describe("runAgentSetup", () => {
 
     expect(code).toBe(1);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
-    expect(mockInstallRuleForAgent).toHaveBeenCalledTimes(1);
-    expect(mockInstallSkill).toHaveBeenCalledTimes(1);
+    expect(mockInstallProjectInstructions).toHaveBeenCalledTimes(1);
+    expect(mockInstallSkill).not.toHaveBeenCalled();
     expect(emittedEvents().at(-1)).toMatchObject({
-      step: "agents_md_install",
+      step: "rule_install",
       status: "error",
       reason: "install_failed",
       agent_next_steps: expect.stringContaining("idempotent"),

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -19,21 +19,34 @@ import { installSkill, skillAgentIDsForProviders } from "../commands/skill";
 import {
   type Config,
   loadConfig,
+  MODE_OSS,
   replaceLoginSession,
+  type SetupMode,
   saveConfig,
   updateTarget,
 } from "../config/config";
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
+import { recordProjectProxyEndpoint } from "../mcp/project-proxy";
+import { preflightProjectProxy } from "../mcp/project-proxy-preflight";
 import { allSetupProviders } from "../mcp/providers";
-import { fetchDosuRule, installRuleForAgent, isRuleAgent } from "../rules/installer";
-import { inGitWorkTree, upsertDosuAgentsSection } from "../setup/agents-md-step";
+import { type ProviderId, resolveProjectProof } from "../migration";
+import { fetchDosuRule } from "../rules/installer";
+import {
+  installProjectInstructions,
+  providerUsesProjectInstructions,
+} from "../setup/project-instructions";
+import { requireProjectRoot } from "../setup/project-root";
+import { runProjectScopeMigration } from "../setup/project-scope-migration";
+import { type RequestedProjectTarget, resolveProjectPinnedTarget } from "../setup/project-target";
+import { VERSION } from "../version/version";
 import { emitError, emitNeedUserAction, emitStep } from "./output";
 
 export interface AgentSetupOptions {
   tool: string;
   loginTicket?: string;
   deploymentID?: string;
+  mode?: SetupMode | "cloud";
 }
 
 const NPX_INVOCATION = "npx @dosu/cli@latest";
@@ -53,9 +66,13 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   // 0. Resolve the requested tool up front. We do this before any auth so
   //    the agent gets a usage error immediately instead of after a login
   //    round-trip.
-  const provider = allSetupProviders().find((p) => p.id() === opts.tool.toLowerCase());
+  const setupProviders = allSetupProviders();
+  const provider = setupProviders.find(
+    (candidate) => candidate.id() === opts.tool.toLowerCase() && candidate.supportsLocal(),
+  );
   if (!provider) {
-    const available = allSetupProviders()
+    const available = setupProviders
+      .filter((candidate) => candidate.supportsLocal())
       .map((p) => p.id())
       .join(", ");
     emitError({
@@ -65,10 +82,38 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     });
     return 2;
   }
+  let projectRoot: string;
+  try {
+    projectRoot = requireProjectRoot();
+  } catch (err) {
+    emitError({
+      step: "setup",
+      reason: "project_required",
+      agent_next_steps: err instanceof Error ? err.message : String(err),
+    });
+    return 1;
+  }
+  let cfg = loadConfig();
+  const requestedTarget = requestedProjectTarget(opts, cfg);
+  const projectTarget = requestedTarget
+    ? resolveProjectPinnedTarget(setupProviders, projectRoot, requestedTarget, [provider.id()])
+    : resolveProjectPinnedTarget(setupProviders, projectRoot);
+  if (!projectTarget.ok) {
+    emitError({
+      step: "project_target",
+      reason: projectTarget.reason,
+      providers: projectTarget.providers,
+      paths: projectTarget.paths,
+      agent_next_steps:
+        projectTarget.reason === "ambiguous_project_config"
+          ? "One or more project Dosu entries are foreign or invalid. Inspect the listed paths and remove or repair only those entries, then retry. No authentication or project write was attempted."
+          : "The project's clients do not all match one Dosu target. Make every listed client use the same target before retrying. No authentication or project write was attempted.",
+    });
+    return 1;
+  }
   // 1. Auth: redeem a ticket if one was provided, otherwise verify any
   //    existing session, otherwise mint a fresh ticket and exit so the
   //    agent can hand the URL to the user.
-  let cfg = loadConfig();
   if (opts.loginTicket) {
     const redeemed = await redeemTicket(opts.loginTicket, cfg);
     if (redeemed.code !== 0 || redeemed.exit) return redeemed.code;
@@ -79,10 +124,29 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     cfg = verified.cfg;
   }
 
+  // Match the interactive contract: an explicit deployment always means
+  // Cloud; otherwise an explicit mode overrides saved/global state and
+  // authorizes retargeting this project's owned Dosu entry.
+  if (opts.deploymentID) {
+    cfg.mode = undefined;
+    saveConfig(cfg);
+  } else if (opts.mode) {
+    cfg.mode = opts.mode === "oss" ? MODE_OSS : undefined;
+    saveConfig(cfg);
+  }
+
   // 2. Resolve the deployment. Agent mode never prompts — if there are
   //    multiple options the agent must surface that to the user.
   const client = new Client(cfg);
-  const deploymentResult = await resolveDeployment(client, cfg, opts);
+  let deploymentOptions = opts;
+  if (!opts.deploymentID && opts.mode !== "oss") {
+    if (projectTarget.target?.deploymentID) {
+      deploymentOptions = { ...opts, deploymentID: projectTarget.target.deploymentID };
+    } else if (projectTarget.target?.oss) {
+      cfg.mode = MODE_OSS;
+    }
+  }
+  const deploymentResult = await resolveDeployment(client, cfg, deploymentOptions);
   if (deploymentResult.code !== 0) return deploymentResult.code;
   cfg = deploymentResult.cfg;
 
@@ -90,15 +154,31 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   const keyResult = await ensureAPIKey(client, cfg);
   if (keyResult.code !== 0) return keyResult.code;
   cfg = keyResult.cfg;
+  recordProjectProxyEndpoint(cfg);
+  saveConfig(cfg);
+
+  const preflight = await preflightProjectProxy(cfg, projectRoot);
+  if (!preflight.ok) {
+    emitError({
+      step: "mcp_preflight",
+      reason: preflight.reason,
+      agent_next_steps:
+        "The exact project MCP command could not initialize, so no project files or legacy globals were changed. Check Node.js 22+ and npx, then retry.",
+    });
+    return 1;
+  }
 
   // 4. Install Dosu MCP into the requested tool.
   try {
-    provider.install(cfg, /* global */ true);
+    provider.install(cfg, /* global */ false, {
+      projectRoot,
+      allowProjectRetarget: Boolean(opts.deploymentID || opts.mode),
+    });
     emitStep({
       step: "mcp_install",
       tool: provider.id(),
       tool_name: provider.name(),
-      config_path: provider.globalConfigPath(),
+      config_path: provider.projectConfigPath(projectRoot) ?? "",
     });
   } catch (err: unknown) {
     emitError({
@@ -111,32 +191,35 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     return 1;
   }
 
-  // 5. Install the matching always-on rule when this agent is part of the
-  // mainstream rule matrix. Unsupported MCP clients simply skip this step.
-  let instruction: string | undefined;
-  try {
-    if (isRuleAgent(provider.id())) {
-      instruction = await fetchDosuRule();
-      const rule = installRuleForAgent(provider.id(), instruction);
-      if (rule) {
-        emitStep({
-          step: "rule_install",
-          tool: provider.id(),
-          tool_name: provider.name(),
-          rule_path: rule.path,
-          action: rule.action,
-        });
-      }
+  // 5. Install the canonical project instructions plus the provider's thin adapter.
+  // Keep the exact fetched body: legacy cleanup re-verifies the checked-in
+  // project bundle against it before removing anything outside the project.
+  let instructionContent = "";
+  if (providerUsesProjectInstructions(provider.id())) {
+    try {
+      instructionContent = await fetchDosuRule();
+      const installed = installProjectInstructions({
+        projectRoot,
+        providerIDs: [provider.id()],
+        content: instructionContent,
+      });
+      emitStep({
+        step: "rule_install",
+        tool: provider.id(),
+        tool_name: provider.name(),
+        rule_path: installed.agentsMd.path,
+        action: installed.agentsMd.action,
+      });
+    } catch (err: unknown) {
+      emitError({
+        step: "rule_install",
+        reason: "install_failed",
+        agent_next_steps: `Dosu MCP was installed, but its rule could not be installed for ${provider.name()}: ${
+          err instanceof Error ? err.message : String(err)
+        }. Re-run this setup command; installation is idempotent.`,
+      });
+      return 1;
     }
-  } catch (err: unknown) {
-    emitError({
-      step: "rule_install",
-      reason: "install_failed",
-      agent_next_steps: `Dosu MCP was installed, but its rule could not be installed for ${provider.name()}: ${
-        err instanceof Error ? err.message : String(err)
-      }. Re-run this setup command; installation is idempotent.`,
-    });
-    return 1;
   }
 
   // 6. Install the remote Dosu skill only for the requested agent. Keep the
@@ -144,7 +227,7 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   // stdout contract.
   if (skillAgentIDsForProviders([provider.id()]).length > 0) {
     try {
-      const skill = await installSkill([provider.id()], { quiet: true });
+      const skill = await installSkill([provider.id()], { quiet: true, projectRoot });
       if (!skill.success) {
         throw new Error("the skills installer failed");
       }
@@ -166,35 +249,80 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     }
   }
 
-  // 7. Add the project-level pointer when setup runs from a git work tree.
-  // Use the low-level writer instead of the clack wrapper so stdout stays
-  // valid NDJSON.
-  if (inGitWorkTree()) {
-    try {
-      instruction ??= await fetchDosuRule();
-      const agentsMd = upsertDosuAgentsSection(process.cwd(), instruction);
-      emitStep({
-        step: "agents_md_install",
-        path: agentsMd.path,
-        action: agentsMd.action,
-      });
-    } catch (err: unknown) {
-      emitError({
-        step: "agents_md_install",
-        reason: "install_failed",
-        agent_next_steps: `Dosu's agent integrations were installed, but AGENTS.md could not be updated: ${
-          err instanceof Error ? err.message : String(err)
-        }. Re-run this setup command; installation is idempotent.`,
-      });
-      return 1;
-    }
+  // 7. Re-prove and re-verify the complete project bundle before touching any
+  // legacy global state. The successful runtime preflight above is the only
+  // authority that permits the migration layer to remove exact owned entries.
+  const project = resolveProjectProof(projectRoot);
+  if (!project.ok) {
+    emitError({
+      step: "legacy_migration",
+      reason: "project_reverification_failed",
+      project_reason: project.reason,
+      receipt_root: null,
+      counts: { removed: 0, not_found: 0, preserved: 0, failed: 0, total: 0 },
+      agent_next_steps:
+        "Project setup succeeded, but the Git project could not be re-verified, so legacy global configuration was preserved. Re-run setup from the same project root.",
+    });
+    return 1;
   }
+
+  const proxy =
+    cfg.mode === MODE_OSS
+      ? ({ packageVersion: VERSION, oss: true } as const)
+      : {
+          packageVersion: VERSION,
+          deploymentID: cfg.active_account?.target?.deployment_id as string,
+        };
+  const migration = runProjectScopeMigration({
+    project: project.proof,
+    providerIDs: [provider.id() as ProviderId],
+    proxy,
+    instructionContent,
+    runtimeVerified: true,
+  });
+  for (const warning of migration.warnings) logger.warn("agent.flow", warning);
+  if (!migration.ok) {
+    const cleanupProgress =
+      migration.counts.removed > 0
+        ? `${migration.counts.removed} proven global item(s) were already backed up and removed before cleanup stopped.`
+        : "No global item was removed.";
+    emitError({
+      step: "legacy_migration",
+      reason: migration.reason,
+      receipt_root: migration.receiptRoot,
+      counts: migration.counts,
+      agent_next_steps:
+        `Project setup succeeded, but safe legacy cleanup could not finish. ${cleanupProgress} ` +
+        "Nothing ambiguous was deleted. Re-run setup; use the receipt path for recovery if needed.",
+    });
+    return 1;
+  }
+  emitStep({
+    step: "legacy_migration",
+    receipt_root: migration.receiptRoot,
+    counts: migration.counts,
+  });
 
   emitStep({
     step: "done",
-    agent_next_steps: `Dosu is configured for ${provider.name()}. Tell the user setup is complete and they can ask their agent a Dosu question. Run 'dosu status --json' to verify.`,
+    agent_next_steps: `Dosu project files were written for ${provider.name()}. Tell the user to restart or reload the client, approve the project's MCP server if prompted, and then ask a Dosu question. 'dosu status --json' verifies authentication, not the client runtime.`,
   });
   return 0;
+}
+
+function requestedProjectTarget(
+  opts: AgentSetupOptions,
+  cfg: Config,
+): RequestedProjectTarget | undefined {
+  if (opts.deploymentID) return { mode: "cloud", deploymentID: opts.deploymentID };
+  if (opts.mode === "oss") return { mode: "oss" };
+  if (opts.mode === "cloud") {
+    return {
+      mode: "cloud",
+      deploymentID: cfg.active_account?.target?.deployment_id,
+    };
+  }
+  return undefined;
 }
 
 async function redeemTicket(
@@ -283,7 +411,7 @@ async function verifyOrMint(
       step: "auth",
       url: minted.url,
       ticket: minted.ticket,
-      resume_command: buildResumeCommand(opts.tool, minted.ticket, opts.deploymentID),
+      resume_command: buildResumeCommand(opts.tool, minted.ticket, opts.deploymentID, opts.mode),
       expires_in: minted.expires_in,
       agent_next_steps:
         "Give the URL to the user so they can sign in. Wait for the user to confirm they've signed in, then run resume_command to finish setup.",
@@ -484,15 +612,25 @@ async function ensureAPIKey(client: Client, cfg: Config): Promise<{ code: number
  * Build the exact command the agent should run after the user signs in.
  * Mirrors the marketing one-liner so the agent can copy/paste it back.
  */
-export function buildResumeCommand(tool: string, ticket: string, deploymentID?: string): string {
+export function buildResumeCommand(
+  tool: string,
+  ticket: string,
+  deploymentID?: string,
+  mode?: SetupMode | "cloud",
+): string {
   const parts = [NPX_INVOCATION, "setup", "--agent", "--tool", tool, "--login-ticket", ticket];
   if (deploymentID) {
     parts.push("--deployment", deploymentID);
+  }
+  if (mode) {
+    parts.push("--mode", mode);
   }
   return parts.join(" ");
 }
 
 /** Provider listing for `--tool` validation. Exported for tests. */
 export function listAgentSupportedToolIDs(): string[] {
-  return allSetupProviders().map((p) => p.id());
+  return allSetupProviders()
+    .filter((provider) => provider.supportsLocal())
+    .map((provider) => provider.id());
 }

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -1075,6 +1075,27 @@ describe("CLI actions", () => {
         deploymentID: "dep_456",
       });
     });
+
+    it("passes a validated mode to agent setup", async () => {
+      mockRunAgentSetup.mockResolvedValue(0);
+
+      await run("setup", "--agent", "--tool", "codex", "--mode", "oss");
+
+      expect(mockRunAgentSetup).toHaveBeenCalledWith({
+        tool: "codex",
+        loginTicket: undefined,
+        deploymentID: undefined,
+        mode: "oss",
+      });
+    });
+
+    it("rejects an invalid mode before starting agent setup", async () => {
+      await expect(
+        run("setup", "--agent", "--tool", "codex", "--mode", "nonsense"),
+      ).rejects.toThrow("invalid --mode value 'nonsense'");
+
+      expect(mockRunAgentSetup).not.toHaveBeenCalled();
+    });
   });
 
   // ── logs ────────────────────────────────────────────────────────────────

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -546,6 +546,15 @@ export function createProgram(): Command {
         tool?: string;
         loginTicket?: string;
       }) => {
+        let mode: "oss" | "cloud" | undefined;
+        if (opts.mode !== undefined) {
+          const normalized = opts.mode.toLowerCase();
+          if (normalized !== "oss" && normalized !== "cloud") {
+            throw new Error(`invalid --mode value '${opts.mode}' (expected 'oss' or 'cloud')`);
+          }
+          mode = normalized;
+        }
+
         if (opts.agent) {
           if (!opts.tool) {
             const { emitError } = await import("../agent/output");
@@ -563,6 +572,7 @@ export function createProgram(): Command {
             tool: opts.tool,
             loginTicket: opts.loginTicket,
             deploymentID: opts.deployment,
+            mode,
           });
           return;
         }
@@ -573,14 +583,6 @@ export function createProgram(): Command {
         }
 
         const { runSetup } = await import("../setup/flow");
-        let mode: "oss" | "cloud" | undefined;
-        if (opts.mode !== undefined) {
-          const normalized = opts.mode.toLowerCase();
-          if (normalized !== "oss" && normalized !== "cloud") {
-            throw new Error(`invalid --mode value '${opts.mode}' (expected 'oss' or 'cloud')`);
-          }
-          mode = normalized;
-        }
         await runSetup({ deploymentID: opts.deployment, mode });
       },
     );

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -39,6 +47,34 @@ vi.mock("@clack/prompts", () => ({
 
 vi.mock("../auth/flow", () => ({
   startOAuthFlow: vi.fn(),
+}));
+
+vi.mock("../mcp/project-credential-store", () => ({
+  saveProjectMcpCredential: vi.fn(),
+  readProjectMcpCredential: vi.fn(),
+}));
+
+const { mockPreflightProjectProxy } = vi.hoisted(() => ({
+  mockPreflightProjectProxy: vi.fn(),
+}));
+vi.mock("../mcp/project-proxy-preflight", () => ({
+  preflightProjectProxy: (...args: unknown[]) => mockPreflightProjectProxy(...args),
+}));
+
+const { mockResolveProjectProof, mockResolveProjectPinnedTarget, mockRunProjectScopeMigration } =
+  vi.hoisted(() => ({
+    mockResolveProjectProof: vi.fn(),
+    mockResolveProjectPinnedTarget: vi.fn(),
+    mockRunProjectScopeMigration: vi.fn(),
+  }));
+vi.mock("../migration", () => ({
+  resolveProjectProof: (...args: unknown[]) => mockResolveProjectProof(...args),
+}));
+vi.mock("./project-target", () => ({
+  resolveProjectPinnedTarget: (...args: unknown[]) => mockResolveProjectPinnedTarget(...args),
+}));
+vi.mock("./project-scope-migration", () => ({
+  runProjectScopeMigration: (...args: unknown[]) => mockRunProjectScopeMigration(...args),
 }));
 
 vi.mock("../debug/logger", () => ({
@@ -145,6 +181,20 @@ vi.mock("./agents-md-step", () => ({
 const { mockStepConfigureAgentRules } = vi.hoisted(() => ({
   mockStepConfigureAgentRules: vi.fn(),
 }));
+const { mockRequireProjectRoot, mockInstallProjectInstructions, mockRemoveProjectAdapters } =
+  vi.hoisted(() => ({
+    mockRequireProjectRoot: vi.fn(),
+    mockInstallProjectInstructions: vi.fn(),
+    mockRemoveProjectAdapters: vi.fn(),
+  }));
+vi.mock("./project-root", () => ({
+  requireProjectRoot: (...args: unknown[]) => mockRequireProjectRoot(...args),
+}));
+vi.mock("./project-instructions", () => ({
+  installProjectInstructions: (...args: unknown[]) => mockInstallProjectInstructions(...args),
+  removeProjectInstructionAdapters: (...args: unknown[]) => mockRemoveProjectAdapters(...args),
+  providerUsesProjectInstructions: (providerID: string) => providerID !== "mcporter",
+}));
 vi.mock("./rules-step", () => ({
   stepConfigureAgentRules: (...args: unknown[]) => mockStepConfigureAgentRules(...args),
 }));
@@ -161,11 +211,14 @@ import { Client } from "../client/client";
 import type { Config } from "../config/config";
 import { loadConfig, saveConfig } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
-import { loadJSONConfig, saveJSONConfig } from "../mcp/config-helpers";
+import { loadJSONConfig, saveJSONConfig, writeProjectFile } from "../mcp/config-helpers";
 import * as providersModule from "../mcp/providers";
 import { ClaudeProvider } from "../mcp/providers/claude";
 import { ClaudeDesktopProvider } from "../mcp/providers/claude-desktop";
+import { CodexProvider } from "../mcp/providers/codex";
+import { CopilotProvider } from "../mcp/providers/copilot";
 import { CursorProvider } from "../mcp/providers/cursor";
+import { GeminiProvider } from "../mcp/providers/gemini";
 import { OpenCodeProvider } from "../mcp/providers/opencode";
 import {
   type ConfigResult,
@@ -191,10 +244,30 @@ function mockToolSelection(selection: string[]) {
 }
 
 function installSetupStepDefaults() {
+  mockPreflightProjectProxy.mockResolvedValue({ ok: true, reason: "initialize_ok" });
+  mockResolveProjectPinnedTarget.mockReturnValue({ ok: true, providers: [] });
+  mockResolveProjectProof.mockImplementation((root: string) => ({
+    ok: true,
+    proof: { root, cwd: root },
+  }));
+  mockRunProjectScopeMigration.mockReturnValue({
+    ok: true,
+    cleanupAttempted: true,
+    runtimeVerified: true,
+    receiptRoot: "/tmp/dosu-test-migration-receipts",
+    counts: { removed: 0, not_found: 3, preserved: 0, failed: 0, total: 3 },
+    warnings: [],
+  });
   mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
   mockInGitWorkTree.mockReturnValue(false);
   mockStepUpdateAgentsMd.mockReturnValue(true);
   mockStepConfigureAgentRules.mockResolvedValue([]);
+  mockRequireProjectRoot.mockImplementation(() => projectDir);
+  mockInstallProjectInstructions.mockImplementation(({ projectRoot }: { projectRoot: string }) => ({
+    agentsMd: { path: join(projectRoot, "AGENTS.md"), action: "created" },
+    adapters: [],
+  }));
+  mockRemoveProjectAdapters.mockReturnValue([]);
 }
 
 function installRemoteSetupDefaults() {
@@ -216,11 +289,14 @@ function installRemoteSetupDefaults() {
 // ---------------------------------------------------------------------------
 
 let tempDir: string;
+let projectDir: string;
 let origHome: string | undefined;
 let origXdg: string | undefined;
 
 function setupTempEnv() {
   tempDir = mkdtempSync(join(tmpdir(), "dosu-flow-test-"));
+  projectDir = join(tempDir, "project");
+  mkdirSync(projectDir, { recursive: true });
   origHome = process.env.HOME;
   origXdg = process.env.XDG_CONFIG_HOME;
   process.env.HOME = tempDir;
@@ -316,7 +392,7 @@ describe("stepDetectTools", () => {
     expect(detected[0].id()).toBe("cursor");
   });
 
-  it("includes Claude Desktop when its app dir exists", () => {
+  it("excludes detected agents that have no official project MCP scope", () => {
     const desktop = ClaudeDesktopProvider();
     for (const detectPath of desktop.detectPaths()) {
       mkdirSync(detectPath, { recursive: true });
@@ -327,7 +403,7 @@ describe("stepDetectTools", () => {
     });
 
     const detected = stepDetectTools();
-    expect(detected.map((p2) => p2.id())).toEqual(["claude-desktop"]);
+    expect(detected.map((p2) => p2.id())).toEqual([]);
   });
 
   it("returns empty array when no providers are installed", () => {
@@ -378,21 +454,24 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("install");
     expect(results[0].error).toBeUndefined();
 
     // Verify the file was actually written to disk
-    const configPath = cursor.globalConfigPath();
+    const configPath = cursor.projectConfigPath(projectDir) ?? "";
     expect(existsSync(configPath)).toBe(true);
 
     const written = loadJSONConfig(configPath);
     expect(written.mcpServers).toBeDefined();
     expect(written.mcpServers.dosu).toBeDefined();
-    expect(written.mcpServers.dosu.url).toContain("dep-123");
-    expect(written.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+    expect(written.mcpServers.dosu.command).toBe("npx");
+    expect(written.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "dep-123"]),
+    );
+    expect(JSON.stringify(written)).not.toContain("key-abc");
   });
 
   it("removes a provider and deletes the dosu entry from disk", () => {
@@ -400,8 +479,8 @@ describe("stepConfigureTools", () => {
     const cursor = CursorProvider();
 
     // First install so there's something to remove
-    cursor.install(cfg, true);
-    const configPath = cursor.globalConfigPath();
+    cursor.install(cfg, false, { projectRoot: projectDir });
+    const configPath = cursor.projectConfigPath(projectDir) ?? "";
     let written = loadJSONConfig(configPath);
     expect(written.mcpServers.dosu).toBeDefined();
 
@@ -411,7 +490,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("remove");
@@ -431,13 +510,13 @@ describe("stepConfigureTools", () => {
       skipped: [cursor],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("skip");
     expect(results[0].error).toBeUndefined();
     // No file should have been created
-    expect(existsSync(cursor.globalConfigPath())).toBe(false);
+    expect(existsSync(cursor.projectConfigPath(projectDir) ?? "")).toBe(false);
   });
 
   it("handles install errors and records them in results", () => {
@@ -449,7 +528,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("install");
@@ -468,7 +547,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("remove");
@@ -477,17 +556,63 @@ describe("stepConfigureTools", () => {
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Broken Tool"));
   });
 
+  it.each([
+    "install",
+    "remove",
+  ] as const)("fails before mutation when a provider's project path throws during %s planning", (action) => {
+    const broken = {
+      ...throwingProvider(),
+      projectConfigPath: () => {
+        throw new Error(`${action} path failed`);
+      },
+    };
+    const selection: ToolSelection = {
+      toInstall: action === "install" ? [broken] : [],
+      toRemove: action === "remove" ? [broken] : [],
+      skipped: [],
+    };
+
+    const results = stepConfigureTools(makeCfg(), selection, projectDir);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe(action);
+    expect(results[0].error?.message).toContain(`${action} path failed`);
+  });
+
+  it("fails before the first write when a target cannot be safely captured", () => {
+    const cursor = CursorProvider();
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const directoryPath = join(projectDir, ".unsafe-config");
+    mkdirSync(directoryPath);
+    const unsafeInstall = vi.fn();
+    const unsafe = {
+      ...throwingProvider(),
+      projectConfigPath: () => directoryPath,
+      install: unsafeInstall,
+    };
+
+    const results = stepConfigureTools(
+      makeCfg(),
+      { toInstall: [cursor, unsafe], toRemove: [], skipped: [] },
+      projectDir,
+    );
+
+    expect(existsSync(cursorPath)).toBe(false);
+    expect(unsafeInstall).not.toHaveBeenCalled();
+    expect(results[0].error?.message).toContain("not a regular file");
+  });
+
   it("handles mixed install, remove, and skip in one call", () => {
     const cfg = makeCfg();
     const _cursor = CursorProvider();
     const opencode = OpenCodeProvider();
 
     // Pre-install opencode so we can remove it
-    opencode.install(cfg, true);
+    opencode.install(cfg, false, { projectRoot: projectDir });
 
     const cursorForSkip = CursorProvider();
     // Pre-install cursor so the skip entry refers to an installed provider
-    cursorForSkip.install(cfg, true);
+    cursorForSkip.install(cfg, false, { projectRoot: projectDir });
 
     // Fresh providers for this call
     const freshCursor = CursorProvider();
@@ -500,7 +625,7 @@ describe("stepConfigureTools", () => {
       skipped: [anotherCursor],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, projectDir);
 
     expect(results).toHaveLength(3);
 
@@ -515,12 +640,284 @@ describe("stepConfigureTools", () => {
     expect(skipResult).toBeDefined();
 
     // Verify cursor config was written
-    const cursorConfig = loadJSONConfig(freshCursor.globalConfigPath());
+    const cursorConfig = loadJSONConfig(freshCursor.projectConfigPath(projectDir) ?? "");
     expect(cursorConfig.mcpServers.dosu).toBeDefined();
 
     // Verify opencode dosu entry was removed
-    const opencodeConfig = loadJSONConfig(freshOpencode.globalConfigPath());
+    const opencodeConfig = loadJSONConfig(freshOpencode.projectConfigPath(projectDir) ?? "");
     expect(opencodeConfig.mcp.dosu).toBeUndefined();
+  });
+
+  it("restores an earlier Cursor retarget when a later Codex install fails", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const before = readFileSync(cursorPath, "utf8");
+    const codex = CodexProvider();
+    codex.install = () => {
+      throw new Error("codex failed");
+    };
+
+    const results = stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [cursor, codex], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(before);
+    expect(results.find((result) => result.provider.id() === "codex")?.error?.message).toContain(
+      "codex failed",
+    );
+    expect(results.find((result) => result.provider.id() === "cursor")?.error?.message).toContain(
+      "rolled back",
+    );
+  });
+
+  it("removes a newly created project config when a later provider fails", () => {
+    const cursor = CursorProvider();
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const broken = throwingProvider();
+
+    stepConfigureTools(
+      makeCfg(),
+      { toInstall: [cursor, broken], toRemove: [], skipped: [] },
+      projectDir,
+    );
+
+    expect(existsSync(cursorPath)).toBe(false);
+  });
+
+  it("restores a removed project entry when a later removal fails", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg(), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const before = readFileSync(cursorPath, "utf8");
+
+    const results = stepConfigureTools(
+      makeCfg(),
+      { toInstall: [], toRemove: [cursor, throwingProvider()], skipped: [] },
+      projectDir,
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(before);
+    expect(results[0].action).toBe("remove");
+    expect(results[0].error?.message).toContain("rolled back");
+    expect(results[1].error?.message).toContain("provider failure");
+  });
+
+  it("captures a shared .mcp.json preimage only once for rollback", () => {
+    const claude = ClaudeProvider();
+    const copilot = CopilotProvider();
+    claude.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const sharedPath = claude.projectConfigPath(projectDir) ?? "";
+    const before = readFileSync(sharedPath, "utf8");
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [claude, copilot, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    expect(copilot.projectConfigPath(projectDir)).toBe(sharedPath);
+    expect(readFileSync(sharedPath, "utf8")).toBe(before);
+  });
+
+  it("tracks the latest output when two providers write the same project path", () => {
+    const sharedPath = join(projectDir, ".mcp.json");
+    writeFileSync(sharedPath, "before");
+    const sharedProvider = (id: string, output: string): providersModule.SetupProvider => ({
+      ...throwingProvider(),
+      name: () => id,
+      id: () => id,
+      projectConfigPath: () => sharedPath,
+      install: () => writeProjectFile(sharedPath, output, readFileSync(sharedPath, "utf8")),
+    });
+
+    stepConfigureTools(
+      makeCfg(),
+      {
+        toInstall: [
+          sharedProvider("first", "first-output"),
+          sharedProvider("second", "second-output"),
+          throwingProvider(),
+        ],
+        toRemove: [],
+        skipped: [],
+      },
+      projectDir,
+    );
+
+    expect(readFileSync(sharedPath, "utf8")).toBe("before");
+  });
+
+  it("stops before a provider write when an earlier provider changed its captured target", () => {
+    const firstPath = join(projectDir, ".first.json");
+    const victimPath = join(projectDir, ".victim.json");
+    writeFileSync(victimPath, "victim-before");
+    const first = {
+      ...throwingProvider(),
+      name: () => "First",
+      id: () => "first",
+      projectConfigPath: () => firstPath,
+      install: () => {
+        const receipt = writeProjectFile(firstPath, "first-output", null);
+        writeFileSync(victimPath, "user-edit");
+        return receipt;
+      },
+    };
+    const victimInstall = vi.fn(() => undefined);
+    const victim = {
+      ...throwingProvider(),
+      name: () => "Victim",
+      id: () => "victim",
+      projectConfigPath: () => victimPath,
+      install: victimInstall,
+    };
+
+    const results = stepConfigureTools(
+      makeCfg(),
+      { toInstall: [first, victim], toRemove: [], skipped: [] },
+      projectDir,
+    );
+
+    expect(victimInstall).not.toHaveBeenCalled();
+    expect(readFileSync(victimPath, "utf8")).toBe("user-edit");
+    expect(existsSync(firstPath)).toBe(false);
+    expect(results[1].error?.message).toContain("changed after setup started");
+  });
+
+  it("preserves an unprovable provider output that is not a regular file", () => {
+    const outputPath = join(projectDir, ".unexpected-directory");
+    const provider = {
+      ...throwingProvider(),
+      projectConfigPath: () => outputPath,
+      install: () => {
+        mkdirSync(outputPath);
+        return undefined;
+      },
+    };
+
+    const results = stepConfigureTools(
+      makeCfg(),
+      { toInstall: [provider], toRemove: [], skipped: [] },
+      projectDir,
+    );
+
+    expect(lstatSync(outputPath).isDirectory()).toBe(true);
+    expect(results[0].error?.message).toContain("not a regular file");
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("preserving it for safety"));
+  });
+
+  it("preserves a concurrent user edit instead of rolling it back", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const userEdit = '{\n  "mcpServers": {\n    "dosu": { "user": "edit" }\n  }\n}\n';
+    const codex = CodexProvider();
+    codex.install = () => {
+      writeFileSync(cursorPath, userEdit);
+      throw new Error("codex failed after concurrent edit");
+    };
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [cursor, codex], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(userEdit);
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining(cursorPath));
+  });
+
+  it("preserves a sibling added inside a built-in provider install before a later failure", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const racedCursor: providersModule.SetupProvider = {
+      ...cursor,
+      install(cfg, global, opts) {
+        const current = loadJSONConfig(cursorPath);
+        current.mcpServers.user = { command: "user-owned" };
+        writeFileSync(cursorPath, JSON.stringify(current, null, 2));
+        return cursor.install(cfg, global, opts);
+      },
+    };
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [racedCursor, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    const after = loadJSONConfig(cursorPath);
+    expect(after.mcpServers.user).toEqual({ command: "user-owned" });
+    expect(after.mcpServers.dosu.args).toContain("dep-b");
+  });
+
+  it("preserves an inside-install sibling on the shared Claude and Copilot path", () => {
+    const claude = ClaudeProvider();
+    const copilot = CopilotProvider();
+    claude.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const sharedPath = claude.projectConfigPath(projectDir) ?? "";
+    const racedCopilot: providersModule.SetupProvider = {
+      ...copilot,
+      install(cfg, global, opts) {
+        const current = loadJSONConfig(sharedPath);
+        current.mcpServers.user = { command: "shared-user-owned" };
+        writeFileSync(sharedPath, JSON.stringify(current, null, 2));
+        return copilot.install(cfg, global, opts);
+      },
+    };
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [claude, racedCopilot, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+    );
+
+    const after = loadJSONConfig(sharedPath);
+    expect(after.mcpServers.user).toEqual({ command: "shared-user-owned" });
+    expect(after.mcpServers.dosu.args).toContain("dep-b");
+  });
+
+  it("does not overwrite a replacement racing an existing-file rollback", () => {
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-a" }), false, { projectRoot: projectDir });
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const userEdit = '{\n  "mcpServers": {\n    "dosu": { "user": "restore-race" }\n  }\n}\n';
+
+    stepConfigureTools(
+      makeCfg({ deployment_id: "dep-b" }),
+      { toInstall: [cursor, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      true,
+      { beforeCapture: () => writeFileSync(cursorPath, userEdit) },
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(userEdit);
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("roll back"));
+  });
+
+  it("does not delete a replacement racing a newly-created-file rollback", () => {
+    const cursor = CursorProvider();
+    const cursorPath = cursor.projectConfigPath(projectDir) ?? "";
+    const userEdit = '{\n  "mcpServers": {\n    "dosu": { "user": "delete-race" }\n  }\n}\n';
+
+    stepConfigureTools(
+      makeCfg(),
+      { toInstall: [cursor, throwingProvider()], toRemove: [], skipped: [] },
+      projectDir,
+      false,
+      { beforeCapture: () => writeFileSync(cursorPath, userEdit) },
+    );
+
+    expect(readFileSync(cursorPath, "utf8")).toBe(userEdit);
+    expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining("roll back"));
   });
 });
 
@@ -757,26 +1154,336 @@ describe("runSetup integration", () => {
     // Create Cursor detect path
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
 
-    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    const cursor = CursorProvider();
+    const undetectedCodex = CodexProvider();
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [
+      cursor,
+      undetectedCodex,
+    ]);
 
     // User selects cursor in multiselect
     mockToolSelection(["cursor"]);
 
     await runSetup();
 
+    expect(mockResolveProjectPinnedTarget).toHaveBeenCalledWith(
+      [cursor, undetectedCodex],
+      projectDir,
+    );
     // Verify the config was actually written to disk
-    const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
+    const cursorConfigPath = join(projectDir, ".cursor", "mcp.json");
     expect(existsSync(cursorConfigPath)).toBe(true);
     const cursorConfig = loadJSONConfig(cursorConfigPath);
     expect(cursorConfig.mcpServers.dosu).toBeDefined();
-    expect(cursorConfig.mcpServers.dosu.url).toContain("d1");
+    expect(cursorConfig.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "d1"]),
+    );
+    expect(JSON.stringify(cursorConfig)).not.toContain("minted-key");
 
     // Verify summary was shown
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
-    expect(mockStepConfigureAgentRules).toHaveBeenCalledWith(
-      expect.objectContaining({ toInstall: [expect.objectContaining({})] }),
-      [expect.objectContaining({ action: "install" })],
+    expect(mockInstallProjectInstructions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRoot: projectDir,
+        providerIDs: ["cursor"],
+      }),
     );
+    expect(mockPreflightProjectProxy).toHaveBeenCalledWith(expect.any(Object), projectDir);
+    expect(mockRunProjectScopeMigration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerIDs: ["cursor"],
+        runtimeVerified: true,
+        proxy: expect.objectContaining({ deploymentID: "d1" }),
+      }),
+    );
+    expect(mockRunProjectScopeMigration.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mockInstallProjectInstructions.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("fails closed without an outro when recoverable legacy cleanup cannot finish", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockRunProjectScopeMigration.mockReturnValue({
+      ok: false,
+      cleanupAttempted: true,
+      runtimeVerified: true,
+      reason: "migration_failed",
+      receiptRoot: "/tmp/dosu-test-migration-receipts",
+      counts: { removed: 0, not_found: 0, preserved: 1, failed: 1, total: 2 },
+      warnings: [],
+    });
+
+    await runSetup();
+
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(true);
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("safe legacy cleanup could not finish"),
+    );
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("/tmp/dosu-test-migration-receipts"),
+    );
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("keeps an exact project deployment pin instead of silently following the active global target", async () => {
+    saveConfig(makeCfg({ deployment_id: "d-global", deployment_name: "Global" }));
+    const clientMethods = setupAuthenticatedClient({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([
+          makeDeployment({ deployment_id: "d-project", name: "Project" }),
+          makeDeployment({ deployment_id: "d-global", name: "Global" }),
+        ]),
+    });
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["cursor"],
+      target: { packageVersion: "0.42.0", deploymentID: "d-project" },
+    });
+
+    await runSetup();
+
+    expect(clientMethods.getDeployments).toHaveBeenCalled();
+    expect(loadConfig().active_account?.target?.deployment_id).toBe("d-project");
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "d-project"]),
+    );
+  });
+
+  it("stops before project writes when exact project configs disagree on their target", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "conflicting_project_targets",
+      providers: ["cursor", "codex"],
+      paths: [join(projectDir, ".cursor", "mcp.json"), join(projectDir, ".codex", "config.toml")],
+    });
+
+    await runSetup();
+
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(mockInstallProjectInstructions).not.toHaveBeenCalled();
+    expect(mockRunProjectScopeMigration).not.toHaveBeenCalled();
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(false);
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("stops before authentication when a project Dosu entry is ambiguous", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg({ access_token: undefined, refresh_token: undefined }));
+    const cursor = CursorProvider();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([cursor]);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: false,
+      reason: "ambiguous_project_config",
+      providers: ["cursor"],
+      paths: [join(projectDir, ".cursor", "mcp.json")],
+    });
+
+    await runSetup();
+
+    expect(mockStartOAuthFlow).not.toHaveBeenCalled();
+    expect(mockClient).not.toHaveBeenCalled();
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining(".cursor/mcp.json"));
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("rejects an explicit deployment split-brain before project writes", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthenticatedClient({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "dep-explicit" })]),
+    });
+    const cursor = CursorProvider();
+    const undetectedCodex = CodexProvider();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([cursor, undetectedCodex]);
+    mockToolSelection(["cursor"]);
+    mockResolveProjectPinnedTarget
+      .mockReturnValueOnce({
+        ok: true,
+        providers: ["cursor", "codex"],
+        target: { deploymentID: "dep-old" },
+      })
+      .mockReturnValueOnce({
+        ok: false,
+        reason: "requested_project_target_conflict",
+        providers: ["codex"],
+        paths: [join(projectDir, ".codex", "config.toml")],
+      });
+
+    await runSetup({ deploymentID: "dep-explicit" });
+
+    expect(mockResolveProjectPinnedTarget).toHaveBeenNthCalledWith(
+      1,
+      [cursor, undetectedCodex],
+      projectDir,
+    );
+    expect(mockResolveProjectPinnedTarget).toHaveBeenNthCalledWith(
+      2,
+      [cursor, undetectedCodex],
+      projectDir,
+      { mode: "cloud", deploymentID: "dep-explicit" },
+      ["cursor"],
+    );
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+    expect(mockInstallProjectInstructions).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("allows one selected Cursor client to retarget its own pin explicitly", async () => {
+    saveConfig(makeCfg({ deployment_id: "dep-old", deployment_name: "Old" }));
+    setupAuthenticatedClient({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "dep-new", name: "New" })]),
+    });
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    const cursor = CursorProvider();
+    cursor.install(makeCfg({ deployment_id: "dep-old" }), false, { projectRoot: projectDir });
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([cursor]);
+    mockToolSelection(["cursor"]);
+    mockResolveProjectPinnedTarget
+      .mockReturnValueOnce({
+        ok: true,
+        providers: ["cursor"],
+        target: { deploymentID: "dep-old" },
+      })
+      .mockReturnValueOnce({
+        ok: true,
+        providers: ["cursor"],
+        target: { deploymentID: "dep-new" },
+      });
+
+    await runSetup({ deploymentID: "dep-new" });
+
+    expect(mockResolveProjectPinnedTarget).toHaveBeenNthCalledWith(
+      2,
+      [cursor],
+      projectDir,
+      { mode: "cloud", deploymentID: "dep-new" },
+      ["cursor"],
+    );
+    const config = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(config.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["--deployment", "dep-new"]),
+    );
+  });
+
+  it("stops before project writes when the pinned deployment is not available to this account", async () => {
+    saveConfig(makeCfg({ deployment_id: "d-global", deployment_name: "Global" }));
+    setupAuthenticatedClient({
+      getDeployments: vi
+        .fn()
+        .mockResolvedValue([makeDeployment({ deployment_id: "d-global", name: "Global" })]),
+    });
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockResolveProjectPinnedTarget.mockReturnValue({
+      ok: true,
+      providers: ["cursor"],
+      target: { packageVersion: "0.42.0", deploymentID: "d-project" },
+    });
+
+    await runSetup();
+
+    expect(mockPreflightProjectProxy).not.toHaveBeenCalled();
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(mockRunProjectScopeMigration).not.toHaveBeenCalled();
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(false);
+  });
+
+  it("fails before every project write when the exact MCP command cannot initialize", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockPreflightProjectProxy.mockResolvedValue({ ok: false, reason: "timeout" });
+
+    await runSetup();
+
+    expect(existsSync(join(projectDir, ".cursor", "mcp.json"))).toBe(false);
+    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(mockInstallProjectInstructions).not.toHaveBeenCalled();
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("No project files"));
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("removes a deselected adapter when another agent retains the shared project MCP file", async () => {
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".claude"), { recursive: true });
+    mkdirSync(join(tempDir, ".copilot"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [
+      ClaudeProvider(),
+      CopilotProvider(),
+    ]);
+    ClaudeProvider().install(makeCfg(), false, { projectRoot: projectDir });
+    expect(ClaudeProvider().isProjectConfigured(projectDir)).toBe(true);
+    expect(CopilotProvider().isProjectConfigured(projectDir)).toBe(true);
+    mockToolSelection(["copilot"]);
+
+    await runSetup();
+
+    expect(loadJSONConfig(join(projectDir, ".mcp.json")).mcpServers.dosu).toBeDefined();
+    expect(mockRemoveProjectAdapters).toHaveBeenCalledWith(projectDir, ["claude"]);
+  });
+
+  it("keeps a deselected shared-path adapter when a later MCP removal fails", async () => {
+    saveConfig(makeCfg());
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".claude"), { recursive: true });
+    mkdirSync(join(tempDir, ".copilot"), { recursive: true });
+    mkdirSync(join(tempDir, ".gemini"), { recursive: true });
+    const claude = ClaudeProvider();
+    const copilot = CopilotProvider();
+    const gemini = GeminiProvider();
+    claude.install(makeCfg(), false, { projectRoot: projectDir });
+    gemini.install(makeCfg(), false, { projectRoot: projectDir });
+    const claudeAdapter = join(projectDir, "CLAUDE.md");
+    writeFileSync(claudeAdapter, "user-visible adapter\n");
+    gemini.remove = () => {
+      throw new Error("gemini removal failed");
+    };
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [
+      claude,
+      copilot,
+      gemini,
+    ]);
+    mockToolSelection(["copilot"]);
+
+    await runSetup();
+
+    expect(loadJSONConfig(join(projectDir, ".mcp.json")).mcpServers.dosu).toBeDefined();
+    expect(readFileSync(claudeAdapter, "utf8")).toBe("user-visible adapter\n");
+    expect(mockRemoveProjectAdapters).not.toHaveBeenCalled();
   });
 
   it("runs OAuth flow and saves tokens to real config", async () => {
@@ -877,9 +1584,11 @@ describe("runSetup integration", () => {
     expect(savedCfg.active_account?.target?.deployment_id).toBe("d2");
     expect(savedCfg.active_account?.target?.api_key).toBe("key-abc");
 
-    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
-    expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp/deployments/d2");
-    expect(cursorConfig.mcpServers.dosu.url).not.toBe(ossConfig.mcpServers.dosu.url);
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "d2"]),
+    );
+    expect(cursorConfig.mcpServers.dosu.url).toBeUndefined();
   });
 
   it("creates new API key when existing one is invalid", async () => {
@@ -921,8 +1630,10 @@ describe("runSetup integration", () => {
     await runSetup();
 
     // Cursor should have been reinstalled (not skipped) because api_key changed
-    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
-    expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("new-key");
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.args).toContain("d1");
+    expect(JSON.stringify(cursorConfig)).not.toContain("new-key");
+    expect(loadConfig().active_account?.target?.api_key).toBe("new-key");
   });
 
   it("reinstalls configured tools when setup is re-run with the same target", async () => {
@@ -930,8 +1641,8 @@ describe("runSetup integration", () => {
     const cfg = makeCfg({ deployment_id: "d1", deployment_name: "Deploy1", api_key: "key-abc" });
     saveConfig(cfg);
 
-    const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
-    saveJSONConfig(cursorConfigPath, {
+    const legacyGlobalConfigPath = join(tempDir, ".cursor", "mcp.json");
+    saveJSONConfig(legacyGlobalConfigPath, {
       mcpServers: {
         dosu: {
           type: "http",
@@ -952,9 +1663,11 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    const cursorConfig = loadJSONConfig(cursorConfigPath);
-    expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp/deployments/d1");
-    expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
+    expect(cursorConfig.mcpServers.dosu.args).toEqual(
+      expect.arrayContaining(["mcp", "proxy", "d1"]),
+    );
+    expect(JSON.stringify(cursorConfig)).not.toContain("key-abc");
   });
 
   it("shows error when OAuth fails", async () => {
@@ -1382,32 +2095,22 @@ describe("runSetup integration", () => {
       OpenCodeProvider(),
     ]);
 
-    // Pre-configure both providers with the production-shaped absolute URL
-    // required by the stricter ownership check introduced in this stack layer.
-    const previousBackendOverride = process.env.DOSU_BACKEND_URL_OVERRIDE;
-    try {
-      process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api.dosu.dev";
-      CursorProvider().install(cfg, true);
-      OpenCodeProvider().install(cfg, true);
-    } finally {
-      if (previousBackendOverride === undefined) delete process.env.DOSU_BACKEND_URL_OVERRIDE;
-      else process.env.DOSU_BACKEND_URL_OVERRIDE = previousBackendOverride;
-    }
+    // Pre-configure both providers so isConfigured() returns true
+    CursorProvider().install(cfg, true);
+    OpenCodeProvider().install(cfg, true);
 
     // User deselects opencode but keeps cursor
     mockToolSelection(["cursor"]);
 
     await runSetup();
 
-    // OpenCode should have been removed (configured + deselected)
+    // A global-only legacy OpenCode entry is preserved until a verified project equivalent exists.
     const opencodeConfig = loadJSONConfig(join(tempDir, ".config", "opencode", "opencode.json"));
-    expect(opencodeConfig.mcp?.dosu).toBeUndefined();
+    expect(opencodeConfig.mcp?.dosu).toBeDefined();
 
-    // Cursor config should still have dosu entry (was skipped)
-    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    // Cursor gets the selected project-scoped entry.
+    const cursorConfig = loadJSONConfig(join(projectDir, ".cursor", "mcp.json"));
     expect(cursorConfig.mcpServers?.dosu).toBeDefined();
-
-    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 agent"));
   });
 
   it("OSS mode configures MCP but never offers the audit handoff", async () => {
@@ -1439,7 +2142,10 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], {
+      quiet: true,
+      projectRoot: projectDir,
+    });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/skills/cursor/dosu"));
   });
@@ -1470,7 +2176,10 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], {
+      quiet: true,
+      projectRoot: projectDir,
+    });
   });
 
   it("goes directly to agent selection without a component-selection prompt", async () => {
@@ -1503,7 +2212,9 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockStepUpdateAgentsMd).toHaveBeenCalledTimes(1);
+    expect(mockInstallProjectInstructions).toHaveBeenCalledWith(
+      expect.objectContaining({ projectRoot: projectDir, providerIDs: ["cursor"] }),
+    );
 
     const completed = trackedCliOnboardingEvents().find(
       (e) => e.event === "cli_onboarding_completed",
@@ -2248,9 +2959,8 @@ describe("runSetup additional branches", () => {
     expect(saved.mode).toBeUndefined();
   });
 
-  it("continues to the outro when the skill install reports failure", async () => {
-    // skillCompleted is false → the `if (skillCompleted)` tracking branch is
-    // skipped, but the flow still completes (MCP/docs unaffected).
+  it("does not claim setup completed when the project skill is missing", async () => {
+    const originalExitCode = process.exitCode;
     saveConfig(makeCfg());
     setupAuthed();
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
@@ -2261,8 +2971,36 @@ describe("runSetup additional branches", () => {
     await runSetup();
 
     expect(p.log.error).toHaveBeenCalledWith(expect.stringContaining("Failed to install skill"));
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Project setup is incomplete"),
+    );
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
     const skillEvents = trackedCliOnboardingEvents().map((e) => e.event);
     expect(skillEvents).not.toContain("cli_onboarding_skill_installed");
+    expect(skillEvents).toContain("cli_onboarding_failed");
+    process.exitCode = originalExitCode;
+  });
+
+  it("does not claim setup completed when project instructions fail", async () => {
+    const originalExitCode = process.exitCode;
+    saveConfig(makeCfg());
+    setupAuthed();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockInstallProjectInstructions.mockImplementation(() => {
+      throw new Error("instructions are read-only");
+    });
+
+    await runSetup();
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("Could not configure project instructions"),
+    );
+    expect(p.outro).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
   });
 
   it("neither installs nor removes a detected tool that is unconfigured and left unticked", async () => {

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -3,6 +3,8 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { lstatSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { Client, type Deployment, type Org, SessionExpiredError } from "../client/client";
 import { installSkill, skillInstallTargetForProvider } from "../commands/skill";
@@ -17,12 +19,34 @@ import {
   updateTarget,
 } from "../config/config";
 import { logger } from "../debug/logger";
+import {
+  type ProjectFileMutationHooks,
+  type ProjectFileMutationReceipt,
+  removeProjectFile,
+  writeProjectFile,
+} from "../mcp/config-helpers";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
+import { recordProjectProxyEndpoint } from "../mcp/project-proxy";
+import { preflightProjectProxy } from "../mcp/project-proxy-preflight";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
-import { inGitWorkTree, stepUpdateAgentsMd } from "./agents-md-step";
+import { type ProviderId, resolveProjectProof } from "../migration";
+import { fetchDosuRule } from "../rules/installer";
+import { VERSION } from "../version/version";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
 import { launchAuditAgent, offerAuditHandoff } from "./audit-handoff";
-import { stepConfigureAgentRules } from "./rules-step";
+import {
+  installProjectInstructions,
+  providerUsesProjectInstructions,
+  removeProjectInstructionAdapters,
+} from "./project-instructions";
+import { assertSafeProjectPath } from "./project-path";
+import { requireProjectRoot } from "./project-root";
+import { runProjectScopeMigration } from "./project-scope-migration";
+import {
+  type ProjectPinnedTargetResolution,
+  type RequestedProjectTarget,
+  resolveProjectPinnedTarget,
+} from "./project-target";
 import { browserFallbackHint, dim, formatSetupSummary, IconRemove, info } from "./styles";
 
 export interface SetupOptions {
@@ -73,12 +97,33 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     }`,
   );
   p.intro("Dosu CLI Setup");
+  let projectRoot: string;
+  try {
+    projectRoot = requireProjectRoot();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    p.log.error(message);
+    process.exitCode = 1;
+    return;
+  }
+  let cfg = loadConfig();
+  const setupProviders = allSetupProviders();
+  const initialRequestedTarget = requestedProjectTarget(opts, cfg);
+  // First pass is read-only and happens before authentication: reject every
+  // foreign/invalid entry and repositories whose existing exact pins already
+  // disagree. Explicit retargeting gets a second, selection-aware check just
+  // before any project file can be written.
+  const projectTarget = resolveProjectPinnedTarget(setupProviders, projectRoot);
+  if (!projectTarget.ok) {
+    p.log.error(projectTargetFailureMessage(projectTarget));
+    process.exitCode = 1;
+    return;
+  }
+
   await trackCliOnboardingPreAuthEvent(onboardingRunID, "cli_onboarding_launch_attempted", {
     has_deployment_option: Boolean(opts.deploymentID),
     mode_option: opts.mode,
   });
-
-  let cfg = loadConfig();
 
   applyModeOverride(cfg, opts);
 
@@ -169,12 +214,45 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     cloudSetupContext = refreshed;
   }
 
+  const detectedProviders = stepDetectTools(setupProviders);
+  let projectDeploymentResolved = false;
+  if (
+    !opts.deploymentID &&
+    opts.mode !== "oss" &&
+    (opts.mode !== "cloud" ||
+      initialRequestedTarget?.mode !== "cloud" ||
+      !initialRequestedTarget.deploymentID)
+  ) {
+    // Existing pins were inspected before authentication, including clients
+    // not installed on this machine. A Cloud request with no explicit ID may
+    // reuse the repository's one proven Cloud pin; an explicit ID was already
+    // checked for equality and is resolved by the normal explicit path below.
+    if (projectTarget.target?.oss && !opts.mode) {
+      cfg.mode = MODE_OSS;
+    } else if (projectTarget.target?.deploymentID) {
+      const ok = await resolveDeployment(apiClient, cfg, {
+        ...opts,
+        deploymentID: projectTarget.target.deploymentID,
+      });
+      if (!ok) {
+        await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+          reason: "project_deployment_unavailable",
+        });
+        return;
+      }
+      projectDeploymentResolved = true;
+    }
+  }
+
   // Deployment: run the picker only when nothing is locked in yet, or when
   // `--deployment` explicitly asks to switch. Everyday re-runs reuse the
   // stored deployment silently. (After an account change the handshake
   // dropped the old target, so the fresh account resolves here —
   // stepSelectDeployment auto-picks the single real MCP.)
-  if (!cfg.active_account?.target?.deployment_id || opts.deploymentID) {
+  if (
+    !projectDeploymentResolved &&
+    (!cfg.active_account?.target?.deployment_id || opts.deploymentID)
+  ) {
     const ok = await resolveDeployment(apiClient, cfg, opts);
     if (!ok) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
@@ -194,23 +272,40 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     return;
   }
   updateTarget(cfg, { api_key: apiKey });
+  recordProjectProxyEndpoint(cfg);
   saveConfig(cfg);
 
   // Agent selection is the only install choice. Every successfully configured
   // agent receives the full supported bundle: MCP, rules, and skill.
-  const configured = await stepConfigureMcpTools(cfg);
-  if (configured === null) {
+  const configuration = await stepConfigureMcpTools(
+    cfg,
+    projectRoot,
+    Boolean(opts.deploymentID || opts.mode),
+    detectedProviders,
+    setupProviders,
+    opts.deploymentID || opts.mode ? configuredProjectTarget(cfg) : undefined,
+  );
+  if (configuration === null) {
     await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
       reason: "mcp_selection_cancelled",
     });
     return;
   }
+  if (!configuration.ok) {
+    process.exitCode = 1;
+    await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+      reason: configuration.reason,
+    });
+    return;
+  }
+  const configured = configuration.results;
+  const runtimeVerified = configuration.runtimeVerified;
 
   const mcpConfiguredThisRun = configured.some(
-    (result) => result.action === "install" || result.action === "skip",
+    (result) => result.action === "install" && !result.error,
   );
   const configuredProviders = configured.filter(
-    (result) => (result.action === "install" || result.action === "skip") && !result.error,
+    (result) => result.action === "install" && !result.error,
   );
   const mcpCompleted = configuredProviders.length > 0;
   if (mcpCompleted) {
@@ -228,7 +323,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     .map((result) => result.provider)
     .filter((provider) => skillInstallTargetForProvider(provider.id()) !== null);
   if (skillProviders.length > 0) {
-    skillCompleted = await runInstallSkill(skillProviders);
+    skillCompleted = await runInstallSkill(skillProviders, projectRoot);
     if (skillCompleted) {
       await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_skill_installed");
     }
@@ -237,8 +332,97 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   // Project instructions are part of the bundle when setup runs inside a git
   // work tree and at least one agent was configured.
   let agentsMdCompleted = false;
-  if (mcpCompleted && inGitWorkTree()) {
-    agentsMdCompleted = await stepUpdateAgentsMd();
+  let instructionContent = "";
+  const instructionProviderIDs = configuredProviders
+    .map((result) => result.provider.id())
+    .filter(providerUsesProjectInstructions);
+  if (instructionProviderIDs.length > 0) {
+    try {
+      instructionContent = await fetchDosuRule();
+      const projectInstructions = installProjectInstructions({
+        projectRoot,
+        providerIDs: instructionProviderIDs,
+        content: instructionContent,
+      });
+      agentsMdCompleted = true;
+      p.log.success(
+        formatSetupSummary("Project instructions ready:", [
+          { path: projectInstructions.agentsMd.path },
+          ...projectInstructions.adapters.map((adapter) => ({ path: adapter.path })),
+        ]),
+      );
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("setup", `Project instruction install failed: ${message}`);
+      p.log.error(`Could not configure project instructions: ${message}`);
+    }
+  }
+
+  const projectBundleIncomplete =
+    configured.some((result) => Boolean(result.error)) ||
+    (skillProviders.length > 0 && !skillCompleted) ||
+    (instructionProviderIDs.length > 0 && !agentsMdCompleted);
+  if (projectBundleIncomplete) {
+    p.log.error(
+      "Project setup is incomplete. Legacy global configuration was preserved; fix the error above and re-run `dosu setup`.",
+    );
+    process.exitCode = 1;
+    await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+      reason: "project_bundle_incomplete",
+    });
+    return;
+  }
+
+  if (configuredProviders.length > 0) {
+    const project = resolveProjectProof(projectRoot);
+    if (!project.ok) {
+      p.log.error(
+        "Could not re-verify the Git project before legacy cleanup. Project files remain installed and global configuration was preserved.",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    const providerIDs = configuredProviders.map((result) => result.provider.id()) as ProviderId[];
+    const proxy =
+      cfg.mode === MODE_OSS
+        ? ({ packageVersion: VERSION, oss: true } as const)
+        : {
+            packageVersion: VERSION,
+            deploymentID: cfg.active_account?.target?.deployment_id as string,
+          };
+    const migration = runProjectScopeMigration({
+      project: project.proof,
+      providerIDs,
+      proxy,
+      instructionContent,
+      runtimeVerified,
+    });
+    for (const warning of migration.warnings) logger.warn("setup", warning);
+    if (!migration.ok) {
+      const cleanupProgress =
+        migration.counts.removed > 0
+          ? `${migration.counts.removed} proven global item(s) were already backed up and removed before cleanup stopped.`
+          : "No global item was removed.";
+      p.log.error(
+        `Project setup succeeded, but safe legacy cleanup could not finish (${migration.reason}). ` +
+          `${cleanupProgress} Nothing ambiguous was deleted. Recovery receipts: ${migration.receiptRoot}`,
+      );
+      process.exitCode = 1;
+      await trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_failed", {
+        reason: "legacy_migration_failed",
+      });
+      return;
+    }
+    if (migration.counts.removed > 0) {
+      p.log.success(
+        `Migrated ${migration.counts.removed} legacy global item(s). Recovery receipts: ${migration.receiptRoot}`,
+      );
+    }
+    if (migration.counts.preserved > 0) {
+      p.log.warn(
+        `Preserved ${migration.counts.preserved} ambiguous global item(s); nothing unproven was deleted. Receipts: ${migration.receiptRoot}`,
+      );
+    }
   }
 
   // Codebase audit handoff (cloud mode only — it acts on the user's own
@@ -298,32 +482,130 @@ function applyModeOverride(cfg: Config, opts: SetupOptions): void {
   saveConfig(cfg);
 }
 
+function requestedProjectTarget(
+  opts: SetupOptions,
+  cfg: Config,
+): RequestedProjectTarget | undefined {
+  if (opts.deploymentID) return { mode: "cloud", deploymentID: opts.deploymentID };
+  if (opts.mode === "oss") return { mode: "oss" };
+  if (opts.mode === "cloud") {
+    return {
+      mode: "cloud",
+      deploymentID: cfg.active_account?.target?.deployment_id,
+    };
+  }
+  return undefined;
+}
+
+function configuredProjectTarget(cfg: Config): RequestedProjectTarget {
+  return cfg.mode === MODE_OSS
+    ? { mode: "oss" }
+    : {
+        mode: "cloud",
+        deploymentID: cfg.active_account?.target?.deployment_id,
+      };
+}
+
+function projectTargetFailureMessage(
+  result: Extract<ProjectPinnedTargetResolution, { ok: false }>,
+): string {
+  const locations = result.paths.join(", ");
+  if (result.reason === "ambiguous_project_config") {
+    return (
+      `Cannot safely use the project's Dosu MCP config because these entries are foreign or invalid: ${locations}. ` +
+      "No project file was changed; inspect or remove those entries, then retry."
+    );
+  }
+  if (result.reason === "requested_project_target_conflict") {
+    return (
+      `The requested Dosu target conflicts with existing project clients (${result.providers.join(", ")}): ${locations}. ` +
+      "Make every listed client use the same target before retrying; no project file was changed."
+    );
+  }
+  return (
+    `This project has Dosu agent configs pointing at different MCPs (${result.providers.join(", ")}): ${locations}. ` +
+    "Make every listed client use the same target before retrying; no project file was changed."
+  );
+}
+
 /**
  * Runs MCP tool detection → selection → configuration as a single unit.
  * Returns the ConfigResult array on success, or null if the user cancelled.
  * An empty detection pool is treated as success (nothing to do).
  */
-async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null> {
-  const detected = stepDetectTools();
+async function stepConfigureMcpTools(
+  cfg: Config,
+  projectRoot: string,
+  allowProjectRetarget = false,
+  detected: SetupProvider[] = stepDetectTools(),
+  allProviders: readonly SetupProvider[] = detected,
+  requestedTarget?: RequestedProjectTarget,
+): Promise<
+  | { ok: true; results: ConfigResult[]; runtimeVerified: boolean }
+  | {
+      ok: false;
+      reason: "project_proxy_preflight_failed" | "project_target_conflict";
+    }
+  | null
+> {
   if (detected.length === 0) {
     p.log.warn(
       `No supported AI agents detected on your system.\nRun ${info("dosu mcp add <agent>")} to manually configure an agent.`,
     );
-    return [];
+    return { ok: true, results: [], runtimeVerified: false };
   }
-  const selection = await stepSelectTools(detected);
+  const selection = await stepSelectTools(detected, projectRoot);
   if (!selection) return null;
-  const results = stepConfigureTools(cfg, selection);
-  stepShowSummary(results);
-  await stepConfigureAgentRules(selection, results);
-  return results;
+  if (allowProjectRetarget && requestedTarget && selection.toInstall.length > 0) {
+    const targetCheck = resolveProjectPinnedTarget(
+      allProviders,
+      projectRoot,
+      requestedTarget,
+      selection.toInstall.map((provider) => provider.id()),
+    );
+    if (!targetCheck.ok) {
+      p.log.error(projectTargetFailureMessage(targetCheck));
+      return { ok: false, reason: "project_target_conflict" };
+    }
+  }
+  let runtimeVerified = false;
+  if (selection.toInstall.length > 0) {
+    const preflight = await preflightProjectProxy(cfg, projectRoot);
+    if (!preflight.ok) {
+      p.log.error(
+        `Could not start the project MCP (${preflight.reason}). No project files or legacy globals were changed.`,
+      );
+      return { ok: false, reason: "project_proxy_preflight_failed" };
+    }
+    runtimeVerified = true;
+  }
+  const results = stepConfigureTools(cfg, selection, projectRoot, allowProjectRetarget);
+  stepShowSummary(results, projectRoot);
+  // MCP writes/removals are one transaction. A shared-path skip (Claude while
+  // Copilot retains .mcp.json) must not trigger adapter cleanup if any later
+  // provider failed and caused the MCP batch to roll back.
+  if (results.every((result) => !result.error)) {
+    const deselectedProviders = new Set(selection.toRemove.map((provider) => provider.id()));
+    const removedProviders = results
+      .filter(
+        (result) =>
+          result.action === "remove" ||
+          (result.action === "skip" && deselectedProviders.has(result.provider.id())),
+      )
+      .map((result) => result.provider.id());
+    removeProjectInstructionAdapters(projectRoot, removedProviders);
+  }
+  return { ok: true, results, runtimeVerified };
 }
 
 /**
  * Install the skill for the same providers selected during MCP setup.
  * Returns `true` on success.
  */
-export async function runInstallSkill(providers: readonly SetupProvider[]): Promise<boolean> {
+export async function runInstallSkill(
+  providers: readonly SetupProvider[],
+  projectRoot?: string,
+): Promise<boolean> {
   logger.info("setup", "Step: install skill");
   const spinner = p.spinner();
   const agentLabel = providers.length === 1 ? "agent" : "agents";
@@ -335,12 +617,12 @@ export async function runInstallSkill(providers: readonly SetupProvider[]): Prom
     // verbose.
     const result = await installSkill(
       providers.map((provider) => provider.id()),
-      { quiet: true },
+      { quiet: true, projectRoot },
     );
     if (result.success) {
       logger.info("setup", `Skill installed${result.sha ? ` sha=${result.sha}` : ""}`);
       const items = providers.flatMap((provider) => {
-        const target = skillInstallTargetForProvider(provider.id());
+        const target = skillInstallTargetForProvider(provider.id(), projectRoot);
         if (!target) return [];
         return [
           {
@@ -759,26 +1041,42 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
   }
 }
 
-export function stepDetectTools(): SetupProvider[] {
-  return allSetupProviders().filter((p) => p.isInstalled());
+export function stepDetectTools(
+  providers: readonly SetupProvider[] = allSetupProviders(),
+): SetupProvider[] {
+  return providers.filter((provider) => provider.supportsLocal() && provider.isInstalled());
 }
 
-async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection | null> {
-  const configuredMap = new Map<string, boolean>();
+async function stepSelectTools(
+  detected: SetupProvider[],
+  projectRoot: string,
+): Promise<ToolSelection | null> {
+  const projectConfiguredMap = new Map<string, boolean>();
+  const legacyGlobalMap = new Map<string, boolean>();
   for (const p of detected) {
-    configuredMap.set(p.id(), p.isConfigured());
+    projectConfiguredMap.set(p.id(), p.isProjectConfigured(projectRoot));
+    legacyGlobalMap.set(p.id(), p.isConfigured());
   }
 
   const options = detected.map((p) => {
-    const configured = configuredMap.get(p.id()) ?? false;
+    const projectConfigured = projectConfiguredMap.get(p.id()) ?? false;
+    const legacyGlobal = legacyGlobalMap.get(p.id()) ?? false;
     return {
       label: p.name(),
       value: p.id(),
-      hint: configured ? "configured — untick to remove" : undefined,
+      hint: projectConfigured
+        ? "configured here — untick to remove the project MCP"
+        : legacyGlobal
+          ? "legacy global config — selected to migrate"
+          : undefined,
     };
   });
 
-  const preselected = detected.filter((p) => configuredMap.get(p.id())).map((p) => p.id());
+  const preselected = detected
+    .filter(
+      (provider) => projectConfiguredMap.get(provider.id()) || legacyGlobalMap.get(provider.id()),
+    )
+    .map((provider) => provider.id());
 
   const selected = await p.multiselect({
     message: "Select agents — tick to configure, untick to remove",
@@ -793,49 +1091,316 @@ async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection
 
   for (const provider of detected) {
     const isSelected = selectedSet.has(provider.id());
-    const isConfigured = configuredMap.get(provider.id()) ?? false;
+    const isProjectConfigured = projectConfiguredMap.get(provider.id()) ?? false;
 
     if (isSelected) result.toInstall.push(provider);
-    else if (isConfigured) result.toRemove.push(provider);
+    else if (isProjectConfigured) result.toRemove.push(provider);
   }
 
   return result;
 }
 
-export function stepConfigureTools(cfg: Config, selection: ToolSelection): ConfigResult[] {
-  const results: ConfigResult[] = [];
+type ProjectConfigFileState =
+  | { kind: "absent" }
+  | {
+      kind: "file";
+      content: string;
+      mode: number;
+    };
 
-  for (const provider of selection.toInstall) {
+interface ProjectConfigSnapshot {
+  before: ProjectConfigFileState;
+  /** Last exact state observed immediately after one of this batch's provider calls. */
+  output?: ProjectConfigFileState;
+  /** Actual writer preimage diverged from the batch view; whole-file rollback would lose edits. */
+  rollbackConflict?: boolean;
+}
+
+function errnoCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String(error.code)
+    : undefined;
+}
+
+/**
+ * Capture an exact project-config state without following a target symlink.
+ * Metadata checks around the byte read reject a torn preimage.
+ */
+function captureProjectConfigState(
+  projectRoot: string,
+  configPath: string,
+): ProjectConfigFileState {
+  assertSafeProjectPath(projectRoot, configPath);
+  try {
+    const before = lstatSync(configPath, { bigint: true });
+    if (!before.isFile()) throw new Error(`Project config is not a regular file: ${configPath}`);
+    const content = readFileSync(configPath, "utf8");
+    const after = lstatSync(configPath, { bigint: true });
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeNs !== after.mtimeNs
+    ) {
+      throw new Error(`Project config changed while it was being read: ${configPath}`);
+    }
+    return { kind: "file", content, mode: Number(after.mode & 0o777n) };
+  } catch (error: unknown) {
+    if (errnoCode(error) === "ENOENT") return { kind: "absent" };
+    throw error;
+  }
+}
+
+function sameProjectConfigState(
+  left: ProjectConfigFileState,
+  right: ProjectConfigFileState,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "absent" || right.kind === "absent") return true;
+  return left.mode === right.mode && left.content === right.content;
+}
+
+function rememberProjectConfigOutput(
+  snapshot: ProjectConfigSnapshot,
+  state: ProjectConfigFileState,
+): void {
+  const previous = snapshot.output ?? snapshot.before;
+  if (!sameProjectConfigState(previous, state)) snapshot.output = state;
+}
+
+function receiptState(content: string | null, mode: number | null): ProjectConfigFileState | null {
+  if (content === null) return mode === null ? { kind: "absent" } : null;
+  return mode === null ? null : { kind: "file", content, mode };
+}
+
+function receiptProvesMutation(
+  receipt: ProjectFileMutationReceipt | undefined,
+  path: string,
+  expectedBefore: ProjectConfigFileState,
+  observedAfter: ProjectConfigFileState,
+): boolean {
+  if (!receipt || resolve(receipt.path) !== path) return false;
+  const actualBefore = receiptState(receipt.beforeContent, receipt.beforeMode);
+  const actualAfter = receiptState(receipt.afterContent, receipt.afterMode);
+  return Boolean(
+    actualBefore &&
+      actualAfter &&
+      sameProjectConfigState(actualBefore, expectedBefore) &&
+      sameProjectConfigState(actualAfter, observedAfter),
+  );
+}
+
+interface ProjectConfigRollback {
+  restored: Set<string>;
+  conflicts: Set<string>;
+}
+
+function rollbackProjectConfigs(
+  projectRoot: string,
+  snapshots: ReadonlyMap<string, ProjectConfigSnapshot>,
+  changedPaths: readonly string[],
+  mutationHooks?: ProjectFileMutationHooks,
+): ProjectConfigRollback {
+  const restored = new Set<string>();
+  const conflicts = new Set<string>();
+
+  for (const path of [...changedPaths].reverse()) {
+    const snapshot = snapshots.get(path);
+    if (!snapshot?.output) continue;
+    if (snapshot.rollbackConflict) {
+      conflicts.add(path);
+      p.log.warn(`Kept ${path} because it changed inside a provider operation.`);
+      continue;
+    }
     try {
-      provider.install(cfg, true);
-      logger.info("setup", `Configured ${provider.name()}`);
-      results.push({ provider, action: "install" });
-    } catch (err: unknown) {
-      /* v8 ignore next -- err is always Error in practice */
-      const error = err instanceof Error ? err : new Error(String(err));
-      logger.error(
-        "setup",
-        `Config failed for ${provider.name()}: ${error.stack ?? error.message}`,
-      );
-      p.log.error(`Failed to configure ${provider.name()}: ${error.message}`);
-      results.push({ provider, action: "install", error });
+      const current = captureProjectConfigState(projectRoot, path);
+      if (!sameProjectConfigState(current, snapshot.output)) {
+        conflicts.add(path);
+        p.log.warn(`Kept ${path} because it changed while setup was rolling back.`);
+        continue;
+      }
+
+      if (snapshot.before.kind === "absent") {
+        if (current.kind === "file") removeProjectFile(path, current.content, mutationHooks);
+      } else {
+        writeProjectFile(
+          path,
+          snapshot.before.content,
+          current.kind === "file" ? current.content : null,
+          mutationHooks,
+        );
+      }
+      restored.add(path);
+    } catch (error: unknown) {
+      conflicts.add(path);
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error("setup", `Could not safely roll back ${path}: ${message}`);
+      p.log.warn(`Could not safely roll back ${path}: ${message}`);
     }
   }
 
+  return { restored, conflicts };
+}
+
+function configOperationError(provider: SetupProvider, action: "install" | "remove", error: Error) {
+  const verb = action === "install" ? "configure" : "remove";
+  logger.error(
+    "setup",
+    `${action === "install" ? "Config" : "Remove"} failed for ${provider.name()}: ${error.stack ?? error.message}`,
+  );
+  p.log.error(`Failed to ${verb} ${provider.name()}: ${error.message}`);
+}
+
+export function stepConfigureTools(
+  cfg: Config,
+  selection: ToolSelection,
+  projectRoot: string,
+  allowProjectRetarget = false,
+  rollbackHooks?: ProjectFileMutationHooks,
+): ConfigResult[] {
+  const results: ConfigResult[] = [];
+
+  type ProjectConfigOperation = {
+    provider: SetupProvider;
+    action: "install" | "remove" | "skip";
+    path: string | null;
+  };
+
+  const operations: ProjectConfigOperation[] = [];
+  const addOperation = (provider: SetupProvider, action: "install" | "remove"): boolean => {
+    try {
+      const path = provider.projectConfigPath(projectRoot);
+      operations.push({ provider, action, path: path ? resolve(path) : null });
+      return true;
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      configOperationError(provider, action, error);
+      results.push({ provider, action, error });
+      return false;
+    }
+  };
+
+  for (const provider of selection.toInstall) {
+    if (!addOperation(provider, "install")) return results;
+  }
+  const installedPaths = new Set(
+    operations.map((operation) => operation.path).filter((path): path is string => path !== null),
+  );
   for (const provider of selection.toRemove) {
     try {
-      provider.remove(true);
-      logger.info("setup", `Removed ${provider.name()}`);
-      results.push({ provider, action: "remove" });
+      const path = provider.projectConfigPath(projectRoot);
+      const normalizedPath = path ? resolve(path) : null;
+      if (normalizedPath && installedPaths.has(normalizedPath)) {
+        operations.push({ provider, action: "skip", path: normalizedPath });
+      } else {
+        operations.push({ provider, action: "remove", path: normalizedPath });
+      }
     } catch (err: unknown) {
-      /* v8 ignore next -- err is always Error in practice */
       const error = err instanceof Error ? err : new Error(String(err));
-      logger.error(
-        "setup",
-        `Remove failed for ${provider.name()}: ${error.stack ?? error.message}`,
-      );
-      p.log.error(`Failed to remove ${provider.name()}: ${error.message}`);
+      configOperationError(provider, "remove", error);
       results.push({ provider, action: "remove", error });
+      return results;
+    }
+  }
+
+  // Capture every unique project config before the first provider can write.
+  // Claude and Copilot intentionally share .mcp.json, so path-keying is part
+  // of the transaction contract rather than an optimization.
+  const snapshots = new Map<string, ProjectConfigSnapshot>();
+  for (const operation of operations) {
+    if (operation.action === "skip" || !operation.path || snapshots.has(operation.path)) continue;
+    try {
+      snapshots.set(operation.path, {
+        before: captureProjectConfigState(projectRoot, operation.path),
+      });
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      configOperationError(operation.provider, operation.action, error);
+      results.push({ provider: operation.provider, action: operation.action, error });
+      return results;
+    }
+  }
+
+  const changedPaths: string[] = [];
+  let failedProvider: SetupProvider | null = null;
+
+  for (const operation of operations) {
+    if (operation.action === "skip") {
+      results.push({ provider: operation.provider, action: "skip" });
+      continue;
+    }
+    let providerCompleted = false;
+    try {
+      let expectedBefore: ProjectConfigFileState | undefined;
+      if (operation.path) {
+        const snapshot = snapshots.get(operation.path);
+        if (snapshot) {
+          const current = captureProjectConfigState(projectRoot, operation.path);
+          const expected = snapshot.output ?? snapshot.before;
+          if (!sameProjectConfigState(current, expected)) {
+            throw new Error(
+              `Project config changed after setup started; refusing to overwrite ${operation.path}`,
+            );
+          }
+          expectedBefore = expected;
+        }
+      }
+      let receipt: ProjectFileMutationReceipt | undefined;
+      if (operation.action === "install") {
+        receipt = operation.provider.install(cfg, false, { projectRoot, allowProjectRetarget });
+        logger.info("setup", `Configured ${operation.provider.name()}`);
+      } else {
+        receipt = operation.provider.remove(false, { projectRoot });
+        logger.info("setup", `Removed ${operation.provider.name()}`);
+      }
+      providerCompleted = true;
+      if (operation.path) {
+        const snapshot = snapshots.get(operation.path);
+        if (snapshot) {
+          const observedAfter = captureProjectConfigState(projectRoot, operation.path);
+          const previousOutput = snapshot.output;
+          rememberProjectConfigOutput(snapshot, observedAfter);
+          if (!previousOutput && snapshot.output) changedPaths.push(operation.path);
+          if (
+            snapshot.output &&
+            expectedBefore &&
+            !receiptProvesMutation(receipt, operation.path, expectedBefore, observedAfter)
+          ) {
+            snapshot.rollbackConflict = true;
+          }
+        }
+      }
+      results.push({ provider: operation.provider, action: operation.action });
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      failedProvider = operation.provider;
+      configOperationError(operation.provider, operation.action, error);
+      results.push({ provider: operation.provider, action: operation.action, error });
+      if (providerCompleted && operation.path) {
+        p.log.warn(
+          `Could not prove the completed output at ${operation.path}; preserving it for safety.`,
+        );
+      }
+      break;
+    }
+  }
+
+  if (failedProvider) {
+    const rollback = rollbackProjectConfigs(projectRoot, snapshots, changedPaths, rollbackHooks);
+    for (const result of results) {
+      if (result.error || result.action === "skip") continue;
+      const path = result.provider.projectConfigPath(projectRoot);
+      const normalizedPath = path ? resolve(path) : null;
+      const rollbackStatus = normalizedPath
+        ? rollback.restored.has(normalizedPath)
+          ? "rolled back"
+          : rollback.conflicts.has(normalizedPath)
+            ? "not rolled back because the project file changed concurrently"
+            : "cancelled"
+        : "cancelled";
+      result.error = new Error(
+        `${result.provider.name()} was ${rollbackStatus} after ${failedProvider.name()} failed`,
+      );
     }
   }
 
@@ -846,7 +1411,10 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
   return results;
 }
 
-export function stepShowSummary(results: ConfigResult[]): void {
+export function stepShowSummary(
+  results: ConfigResult[],
+  projectRoot: string = process.cwd(),
+): void {
   const installed = results.filter((r) => r.action === "install" && !r.error);
   const removed = results.filter((r) => r.action === "remove" && !r.error);
   const skipped = results.filter((r) => r.action === "skip");
@@ -857,7 +1425,7 @@ export function stepShowSummary(results: ConfigResult[]): void {
         `Configured ${installed.length} agent(s):`,
         installed.map((result) => ({
           label: result.provider.name(),
-          path: result.provider.globalConfigPath(),
+          path: result.provider.projectConfigPath(projectRoot) ?? "unsupported",
         })),
       ),
     );
@@ -869,7 +1437,7 @@ export function stepShowSummary(results: ConfigResult[]): void {
         `Removed from ${removed.length} agent(s):`,
         removed.map((result) => ({
           label: result.provider.name(),
-          path: result.provider.globalConfigPath(),
+          path: result.provider.projectConfigPath(projectRoot) ?? "unsupported",
         })),
         IconRemove,
       ),


### PR DESCRIPTION
<!-- Is this PR related to a Linear issue? -->
<!-- Example: Fixes [ENG-123](https://linear.app/dosu/issue/ENG-123) -->

### Description

Stack 7/8, based on #162. Switches interactive setup and agent setup to the verified current Git project, installs the complete MCP/instructions/skills bundle transactionally, preflights the exact proxy, and only then migrates exact Dosu-owned legacy globals.

Existing project targets are preserved unless the user explicitly selects a retarget. Unsupported global-only clients are reported instead of silently configured globally.

Validated locally with `bun run typecheck`, `bun run check`, all 2,187 tests, 236 focused setup/agent/CLI tests, `git diff --check`, and `bun run build:npm`.

Stack review order:

1. #157 feat(mcp): add safe project file foundation
2. #158 feat(mcp): add secretless project proxy runtime
3. #159 feat(setup): add project agent assets
4. #160 feat(migration): prove complete project bundles
5. #161 feat(migration): add proof-gated global cleanup
6. #162 feat(mcp): enable project-scoped providers
7. #163 feat(setup): scope setup to the current project
8. #164 docs(setup): document project-scoped agent setup

Because this repository is squash-only, land by collapsing leaf into base: #164 -> #163 -> #162 -> #161 -> #160 -> #159 -> #158 -> #157 -> main.

### Review Tasks - Only request review after completing these.

* [ ] I self-reviewed this PR
* [ ] Testing is adequate for this change
* [ ] I reviewed AI-generated code and resolved suggestions

### Details (for context) - Not tasks; tooling uses tasks to determine review readiness

- Generated with AI: (N/Claude/Codex/Other)
- Manual testing: (Y/N/NA)
- Tests updated: (Y/N/NA)

<!-- Describe any manual testing or special testing approach -->
