### PR TITLE
feat(setup): activate Dosu per project (1/3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.2"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.2"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.2"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.2"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -84,6 +84,10 @@ jobs:
         run: |
           bun run build
           ./bin/dosu --version
+          mkdir -p /tmp/dosu-untrusted-project
+          printf 'XDG_CONFIG_HOME=/tmp/attacker-controlled\nDOSU_TELEMETRY_DEBUG=1\n' > /tmp/dosu-untrusted-project/.env
+          test "$(cd /tmp/dosu-untrusted-project && "$GITHUB_WORKSPACE/bin/dosu" logs)" != "/tmp/attacker-controlled/dosu-cli/debug.log"
+          ! (cd /tmp/dosu-untrusted-project && "$GITHUB_WORKSPACE/bin/dosu" telemetry status --json) | grep -q '"debug_mode": true'
           rm -f bin/dosu
 
       - name: Verify cross-platform build matrix
@@ -104,7 +108,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.2"
+          bun-version: "1.4.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -153,7 +157,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.2"
+          bun-version: "1.4.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -33,20 +33,18 @@ To install a specific release tag:
 DOSU_INSTALL_VERSION=v0.2.0-rc1 curl -fsSL https://cli.dosu.dev/install | sh
 ```
 
-### npx / npm
+### npm
 
 Requires Node.js 22+.
-
-```bash
-npx @dosu/cli setup
-```
-
-Or install globally:
 
 ```bash
 npm install -g @dosu/cli
 dosu setup
 ```
+
+Project setup writes MCP entries that call the stable `dosu` command, so setup
+requires a global CLI installation. A temporary `npx @dosu/cli` invocation will
+stop before changing credentials or project files.
 
 ### Homebrew
 
@@ -102,7 +100,9 @@ Or right-click the binary, select "Open", and click "Open" in the dialog.
 | `dosu logs` | View or manage debug logs (`--tail`, `--clear`) |
 | `dosu telemetry` | Manage usage analytics and error diagnostics (`status`, `enable`, `disable`, `reset`) |
 
-`dosu mcp add` takes `-g, --global` to install for all projects instead of project-local, and `--show-secret` to print the full manual config.
+Coding-agent integrations are project-scoped. `dosu mcp add` accepts
+`-g, --global` only for explicit global connectors such as Claude Desktop and
+manual configuration; `--show-secret` prints the full manual config.
 
 `dosu upgrade` delegates to npm, pnpm, Yarn Classic, or Homebrew only after confirming which manager owns the current installation. Temporary package-runner invocations stay ephemeral, ambiguous or local installs are left unchanged, and standalone binaries receive the latest safe manual download path.
 
@@ -132,26 +132,29 @@ Run `dosu <command> --help` for subcommands and flags.
 
 ### Supported AI tools
 
-`dosu mcp add <id>` and the setup wizard support:
+`dosu setup` configures the project-capable tools below. Claude Desktop and
+manual configuration remain explicit global connectors; tools marked
+unavailable are detected but left unchanged until they support safe project
+configuration.
 
-| ID | Tool |
-|---|---|
-| `claude` | Claude Code |
-| `claude-desktop` | Claude Desktop |
-| `cursor` | Cursor |
-| `vscode` | VS Code |
-| `codex` | Codex CLI |
-| `gemini` | Gemini CLI |
-| `windsurf` | Windsurf |
-| `zed` | Zed |
-| `cline` | Cline |
-| `cline-cli` | Cline CLI |
-| `copilot` | GitHub Copilot CLI |
-| `opencode` | OpenCode |
-| `antigravity` | Antigravity |
-| `mcporter` | MCPorter |
-| `factory` | Factory |
-| `manual` | Manual Configuration (prints config to paste yourself) |
+| ID | Tool | Scope |
+|---|---|---|
+| `claude` | Claude Code | Project |
+| `claude-desktop` | Claude Desktop | Explicit global connector |
+| `cursor` | Cursor | Project |
+| `vscode` | VS Code | Project |
+| `codex` | Codex CLI | Project |
+| `gemini` | Gemini CLI | Project |
+| `windsurf` | Windsurf | Project setup unavailable |
+| `zed` | Zed | Project |
+| `cline` | Cline | Project setup unavailable |
+| `cline-cli` | Cline CLI | Project setup unavailable |
+| `copilot` | GitHub Copilot CLI | Project |
+| `opencode` | OpenCode | Project |
+| `antigravity` | Antigravity | Project setup unavailable |
+| `mcporter` | MCPorter | Project |
+| `factory` | Factory | Project |
+| `manual` | Manual Configuration | Explicit global connector |
 
 ### Non-interactive / agent setup
 
@@ -189,7 +192,14 @@ controls.
 
 ## Configuration
 
-Credentials and the selected deployment live in `~/.config/dosu-cli/config.json`. Set `DOSU_DEV=true` to isolate config under `~/.config/dosu-cli-dev/`.
+Login credentials and per-deployment API keys live in
+`~/.config/dosu-cli/config.json`. Project files contain only a secretless
+`dosu mcp proxy --deployment …` command, so one account can keep multiple
+projects connected to different Dosu deployments. Official Dosu skills are
+installed globally for the agents selected during setup; setup does not copy
+skills into the repository.
+
+Set `DOSU_DEV=true` to isolate config under `~/.config/dosu-cli-dev/`.
 
 To repoint a published build at a different backend without rebuilding, set any of these runtime overrides:
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "picocolors": "^1.1.1",
         "semantic-release": "^25.0.5",
         "superjson": "^2.2.6",
+        "toml-eslint-parser": "1.0.3",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
         "write-file-atomic": "^8.0.0",
@@ -493,6 +494,8 @@
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
@@ -872,6 +875,8 @@
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toml-eslint-parser": ["toml-eslint-parser@1.0.3", "", { "dependencies": { "eslint-visitor-keys": "^5.0.0" } }, "sha512-A5F0cM6+mDleacLIEUkmfpkBbnHJFV1d2rprHU2MXNk7mlxHq2zGojA+SRvQD1RoMo9gqjZPWEaKG4v1BQ48lw=="],
 
     "traverse": ["traverse@0.6.8", "", {}, "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA=="],
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "picocolors": "^1.1.1",
     "semantic-release": "^25.0.5",
     "superjson": "^2.2.6",
+    "toml-eslint-parser": "1.0.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "write-file-atomic": "^8.0.0"

--- a/rules/dosu.md
+++ b/rules/dosu.md
@@ -7,3 +7,5 @@ When `write_knowledge` is listed, use it after the task for durable, non-obvious
 Use `review_knowledge` only when the user asks to inspect or manage pending knowledge. Preview one item at a time and require explicit confirmation before making changes.
 
 When `read_knowledge` or `write_knowledge` returned a `receipt_item_id` this turn, call `finalize_session_knowledge` exactly once at the end of the turn — after completing the task, immediately before your final reply — passing all receipt_item_ids from this turn. Never call it when the current turn produced no receipt_item_id, and never call it more than once per turn.
+
+Use globally installed Dosu skills when their descriptions match the task. A skill does not make an unavailable MCP tool callable.

--- a/scripts/build-all.test.ts
+++ b/scripts/build-all.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildDefines } from "./build-all";
+import { assertSecureCompileRuntime, buildDefines } from "./build-all";
 
 describe("build-all script", () => {
   it("script file exists", () => {
@@ -17,6 +17,18 @@ describe("build-all script", () => {
     expect(content).toContain("bun-linux-x64-musl");
     expect(content).toContain("bun-linux-arm64-musl");
     expect(content).toContain("bun-windows-x64-baseline");
+  });
+
+  it("disables implicit cwd dotenv and bunfig loading in native binaries", () => {
+    const content = readFileSync(join(__dirname, "build-all.ts"), "utf-8");
+    expect(content).toContain('"--no-compile-autoload-dotenv"');
+    expect(content).toContain('"--no-compile-autoload-bunfig"');
+  });
+
+  it("refuses Bun versions that accept but do not enforce compile isolation", () => {
+    expect(() => assertSecureCompileRuntime("1.3.14")).toThrow("Bun >= 1.4.0");
+    expect(() => assertSecureCompileRuntime("1.4.0")).not.toThrow();
+    expect(() => assertSecureCompileRuntime("2.0.0")).not.toThrow();
   });
 });
 

--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -24,6 +24,26 @@ const TARGETS = [
   { target: "bun-windows-x64-baseline", output: "dosu-windows-x64.exe" },
 ];
 
+const MINIMUM_ISOLATED_COMPILE_VERSION = [1, 4, 0] as const;
+
+/** Bun 1.3.x accepts the isolation flags but still autoloads cwd config. */
+export function assertSecureCompileRuntime(version: string = Bun.version): void {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+  const current = match?.slice(1).map(Number) ?? [];
+  const firstDifference = current.findIndex(
+    (part, index) => part !== MINIMUM_ISOLATED_COMPILE_VERSION[index],
+  );
+  const supported =
+    current.length === 3 &&
+    (firstDifference === -1 ||
+      current[firstDifference] > MINIMUM_ISOLATED_COMPILE_VERSION[firstDifference]);
+  if (!supported) {
+    throw new Error(
+      `Bun >= ${MINIMUM_ISOLATED_COMPILE_VERSION.join(".")} is required to build a Dosu binary that ignores project .env and bunfig.toml files (found ${version}).`,
+    );
+  }
+}
+
 function readPackageVersion(): string {
   try {
     return JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")).version ?? "dev";
@@ -84,6 +104,7 @@ export function buildDefines(): string[] {
 }
 
 async function main() {
+  assertSecureCompileRuntime();
   const distDir = join(SCRIPT_DIR, "..", "dist");
   if (!existsSync(distDir)) mkdirSync(distDir, { recursive: true });
 
@@ -106,6 +127,8 @@ async function main() {
         "bun",
         "build",
         "--compile",
+        "--no-compile-autoload-dotenv",
+        "--no-compile-autoload-bunfig",
         ...defines,
         "--target",
         target,

--- a/scripts/build-compile.test.ts
+++ b/scripts/build-compile.test.ts
@@ -12,9 +12,16 @@ describe("build-compile script", () => {
     expect(content).toContain("--compile");
   });
 
+  it("disables implicit cwd dotenv and bunfig loading", () => {
+    const content = readFileSync(join(__dirname, "build-compile.ts"), "utf-8");
+    expect(content).toContain('"--no-compile-autoload-dotenv"');
+    expect(content).toContain('"--no-compile-autoload-bunfig"');
+  });
+
   it("uses --define via buildDefines from build-all", () => {
     const content = readFileSync(join(__dirname, "build-compile.ts"), "utf-8");
-    expect(content).toContain('import { buildDefines } from "./build-all"');
+    expect(content).toContain("buildDefines");
+    expect(content).toContain('from "./build-all"');
     expect(content).toContain("...defines");
   });
 

--- a/scripts/build-compile.ts
+++ b/scripts/build-compile.ts
@@ -9,19 +9,30 @@
 import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { buildDefines } from "./build-all";
+import { assertSecureCompileRuntime, buildDefines } from "./build-all";
 
 const SCRIPT_DIR =
   typeof import.meta.dir === "string" ? import.meta.dir : dirname(fileURLToPath(import.meta.url));
 const OUTFILE = join(SCRIPT_DIR, "..", "bin", "dosu");
 
 async function main() {
+  assertSecureCompileRuntime();
   mkdirSync(dirname(OUTFILE), { recursive: true });
 
   const defines = buildDefines();
 
   const proc = Bun.spawn(
-    ["bun", "build", "--compile", ...defines, "src/index.ts", "--outfile", OUTFILE],
+    [
+      "bun",
+      "build",
+      "--compile",
+      "--no-compile-autoload-dotenv",
+      "--no-compile-autoload-bunfig",
+      ...defines,
+      "src/index.ts",
+      "--outfile",
+      OUTFILE,
+    ],
     { stdout: "inherit", stderr: "inherit", env: process.env },
   );
 

--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -111,7 +111,7 @@ function makeProvider(id: string, opts: Partial<SetupProvider> = {}): SetupProvi
   return {
     id: () => id,
     name: () => opts.name?.() ?? `Tool ${id}`,
-    supportsLocal: () => true,
+    configurationKind: () => "project",
     install: vi.fn(),
     remove: vi.fn(),
     detectPaths: () => [],
@@ -135,16 +135,28 @@ const makeBaseConfig = (overrides: Partial<FlatTestConfig> = {}) =>
 const ticketAccessToken = testAccessTokenFor("ticket-user");
 
 describe("buildResumeCommand", () => {
-  it("includes --tool and --login-ticket and uses the npx invocation", () => {
+  it("includes --tool and --login-ticket and uses the global CLI", () => {
     const cmd = buildResumeCommand("claude", "tkt-1");
-    expect(cmd).toBe("npx @dosu/cli@latest setup --agent --tool claude --login-ticket tkt-1");
+    expect(cmd).toBe("dosu setup --agent --tool claude --login-ticket tkt-1");
   });
 
   it("appends --deployment when provided", () => {
     const cmd = buildResumeCommand("cursor", "tkt-2", "dep-9");
-    expect(cmd).toBe(
-      "npx @dosu/cli@latest setup --agent --tool cursor --login-ticket tkt-2 --deployment dep-9",
+    expect(cmd).toBe("dosu setup --agent --tool cursor --login-ticket tkt-2 --deployment dep-9");
+  });
+
+  it.each([
+    "dep; echo PWNED",
+    "dep value",
+    "$(touch bad)",
+  ])("refuses a shell-active deployment ID: %s", (deploymentID) => {
+    expect(() => buildResumeCommand("cursor", "tkt-2", deploymentID)).toThrow(
+      /invalid deployment ID/,
     );
+  });
+
+  it("refuses an unsafe server ticket instead of emitting an executable command", () => {
+    expect(() => buildResumeCommand("cursor", "tkt-2;bad")).toThrow(/unsafe arguments/);
   });
 });
 
@@ -152,7 +164,7 @@ describe("listAgentSupportedToolIDs", () => {
   it("lists only providers with project-scoped configuration", () => {
     mockAllSetupProviders.mockReturnValue([
       makeProvider("claude"),
-      makeProvider("claude-desktop", { supportsLocal: () => false }),
+      makeProvider("claude-desktop", { configurationKind: () => "global-connector" }),
       makeProvider("cursor"),
     ]);
 
@@ -191,7 +203,7 @@ describe("runAgentSetup", () => {
     claudeProvider = makeProvider("claude", { name: () => "Claude Code" });
     desktopProvider = makeProvider("claude-desktop", {
       name: () => "Claude Desktop",
-      supportsLocal: () => false,
+      configurationKind: () => "global-connector",
     });
 
     mockAllSetupProviders.mockReturnValue([claudeProvider, desktopProvider]);
@@ -232,6 +244,34 @@ describe("runAgentSetup", () => {
     ]);
   });
 
+  it("refuses agent setup through temporary npx before touching the project", async () => {
+    const originalNpmCommand = process.env.npm_command;
+    const originalArgv = process.argv;
+    process.env.npm_command = "exec";
+    process.argv = [
+      process.execPath,
+      "/home/user/.npm/_npx/abc123/node_modules/.bin/dosu",
+      "setup",
+    ];
+    let code: number;
+    try {
+      code = await runAgentSetup({ tool: "claude" });
+    } finally {
+      if (originalNpmCommand === undefined) delete process.env.npm_command;
+      else process.env.npm_command = originalNpmCommand;
+      process.argv = originalArgv;
+    }
+
+    expect(code).toBe(2);
+    expect(mockRequireProjectRoot).not.toHaveBeenCalled();
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "setup",
+      status: "error",
+      reason: "global_install_required",
+      agent_next_steps: expect.stringContaining("globally installed Dosu CLI"),
+    });
+  });
+
   it("rejects global-only tools before authentication", async () => {
     const code = await runAgentSetup({ tool: "claude-desktop" });
 
@@ -261,6 +301,19 @@ describe("runAgentSetup", () => {
     });
   });
 
+  it("rejects an unsafe deployment before authentication or ticket minting", async () => {
+    const code = await runAgentSetup({ tool: "claude", deploymentID: "dep; echo PWNED" });
+
+    expect(code).toBe(2);
+    expect(mockMintTicket).not.toHaveBeenCalled();
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+    expect(emittedEvents()[0]).toMatchObject({
+      step: "setup",
+      status: "error",
+      reason: "invalid_deployment",
+    });
+  });
+
   it("mints a ticket and emits need_user_action when not authenticated", async () => {
     mockMintTicket.mockResolvedValue({
       ticket: "tkt-1",
@@ -278,7 +331,7 @@ describe("runAgentSetup", () => {
       status: "need_user_action",
       ticket: "tkt-1",
       url: "https://app.dosu.dev/cli/auth?ticket=tkt-1",
-      resume_command: "npx @dosu/cli@latest setup --agent --tool claude --login-ticket tkt-1",
+      resume_command: "dosu setup --agent --tool claude --login-ticket tkt-1",
     });
   });
 
@@ -326,7 +379,8 @@ describe("runAgentSetup", () => {
       "done",
     ]);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
-    expect(claudeProvider.install).toHaveBeenCalledWith(expect.any(Object), false, {
+    expect(claudeProvider.install).toHaveBeenCalledWith(expect.any(Object), {
+      scope: "project",
       projectRoot: "/tmp/repo",
     });
     expect(mockSaveConfig).toHaveBeenCalled();
@@ -340,10 +394,7 @@ describe("runAgentSetup", () => {
       agent_next_steps: expect.stringMatching(/Claude Code.*dosu status --json/),
     });
     expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n", "/tmp/repo");
-    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], {
-      quiet: true,
-      projectRoot: "/tmp/repo",
-    });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
     expect(mockUpsertDosuAgentsSection).toHaveBeenCalledWith("/tmp/repo", "canonical rule\n");
   });
 

--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -24,6 +24,7 @@ const {
   mockSkillAgentIDsForProviders,
   mockInGitWorkTree,
   mockUpsertDosuAgentsSection,
+  mockRequireProjectRoot,
 } = vi.hoisted(() => {
   return {
     mockMintTicket: vi.fn(),
@@ -46,6 +47,7 @@ const {
     mockSkillAgentIDsForProviders: vi.fn(),
     mockInGitWorkTree: vi.fn(),
     mockUpsertDosuAgentsSection: vi.fn(),
+    mockRequireProjectRoot: vi.fn(),
   };
 });
 
@@ -80,6 +82,11 @@ vi.mock("../setup/agents-md-step", () => ({
   upsertDosuAgentsSection: mockUpsertDosuAgentsSection,
 }));
 
+vi.mock("../setup/project-root", () => ({
+  assertSafeProjectPath: vi.fn(),
+  requireProjectRoot: mockRequireProjectRoot,
+}));
+
 vi.mock("../client/client", () => ({
   Client: vi.fn().mockImplementation(function (cfg: unknown) {
     mockClientConstructor(cfg);
@@ -111,6 +118,8 @@ function makeProvider(id: string, opts: Partial<SetupProvider> = {}): SetupProvi
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => `/tmp/${id}/mcp.json`,
+    projectConfigPath: (root) => `${root}/mcp.json`,
+    isProjectConfigured: () => false,
     priority: () => 0,
     ...opts,
   };
@@ -140,14 +149,14 @@ describe("buildResumeCommand", () => {
 });
 
 describe("listAgentSupportedToolIDs", () => {
-  it("lists every setup provider id, including Claude Desktop", () => {
+  it("lists only providers with project-scoped configuration", () => {
     mockAllSetupProviders.mockReturnValue([
       makeProvider("claude"),
-      makeProvider("claude-desktop"),
+      makeProvider("claude-desktop", { supportsLocal: () => false }),
       makeProvider("cursor"),
     ]);
 
-    expect(listAgentSupportedToolIDs()).toEqual(["claude", "claude-desktop", "cursor"]);
+    expect(listAgentSupportedToolIDs()).toEqual(["claude", "cursor"]);
   });
 });
 
@@ -175,10 +184,15 @@ describe("runAgentSetup", () => {
     mockSkillAgentIDsForProviders.mockReset();
     mockInGitWorkTree.mockReset();
     mockUpsertDosuAgentsSection.mockReset();
+    mockRequireProjectRoot.mockReset();
+    mockRequireProjectRoot.mockReturnValue("/tmp/repo");
     for (const fn of Object.values(mockClient)) fn.mockReset();
 
     claudeProvider = makeProvider("claude", { name: () => "Claude Code" });
-    desktopProvider = makeProvider("claude-desktop", { name: () => "Claude Desktop" });
+    desktopProvider = makeProvider("claude-desktop", {
+      name: () => "Claude Desktop",
+      supportsLocal: () => false,
+    });
 
     mockAllSetupProviders.mockReturnValue([claudeProvider, desktopProvider]);
     mockLoadConfig.mockReturnValue(makeBaseConfig());
@@ -216,6 +230,35 @@ describe("runAgentSetup", () => {
         agent_next_steps: expect.stringContaining("'nope' is not"),
       }),
     ]);
+  });
+
+  it("rejects global-only tools before authentication", async () => {
+    const code = await runAgentSetup({ tool: "claude-desktop" });
+
+    expect(code).toBe(2);
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+    expect(emittedEvents()[0]).toMatchObject({
+      step: "setup",
+      status: "error",
+      reason: "unknown_tool",
+    });
+    expect(String(emittedEvents()[0].agent_next_steps)).toContain("Choose one of: claude.");
+  });
+
+  it("stops before authentication outside a Git project", async () => {
+    mockRequireProjectRoot.mockImplementationOnce(() => {
+      throw new Error("Run Dosu setup inside a Git project.");
+    });
+
+    const code = await runAgentSetup({ tool: "claude" });
+
+    expect(code).toBe(2);
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+    expect(emittedEvents()[0]).toMatchObject({
+      step: "setup",
+      status: "error",
+      reason: "not_in_git_project",
+    });
   });
 
   it("mints a ticket and emits need_user_action when not authenticated", async () => {
@@ -283,6 +326,9 @@ describe("runAgentSetup", () => {
       "done",
     ]);
     expect(claudeProvider.install).toHaveBeenCalledTimes(1);
+    expect(claudeProvider.install).toHaveBeenCalledWith(expect.any(Object), false, {
+      projectRoot: "/tmp/repo",
+    });
     expect(mockSaveConfig).toHaveBeenCalled();
     const lastSave = mockSaveConfig.mock.calls.at(-1)?.[0];
     expect(testSession(lastSave).access_token).toBe(ticketAccessToken);
@@ -293,9 +339,12 @@ describe("runAgentSetup", () => {
       status: "ok",
       agent_next_steps: expect.stringMatching(/Claude Code.*dosu status --json/),
     });
-    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n");
-    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
-    expect(mockUpsertDosuAgentsSection).toHaveBeenCalledWith(process.cwd(), "canonical rule\n");
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n", "/tmp/repo");
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], {
+      quiet: true,
+      projectRoot: "/tmp/repo",
+    });
+    expect(mockUpsertDosuAgentsSection).toHaveBeenCalledWith("/tmp/repo", "canonical rule\n");
   });
 
   it("errors with multiple_deployments when the user has more than one dosu_mcp", async () => {

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -25,9 +25,11 @@ import {
 } from "../config/config";
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
+import { isSafeDeploymentID } from "../mcp/project-proxy";
 import { allSetupProviders } from "../mcp/providers";
 import { fetchDosuRule, installRuleForAgent, isRuleAgent } from "../rules/installer";
 import { upsertDosuAgentsSection } from "../setup/agents-md-step";
+import { GLOBAL_INSTALL_REQUIRED_MESSAGE, setupNeedsGlobalInstall } from "../setup/global-install";
 import { requireProjectRoot } from "../setup/project-root";
 import { emitError, emitNeedUserAction, emitStep } from "./output";
 
@@ -37,7 +39,7 @@ export interface AgentSetupOptions {
   deploymentID?: string;
 }
 
-const NPX_INVOCATION = "npx @dosu/cli@latest";
+const NPX_INVOCATION = "dosu";
 
 /**
  * Run agent-mediated setup end-to-end. Returns the process exit code the
@@ -51,20 +53,37 @@ const NPX_INVOCATION = "npx @dosu/cli@latest";
  * - `2` — CLI usage error (unknown tool, invalid combination of flags).
  */
 export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
+  if (setupNeedsGlobalInstall()) {
+    emitError({
+      step: "setup",
+      reason: "global_install_required",
+      agent_next_steps: GLOBAL_INSTALL_REQUIRED_MESSAGE,
+    });
+    return 2;
+  }
   // 0. Resolve the requested tool up front. We do this before any auth so
   //    the agent gets a usage error immediately instead of after a login
   //    round-trip.
   const providers = allSetupProviders();
   const provider = providers.find((p) => p.id() === opts.tool.toLowerCase());
-  if (!provider?.supportsLocal()) {
+  if (provider?.configurationKind() !== "project") {
     const available = providers
-      .filter((candidate) => candidate.supportsLocal())
+      .filter((candidate) => candidate.configurationKind() === "project")
       .map((p) => p.id())
       .join(", ");
     emitError({
       step: "setup",
       reason: "unknown_tool",
       agent_next_steps: `'${opts.tool}' is not a supported tool. Choose one of: ${available}. Re-run with --tool <id>.`,
+    });
+    return 2;
+  }
+  if (opts.deploymentID !== undefined && !isSafeDeploymentID(opts.deploymentID)) {
+    emitError({
+      step: "setup",
+      reason: "invalid_deployment",
+      agent_next_steps:
+        "The deployment ID contains unsupported characters. Choose an ID reported by Dosu and retry.",
     });
     return 2;
   }
@@ -107,7 +126,7 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
 
   // 4. Install Dosu MCP into the requested tool.
   try {
-    provider.install(cfg, false, { projectRoot });
+    provider.install(cfg, { scope: "project", projectRoot });
     emitStep({
       step: "mcp_install",
       tool: provider.id(),
@@ -158,7 +177,7 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   // stdout contract.
   if (skillAgentIDsForProviders([provider.id()]).length > 0) {
     try {
-      const skill = await installSkill([provider.id()], { quiet: true, projectRoot });
+      const skill = await installSkill([provider.id()], { quiet: true });
       if (!skill.success) {
         throw new Error("the skills installer failed");
       }
@@ -496,6 +515,13 @@ async function ensureAPIKey(client: Client, cfg: Config): Promise<{ code: number
  * Mirrors the marketing one-liner so the agent can copy/paste it back.
  */
 export function buildResumeCommand(tool: string, ticket: string, deploymentID?: string): string {
+  const safeToken = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,1023}$/;
+  if (!safeToken.test(tool) || !safeToken.test(ticket)) {
+    throw new Error("Cannot build a resume command with unsafe arguments");
+  }
+  if (deploymentID !== undefined && !isSafeDeploymentID(deploymentID)) {
+    throw new Error("Cannot build a resume command with an invalid deployment ID");
+  }
   const parts = [NPX_INVOCATION, "setup", "--agent", "--tool", tool, "--login-ticket", ticket];
   if (deploymentID) {
     parts.push("--deployment", deploymentID);
@@ -506,6 +532,6 @@ export function buildResumeCommand(tool: string, ticket: string, deploymentID?: 
 /** Provider listing for `--tool` validation. Exported for tests. */
 export function listAgentSupportedToolIDs(): string[] {
   return allSetupProviders()
-    .filter((provider) => provider.supportsLocal())
+    .filter((provider) => provider.configurationKind() === "project")
     .map((provider) => provider.id());
 }

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -27,7 +27,8 @@ import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders } from "../mcp/providers";
 import { fetchDosuRule, installRuleForAgent, isRuleAgent } from "../rules/installer";
-import { inGitWorkTree, upsertDosuAgentsSection } from "../setup/agents-md-step";
+import { upsertDosuAgentsSection } from "../setup/agents-md-step";
+import { requireProjectRoot } from "../setup/project-root";
 import { emitError, emitNeedUserAction, emitStep } from "./output";
 
 export interface AgentSetupOptions {
@@ -53,15 +54,28 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   // 0. Resolve the requested tool up front. We do this before any auth so
   //    the agent gets a usage error immediately instead of after a login
   //    round-trip.
-  const provider = allSetupProviders().find((p) => p.id() === opts.tool.toLowerCase());
-  if (!provider) {
-    const available = allSetupProviders()
+  const providers = allSetupProviders();
+  const provider = providers.find((p) => p.id() === opts.tool.toLowerCase());
+  if (!provider?.supportsLocal()) {
+    const available = providers
+      .filter((candidate) => candidate.supportsLocal())
       .map((p) => p.id())
       .join(", ");
     emitError({
       step: "setup",
       reason: "unknown_tool",
       agent_next_steps: `'${opts.tool}' is not a supported tool. Choose one of: ${available}. Re-run with --tool <id>.`,
+    });
+    return 2;
+  }
+  let projectRoot: string;
+  try {
+    projectRoot = requireProjectRoot();
+  } catch (err: unknown) {
+    emitError({
+      step: "setup",
+      reason: "not_in_git_project",
+      agent_next_steps: err instanceof Error ? err.message : String(err),
     });
     return 2;
   }
@@ -93,12 +107,12 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
 
   // 4. Install Dosu MCP into the requested tool.
   try {
-    provider.install(cfg, /* global */ true);
+    provider.install(cfg, false, { projectRoot });
     emitStep({
       step: "mcp_install",
       tool: provider.id(),
       tool_name: provider.name(),
-      config_path: provider.globalConfigPath(),
+      config_path: provider.projectConfigPath(projectRoot),
     });
   } catch (err: unknown) {
     emitError({
@@ -117,7 +131,7 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   try {
     if (isRuleAgent(provider.id())) {
       instruction = await fetchDosuRule();
-      const rule = installRuleForAgent(provider.id(), instruction);
+      const rule = installRuleForAgent(provider.id(), instruction, projectRoot);
       if (rule) {
         emitStep({
           step: "rule_install",
@@ -144,7 +158,7 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
   // stdout contract.
   if (skillAgentIDsForProviders([provider.id()]).length > 0) {
     try {
-      const skill = await installSkill([provider.id()], { quiet: true });
+      const skill = await installSkill([provider.id()], { quiet: true, projectRoot });
       if (!skill.success) {
         throw new Error("the skills installer failed");
       }
@@ -166,28 +180,25 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
     }
   }
 
-  // 7. Add the project-level pointer when setup runs from a git work tree.
-  // Use the low-level writer instead of the clack wrapper so stdout stays
-  // valid NDJSON.
-  if (inGitWorkTree()) {
-    try {
-      instruction ??= await fetchDosuRule();
-      const agentsMd = upsertDosuAgentsSection(process.cwd(), instruction);
-      emitStep({
-        step: "agents_md_install",
-        path: agentsMd.path,
-        action: agentsMd.action,
-      });
-    } catch (err: unknown) {
-      emitError({
-        step: "agents_md_install",
-        reason: "install_failed",
-        agent_next_steps: `Dosu's agent integrations were installed, but AGENTS.md could not be updated: ${
-          err instanceof Error ? err.message : String(err)
-        }. Re-run this setup command; installation is idempotent.`,
-      });
-      return 1;
-    }
+  // 7. Add the canonical project instructions. Use the low-level writer so
+  // stdout stays valid NDJSON.
+  try {
+    instruction ??= await fetchDosuRule();
+    const agentsMd = upsertDosuAgentsSection(projectRoot, instruction);
+    emitStep({
+      step: "agents_md_install",
+      path: agentsMd.path,
+      action: agentsMd.action,
+    });
+  } catch (err: unknown) {
+    emitError({
+      step: "agents_md_install",
+      reason: "install_failed",
+      agent_next_steps: `Dosu's agent integrations were installed, but AGENTS.md could not be updated: ${
+        err instanceof Error ? err.message : String(err)
+      }. Re-run this setup command; installation is idempotent.`,
+    });
+    return 1;
   }
 
   emitStep({
@@ -494,5 +505,7 @@ export function buildResumeCommand(tool: string, ticket: string, deploymentID?: 
 
 /** Provider listing for `--tool` validation. Exported for tests. */
 export function listAgentSupportedToolIDs(): string[] {
-  return allSetupProviders().map((p) => p.id());
+  return allSetupProviders()
+    .filter((provider) => provider.supportsLocal())
+    .map((provider) => provider.id());
 }

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -65,6 +65,37 @@ vi.mock("../setup/flow", () => ({
   runSetup: (...args: unknown[]) => mockRunSetup(...args),
 }));
 
+const { mockRequireProjectRoot } = vi.hoisted(() => ({
+  mockRequireProjectRoot: vi.fn(),
+}));
+vi.mock("../setup/project-root", () => ({
+  assertSafeProjectPath: vi.fn(),
+  requireProjectRoot: mockRequireProjectRoot,
+}));
+
+const { mockRunProjectProxy } = vi.hoisted(() => ({
+  mockRunProjectProxy: vi.fn(),
+}));
+vi.mock("../mcp/project-proxy", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../mcp/project-proxy")>()),
+  runProjectProxy: (...args: unknown[]) => mockRunProjectProxy(...args),
+}));
+
+const { mockCheckForUpdates, mockCheckForSkillUpdates, mockCheckForReadyTasks } = vi.hoisted(
+  () => ({
+    mockCheckForUpdates: vi.fn(),
+    mockCheckForSkillUpdates: vi.fn(),
+    mockCheckForReadyTasks: vi.fn(),
+  }),
+);
+vi.mock("../version/update-check", () => ({ checkForUpdates: mockCheckForUpdates }));
+vi.mock("../version/skill-update-check", () => ({
+  checkForSkillUpdates: mockCheckForSkillUpdates,
+}));
+vi.mock("../version/pending-tasks-check", () => ({
+  checkForReadyTasks: mockCheckForReadyTasks,
+}));
+
 const { mockLoggerGetLogPath } = vi.hoisted(() => ({
   mockLoggerGetLogPath: vi.fn(),
 }));
@@ -96,6 +127,7 @@ beforeEach(() => {
 
   vi.clearAllMocks();
   mockIsHeadless.mockReturnValue(false);
+  mockRequireProjectRoot.mockImplementation(() => tempDir);
   mockLoggerGetLogPath.mockReturnValue(join(tempDir, "dosu-cli", "debug.log"));
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 });
@@ -695,6 +727,17 @@ describe("CLI actions", () => {
   // ── mcp add ─────────────────────────────────────────────────────────────
 
   describe("mcp add", () => {
+    it("creates a secretless project config by default", async () => {
+      saveConfig(authenticatedConfig());
+
+      await run("mcp", "add", "cursor");
+
+      const config = JSON.parse(readFileSync(join(tempDir, ".cursor", "mcp.json"), "utf-8"));
+      expect(config.mcpServers.dosu.command).toBe("npx");
+      expect(config.mcpServers.dosu.args).toContain("dep_123");
+      expect(JSON.stringify(config)).not.toContain("key_abc");
+    });
+
     it("creates real cursor config file with --global", async () => {
       const cfg = authenticatedConfig();
       saveConfig(cfg);
@@ -801,15 +844,13 @@ describe("CLI actions", () => {
       expect(allLogOutput()).toContain("key_abc");
     });
 
-    it("auto-sets global when provider does not support local", async () => {
+    it("does not silently fall back to global for a global-only provider", async () => {
       saveConfig(authenticatedConfig());
 
-      // Windsurf only supports global installation
-      await run("mcp", "add", "windsurf");
-
-      const output = allLogOutput();
-      expect(output).toContain("only supports global installation");
-      expect(output).toContain("Successfully added Dosu MCP to Windsurf");
+      await expect(run("mcp", "add", "windsurf")).rejects.toThrow(
+        "does not support project-local MCP configuration",
+      );
+      expect(allLogOutput()).not.toContain("Successfully added Dosu MCP to Windsurf");
     });
 
     it("installs globally when --global flag is passed", async () => {
@@ -820,6 +861,62 @@ describe("CLI actions", () => {
       const output = allLogOutput();
       expect(output).toContain("global (all projects)");
       expect(output).toContain("Successfully added Dosu MCP to Cursor");
+    });
+  });
+
+  describe("mcp proxy", () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+    let originalArgv: string[];
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+      errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockRunProjectProxy.mockResolvedValue(0);
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      process.exitCode = undefined;
+      errorSpy.mockRestore();
+    });
+
+    it("runs the hidden proxy for one deployment and skips update checks", async () => {
+      process.argv = ["node", "dosu", "mcp", "proxy", "--deployment", "dep_123"];
+
+      await run("mcp", "proxy", "--deployment", "dep_123");
+
+      expect(mockRunProjectProxy).toHaveBeenCalledWith({
+        deploymentID: "dep_123",
+        oss: false,
+      });
+      expect(mockCheckForUpdates).not.toHaveBeenCalled();
+      expect(mockCheckForSkillUpdates).not.toHaveBeenCalled();
+      expect(mockCheckForReadyTasks).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(0);
+    });
+
+    it("runs the OSS proxy", async () => {
+      process.argv = ["node", "dosu", "mcp", "proxy", "--oss"];
+
+      await run("mcp", "proxy", "--oss");
+
+      expect(mockRunProjectProxy).toHaveBeenCalledWith({
+        deploymentID: undefined,
+        oss: true,
+      });
+    });
+
+    it.each([
+      ["neither target", ["mcp", "proxy"]],
+      ["both targets", ["mcp", "proxy", "--deployment", "dep_123", "--oss"]],
+    ])("rejects %s before starting", async (_name, args) => {
+      process.argv = ["node", "dosu", ...args];
+
+      await run(...args);
+
+      expect(mockRunProjectProxy).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith("Exactly one of --deployment or --oss is required.");
+      expect(process.exitCode).toBe(2);
     });
   });
 

--- a/src/cli/cli-actions.test.ts
+++ b/src/cli/cli-actions.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -703,21 +703,15 @@ describe("CLI actions", () => {
         expect(output).toContain(p.name());
       }
 
-      // Verify scope labels are present for providers
+      // Verify each provider advertises the scope setup actually supports.
       for (const p of providers) {
-        if (p.id() === "manual") {
-          // Manual provider should have NO scope label
-          // Check that the line with "manual" does not include "(global only)" or "(local + global)"
-          const lines = output.split("\n");
-          const manualLine = lines.find((l: string) => l.includes("manual"));
-          expect(manualLine).toBeDefined();
-          expect(manualLine).not.toContain("(global only)");
-          expect(manualLine).not.toContain("(local + global)");
-        } else if (!p.supportsLocal()) {
-          expect(output).toContain("(global only)");
-        } else {
-          expect(output).toContain("(local + global)");
-        }
+        const line = output.split("\n").find((candidate: string) => candidate.includes(p.id()));
+        expect(line).toBeDefined();
+        if (p.configurationKind() === "project") expect(line).toContain("(project)");
+        if (p.configurationKind() === "global-connector")
+          expect(line).toContain("(explicit global connector)");
+        if (p.configurationKind() === "unsupported")
+          expect(line).toContain("(project setup unavailable)");
       }
 
       expect(output).toContain("Use 'dosu mcp add <agent>' to add Dosu MCP to a tool.");
@@ -733,28 +727,40 @@ describe("CLI actions", () => {
       await run("mcp", "add", "cursor");
 
       const config = JSON.parse(readFileSync(join(tempDir, ".cursor", "mcp.json"), "utf-8"));
-      expect(config.mcpServers.dosu.command).toBe("npx");
+      expect(config.mcpServers.dosu.command).toBe("dosu");
       expect(config.mcpServers.dosu.args).toContain("dep_123");
       expect(JSON.stringify(config)).not.toContain("key_abc");
     });
 
-    it("creates real cursor config file with --global", async () => {
+    it("refuses a project MCP write from an ephemeral npx CLI", async () => {
+      saveConfig(authenticatedConfig());
+      const originalNpmCommand = process.env.npm_command;
+      const originalArgv = process.argv;
+      process.env.npm_command = "exec";
+      process.argv = [
+        process.execPath,
+        "/home/user/.npm/_npx/abc123/node_modules/.bin/dosu",
+        "mcp",
+        "add",
+        "cursor",
+      ];
+      try {
+        await expect(run("mcp", "add", "cursor")).rejects.toThrow(/globally installed Dosu CLI/);
+      } finally {
+        if (originalNpmCommand === undefined) delete process.env.npm_command;
+        else process.env.npm_command = originalNpmCommand;
+        process.argv = originalArgv;
+      }
+
+      expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
+    });
+
+    it("rejects global installation for a project-scoped coding agent", async () => {
       const cfg = authenticatedConfig();
       saveConfig(cfg);
 
-      await run("mcp", "add", "cursor", "--global");
-
-      // Verify real file was created on disk
-      const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
-      const cursorConfig = JSON.parse(readFileSync(cursorConfigPath, "utf-8"));
-      expect(cursorConfig.mcpServers).toBeDefined();
-      expect(cursorConfig.mcpServers.dosu).toBeDefined();
-      expect(cursorConfig.mcpServers.dosu.url).toContain("dep_123");
-      expect(cursorConfig.mcpServers.dosu.headers).toBeDefined();
-      expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key_abc");
-
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Successfully added Dosu MCP to Cursor"),
+      await expect(run("mcp", "add", "cursor", "--global")).rejects.toThrow(
+        "Cursor is project-scoped",
       );
     });
 
@@ -784,7 +790,7 @@ describe("CLI actions", () => {
       saveConfig(cfg);
       mockSuccessfulRefresh("mcp_tok", "mcp_ref");
 
-      await run("mcp", "add", "cursor", "--global");
+      await run("mcp", "add", "cursor");
 
       const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
       const cursorConfig = JSON.parse(readFileSync(cursorConfigPath, "utf-8"));
@@ -805,7 +811,7 @@ describe("CLI actions", () => {
       testTarget(cfg).api_key = undefined;
       saveConfig(cfg);
 
-      await expect(run("mcp", "add", "cursor", "--global")).rejects.toThrow("no API key available");
+      await expect(run("mcp", "add", "cursor")).rejects.toThrow("no API key available");
     });
 
     it("supports OSS mode without a selected deployment", async () => {
@@ -815,31 +821,30 @@ describe("CLI actions", () => {
       testTarget(cfg).deployment_name = undefined;
       saveConfig(cfg);
 
-      await run("mcp", "add", "cursor", "--global");
+      await run("mcp", "add", "cursor");
 
       const cursorConfigPath = join(tempDir, ".cursor", "mcp.json");
       const cursorConfig = JSON.parse(readFileSync(cursorConfigPath, "utf-8"));
-      expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp");
-      expect(cursorConfig.mcpServers.dosu.url).not.toContain("/deployments/");
+      expect(cursorConfig.mcpServers.dosu.command).toBe("dosu");
+      expect(cursorConfig.mcpServers.dosu.args).toEqual(["mcp", "proxy", "--oss"]);
     });
 
     it("logs manual config details without writing files", async () => {
       saveConfig(authenticatedConfig());
 
-      await run("mcp", "add", "manual");
+      await run("mcp", "add", "manual", "--global");
 
       const output = allLogOutput();
       expect(output).toContain("dep_123");
       expect(output).not.toContain("key_abc");
       expect(output).toContain("Secret hidden");
-      // Manual provider returns early, no "Successfully added" message
-      expect(output).not.toContain("Successfully added");
+      expect(output).toContain("Successfully added");
     });
 
     it("only prints the full manual API key when --show-secret is passed", async () => {
       saveConfig(authenticatedConfig());
 
-      await run("mcp", "add", "manual", "--show-secret");
+      await run("mcp", "add", "manual", "--global", "--show-secret");
 
       expect(allLogOutput()).toContain("key_abc");
     });
@@ -848,19 +853,19 @@ describe("CLI actions", () => {
       saveConfig(authenticatedConfig());
 
       await expect(run("mcp", "add", "windsurf")).rejects.toThrow(
-        "does not support project-local MCP configuration",
+        "does not currently support project-scoped Dosu configuration",
       );
       expect(allLogOutput()).not.toContain("Successfully added Dosu MCP to Windsurf");
     });
 
-    it("installs globally when --global flag is passed", async () => {
+    it("allows an explicit global connector with --global", async () => {
       saveConfig(authenticatedConfig());
 
-      await run("mcp", "add", "cursor", "--global");
+      await run("mcp", "add", "manual", "--global");
 
       const output = allLogOutput();
-      expect(output).toContain("global (all projects)");
-      expect(output).toContain("Successfully added Dosu MCP to Cursor");
+      expect(output).toContain("global connector");
+      expect(output).toContain("Successfully added Dosu MCP to Manual Configuration");
     });
   });
 

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -20,6 +20,7 @@ vi.mock("../version/skill-update-check", () => ({ checkForSkillUpdates: vi.fn() 
 vi.mock("../version/pending-tasks-check", () => ({ checkForReadyTasks: vi.fn() }));
 
 import { saveConfig } from "../config/config";
+import { CONFIG_SCHEMA_VERSION } from "../config/schema";
 import type { CommandTelemetry } from "../telemetry/telemetry";
 import { createProgram, shouldRunBackgroundChecks } from "./cli";
 
@@ -195,7 +196,7 @@ describe("CLI", () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     try {
       saveConfig({
-        schema_version: 2,
+        schema_version: CONFIG_SCHEMA_VERSION,
         active_account: {
           user_id: userID,
           session: { access_token: accessToken, refresh_token: "refresh-secret", expires_at: 0 },

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -50,9 +50,10 @@ describe("CLI", () => {
     expect(cmd?.description()).toContain("latest version");
   });
 
-  it("skips background notices for upgrade", () => {
-    expect(shouldRunBackgroundChecks("upgrade")).toBe(false);
-    expect(shouldRunBackgroundChecks("status")).toBe(true);
+  it("skips background notices for upgrade and the MCP proxy", () => {
+    expect(shouldRunBackgroundChecks("upgrade", ["node", "dosu", "upgrade"])).toBe(false);
+    expect(shouldRunBackgroundChecks("proxy", ["node", "dosu", "mcp", "proxy"])).toBe(false);
+    expect(shouldRunBackgroundChecks("status", ["node", "dosu", "status"])).toBe(true);
   });
 
   it("has login command", () => {
@@ -77,12 +78,17 @@ describe("CLI", () => {
     expect(cmd?.options.find((o) => o.long === "--json")).toBeDefined();
   });
 
-  it("has mcp command with add and list subcommands", () => {
+  it("has mcp command with add, list, and hidden proxy subcommands", () => {
     const program = createProgram();
     const mcpCmd = program.commands.find((c) => c.name() === "mcp");
     expect(mcpCmd).toBeDefined();
     expect(mcpCmd?.commands.find((c) => c.name() === "add")).toBeDefined();
     expect(mcpCmd?.commands.find((c) => c.name() === "list")).toBeDefined();
+    const proxy = mcpCmd?.commands.find((c) => c.name() === "proxy");
+    expect(proxy).toBeDefined();
+    expect(mcpCmd?.helpInformation()).not.toContain("proxy");
+    expect(proxy?.options.find((o) => o.long === "--deployment")).toBeDefined();
+    expect(proxy?.options.find((o) => o.long === "--oss")).toBeDefined();
   });
 
   it("has setup command with --deployment option", () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -46,7 +46,9 @@ import {
 } from "../config/config";
 import { getAccessTokenEmail, getAccessTokenUserID } from "../config/identity";
 import { logger } from "../debug/logger";
+import { runProjectProxy } from "../mcp/project-proxy";
 import { allProviders, getProvider, type Provider } from "../mcp/providers";
+import { requireProjectRoot } from "../setup/project-root";
 import { browserFallbackHint } from "../setup/styles";
 import {
   getOrCreateInstallID,
@@ -63,8 +65,17 @@ import { checkForSkillUpdates } from "../version/skill-update-check";
 import { checkForUpdates } from "../version/update-check";
 import { getVersionString } from "../version/version";
 
-export function shouldRunBackgroundChecks(actionName: string): boolean {
-  return actionName !== "upgrade";
+/**
+ * The MCP proxy is an agent hot path and must stay fast and stdout-clean.
+ * Update notices would corrupt MCP stdio and delay startup.
+ */
+function isMcpProxyInvocation(argv: string[]): boolean {
+  const mcpIndex = argv.indexOf("mcp");
+  return mcpIndex >= 0 && argv[mcpIndex + 1] === "proxy";
+}
+
+export function shouldRunBackgroundChecks(actionName: string, argv: string[]): boolean {
+  return actionName !== "upgrade" && !isMcpProxyInvocation(argv);
 }
 
 const TELEMETRY_FLUSH_TIMEOUT_MS = 750;
@@ -214,7 +225,7 @@ export function createProgram(options: { telemetry?: CommandTelemetry } = {}): C
     .hook("preAction", async (thisCommand, actionCommand) => {
       const opts = thisCommand.optsWithGlobals();
       logger.init({ debug: opts.debug });
-      if (shouldRunBackgroundChecks(actionCommand.name())) {
+      if (shouldRunBackgroundChecks(actionCommand.name(), process.argv)) {
         if (process.env.NODE_ENV !== "test" && !process.env.CI) {
           await checkForUpdates();
         }
@@ -503,16 +514,19 @@ export function createProgram(options: { telemetry?: CommandTelemetry } = {}): C
         return;
       }
 
-      let global = opts.global;
+      const global = opts.global;
       if (!provider.supportsLocal() && !global) {
-        console.log(`Note: ${provider.name()} only supports global installation.\n`);
-        global = true;
+        throw new Error(
+          `${provider.name()} does not support project-local MCP configuration. Use --global explicitly if you want a global install.`,
+        );
       }
+
+      const projectRoot = global ? undefined : requireProjectRoot();
 
       const scope = global ? "global (all projects)" : "project-local";
       console.log(`Adding Dosu MCP to ${provider.name()} (${scope})...`);
 
-      provider.install(cfg, global, { showSecret: opts.showSecret });
+      provider.install(cfg, global, { showSecret: opts.showSecret, projectRoot });
 
       console.log(`\n✓ Successfully added Dosu MCP to ${provider.name()}!`);
       if (global) {
@@ -521,6 +535,23 @@ export function createProgram(options: { telemetry?: CommandTelemetry } = {}): C
         console.log(`\nStart ${provider.name()} in this project directory to use the Dosu MCP.`);
       }
     });
+
+  const proxyCommand = new Command("proxy")
+    .description("Internal project MCP credential bridge")
+    .option("--deployment <id>", "Expected project deployment")
+    .option("--oss", "Use the configured public-libraries endpoint", false)
+    .action(async (opts: { deployment?: string; oss: boolean }) => {
+      if (Boolean(opts.deployment) === opts.oss) {
+        console.error("Exactly one of --deployment or --oss is required.");
+        process.exitCode = 2;
+        return;
+      }
+      process.exitCode = await runProjectProxy({
+        deploymentID: opts.deployment,
+        oss: opts.oss,
+      });
+    });
+  mcp.addCommand(proxyCommand, { hidden: true });
 
   mcp
     .command("list")
@@ -671,7 +702,7 @@ async function ensureFreshSession(cfg: Config): Promise<boolean> {
 }
 
 export async function execute(): Promise<void> {
-  const telemetry = processCommandTelemetry();
+  const telemetry = isMcpProxyInvocation(process.argv) ? undefined : processCommandTelemetry();
   const program = createProgram({ telemetry });
   try {
     await program.parseAsync(process.argv);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -48,6 +48,7 @@ import { getAccessTokenEmail, getAccessTokenUserID } from "../config/identity";
 import { logger } from "../debug/logger";
 import { runProjectProxy } from "../mcp/project-proxy";
 import { allProviders, getProvider, type Provider } from "../mcp/providers";
+import { GLOBAL_INSTALL_REQUIRED_MESSAGE, setupNeedsGlobalInstall } from "../setup/global-install";
 import { requireProjectRoot } from "../setup/project-root";
 import { browserFallbackHint } from "../setup/styles";
 import {
@@ -483,7 +484,7 @@ export function createProgram(options: { telemetry?: CommandTelemetry } = {}): C
   mcp
     .command("add <agent>")
     .description("Add Dosu MCP to an AI tool")
-    .option("-g, --global", "Add globally (all projects) instead of project-local", false)
+    .option("-g, --global", "Use an explicit global connector when the tool requires one", false)
     .option("--show-secret", "Print full manual configuration secrets", false)
     .action(async (toolId: string, opts: { global: boolean; showSecret: boolean }) => {
       let provider: Provider;
@@ -493,6 +494,10 @@ export function createProgram(options: { telemetry?: CommandTelemetry } = {}): C
         throw new CliUsageError(
           `unknown tool '${toolId}'. Use 'dosu mcp list' to see available tools`,
         );
+      }
+      const kind = provider.configurationKind();
+      if (kind === "project" && setupNeedsGlobalInstall()) {
+        throw new CliUsageError(GLOBAL_INSTALL_REQUIRED_MESSAGE);
       }
       const cfg = loadConfig();
 
@@ -509,27 +514,36 @@ export function createProgram(options: { telemetry?: CommandTelemetry } = {}): C
         throw new CliUsageError("no API key available. Run 'dosu setup' to create one");
       }
 
-      if (provider.id() === "manual") {
-        provider.install(cfg, false, { showSecret: opts.showSecret });
-        return;
-      }
-
       const global = opts.global;
-      if (!provider.supportsLocal() && !global) {
-        throw new Error(
-          `${provider.name()} does not support project-local MCP configuration. Use --global explicitly if you want a global install.`,
+      if (kind === "unsupported") {
+        throw new CliUsageError(
+          `${provider.name()} does not currently support project-scoped Dosu configuration`,
+        );
+      }
+      if (kind === "project" && global) {
+        throw new CliUsageError(
+          `${provider.name()} is project-scoped. Run this command inside the project without --global`,
+        );
+      }
+      if (kind === "global-connector" && !global) {
+        throw new CliUsageError(
+          `${provider.name()} is an explicit global connector. Re-run with --global`,
         );
       }
 
-      const projectRoot = global ? undefined : requireProjectRoot();
+      const projectRoot = kind === "project" ? requireProjectRoot() : undefined;
 
-      const scope = global ? "global (all projects)" : "project-local";
-      console.log(`Adding Dosu MCP to ${provider.name()} (${scope})...`);
+      const scopeLabel = kind === "project" ? "project-local" : "global connector";
+      console.log(`Adding Dosu MCP to ${provider.name()} (${scopeLabel})...`);
 
-      provider.install(cfg, global, { showSecret: opts.showSecret, projectRoot });
+      provider.install(cfg, {
+        scope: kind === "project" ? "project" : "global",
+        showSecret: opts.showSecret,
+        projectRoot,
+      });
 
       console.log(`\n✓ Successfully added Dosu MCP to ${provider.name()}!`);
-      if (global) {
+      if (kind === "global-connector") {
         console.log(`\nStart ${provider.name()} in any project to use the Dosu MCP.`);
       } else {
         console.log(`\nStart ${provider.name()} in this project directory to use the Dosu MCP.`);
@@ -559,9 +573,9 @@ export function createProgram(options: { telemetry?: CommandTelemetry } = {}): C
     .action(() => {
       console.log("Available AI tools:\n");
       for (const p of allProviders()) {
-        let scope = "(local + global)";
-        if (!p.supportsLocal()) scope = "(global only)";
-        if (p.id() === "manual") scope = "";
+        let scope = "(project)";
+        if (p.configurationKind() === "global-connector") scope = "(explicit global connector)";
+        if (p.configurationKind() === "unsupported") scope = "(project setup unavailable)";
         console.log(`  ${p.id().padEnd(10)} ${p.name()} ${scope}`);
       }
       console.log("\nUse 'dosu mcp add <agent>' to add Dosu MCP to a tool.");

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -288,6 +288,35 @@ describe("Client", () => {
       expect(options.headers.apikey).toBeTruthy();
       expect(options.signal).toBeInstanceOf(AbortSignal);
     });
+
+    it("preserves credentials for every deployment while refreshing the account session", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "new-tok",
+          refresh_token: "new-ref",
+          expires_in: 3600,
+        }),
+      );
+
+      const cfg = makeConfig({ deployment_id: "dep-a", api_key: "key-a" });
+      if (!cfg.active_account) throw new Error("test account missing");
+      cfg.active_account.targets = {
+        "dep-a": { deployment_id: "dep-a", api_key: "key-a" },
+        "dep-b": { deployment_id: "dep-b", api_key: "key-b" },
+      };
+      saveConfig(cfg);
+
+      await new Client(cfg).refreshToken();
+
+      expect(cfg.active_account.targets).toEqual({
+        "dep-a": { deployment_id: "dep-a", api_key: "key-a" },
+        "dep-b": { deployment_id: "dep-b", api_key: "key-b" },
+      });
+      expect(cfg.active_account.session).toMatchObject({
+        access_token: "new-tok",
+        refresh_token: "new-ref",
+      });
+    });
   });
 
   describe("createAPIKey", () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -241,6 +241,7 @@ export class Client {
           ...source.active_account,
           session: { ...source.active_account.session },
           target: source.active_account.target ? { ...source.active_account.target } : undefined,
+          targets: cloneAccountTargets(source.active_account.targets),
         }
       : undefined;
   }
@@ -370,8 +371,17 @@ function configWithSession(
       ...account,
       session,
       target: account.target ? { ...account.target } : undefined,
+      targets: cloneAccountTargets(account.targets),
     },
   };
+}
+
+function cloneAccountTargets(
+  targets: NonNullable<Config["active_account"]>["targets"],
+): NonNullable<Config["active_account"]>["targets"] {
+  return Object.fromEntries(
+    Object.entries(targets ?? {}).map(([deploymentID, target]) => [deploymentID, { ...target }]),
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -309,6 +309,23 @@ describe("installSkill helper", () => {
     });
   });
 
+  it("reports project-local targets for Claude, Codex, and Factory", () => {
+    const root = "/tmp/project";
+
+    expect(skillInstallTargetForProvider("claude", root)).toEqual({
+      path: join(root, ".claude", "skills", "dosu"),
+      symlink: false,
+    });
+    expect(skillInstallTargetForProvider("codex", root)).toEqual({
+      path: join(root, ".agents", "skills", "dosu"),
+      symlink: false,
+    });
+    expect(skillInstallTargetForProvider("factory", root)).toEqual({
+      path: join(root, ".factory", "skills", "dosu"),
+      symlink: false,
+    });
+  });
+
   it("reports the Windsurf symlink target", () => {
     expect(skillInstallTargetForProvider("windsurf")).toEqual({
       path: join(homedir(), ".codeium", "windsurf", "skills", "dosu"),
@@ -329,6 +346,30 @@ describe("installSkill helper", () => {
       expect.any(Function),
     );
     expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("installs selected skills in the project without the global flag", async () => {
+    await installSkill(["claude", "codex"], { quiet: true, projectRoot: "/tmp/project" });
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'npx skills add dosu-ai/dosu-skill -a claude-code codex -s "*" --copy -y',
+      { windowsHide: true, cwd: "/tmp/project" },
+      expect.any(Function),
+    );
+  });
+
+  it("refuses a symlinked project skills lock before running the installer", async () => {
+    const projectRoot = join(tempDir, "project");
+    mkdirSync(projectRoot);
+    const outsideLock = join(tempDir, "outside-skills-lock.json");
+    writeFileSync(outsideLock, "{}\n");
+    symlinkSync(outsideLock, join(projectRoot, "skills-lock.json"));
+
+    await expect(installSkill(["claude"], { quiet: true, projectRoot })).rejects.toThrow(
+      "symbolic link",
+    );
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(readFileSync(outsideLock, "utf-8")).toBe("{}\n");
   });
 
   it("returns failure when the async quiet installer fails", async () => {

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,17 +1,23 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockExecSync = vi.fn();
-const mockExec = vi.fn();
+const mockSpawnSync = vi.fn();
+const mockSpawn = vi.fn();
 vi.mock("node:child_process", () => ({
-  exec: (...args: unknown[]) => mockExec(...args),
-  execSync: (...args: unknown[]) => mockExecSync(...args),
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+  spawnSync: (...args: unknown[]) => mockSpawnSync(...args),
+}));
+vi.mock("../mcp/detect", () => ({
+  findNpx: () => "/trusted/bin/npx",
+  npxPathEnv: () => "/trusted/bin:/usr/bin:/bin",
 }));
 
 import {
+  installedDosuSkillState,
   installSkill,
+  installSkillForAgents,
   skillAgentIDsForProviders,
   skillCommand,
   skillInstallTargetForProvider,
@@ -40,12 +46,18 @@ async function run(...args: string[]) {
 }
 
 beforeEach(() => {
-  mockExec.mockReset();
-  mockExec.mockImplementation((...args: unknown[]) => {
-    const callback = args.at(-1) as (error: Error | null) => void;
-    callback(null);
+  mockSpawn.mockReset();
+  mockSpawn.mockImplementation(() => {
+    const child = {
+      once(event: string, callback: (...args: unknown[]) => void) {
+        if (event === "close") callback(0);
+        return child;
+      },
+    };
+    return child;
   });
-  mockExecSync.mockReset();
+  mockSpawnSync.mockReset();
+  mockSpawnSync.mockReturnValue({ status: 0, stdout: "" });
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -85,24 +97,48 @@ afterEach(() => {
 describe("skill install", () => {
   it("runs npx skills add with correct args", async () => {
     await run("install");
-    expect(mockExecSync).toHaveBeenCalledWith(
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
       [
-        "npx skills add dosu-ai/dosu-skill -g",
-        "-a claude-code -a cursor -a gemini-cli -a codex -a windsurf",
-        "-a zed -a cline -a github-copilot -a opencode -a antigravity",
-        '-s "*" -y',
-      ].join(" "),
-      {
-        stdio: "inherit",
-      },
+        "skills",
+        "add",
+        "dosu-ai/dosu-skill",
+        "-g",
+        "-a",
+        "claude-code",
+        "-a",
+        "cursor",
+        "-a",
+        "gemini-cli",
+        "-a",
+        "codex",
+        "-a",
+        "windsurf",
+        "-a",
+        "zed",
+        "-a",
+        "cline",
+        "-a",
+        "github-copilot",
+        "-a",
+        "opencode",
+        "-a",
+        "antigravity",
+        "-a",
+        "droid",
+        "-s",
+        "*",
+        "-y",
+      ],
+      expect.objectContaining({ cwd: homedir(), shell: false, stdio: "inherit" }),
     );
   });
 
   it("does not let skills auto-target PromptScript", async () => {
     await run("install");
-    const command = String(mockExecSync.mock.calls[0][0]);
-    expect(command).toContain("-a claude-code");
-    expect(command).not.toContain("promptscript");
+    const args = mockSpawnSync.mock.calls[0][1] as string[];
+    expect(args).toContain("claude-code");
+    expect(args).not.toContain("promptscript");
   });
 
   it("prints success message", async () => {
@@ -110,8 +146,8 @@ describe("skill install", () => {
     expect(allOutput()).toContain("installed successfully");
   });
 
-  it("exits with error when execSync throws", async () => {
-    mockExecSync.mockImplementation(() => {
+  it("exits with error when the installer throws", async () => {
+    mockSpawnSync.mockImplementation(() => {
       throw new Error("command failed");
     });
     await expect(run("install")).rejects.toThrow("exit");
@@ -122,9 +158,10 @@ describe("skill install", () => {
 describe("skill remove", () => {
   /** Make `npx skills list -g --json` resolve to the given inventory. */
   function stubInventory(entries: unknown[]): void {
-    mockExecSync.mockImplementation((command: string) =>
-      command.includes("skills list") ? JSON.stringify(entries) : undefined,
-    );
+    mockSpawnSync.mockImplementation((_command: string, args: string[]) => ({
+      status: 0,
+      stdout: args.includes("list") ? JSON.stringify(entries) : "",
+    }));
   }
 
   it("removes every skill installed from the Dosu repo", async () => {
@@ -133,9 +170,11 @@ describe("skill remove", () => {
       { name: "dosu-review", source: "dosu-ai/dosu-skill" },
     ]);
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu dosu-review -y", {
-      stdio: "inherit",
-    });
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      ["skills", "remove", "-g", "dosu", "dosu-review", "-y"],
+      expect.objectContaining({ cwd: homedir(), shell: false, stdio: "inherit" }),
+    );
   });
 
   it("leaves skills from other sources alone", async () => {
@@ -145,9 +184,11 @@ describe("skill remove", () => {
       { name: "local-skill", source: null },
     ]);
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
-      stdio: "inherit",
-    });
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      ["skills", "remove", "-g", "dosu", "-y"],
+      expect.objectContaining({ shell: false }),
+    );
   });
 
   it("skips names that are unsafe to interpolate into a shell command", async () => {
@@ -156,9 +197,11 @@ describe("skill remove", () => {
       { name: "evil; rm -rf /", source: "dosu-ai/dosu-skill" },
     ]);
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
-      stdio: "inherit",
-    });
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      ["skills", "remove", "-g", "dosu", "-y"],
+      expect.anything(),
+    );
   });
 
   // `skills list` echoes the front-matter name without validating it, and
@@ -169,17 +212,18 @@ describe("skill remove", () => {
       { name: "--all", source: "dosu-ai/dosu-skill" },
     ]);
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
-      stdio: "inherit",
-    });
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      ["skills", "remove", "-g", "dosu", "-y"],
+      expect.anything(),
+    );
   });
 
   it("does nothing when the inventory holds no skills of ours", async () => {
     stubInventory([{ name: "web-design", source: "vercel-labs/agent-skills" }]);
     await run("remove");
-    expect(mockExecSync).not.toHaveBeenCalledWith(
-      expect.stringContaining("skills remove"),
-      expect.anything(),
+    expect(mockSpawnSync.mock.calls.some((call) => (call[1] as string[]).includes("remove"))).toBe(
+      false,
     );
     expect(allOutput()).toContain("No skills from dosu-ai/dosu-skill are installed");
   });
@@ -203,20 +247,24 @@ describe("skill remove", () => {
   it("treats a non-array inventory as unreadable", async () => {
     stubInventory({ unexpected: "shape" } as unknown as unknown[]);
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
-      stdio: "inherit",
-    });
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      ["skills", "remove", "-g", "dosu", "-y"],
+      expect.anything(),
+    );
   });
 
   it("falls back to the known skill when the inventory is unreadable", async () => {
-    mockExecSync.mockImplementation((command: string) => {
-      if (command.includes("skills list")) throw new Error("npx unavailable");
-      return undefined;
+    mockSpawnSync.mockImplementation((_command: string, args: string[]) => {
+      if (args.includes("list")) throw new Error("npx unavailable");
+      return { status: 0, stdout: "" };
     });
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
-      stdio: "inherit",
-    });
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      ["skills", "remove", "-g", "dosu", "-y"],
+      expect.anything(),
+    );
   });
 
   it("prints success message", async () => {
@@ -224,8 +272,8 @@ describe("skill remove", () => {
     expect(allOutput()).toContain("removed");
   });
 
-  it("exits with error when execSync throws", async () => {
-    mockExecSync.mockImplementation(() => {
+  it("exits with error when the command throws", async () => {
+    mockSpawnSync.mockImplementation(() => {
       throw new Error("command failed");
     });
     await expect(run("remove")).rejects.toThrow("exit");
@@ -234,15 +282,42 @@ describe("skill remove", () => {
 });
 
 describe("skill update", () => {
+  beforeEach(() => {
+    mockSpawnSync.mockImplementation((_command: string, args: string[]) => ({
+      status: 0,
+      stdout: args.includes("list")
+        ? JSON.stringify([
+            {
+              name: "dosu",
+              source: "dosu-ai/dosu-skill",
+              agents: ["Claude Code", "Factory"],
+            },
+          ])
+        : "",
+    }));
+  });
+
   it("reinstalls via npx skills add (update can't follow repo-layout moves)", async () => {
     await run("update");
-    expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringContaining("npx skills add dosu-ai/dosu-skill -g"),
-      { stdio: "inherit" },
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      [
+        "skills",
+        "add",
+        "dosu-ai/dosu-skill",
+        "-g",
+        "-a",
+        "claude-code",
+        "-a",
+        "droid",
+        "-s",
+        "*",
+        "-y",
+      ],
+      expect.objectContaining({ cwd: homedir(), shell: false }),
     );
-    expect(mockExecSync).not.toHaveBeenCalledWith(
-      expect.stringContaining("npx skills update"),
-      expect.anything(),
+    expect(mockSpawnSync.mock.calls.some((call) => (call[1] as string[]).includes("update"))).toBe(
+      false,
     );
   });
 
@@ -251,8 +326,16 @@ describe("skill update", () => {
     expect(allOutput()).toContain("updated");
   });
 
-  it("exits with error when execSync throws", async () => {
-    mockExecSync.mockImplementation(() => {
+  it("exits with error when the update command throws", async () => {
+    mockSpawnSync.mockImplementation((_command: string, args: string[]) => {
+      if (args.includes("list")) {
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            { name: "dosu", source: "dosu-ai/dosu-skill", agents: ["Claude Code"] },
+          ]),
+        };
+      }
       throw new Error("command failed");
     });
     await expect(run("update")).rejects.toThrow("exit");
@@ -281,9 +364,22 @@ describe("installSkill helper", () => {
     const result = await installSkill(["claude", "codex"]);
 
     expect(result.success).toBe(true);
-    expect(mockExecSync).toHaveBeenCalledWith(
-      'npx skills add dosu-ai/dosu-skill -g -a claude-code -a codex -s "*" -y',
-      { stdio: "inherit" },
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      [
+        "skills",
+        "add",
+        "dosu-ai/dosu-skill",
+        "-g",
+        "-a",
+        "claude-code",
+        "-a",
+        "codex",
+        "-s",
+        "*",
+        "-y",
+      ],
+      expect.objectContaining({ cwd: homedir(), shell: false }),
     );
   });
 
@@ -309,23 +405,6 @@ describe("installSkill helper", () => {
     });
   });
 
-  it("reports project-local targets for Claude, Codex, and Factory", () => {
-    const root = "/tmp/project";
-
-    expect(skillInstallTargetForProvider("claude", root)).toEqual({
-      path: join(root, ".claude", "skills", "dosu"),
-      symlink: false,
-    });
-    expect(skillInstallTargetForProvider("codex", root)).toEqual({
-      path: join(root, ".agents", "skills", "dosu"),
-      symlink: false,
-    });
-    expect(skillInstallTargetForProvider("factory", root)).toEqual({
-      path: join(root, ".factory", "skills", "dosu"),
-      symlink: false,
-    });
-  });
-
   it("reports the Windsurf symlink target", () => {
     expect(skillInstallTargetForProvider("windsurf")).toEqual({
       path: join(homedir(), ".codeium", "windsurf", "skills", "dosu"),
@@ -340,42 +419,50 @@ describe("installSkill helper", () => {
   it("keeps the installer quiet for agent-mediated setup", async () => {
     await installSkill(["claude"], { quiet: true });
 
-    expect(mockExec).toHaveBeenCalledWith(
-      expect.any(String),
-      { windowsHide: true },
-      expect.any(Function),
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      expect.any(Array),
+      expect.objectContaining({
+        cwd: homedir(),
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true,
+      }),
     );
-    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
   });
 
-  it("installs selected skills in the project without the global flag", async () => {
-    await installSkill(["claude", "codex"], { quiet: true, projectRoot: "/tmp/project" });
+  it("always keeps quiet setup installs global", async () => {
+    await installSkill(["claude", "codex"], { quiet: true });
 
-    expect(mockExec).toHaveBeenCalledWith(
-      'npx skills add dosu-ai/dosu-skill -a claude-code codex -s "*" --copy -y',
-      { windowsHide: true, cwd: "/tmp/project" },
-      expect.any(Function),
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      [
+        "skills",
+        "add",
+        "dosu-ai/dosu-skill",
+        "-g",
+        "-a",
+        "claude-code",
+        "-a",
+        "codex",
+        "-s",
+        "*",
+        "-y",
+      ],
+      expect.objectContaining({ cwd: homedir(), shell: false }),
     );
-  });
-
-  it("refuses a symlinked project skills lock before running the installer", async () => {
-    const projectRoot = join(tempDir, "project");
-    mkdirSync(projectRoot);
-    const outsideLock = join(tempDir, "outside-skills-lock.json");
-    writeFileSync(outsideLock, "{}\n");
-    symlinkSync(outsideLock, join(projectRoot, "skills-lock.json"));
-
-    await expect(installSkill(["claude"], { quiet: true, projectRoot })).rejects.toThrow(
-      "symbolic link",
-    );
-    expect(mockExec).not.toHaveBeenCalled();
-    expect(readFileSync(outsideLock, "utf-8")).toBe("{}\n");
   });
 
   it("returns failure when the async quiet installer fails", async () => {
-    mockExec.mockImplementation((...args: unknown[]) => {
-      const callback = args.at(-1) as (error: Error | null) => void;
-      callback(new Error("command failed"));
+    mockSpawn.mockImplementation(() => {
+      const child = {
+        once(event: string, callback: (...args: unknown[]) => void) {
+          if (event === "error") callback(new Error("command failed"));
+          return child;
+        },
+      };
+      return child;
     });
 
     const result = await installSkill(["claude"], { quiet: true });
@@ -387,7 +474,53 @@ describe("installSkill helper", () => {
     const result = await installSkill(["manual"]);
 
     expect(result.success).toBe(true);
-    expect(mockExecSync).not.toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it("installs an explicit agent set without broadening it", async () => {
+    const result = await installSkillForAgents(["claude-code", "droid"]);
+
+    expect(result.success).toBe(true);
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "/trusted/bin/npx",
+      [
+        "skills",
+        "add",
+        "dosu-ai/dosu-skill",
+        "-g",
+        "-a",
+        "claude-code",
+        "-a",
+        "droid",
+        "-s",
+        "*",
+        "-y",
+      ],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+
+  it("recovers the existing agent targets from the official skill inventory", () => {
+    mockSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([
+        {
+          name: "dosu",
+          source: "dosu-ai/dosu-skill",
+          agents: ["Claude Code", "Codex", "Factory", "Unknown Agent"],
+        },
+        {
+          name: "foreign",
+          source: "other/repo",
+          agents: ["Cursor"],
+        },
+      ]),
+    });
+
+    expect(installedDosuSkillState()).toEqual({
+      names: ["dosu"],
+      agentIDs: ["claude-code", "codex", "droid"],
+    });
   });
 
   it("writes cache with SHA on success", async () => {
@@ -416,8 +549,8 @@ describe("installSkill helper", () => {
     expect(result.sha).toBeUndefined();
   });
 
-  it("returns failure when execSync throws", async () => {
-    mockExecSync.mockImplementation(() => {
+  it("returns failure when the process throws", async () => {
+    mockSpawnSync.mockImplementation(() => {
       throw new Error("command failed");
     });
     const result = await installSkill();

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -2,13 +2,13 @@
  * `dosu skill` — manage the Dosu agent skill.
  */
 
-import { exec, execSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 import { Command } from "commander";
 import pc from "picocolors";
 import { logger } from "../debug/logger";
-import { assertSafeProjectPath } from "../setup/project-root";
+import { findNpx, npxPathEnv } from "../mcp/detect";
 import { clearInstalledSha, fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
@@ -32,7 +32,25 @@ const SUPPORTED_SKILL_AGENTS = [
   "github-copilot",
   "opencode",
   "antigravity",
+  "droid",
 ];
+
+const SKILL_AGENT_ID_BY_DISPLAY_NAME: Readonly<Record<string, string>> = {
+  Antigravity: "antigravity",
+  "Claude Code": "claude-code",
+  Cline: "cline",
+  Codex: "codex",
+  Cursor: "cursor",
+  Droid: "droid",
+  Factory: "droid",
+  "Gemini CLI": "gemini-cli",
+  "GitHub Copilot": "github-copilot",
+  OpenCode: "opencode",
+  Windsurf: "windsurf",
+  Zed: "zed",
+};
+
+const SUPPORTED_SKILL_AGENT_SET = new Set(SUPPORTED_SKILL_AGENTS);
 
 const SKILL_AGENT_BY_PROVIDER: Readonly<Record<string, string>> = {
   claude: "claude-code",
@@ -65,25 +83,16 @@ export interface SkillInstallTarget {
   symlink: boolean;
 }
 
-export function skillInstallTargetForProvider(
-  providerID: string,
-  projectRoot?: string,
-): SkillInstallTarget | null {
+export function skillInstallTargetForProvider(providerID: string): SkillInstallTarget | null {
   const agentID = SKILL_AGENT_BY_PROVIDER[providerID];
   if (!agentID) return null;
 
   if (agentID === "claude-code") {
-    if (projectRoot) {
-      return { path: join(projectRoot, ".claude", "skills", SKILL_NAME), symlink: false };
-    }
     const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude");
     return { path: join(claudeConfigDir, "skills", SKILL_NAME), symlink: true };
   }
 
   if (agentID === "windsurf") {
-    if (projectRoot) {
-      return { path: join(projectRoot, ".windsurf", "skills", SKILL_NAME), symlink: false };
-    }
     return {
       path: join(homedir(), ".codeium", "windsurf", "skills", SKILL_NAME),
       symlink: true,
@@ -92,36 +101,107 @@ export function skillInstallTargetForProvider(
 
   if (agentID === "droid") {
     return {
-      path: projectRoot
-        ? join(projectRoot, ".factory", "skills", SKILL_NAME)
-        : join(homedir(), ".factory", "skills", SKILL_NAME),
-      symlink: !projectRoot,
+      path: join(homedir(), ".factory", "skills", SKILL_NAME),
+      symlink: true,
     };
   }
 
   return {
-    path: projectRoot
-      ? join(projectRoot, ".agents", "skills", SKILL_NAME)
-      : join(homedir(), ".agents", "skills", SKILL_NAME),
+    path: join(homedir(), ".agents", "skills", SKILL_NAME),
     symlink: false,
   };
 }
 
-function skillAgentArgs(providerIDs?: readonly string[], project = false): string {
-  const agents =
-    providerIDs === undefined ? SUPPORTED_SKILL_AGENTS : skillAgentIDsForProviders(providerIDs);
-  return project
-    ? agents.length > 0
-      ? `-a ${agents.join(" ")}`
-      : ""
-    : agents.map((agent) => `-a ${agent}`).join(" ");
+function skillAgentArgs(agentIDs: readonly string[]): string[] {
+  return agentIDs.flatMap((agent) => ["-a", agent]);
 }
 
-function execQuiet(command: string, cwd?: string): Promise<void> {
+interface SkillInvocation {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+}
+
+function windowsCommandProcessor(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  if (
+    env.ComSpec &&
+    win32.isAbsolute(env.ComSpec) &&
+    win32.basename(env.ComSpec).toLowerCase() === "cmd.exe"
+  ) {
+    return env.ComSpec;
+  }
+  const systemRoot =
+    env.SystemRoot && win32.isAbsolute(env.SystemRoot) ? env.SystemRoot : "C:\\Windows";
+  return win32.join(systemRoot, "System32", "cmd.exe");
+}
+
+function quoteWindowsCommandArg(value: string): string {
+  if (/[\r\n"&|<>^%!]/.test(value)) {
+    throw new Error("npx path or argument contains unsupported Windows shell characters");
+  }
+  return value === "*" || /\s/.test(value) ? `"${value}"` : value;
+}
+
+/** Build a project-independent invocation of the trusted npx found on PATH. */
+function buildSkillInvocation(
+  args: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  npx: string = findNpx(),
+): SkillInvocation {
+  const safeEnv: NodeJS.ProcessEnv = {
+    ...env,
+    PATH: npxPathEnv(npx),
+    COREPACK_ENABLE_NETWORK: "0",
+    COREPACK_ENABLE_PROJECT_SPEC: "0",
+    YARN_IGNORE_PATH: "1",
+  };
+  if (platform !== "win32") return { command: npx, args: [...args], env: safeEnv };
+
+  const commandLine = [npx, ...args].map(quoteWindowsCommandArg).join(" ");
+  return {
+    command: windowsCommandProcessor(env),
+    args: ["/d", "/s", "/c", commandLine],
+    env: { ...safeEnv, NoDefaultCurrentDirectoryInExePath: "1" },
+  };
+}
+
+function runSkillSync(
+  args: readonly string[],
+  output: "inherit" | "capture" = "inherit",
+): string | null {
+  const invocation = buildSkillInvocation(args);
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: homedir(),
+    encoding: output === "capture" ? "utf8" : undefined,
+    env: invocation.env,
+    shell: false,
+    stdio: output === "capture" ? ["ignore", "pipe", "ignore"] : "inherit",
+  });
+  if (result.error || result.status !== 0) {
+    throw (
+      result.error ?? new Error(`skills command exited with status ${result.status ?? "unknown"}`)
+    );
+  }
+  return output === "capture" && typeof result.stdout === "string" ? result.stdout : null;
+}
+
+function runSkillQuiet(args: readonly string[]): Promise<void> {
+  const invocation = buildSkillInvocation(args);
   return new Promise((resolve, reject) => {
-    exec(command, { windowsHide: true, ...(cwd ? { cwd } : {}) }, (error) => {
-      if (error) reject(error);
-      else resolve();
+    const child = spawn(invocation.command, invocation.args, {
+      cwd: homedir(),
+      env: invocation.env,
+      shell: false,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`skills command exited with status ${code ?? "unknown"}`));
     });
   });
 }
@@ -135,41 +215,33 @@ function execQuiet(command: string, cwd?: string): Promise<void> {
  */
 export async function installSkill(
   providerIDs?: readonly string[],
-  options: { quiet?: boolean; projectRoot?: string } = {},
+  options: { quiet?: boolean } = {},
 ): Promise<{ success: boolean; sha?: string }> {
-  const agentArgs = skillAgentArgs(providerIDs, Boolean(options.projectRoot));
-  if (!agentArgs) {
-    logger.debug("skill", "No selected providers support the Dosu skill");
+  const agentIDs =
+    providerIDs === undefined ? SUPPORTED_SKILL_AGENTS : skillAgentIDsForProviders(providerIDs);
+  return installSkillForAgents(agentIDs, options);
+}
+
+/** Install every official skill for an already validated set of agent IDs. */
+export async function installSkillForAgents(
+  requestedAgentIDs: readonly string[],
+  options: { quiet?: boolean } = {},
+): Promise<{ success: boolean; sha?: string }> {
+  const agentIDs = [
+    ...new Set(requestedAgentIDs.filter((agentID) => SUPPORTED_SKILL_AGENT_SET.has(agentID))),
+  ];
+  const agentArgs = skillAgentArgs(agentIDs);
+  if (agentArgs.length === 0) {
+    logger.debug("skill", "No supported agents were selected for the Dosu skill");
     return { success: true };
   }
 
-  if (options.projectRoot) {
-    assertSafeProjectPath(options.projectRoot, join(options.projectRoot, "skills-lock.json"));
-    const targets = new Set(
-      (providerIDs ?? [])
-        .map((providerID) => skillInstallTargetForProvider(providerID, options.projectRoot))
-        .filter((target): target is SkillInstallTarget => target !== null)
-        .map((target) => target.path),
-    );
-    for (const target of targets) assertSafeProjectPath(options.projectRoot, target);
-  }
-
   try {
-    // `-s "*"` installs every skill the repo exposes, so adding one upstream
-    // does not require a CLI release. The quoting is load-bearing and must be
-    // double quotes: this string is run through a shell, so on POSIX a bare `*`
-    // would glob-expand against cwd, while on Windows the shell is cmd.exe,
-    // which does not treat single quotes as delimiters and would forward a
-    // literal `'*'` that matches no skill name.
-    const global = options.projectRoot ? "" : " -g";
-    const copy = options.projectRoot ? " --copy" : "";
-    const command = `npx skills add ${SKILL_REPO}${global} ${agentArgs} -s "*"${copy} -y`;
-    if (options.quiet) await execQuiet(command, options.projectRoot);
-    else
-      execSync(command, {
-        stdio: "inherit",
-        ...(options.projectRoot ? { cwd: options.projectRoot } : {}),
-      });
+    // The literal wildcard asks the upstream installer for every skill in the
+    // reviewed Dosu repository. Argument arrays keep it out of shell globbing.
+    const args = ["skills", "add", SKILL_REPO, "-g", ...agentArgs, "-s", "*", "-y"];
+    if (options.quiet) await runSkillQuiet(args);
+    else runSkillSync(args);
   } catch (err) {
     logger.error("skill", `Failed to install skill: ${err}`);
     return { success: false };
@@ -197,13 +269,16 @@ export async function installSkill(
  * installed; `null` means the inventory could not be read, which is a different
  * situation and gets a different fallback.
  */
-function installedSkillNames(): string[] | null {
-  let entries: { name?: unknown; source?: unknown }[];
+export interface InstalledDosuSkillState {
+  names: string[];
+  agentIDs: string[];
+}
+
+export function installedDosuSkillState(): InstalledDosuSkillState | null {
+  let entries: { name?: unknown; source?: unknown; agents?: unknown }[];
   try {
-    const json = execSync("npx skills list -g --json", {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
+    const json = runSkillSync(["skills", "list", "-g", "--json"], "capture");
+    if (json === null) throw new Error("skills inventory produced no output");
     const parsed = JSON.parse(json);
     if (!Array.isArray(parsed)) throw new Error("expected a JSON array");
     entries = parsed;
@@ -212,16 +287,27 @@ function installedSkillNames(): string[] | null {
     return null;
   }
 
-  const names: string[] = [];
+  const names = new Set<string>();
+  const agentIDs = new Set<string>();
   for (const entry of entries) {
     if (entry.source !== SKILL_REPO || typeof entry.name !== "string") continue;
     if (!SAFE_SKILL_NAME.test(entry.name)) {
       logger.warn("skill", `Skipping skill with an unsupported name: ${entry.name}`);
       continue;
     }
-    names.push(entry.name);
+    names.add(entry.name);
+    if (!Array.isArray(entry.agents)) continue;
+    for (const displayName of entry.agents) {
+      if (typeof displayName !== "string") continue;
+      const agentID = SKILL_AGENT_ID_BY_DISPLAY_NAME[displayName] ?? displayName;
+      if (SUPPORTED_SKILL_AGENT_SET.has(agentID)) agentIDs.add(agentID);
+    }
   }
-  return names;
+  return { names: [...names], agentIDs: [...agentIDs] };
+}
+
+function installedSkillNames(): string[] | null {
+  return installedDosuSkillState()?.names ?? null;
 }
 
 export function skillCommand(): Command {
@@ -256,9 +342,7 @@ export function skillCommand(): Command {
       const targets = installed ?? [SKILL_NAME];
       console.log(`Removing skills from ${SKILL_REPO}...`);
       try {
-        execSync(`npx skills remove -g ${targets.join(" ")} -y`, {
-          stdio: "inherit",
-        });
+        runSkillSync(["skills", "remove", "-g", ...targets, "-y"]);
         clearInstalledSha();
         console.log(pc.green(`\n✓ Skills removed.`));
       } catch {
@@ -272,12 +356,25 @@ export function skillCommand(): Command {
     .description("Update the Dosu skill to the latest version")
     .action(async () => {
       console.log(`Updating skills from ${SKILL_REPO}...`);
+      const installed = installedDosuSkillState();
+      if (installed === null) {
+        console.error(pc.red(`\nCould not inspect installed Dosu skills.`));
+        process.exit(1);
+      }
+      if (installed.names.length === 0) {
+        console.log(`No skills from ${SKILL_REPO} are installed.`);
+        return;
+      }
+      if (installed.agentIDs.length === 0) {
+        console.error(pc.red(`\nCould not determine which agents use the installed Dosu skills.`));
+        process.exit(1);
+      }
       // Reinstall rather than `npx skills update`: update matches on the
       // skillPath recorded in the skills lockfile, so it can't follow the
       // skill across a repo-layout move (it reports "deleted upstream"
       // instead). `skills add` overwrites by name and refreshes the lock
       // entry, so it always converges on the latest layout.
-      const result = await installSkill();
+      const result = await installSkillForAgents(installed.agentIDs);
       if (!result.success) {
         console.error(pc.red(`\nFailed to update skill.`));
         process.exit(1);

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { Command } from "commander";
 import pc from "picocolors";
 import { logger } from "../debug/logger";
+import { assertSafeProjectPath } from "../setup/project-root";
 import { clearInstalledSha, fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
@@ -46,6 +47,7 @@ const SKILL_AGENT_BY_PROVIDER: Readonly<Record<string, string>> = {
   copilot: "github-copilot",
   opencode: "opencode",
   antigravity: "antigravity",
+  factory: "droid",
 };
 
 export function skillAgentIDsForProviders(providerIDs: readonly string[]): string[] {
@@ -63,37 +65,61 @@ export interface SkillInstallTarget {
   symlink: boolean;
 }
 
-export function skillInstallTargetForProvider(providerID: string): SkillInstallTarget | null {
+export function skillInstallTargetForProvider(
+  providerID: string,
+  projectRoot?: string,
+): SkillInstallTarget | null {
   const agentID = SKILL_AGENT_BY_PROVIDER[providerID];
   if (!agentID) return null;
 
   if (agentID === "claude-code") {
+    if (projectRoot) {
+      return { path: join(projectRoot, ".claude", "skills", SKILL_NAME), symlink: false };
+    }
     const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude");
     return { path: join(claudeConfigDir, "skills", SKILL_NAME), symlink: true };
   }
 
   if (agentID === "windsurf") {
+    if (projectRoot) {
+      return { path: join(projectRoot, ".windsurf", "skills", SKILL_NAME), symlink: false };
+    }
     return {
       path: join(homedir(), ".codeium", "windsurf", "skills", SKILL_NAME),
       symlink: true,
     };
   }
 
+  if (agentID === "droid") {
+    return {
+      path: projectRoot
+        ? join(projectRoot, ".factory", "skills", SKILL_NAME)
+        : join(homedir(), ".factory", "skills", SKILL_NAME),
+      symlink: !projectRoot,
+    };
+  }
+
   return {
-    path: join(homedir(), ".agents", "skills", SKILL_NAME),
+    path: projectRoot
+      ? join(projectRoot, ".agents", "skills", SKILL_NAME)
+      : join(homedir(), ".agents", "skills", SKILL_NAME),
     symlink: false,
   };
 }
 
-function skillAgentArgs(providerIDs?: readonly string[]): string {
+function skillAgentArgs(providerIDs?: readonly string[], project = false): string {
   const agents =
     providerIDs === undefined ? SUPPORTED_SKILL_AGENTS : skillAgentIDsForProviders(providerIDs);
-  return agents.map((agent) => `-a ${agent}`).join(" ");
+  return project
+    ? agents.length > 0
+      ? `-a ${agents.join(" ")}`
+      : ""
+    : agents.map((agent) => `-a ${agent}`).join(" ");
 }
 
-function execQuiet(command: string): Promise<void> {
+function execQuiet(command: string, cwd?: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    exec(command, { windowsHide: true }, (error) => {
+    exec(command, { windowsHide: true, ...(cwd ? { cwd } : {}) }, (error) => {
       if (error) reject(error);
       else resolve();
     });
@@ -109,12 +135,23 @@ function execQuiet(command: string): Promise<void> {
  */
 export async function installSkill(
   providerIDs?: readonly string[],
-  options: { quiet?: boolean } = {},
+  options: { quiet?: boolean; projectRoot?: string } = {},
 ): Promise<{ success: boolean; sha?: string }> {
-  const agentArgs = skillAgentArgs(providerIDs);
+  const agentArgs = skillAgentArgs(providerIDs, Boolean(options.projectRoot));
   if (!agentArgs) {
     logger.debug("skill", "No selected providers support the Dosu skill");
     return { success: true };
+  }
+
+  if (options.projectRoot) {
+    assertSafeProjectPath(options.projectRoot, join(options.projectRoot, "skills-lock.json"));
+    const targets = new Set(
+      (providerIDs ?? [])
+        .map((providerID) => skillInstallTargetForProvider(providerID, options.projectRoot))
+        .filter((target): target is SkillInstallTarget => target !== null)
+        .map((target) => target.path),
+    );
+    for (const target of targets) assertSafeProjectPath(options.projectRoot, target);
   }
 
   try {
@@ -124,9 +161,15 @@ export async function installSkill(
     // would glob-expand against cwd, while on Windows the shell is cmd.exe,
     // which does not treat single quotes as delimiters and would forward a
     // literal `'*'` that matches no skill name.
-    const command = `npx skills add ${SKILL_REPO} -g ${agentArgs} -s "*" -y`;
-    if (options.quiet) await execQuiet(command);
-    else execSync(command, { stdio: "inherit" });
+    const global = options.projectRoot ? "" : " -g";
+    const copy = options.projectRoot ? " --copy" : "";
+    const command = `npx skills add ${SKILL_REPO}${global} ${agentArgs} -s "*"${copy} -y`;
+    if (options.quiet) await execQuiet(command, options.projectRoot);
+    else
+      execSync(command, {
+        stdio: "inherit",
+        ...(options.projectRoot ? { cwd: options.projectRoot } : {}),
+      });
   } catch (err) {
     logger.error("skill", `Failed to install skill: ${err}`);
     return { success: false };

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -13,9 +13,12 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...actual, realpathSync: vi.fn(actual.realpathSync) };
 });
 
-vi.mock("./skill", () => ({ installSkill: vi.fn(async () => ({ success: true })) }));
+vi.mock("./skill", () => ({
+  installSkillForAgents: vi.fn(async () => ({ success: true })),
+  installedDosuSkillState: vi.fn(() => ({ names: ["dosu"], agentIDs: ["claude-code"] })),
+}));
 
-import { installSkill } from "./skill";
+import { installedDosuSkillState, installSkillForAgents } from "./skill";
 import {
   buildPackageManagerInvocation,
   completeUpgrade,
@@ -23,7 +26,8 @@ import {
   upgradeCommand,
 } from "./upgrade";
 
-const mockInstallSkill = vi.mocked(installSkill);
+const mockInstallSkillForAgents = vi.mocked(installSkillForAgents);
+const mockInstalledDosuSkillState = vi.mocked(installedDosuSkillState);
 
 const mockSpawnSync = vi.mocked(spawnSync);
 const mockRealpathSync = vi.mocked(realpathSync);
@@ -89,8 +93,10 @@ function errors(): string {
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "dosu-upgrade-test-"));
   mockSpawnSync.mockReset();
-  mockInstallSkill.mockReset();
-  mockInstallSkill.mockResolvedValue({ success: true });
+  mockInstallSkillForAgents.mockReset();
+  mockInstallSkillForAgents.mockResolvedValue({ success: true });
+  mockInstalledDosuSkillState.mockReset();
+  mockInstalledDosuSkillState.mockReturnValue({ names: ["dosu"], agentIDs: ["claude-code"] });
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   originalArgv = process.argv;
@@ -454,7 +460,7 @@ describe("completeUpgrade", () => {
     const status = await completeUpgrade("homebrew", { platform: "darwin" });
 
     expect(status).toBe(0);
-    expect(mockInstallSkill).toHaveBeenCalledOnce();
+    expect(mockInstallSkillForAgents).toHaveBeenCalledWith(["claude-code"]);
     expect(output()).toContain("Skills updated");
   });
 
@@ -464,17 +470,28 @@ describe("completeUpgrade", () => {
     const status = await completeUpgrade("homebrew", { platform: "darwin" });
 
     expect(status).toBe(7);
-    expect(mockInstallSkill).not.toHaveBeenCalled();
+    expect(mockInstallSkillForAgents).not.toHaveBeenCalled();
   });
 
-  it("returns 0 and hints at dosu skill update when skill refresh fails", async () => {
+  it("does not reinstall the official skill package after the user removed it", async () => {
     mockCommands({ "brew upgrade dosu-ai/dosu/dosu": { status: 0 } });
-    mockInstallSkill.mockResolvedValue({ success: false });
+    mockInstalledDosuSkillState.mockReturnValue({ names: [], agentIDs: [] });
 
     const status = await completeUpgrade("homebrew", { platform: "darwin" });
 
     expect(status).toBe(0);
-    expect(mockInstallSkill).toHaveBeenCalledOnce();
+    expect(mockInstallSkillForAgents).not.toHaveBeenCalled();
+    expect(output()).toContain("No Dosu skills are installed");
+  });
+
+  it("returns 0 and hints at dosu skill update when skill refresh fails", async () => {
+    mockCommands({ "brew upgrade dosu-ai/dosu/dosu": { status: 0 } });
+    mockInstallSkillForAgents.mockResolvedValue({ success: false });
+
+    const status = await completeUpgrade("homebrew", { platform: "darwin" });
+
+    expect(status).toBe(0);
+    expect(mockInstallSkillForAgents).toHaveBeenCalledWith(["claude-code"]);
     expect(errors()).toContain("dosu skill update");
   });
 });

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -7,7 +7,7 @@ import { posix, win32 } from "node:path";
 import { Command } from "commander";
 import pc from "picocolors";
 import { INSTALL_CHANNEL, isNpxInvocation } from "../version/version";
-import { installSkill } from "./skill";
+import { installedDosuSkillState, installSkillForAgents } from "./skill";
 
 const PACKAGE_NAME = "@dosu/cli";
 const LATEST_PACKAGE = `${PACKAGE_NAME}@latest`;
@@ -275,9 +275,24 @@ export async function completeUpgrade(
 ): Promise<number> {
   const status = runUpgrade(channel, options);
   if (status !== 0) return status;
+  const installed = installedDosuSkillState();
+  if (installed === null) {
+    console.error('Could not check installed Dosu skills. Run "dosu skill update" to retry.');
+    return 0;
+  }
+  if (installed.names.length === 0) {
+    console.log("No Dosu skills are installed; leaving them removed.");
+    return 0;
+  }
+  if (installed.agentIDs.length === 0) {
+    console.error(
+      'Could not determine which agents use the installed Dosu skills. Run "dosu skill update" to retry.',
+    );
+    return 0;
+  }
   console.log("Updating Dosu skills...");
   try {
-    const result = await installSkill();
+    const result = await installSkillForAgents(installed.agentIDs);
     if (result.success) {
       console.log(pc.green("✓ Skills updated."));
     } else {

--- a/src/config/config-v1-migration.ts
+++ b/src/config/config-v1-migration.ts
@@ -11,6 +11,7 @@ export function migrateLegacyConfig(value: unknown): Config {
   const hasSession = Boolean(accessToken || refreshToken || expiresAt);
   const userID = stringValue(value.user_id) ?? getAccessTokenUserID(accessToken);
 
+  const target = userID ? legacyTarget(value) : undefined;
   return {
     schema_version: CONFIG_SCHEMA_VERSION,
     mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
@@ -23,7 +24,8 @@ export function migrateLegacyConfig(value: unknown): Config {
             expires_at: expiresAt,
           },
           // An unowned legacy target is unsafe to carry into a future login.
-          target: userID ? legacyTarget(value) : undefined,
+          target,
+          targets: target?.deployment_id ? { [target.deployment_id]: { ...target } } : {},
         }
       : undefined,
   };

--- a/src/config/config.atomic.test.ts
+++ b/src/config/config.atomic.test.ts
@@ -74,7 +74,7 @@ describe("saveConfig atomicity", () => {
     // Result round-trips and leaves no stray temp files behind.
     const loaded = loadConfig();
     expect(loaded.active_account?.session).toEqual(cfg.active_account?.session);
-    expect(loaded.schema_version).toBe(2);
+    expect(loaded.schema_version).toBe(3);
     expect(readdirSync(dirname(finalPath))).toEqual(["config.json"]);
   });
 

--- a/src/config/config.test-utils.ts
+++ b/src/config/config.test-utils.ts
@@ -34,6 +34,7 @@ export function makeTestConfig(flat: FlatTestConfig): Config {
         expires_at: flat.expires_at,
       },
       target: Object.values(target).some((value) => value !== undefined) ? target : undefined,
+      targets: target.deployment_id ? { [target.deployment_id]: { ...target } } : {},
     },
   };
 }

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -13,6 +13,8 @@ import {
   replaceLoginSession,
   type SessionCredentials,
   saveConfig,
+  targetForDeployment,
+  updateTarget,
 } from "./config";
 import { makeTestConfig } from "./config.test-utils";
 import { CONFIG_SCHEMA_VERSION } from "./schema";
@@ -131,7 +133,7 @@ describe("config", () => {
 
     const persisted = JSON.parse(readFileSync(getConfigPath(), "utf8"));
     expect(persisted).toEqual({
-      schema_version: 2,
+      schema_version: 3,
       active_account: {
         user_id: "test-user-id",
         session: {
@@ -144,12 +146,94 @@ describe("config", () => {
           deployment_name: "My Deployment",
           api_key: "key-456",
         },
+        targets: {
+          "dep-123": {
+            deployment_id: "dep-123",
+            deployment_name: "My Deployment",
+            api_key: "key-456",
+          },
+        },
       },
     });
     expect(persisted.access_token).toBeUndefined();
   });
 
-  it("migrates a legacy flat config into the account-owned V2 schema", () => {
+  it("keeps credentials for multiple deployments owned by the same account", () => {
+    const cfg = makeTestConfig({
+      access_token: "tok_abc",
+      refresh_token: "ref_xyz",
+      expires_at: 1_700_000_000,
+      deployment_id: "dep-a",
+      deployment_name: "Library A",
+      api_key: "key-a",
+      user_id: "account-a",
+    });
+
+    updateTarget(cfg, {
+      deployment_id: "dep-b",
+      deployment_name: "Library B",
+      api_key: "key-b",
+    });
+
+    expect(cfg.active_account?.target?.deployment_id).toBe("dep-b");
+    expect(targetForDeployment(cfg, "dep-a")?.api_key).toBe("key-a");
+    expect(targetForDeployment(cfg, "dep-b")?.api_key).toBe("key-b");
+
+    saveConfig(cfg);
+    const loaded = loadConfig();
+    expect(targetForDeployment(loaded, "dep-a")?.api_key).toBe("key-a");
+    expect(targetForDeployment(loaded, "dep-b")?.api_key).toBe("key-b");
+  });
+
+  it("switches deployments without carrying the previous deployment key across", () => {
+    const cfg = makeTestConfig({
+      access_token: "tok_abc",
+      refresh_token: "ref_xyz",
+      expires_at: 1_700_000_000,
+      deployment_id: "dep-a",
+      api_key: "key-a",
+      user_id: "account-a",
+    });
+    updateTarget(cfg, { deployment_id: "dep-b", api_key: "key-b" });
+
+    updateTarget(cfg, { deployment_id: "dep-a", deployment_name: "Library A" });
+    expect(cfg.active_account?.target?.api_key).toBe("key-a");
+
+    updateTarget(cfg, { deployment_id: "dep-new", deployment_name: "New Library" });
+    expect(cfg.active_account?.target?.api_key).toBeUndefined();
+  });
+
+  it("migrates a V2 active target into the V3 deployment registry", () => {
+    const path = getConfigPath();
+    writeFileSync(
+      path,
+      JSON.stringify({
+        schema_version: 2,
+        active_account: {
+          user_id: "account-a",
+          session: {
+            access_token: "token-a",
+            refresh_token: "refresh-a",
+            expires_at: 1_700_000_000,
+          },
+          target: {
+            deployment_id: "dep-a",
+            deployment_name: "Library A",
+            api_key: "key-a",
+          },
+        },
+      }),
+    );
+
+    const loaded = loadConfig();
+
+    expect(loaded.schema_version).toBe(3);
+    expect(loaded.active_account?.target?.deployment_id).toBe("dep-a");
+    expect(targetForDeployment(loaded, "dep-a")?.api_key).toBe("key-a");
+    expect(JSON.parse(readFileSync(path, "utf8")).schema_version).toBe(3);
+  });
+
+  it("migrates a legacy flat config into the account-owned V3 schema", () => {
     const path = getConfigPath();
     writeFileSync(
       path,
@@ -185,6 +269,15 @@ describe("config", () => {
           api_key: "legacy-key",
           org_id: "legacy-org",
           space_id: "legacy-space",
+        },
+        targets: {
+          "legacy-deployment": {
+            deployment_id: "legacy-deployment",
+            deployment_name: "Legacy deployment",
+            api_key: "legacy-key",
+            org_id: "legacy-org",
+            space_id: "legacy-space",
+          },
         },
       },
     });
@@ -299,6 +392,7 @@ describe("config", () => {
     replaceLoginSession(cfg, session);
 
     expect(cfg.active_account?.target).toBeUndefined();
+    expect(cfg.active_account?.targets).toEqual({});
     expect(cfg.active_account?.user_id).toBe("account-b");
   });
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -48,6 +48,7 @@ export function replaceLoginSession(cfg: Config, session: SessionCredentials): v
     user_id: nextUserID,
     session: sessionWithoutIdentity(session),
     target: preserveTarget ? cloneTarget(cfg.active_account?.target) : undefined,
+    targets: preserveTarget ? cloneTargets(cfg.active_account?.targets) : {},
   };
 }
 
@@ -55,7 +56,10 @@ export function replaceLoginSession(cfg: Config, session: SessionCredentials): v
 export function bindAccountIdentity(cfg: Config, userID: string): void {
   const account = cfg.active_account;
   if (!account) throw new Error("cannot bind an identity without an authenticated session");
-  if (account.user_id && account.user_id !== userID) account.target = undefined;
+  if (account.user_id && account.user_id !== userID) {
+    account.target = undefined;
+    account.targets = {};
+  }
   account.user_id = userID;
 }
 
@@ -63,7 +67,28 @@ export function updateTarget(cfg: Config, target: AccountTarget): void {
   if (!cfg.active_account?.user_id) {
     throw new Error("cannot bind a target without a verified account identity");
   }
-  cfg.active_account.target = { ...cfg.active_account.target, ...target };
+  const current = cfg.active_account.target;
+  const switchingDeployment =
+    Boolean(target.deployment_id) && target.deployment_id !== current?.deployment_id;
+  const base = switchingDeployment
+    ? cfg.active_account.targets?.[target.deployment_id ?? ""]
+    : current;
+  const next = { ...base, ...target };
+  cfg.active_account.target = next;
+  if (next.deployment_id) {
+    cfg.active_account.targets = {
+      ...cfg.active_account.targets,
+      [next.deployment_id]: { ...next },
+    };
+  }
+}
+
+/** Return the private credential saved for one project deployment. */
+export function targetForDeployment(cfg: Config, deploymentID: string): AccountTarget | undefined {
+  const stored = cfg.active_account?.targets?.[deploymentID];
+  if (stored) return cloneTarget(stored);
+  const active = cfg.active_account?.target;
+  return active?.deployment_id === deploymentID ? cloneTarget(active) : undefined;
 }
 
 /**
@@ -106,10 +131,10 @@ export function loadConfig(): Config {
   }
 
   const parsed = parseConfig(raw);
-  if (isConfigV2(raw)) return parsed;
+  if (isConfigV3(raw)) return parsed;
   // Legacy configs were unversioned. Never rewrite a schema this version does
   // not understand, or downgrading could destroy newer config data.
-  if (isRecord(raw) && "schema_version" in raw) return parsed;
+  if (isRecord(raw) && "schema_version" in raw && !isConfigV2(raw)) return parsed;
 
   try {
     writeConfig(path, parsed);
@@ -122,7 +147,8 @@ export function loadConfig(): Config {
 
 /** Parse config content without performing filesystem writes. */
 export function parseConfig(raw: unknown): Config {
-  if (isConfigV2(raw)) return normalizeV2(raw);
+  if (isConfigV3(raw)) return normalizeV3(raw);
+  if (isConfigV2(raw)) return migrateV2(raw);
   if (isRecord(raw) && "schema_version" in raw) return emptyConfig();
   return migrateLegacyConfig(raw);
 }
@@ -165,11 +191,26 @@ function cloneTarget(target: AccountTarget | undefined): AccountTarget | undefin
   return target ? { ...target } : undefined;
 }
 
-function isConfigV2(value: unknown): value is Config {
+function cloneTargets(
+  targets: Record<string, AccountTarget> | undefined,
+): Record<string, AccountTarget> {
+  return Object.fromEntries(
+    Object.entries(targets ?? {}).map(([deploymentID, target]) => [
+      deploymentID,
+      cloneTarget(target) ?? {},
+    ]),
+  );
+}
+
+function isConfigV3(value: unknown): value is Config {
   return isRecord(value) && value.schema_version === CONFIG_SCHEMA_VERSION;
 }
 
-function normalizeV2(value: Config): Config {
+function isConfigV2(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && value.schema_version === 2;
+}
+
+function normalizeV3(value: Config): Config {
   const active = isRecord(value.active_account) ? value.active_account : undefined;
   const session = active && isRecord(active.session) ? active.session : undefined;
   if (!active || !session) {
@@ -181,6 +222,9 @@ function normalizeV2(value: Config): Config {
 
   const accessToken = stringValue(session.access_token) ?? "";
   const userID = stringValue(active.user_id) ?? getAccessTokenUserID(accessToken);
+  const target = userID ? normalizeTarget(active.target) : undefined;
+  const targets = userID ? normalizeTargets(active.targets) : {};
+  if (target?.deployment_id) targets[target.deployment_id] = { ...target };
   return {
     schema_version: CONFIG_SCHEMA_VERSION,
     mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
@@ -191,7 +235,36 @@ function normalizeV2(value: Config): Config {
         refresh_token: stringValue(session.refresh_token) ?? "",
         expires_at: numberValue(session.expires_at) ?? 0,
       },
-      target: userID ? normalizeTarget(active.target) : undefined,
+      target,
+      targets,
+    },
+  };
+}
+
+function migrateV2(value: Record<string, unknown>): Config {
+  const active = isRecord(value.active_account) ? value.active_account : undefined;
+  const session = active && isRecord(active.session) ? active.session : undefined;
+  if (!active || !session) {
+    return {
+      schema_version: CONFIG_SCHEMA_VERSION,
+      mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
+    };
+  }
+  const accessToken = stringValue(session.access_token) ?? "";
+  const userID = stringValue(active.user_id) ?? getAccessTokenUserID(accessToken);
+  const target = userID ? normalizeTarget(active.target) : undefined;
+  return {
+    schema_version: CONFIG_SCHEMA_VERSION,
+    mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
+    active_account: {
+      user_id: userID,
+      session: {
+        access_token: accessToken,
+        refresh_token: stringValue(session.refresh_token) ?? "",
+        expires_at: numberValue(session.expires_at) ?? 0,
+      },
+      target,
+      targets: target?.deployment_id ? { [target.deployment_id]: { ...target } } : {},
     },
   };
 }
@@ -206,6 +279,17 @@ function normalizeTarget(value: unknown): AccountTarget | undefined {
     space_id: stringValue(value.space_id),
   };
   return Object.values(target).some((field) => field !== undefined) ? target : undefined;
+}
+
+function normalizeTargets(value: unknown): Record<string, AccountTarget> {
+  if (!isRecord(value)) return {};
+  const targets: Record<string, AccountTarget> = {};
+  for (const [deploymentID, rawTarget] of Object.entries(value)) {
+    const target = normalizeTarget(rawTarget);
+    if (!target || target.deployment_id !== deploymentID) continue;
+    targets[deploymentID] = target;
+  }
+  return targets;
 }
 
 function writeConfig(path: string, config: Config): void {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2,7 +2,7 @@
 export const MODE_OSS = "oss" as const;
 export type SetupMode = typeof MODE_OSS;
 
-export const CONFIG_SCHEMA_VERSION = 2 as const;
+export const CONFIG_SCHEMA_VERSION = 3 as const;
 
 export interface SessionCredentials {
   access_token: string;
@@ -24,6 +24,9 @@ interface ActiveAccount {
   /** Missing only when a token does not expose a readable identity. */
   user_id?: string;
   session: Omit<SessionCredentials, "user_id">;
+  /** Cloud deployment credentials retained for project-scoped MCP routing. */
+  targets?: Record<string, AccountTarget>;
+  /** The deployment currently selected for interactive CLI commands. */
   target?: AccountTarget;
 }
 

--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  getJSONServer,
   installJSONServer,
   isJSONKeyConfigured,
   loadJSONConfig,
@@ -107,6 +108,12 @@ describe("JSON config file operations", () => {
       expect(result).toEqual({});
     });
 
+    it("returns empty object for empty file", () => {
+      const path = join(tempDir, "empty.json");
+      writeFileSync(path, "  \n");
+      expect(loadJSONConfig(path)).toEqual({});
+    });
+
     it("reads JSON file", () => {
       const path = join(tempDir, "test.json");
       writeFileSync(path, '{"foo": "bar"}');
@@ -117,6 +124,19 @@ describe("JSON config file operations", () => {
       const path = join(tempDir, "test.jsonc");
       writeFileSync(path, '{\n// comment\n"foo": "bar"\n}');
       expect(loadJSONConfig(path)).toEqual({ foo: "bar" });
+    });
+
+    it("throws for a non-empty malformed JSON file", () => {
+      const path = join(tempDir, "malformed.json");
+      writeFileSync(path, '{"foo":');
+      expect(() => loadJSONConfig(path)).toThrow(SyntaxError);
+    });
+
+    it("throws for an unterminated JSONC block comment", () => {
+      const path = join(tempDir, "malformed.jsonc");
+      writeFileSync(path, '{"foo":"bar"}/*');
+
+      expect(() => loadJSONConfig(path)).toThrow("Unterminated JSONC block comment");
     });
   });
 
@@ -174,6 +194,29 @@ describe("JSON config file operations", () => {
       writeFileSync(path, '{"mcpServers": {"dosu": {"url": "http://x"}}}');
       expect(isJSONKeyConfigured(path, "mcpServers")).toBe(true);
     });
+
+    it("returns false for a malformed config file", () => {
+      const path = join(tempDir, "malformed.json");
+      writeFileSync(path, '{"mcpServers":');
+      expect(isJSONKeyConfigured(path, "mcpServers")).toBe(false);
+    });
+  });
+
+  describe("getJSONServer", () => {
+    it("returns the exact dosu entry when present", () => {
+      const path = join(tempDir, "cfg.json");
+      writeFileSync(path, '{"mcpServers":{"dosu":{"command":"npx"}}}');
+
+      expect(getJSONServer(path, "mcpServers")).toEqual({ command: "npx" });
+    });
+
+    it("returns undefined when the section or entry is absent", () => {
+      const path = join(tempDir, "cfg.json");
+      writeFileSync(path, '{"mcpServers":{"other":{}}}');
+
+      expect(getJSONServer(path, "mcpServers")).toBeUndefined();
+      expect(getJSONServer(path, "servers")).toBeUndefined();
+    });
   });
 
   describe("installJSONServer", () => {
@@ -200,6 +243,28 @@ describe("JSON config file operations", () => {
       const result = loadJSONConfig(path);
       expect(result.mcpServers.dosu).toEqual({ url: "new" });
     });
+
+    it("throws without overwriting a malformed config file", () => {
+      const path = join(tempDir, "malformed.json");
+      const malformed = '{"mcpServers":';
+      writeFileSync(path, malformed);
+
+      expect(() => installJSONServer(path, "mcpServers", { url: "http://dosu" })).toThrow(
+        SyntaxError,
+      );
+      expect(readFileSync(path, "utf-8")).toBe(malformed);
+    });
+
+    it("does not overwrite JSONC with an unterminated block comment", () => {
+      const path = join(tempDir, "malformed.jsonc");
+      const malformed = '{"mcpServers":{}}/*';
+      writeFileSync(path, malformed);
+
+      expect(() => installJSONServer(path, "mcpServers", { url: "http://dosu" })).toThrow(
+        SyntaxError,
+      );
+      expect(readFileSync(path, "utf-8")).toBe(malformed);
+    });
   });
 
   describe("removeJSONServer", () => {
@@ -215,6 +280,24 @@ describe("JSON config file operations", () => {
       const result = loadJSONConfig(path);
       expect(result.mcpServers.dosu).toBeUndefined();
       expect(result.mcpServers.other).toEqual({ url: "y" });
+    });
+
+    it("does not write a malformed config file", () => {
+      const path = join(tempDir, "malformed.json");
+      const malformed = '{"mcpServers":';
+      writeFileSync(path, malformed);
+
+      expect(() => removeJSONServer(path, "mcpServers")).not.toThrow();
+      expect(readFileSync(path, "utf-8")).toBe(malformed);
+    });
+
+    it("does not rewrite JSONC with an unterminated block comment", () => {
+      const path = join(tempDir, "malformed.jsonc");
+      const malformed = '{"mcpServers":{"dosu":{}}}/*';
+      writeFileSync(path, malformed);
+
+      expect(() => removeJSONServer(path, "mcpServers")).not.toThrow();
+      expect(readFileSync(path, "utf-8")).toBe(malformed);
     });
   });
 });

--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -138,6 +138,15 @@ describe("JSON config file operations", () => {
 
       expect(() => loadJSONConfig(path)).toThrow("Unterminated JSONC block comment");
     });
+
+    it.each([[], "string", 7, null])("rejects a non-object config root: %j", (root) => {
+      const path = join(tempDir, "non-object-root.json");
+      const original = JSON.stringify(root);
+      writeFileSync(path, original);
+
+      expect(() => loadJSONConfig(path)).toThrow(/root must be an object/);
+      expect(readFileSync(path, "utf-8")).toBe(original);
+    });
   });
 
   describe("saveJSONConfig", () => {
@@ -217,6 +226,15 @@ describe("JSON config file operations", () => {
       expect(getJSONServer(path, "mcpServers")).toBeUndefined();
       expect(getJSONServer(path, "servers")).toBeUndefined();
     });
+
+    it.each(["string", 7, [], null])("rejects a non-object MCP section: %j", (section) => {
+      const path = join(tempDir, "foreign-section.json");
+      const original = JSON.stringify({ mcpServers: section });
+      writeFileSync(path, original);
+
+      expect(() => getJSONServer(path, "mcpServers")).toThrow(/must be an object/);
+      expect(readFileSync(path, "utf-8")).toBe(original);
+    });
   });
 
   describe("installJSONServer", () => {
@@ -242,6 +260,17 @@ describe("JSON config file operations", () => {
       installJSONServer(path, "mcpServers", { url: "new" });
       const result = loadJSONConfig(path);
       expect(result.mcpServers.dosu).toEqual({ url: "new" });
+    });
+
+    it.each(["string", 7, [], null])("preserves a non-object MCP section: %j", (section) => {
+      const path = join(tempDir, "foreign-section.json");
+      const original = JSON.stringify({ mcpServers: section });
+      writeFileSync(path, original);
+
+      expect(() => installJSONServer(path, "mcpServers", { url: "http://dosu" })).toThrow(
+        /must be an object/,
+      );
+      expect(readFileSync(path, "utf-8")).toBe(original);
     });
 
     it("throws without overwriting a malformed config file", () => {

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -103,7 +103,11 @@ export function loadJSONConfig(path: string): JsonConfig {
   if (path.endsWith(".jsonc")) {
     data = stripJSONComments(data);
   }
-  return JSON.parse(data);
+  const parsed: unknown = JSON.parse(data);
+  if (!isJSONObject(parsed)) {
+    throw new Error("Config root must be an object; refusing to modify the config file");
+  }
+  return parsed;
 }
 
 /**
@@ -195,7 +199,10 @@ export function isJSONKeyConfigured(configPath: string, topLevelKey: string): bo
 export function getJSONServer(configPath: string, topLevelKey: string): unknown {
   const cfg = loadJSONConfig(configPath);
   const section = cfg[topLevelKey];
-  if (typeof section !== "object" || section === null) return undefined;
+  if (section === undefined) return undefined;
+  if (!isJSONObject(section)) {
+    throw new Error(`${topLevelKey} must be an object; refusing to modify the config file`);
+  }
   return section.dosu;
 }
 
@@ -205,8 +212,10 @@ export function getJSONServer(configPath: string, topLevelKey: string): unknown 
 export function installJSONServer(configPath: string, topKey: string, server: JsonConfig): void {
   const jsonCfg = loadJSONConfig(configPath);
   let section = jsonCfg[topKey];
-  if (typeof section !== "object" || section === null) {
+  if (section === undefined) {
     section = {};
+  } else if (!isJSONObject(section)) {
+    throw new Error(`${topKey} must be an object; refusing to modify the config file`);
   }
   section.dosu = server;
   jsonCfg[topKey] = section;
@@ -224,8 +233,12 @@ export function removeJSONServer(configPath: string, topKey: string): void {
     return; // file doesn't exist or can't be read = nothing to remove
   }
   const section = jsonCfg[topKey];
-  if (typeof section === "object" && section !== null) {
-    delete section.dosu;
-  }
+  if (section === undefined) return;
+  if (!isJSONObject(section)) return;
+  delete section.dosu;
   saveJSONConfig(configPath, jsonCfg);
+}
+
+function isJSONObject(value: unknown): value is JsonConfig {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -93,8 +93,8 @@ export function mcpRemoteServer(url: string, apiKey: string | undefined): McpRem
 }
 
 /**
- * Reads and unmarshals a JSON config file. Returns an empty object if the file doesn't exist.
- * For .jsonc files, comments are stripped before parsing.
+ * Reads and unmarshals a JSON config file. Returns an empty object if the file doesn't exist or
+ * is empty. For .jsonc files, comments are stripped before parsing.
  */
 export function loadJSONConfig(path: string): JsonConfig {
   if (!existsSync(path)) return {};
@@ -103,11 +103,7 @@ export function loadJSONConfig(path: string): JsonConfig {
   if (path.endsWith(".jsonc")) {
     data = stripJSONComments(data);
   }
-  try {
-    return JSON.parse(data);
-  } catch {
-    return {};
-  }
+  return JSON.parse(data);
 }
 
 /**
@@ -153,7 +149,8 @@ export function stripJSONComments(data: string): string {
     if (i + 1 < data.length && data[i] === "/" && data[i + 1] === "*") {
       i += 2;
       while (i + 1 < data.length && !(data[i] === "*" && data[i + 1] === "/")) i++;
-      if (i + 1 < data.length) i += 2;
+      if (i + 1 >= data.length) throw new SyntaxError("Unterminated JSONC block comment");
+      i += 2;
       continue;
     }
 
@@ -184,10 +181,22 @@ export function writeSecureFile(path: string, content: string): void {
  * Checks if "dosu" exists under the given top-level key in a JSON config file.
  */
 export function isJSONKeyConfigured(configPath: string, topLevelKey: string): boolean {
+  try {
+    const cfg = loadJSONConfig(configPath);
+    const section = cfg[topLevelKey];
+    if (typeof section !== "object" || section === null) return false;
+    return "dosu" in section;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns the named Dosu entry without treating a foreign same-named entry as configured. */
+export function getJSONServer(configPath: string, topLevelKey: string): unknown {
   const cfg = loadJSONConfig(configPath);
   const section = cfg[topLevelKey];
-  if (typeof section !== "object" || section === null) return false;
-  return "dosu" in section;
+  if (typeof section !== "object" || section === null) return undefined;
+  return section.dosu;
 }
 
 /**

--- a/src/mcp/project-proxy.test.ts
+++ b/src/mcp/project-proxy.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MODE_OSS } from "../config/config";
+import { makeTestConfig } from "../config/config.test-utils";
+import { VERSION } from "../version/version";
+import { mcpBaseURL, mcpRemoteServer, mcpURL } from "./config-helpers";
+import { npxPathEnv } from "./detect";
+import {
+  buildProjectProxyCommand,
+  isDosuOwnedMcpServer,
+  type ProjectProxyDependencies,
+  resolveProjectProxyRuntime,
+  runProjectProxy,
+} from "./project-proxy";
+
+const originalBackendOverride = process.env.DOSU_BACKEND_URL_OVERRIDE;
+
+beforeEach(() => {
+  process.env.DOSU_BACKEND_URL_OVERRIDE = "https://api.example.test";
+});
+
+afterEach(() => {
+  if (originalBackendOverride === undefined) {
+    delete process.env.DOSU_BACKEND_URL_OVERRIDE;
+  } else {
+    process.env.DOSU_BACKEND_URL_OVERRIDE = originalBackendOverride;
+  }
+});
+
+function cloudConfig(deploymentID = "dep_123", apiKey = "key_secret") {
+  return makeTestConfig({
+    access_token: "access-token",
+    refresh_token: "refresh-token",
+    expires_at: 4_102_444_800,
+    deployment_id: deploymentID,
+    api_key: apiKey,
+  });
+}
+
+function ossConfig(apiKey = "key_secret") {
+  return makeTestConfig({
+    access_token: "access-token",
+    refresh_token: "refresh-token",
+    expires_at: 4_102_444_800,
+    api_key: apiKey,
+    mode: MODE_OSS,
+  });
+}
+
+interface MockChild {
+  once: {
+    (event: "error", listener: (error: Error) => void): unknown;
+    (event: "close", listener: (code: number | null) => void): unknown;
+  };
+  emit(event: "error", error: Error): void;
+  emit(event: "close", code: number | null): void;
+}
+
+function mockChild(): MockChild {
+  const listeners = new Map<string, (value: unknown) => void>();
+  const once = ((event: string, listener: (value: unknown) => void) => {
+    listeners.set(event, listener);
+  }) as MockChild["once"];
+  return {
+    once,
+    emit(event: string, value: unknown) {
+      listeners.get(event)?.(value);
+    },
+  } as MockChild;
+}
+
+type SpawnProxy = NonNullable<ProjectProxyDependencies["spawn"]>;
+
+describe("project MCP proxy", () => {
+  describe("Dosu entry ownership", () => {
+    it.each([
+      { command: "npx", args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss"] },
+      {
+        type: "local",
+        command: ["npx", "-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep_123"],
+      },
+      {
+        url: "https://api.example.test/v1/mcp/deployments/dep_123",
+        headers: { "X-Dosu-API-Key": "secret" },
+      },
+      {
+        command: "/opt/node/bin/npx",
+        args: [
+          "-y",
+          "mcp-remote@0.1.38",
+          "https://api.example.test/v1/mcp",
+          "--header",
+          `X-Dosu-API-Key:\${X_DOSU_API_KEY}`,
+        ],
+        env: { X_DOSU_API_KEY: "secret" },
+      },
+    ])("recognizes a released Dosu shape", (server) => {
+      expect(isDosuOwnedMcpServer(server)).toBe(true);
+    });
+
+    it.each([
+      { command: "npx", args: ["-y", "other-cli", "mcp", "proxy", "--oss"] },
+      { url: "https://other.example/v1/mcp", headers: { Authorization: "secret" } },
+      { command: "npx", args: ["-y", "mcp-remote@0.1.38", "https://other.example"] },
+      null,
+    ])("rejects a foreign or ambiguous shape", (server) => {
+      expect(isDosuOwnedMcpServer(server)).toBe(false);
+    });
+  });
+
+  describe("project command", () => {
+    it("pins the CLI version and contains no Cloud secret or endpoint", () => {
+      const command = buildProjectProxyCommand(cloudConfig());
+
+      expect(command).toEqual({
+        command: "npx",
+        args: ["-y", `@dosu/cli@${VERSION}`, "mcp", "proxy", "--deployment", "dep_123"],
+      });
+      const serialized = JSON.stringify(command);
+      expect(serialized).not.toContain("key_secret");
+      expect(serialized).not.toContain("/v1/mcp");
+    });
+
+    it("builds the OSS command", () => {
+      expect(buildProjectProxyCommand(ossConfig())).toEqual({
+        command: "npx",
+        args: ["-y", `@dosu/cli@${VERSION}`, "mcp", "proxy", "--oss"],
+      });
+    });
+
+    it.each([
+      undefined,
+      "",
+      "../other",
+      "dep id",
+      "dep&whoami",
+      "dep%PATH%",
+    ])("rejects an unsafe deployment id: %s", (deploymentID) => {
+      const cfg = cloudConfig();
+      if (cfg.active_account?.target) cfg.active_account.target.deployment_id = deploymentID;
+      expect(() => buildProjectProxyCommand(cfg)).toThrow("Invalid project deployment ID");
+    });
+  });
+
+  describe("active config resolution", () => {
+    it("uses the matching active Cloud target", () => {
+      expect(resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep_123" })).toEqual({
+        endpoint: mcpURL("dep_123"),
+        apiKey: "key_secret",
+      });
+    });
+
+    it("uses OSS only while the active config is OSS", () => {
+      expect(resolveProjectProxyRuntime(ossConfig(), { oss: true })).toEqual({
+        endpoint: mcpBaseURL(),
+        apiKey: "key_secret",
+      });
+    });
+
+    it("fails closed when the project target is not the active target", () => {
+      expect(() =>
+        resolveProjectProxyRuntime(cloudConfig("dep_other"), { deploymentID: "dep_123" }),
+      ).toThrow("does not match the active Dosu MCP");
+    });
+
+    it("fails closed when Cloud and OSS modes disagree", () => {
+      expect(() => resolveProjectProxyRuntime(cloudConfig(), { oss: true })).toThrow(
+        "is not configured for OSS mode",
+      );
+      expect(() => resolveProjectProxyRuntime(ossConfig(), { deploymentID: "dep_123" })).toThrow(
+        "does not match the active Dosu MCP",
+      );
+    });
+
+    it("requires exactly one target", () => {
+      expect(() => resolveProjectProxyRuntime(cloudConfig(), {})).toThrow("Exactly one");
+      expect(() =>
+        resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep_123", oss: true }),
+      ).toThrow("Exactly one");
+    });
+
+    it("rejects unsafe runtime deployment ids", () => {
+      expect(() =>
+        resolveProjectProxyRuntime(cloudConfig("dep&whoami"), {
+          deploymentID: "dep&whoami",
+        }),
+      ).toThrow("Invalid project deployment ID");
+    });
+
+    it("fails before launch when the active API key is missing", () => {
+      expect(() =>
+        resolveProjectProxyRuntime(cloudConfig("dep_123", ""), { deploymentID: "dep_123" }),
+      ).toThrow("API key is missing");
+    });
+
+    it.each([
+      "https://api.example.test&echo%X_DOSU_API_KEY%",
+      "https://user:password@api.example.test",
+      "file:///tmp/mcp",
+    ])("rejects an unsafe runtime endpoint before the key reaches a shell: %s", (endpoint) => {
+      process.env.DOSU_BACKEND_URL_OVERRIDE = endpoint;
+      expect(() => resolveProjectProxyRuntime(cloudConfig(), { deploymentID: "dep_123" })).toThrow(
+        "Invalid Dosu MCP endpoint",
+      );
+    });
+  });
+
+  describe("bridge process", () => {
+    it("passes the key only through the child environment", async () => {
+      const child = mockChild();
+      const spawn = vi.fn<SpawnProxy>(() => child);
+      const result = runProjectProxy(
+        { deploymentID: "dep_123" },
+        {
+          loadConfig: () => cloudConfig(),
+          findNpx: () => "/opt/node/bin/npx",
+          platform: "linux",
+          spawn,
+        },
+      );
+
+      child.emit("close", 0);
+      await expect(result).resolves.toBe(0);
+
+      const remote = mcpRemoteServer(mcpURL("dep_123"), "key_secret");
+      expect(spawn).toHaveBeenCalledWith("/opt/node/bin/npx", remote.args, {
+        stdio: "inherit",
+        shell: false,
+        env: expect.objectContaining({
+          PATH: npxPathEnv("/opt/node/bin/npx"),
+          X_DOSU_API_KEY: "key_secret",
+        }),
+      });
+      expect(JSON.stringify(spawn.mock.calls[0]?.[1])).not.toContain("key_secret");
+    });
+
+    it("uses the cmd launcher through a shell on Windows", async () => {
+      const child = mockChild();
+      const spawn = vi.fn<SpawnProxy>(() => child);
+      const result = runProjectProxy(
+        { deploymentID: "dep_123" },
+        {
+          loadConfig: () => cloudConfig(),
+          findNpx: () => "C:\\Program Files\\nodejs\\npx.cmd",
+          platform: "win32",
+          spawn,
+        },
+      );
+
+      child.emit("close", 7);
+      await expect(result).resolves.toBe(7);
+      expect(spawn).toHaveBeenCalledWith(
+        "npx.cmd",
+        expect.any(Array),
+        expect.objectContaining({ shell: true, stdio: "inherit" }),
+      );
+    });
+
+    it("returns one for a signal-style close without an exit code", async () => {
+      const child = mockChild();
+      const result = runProjectProxy(
+        { deploymentID: "dep_123" },
+        {
+          loadConfig: () => cloudConfig(),
+          findNpx: () => "/opt/node/bin/npx",
+          platform: "linux",
+          spawn: () => child,
+        },
+      );
+
+      child.emit("close", null);
+      await expect(result).resolves.toBe(1);
+    });
+
+    it("surfaces a child launch error", async () => {
+      const child = mockChild();
+      const result = runProjectProxy(
+        { deploymentID: "dep_123" },
+        {
+          loadConfig: () => cloudConfig(),
+          findNpx: () => "/opt/node/bin/npx",
+          platform: "linux",
+          spawn: () => child,
+        },
+      );
+
+      child.emit("error", new Error("spawn failed"));
+      await expect(result).rejects.toThrow("spawn failed");
+    });
+
+    it("does not spawn when active config validation fails", async () => {
+      const spawn = vi.fn();
+      await expect(
+        runProjectProxy(
+          { deploymentID: "dep_123" },
+          {
+            loadConfig: () => cloudConfig("dep_other"),
+            findNpx: () => "/opt/node/bin/npx",
+            platform: "linux",
+            spawn,
+          },
+        ),
+      ).rejects.toThrow("does not match the active Dosu MCP");
+      expect(spawn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/mcp/project-proxy.test.ts
+++ b/src/mcp/project-proxy.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MODE_OSS } from "../config/config";
+import { MODE_OSS, updateTarget } from "../config/config";
 import { makeTestConfig } from "../config/config.test-utils";
-import { VERSION } from "../version/version";
 import { mcpBaseURL, mcpRemoteServer, mcpURL } from "./config-helpers";
 import { npxPathEnv } from "./detect";
 import {
@@ -73,25 +72,15 @@ type SpawnProxy = NonNullable<ProjectProxyDependencies["spawn"]>;
 describe("project MCP proxy", () => {
   describe("Dosu entry ownership", () => {
     it.each([
+      { command: "dosu", args: ["mcp", "proxy", "--oss"] },
+      {
+        type: "local",
+        command: ["dosu", "mcp", "proxy", "--deployment", "dep_123"],
+      },
       { command: "npx", args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss"] },
       {
         type: "local",
         command: ["npx", "-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep_123"],
-      },
-      {
-        url: "https://api.example.test/v1/mcp/deployments/dep_123",
-        headers: { "X-Dosu-API-Key": "secret" },
-      },
-      {
-        command: "/opt/node/bin/npx",
-        args: [
-          "-y",
-          "mcp-remote@0.1.38",
-          "https://api.example.test/v1/mcp",
-          "--header",
-          `X-Dosu-API-Key:\${X_DOSU_API_KEY}`,
-        ],
-        env: { X_DOSU_API_KEY: "secret" },
       },
     ])("recognizes a released Dosu shape", (server) => {
       expect(isDosuOwnedMcpServer(server)).toBe(true);
@@ -99,6 +88,35 @@ describe("project MCP proxy", () => {
 
     it.each([
       { command: "npx", args: ["-y", "other-cli", "mcp", "proxy", "--oss"] },
+      { command: "npx", args: ["-y", "@dosu/cli@latest", "mcp", "proxy", "--oss"] },
+      { command: "npx", args: ["-y", "@dosu/cli@file:../cli", "mcp", "proxy", "--oss"] },
+      { command: "dosu", args: ["mcp", "proxy", "--oss", "--foreign"] },
+      {
+        command: "dosu",
+        args: ["mcp", "proxy", "--deployment", "dep_123", "--foreign"],
+      },
+      {
+        command: "npx",
+        args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss", "--foreign"],
+      },
+      {
+        command: "npx",
+        args: ["-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--deployment", "dep_123", "--foreign"],
+      },
+      {
+        url: "https://foreign.example/v1/mcp/deployments/dep_123",
+        headers: { "X-Dosu-API-Key": "secret" },
+      },
+      {
+        command: "other",
+        args: [
+          "mcp-remote@9.9.9",
+          "https://foreign.example/v1/mcp",
+          "--header",
+          `X-Dosu-API-Key:\${X_DOSU_API_KEY}`,
+        ],
+        env: { X_DOSU_API_KEY: "secret" },
+      },
       { url: "https://other.example/v1/mcp", headers: { Authorization: "secret" } },
       { command: "npx", args: ["-y", "mcp-remote@0.1.38", "https://other.example"] },
       null,
@@ -108,12 +126,12 @@ describe("project MCP proxy", () => {
   });
 
   describe("project command", () => {
-    it("pins the CLI version and contains no Cloud secret or endpoint", () => {
+    it("uses the globally installed CLI and contains no Cloud secret or endpoint", () => {
       const command = buildProjectProxyCommand(cloudConfig());
 
       expect(command).toEqual({
-        command: "npx",
-        args: ["-y", `@dosu/cli@${VERSION}`, "mcp", "proxy", "--deployment", "dep_123"],
+        command: "dosu",
+        args: ["mcp", "proxy", "--deployment", "dep_123"],
       });
       const serialized = JSON.stringify(command);
       expect(serialized).not.toContain("key_secret");
@@ -122,8 +140,8 @@ describe("project MCP proxy", () => {
 
     it("builds the OSS command", () => {
       expect(buildProjectProxyCommand(ossConfig())).toEqual({
-        command: "npx",
-        args: ["-y", `@dosu/cli@${VERSION}`, "mcp", "proxy", "--oss"],
+        command: "dosu",
+        args: ["mcp", "proxy", "--oss"],
       });
     });
 
@@ -156,10 +174,20 @@ describe("project MCP proxy", () => {
       });
     });
 
-    it("fails closed when the project target is not the active target", () => {
+    it("resolves an earlier project after another deployment becomes active", () => {
+      const cfg = cloudConfig("dep_123", "key_first");
+      updateTarget(cfg, { deployment_id: "dep_other", api_key: "key_other" });
+
+      expect(resolveProjectProxyRuntime(cfg, { deploymentID: "dep_123" })).toEqual({
+        endpoint: mcpURL("dep_123"),
+        apiKey: "key_first",
+      });
+    });
+
+    it("fails closed when the project deployment has no stored credential", () => {
       expect(() =>
         resolveProjectProxyRuntime(cloudConfig("dep_other"), { deploymentID: "dep_123" }),
-      ).toThrow("does not match the active Dosu MCP");
+      ).toThrow("No credential is stored for this project's Dosu MCP");
     });
 
     it("fails closed when Cloud and OSS modes disagree", () => {
@@ -167,7 +195,7 @@ describe("project MCP proxy", () => {
         "is not configured for OSS mode",
       );
       expect(() => resolveProjectProxyRuntime(ossConfig(), { deploymentID: "dep_123" })).toThrow(
-        "does not match the active Dosu MCP",
+        "No credential is stored",
       );
     });
 
@@ -251,7 +279,14 @@ describe("project MCP proxy", () => {
       expect(spawn).toHaveBeenCalledWith(
         "npx.cmd",
         expect.any(Array),
-        expect.objectContaining({ shell: true, stdio: "inherit" }),
+        expect.objectContaining({
+          shell: true,
+          stdio: "inherit",
+          env: expect.objectContaining({
+            NoDefaultCurrentDirectoryInExePath: "1",
+            X_DOSU_API_KEY: "key_secret",
+          }),
+        }),
       );
     });
 
@@ -299,7 +334,7 @@ describe("project MCP proxy", () => {
             spawn,
           },
         ),
-      ).rejects.toThrow("does not match the active Dosu MCP");
+      ).rejects.toThrow("No credential is stored");
       expect(spawn).not.toHaveBeenCalled();
     });
   });

--- a/src/mcp/project-proxy.ts
+++ b/src/mcp/project-proxy.ts
@@ -1,7 +1,6 @@
 import { spawn as nodeSpawn } from "node:child_process";
 import { win32 } from "node:path";
-import { type Config, loadConfig, MODE_OSS } from "../config/config";
-import { VERSION } from "../version/version";
+import { type Config, loadConfig, MODE_OSS, targetForDeployment } from "../config/config";
 import { mcpBaseURL, mcpRemoteServer, mcpURL } from "./config-helpers";
 import { findNpx, npxPathEnv } from "./detect";
 
@@ -11,7 +10,7 @@ export interface ProjectProxyOptions {
 }
 
 export interface ProjectProxyCommand {
-  command: "npx";
+  command: "dosu";
   args: string[];
 }
 
@@ -38,49 +37,39 @@ function projectCommand(value: unknown): { command: string; args: string[] } | n
   return null;
 }
 
-function isDosuEndpoint(value: unknown): boolean {
-  if (typeof value !== "string") return false;
-  try {
-    const path = new URL(value, "https://dosu.invalid").pathname;
-    return path === "/v1/mcp" || path.startsWith("/v1/mcp/");
-  } catch {
-    return false;
-  }
-}
-
-function hasDosuHeader(value: unknown): boolean {
-  return (
-    isRecord(value) && Object.keys(value).some((key) => key.toLowerCase() === "x-dosu-api-key")
-  );
-}
-
 /** True only for an MCP entry shape written by a released Dosu CLI flow. */
 export function isDosuOwnedMcpServer(value: unknown): boolean {
   if (!isRecord(value)) return false;
 
   const command = projectCommand(value);
+  if (command?.command === "dosu") {
+    const [mcp, proxy, targetFlag, targetValue] = command.args;
+    const currentProxy =
+      mcp === "mcp" &&
+      proxy === "proxy" &&
+      ((targetFlag === "--oss" && targetValue === undefined && command.args.length === 3) ||
+        (targetFlag === "--deployment" &&
+          targetValue !== undefined &&
+          command.args.length === 4 &&
+          SAFE_DEPLOYMENT_ID.test(targetValue)));
+    if (currentProxy) return true;
+  }
   if (command?.command === "npx") {
     const [yes, cliPackage, mcp, proxy, targetFlag, targetValue] = command.args;
     const projectProxy =
       yes === "-y" &&
       typeof cliPackage === "string" &&
-      /^@dosu\/cli@[^\s]+$/.test(cliPackage) &&
+      /^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(cliPackage) &&
       mcp === "mcp" &&
       proxy === "proxy" &&
-      ((targetFlag === "--oss" && targetValue === undefined) ||
+      ((targetFlag === "--oss" && targetValue === undefined && command.args.length === 5) ||
         (targetFlag === "--deployment" &&
           targetValue !== undefined &&
+          command.args.length === 6 &&
           SAFE_DEPLOYMENT_ID.test(targetValue)));
     if (projectProxy) return true;
   }
 
-  if (isDosuEndpoint(value.url) && hasDosuHeader(value.headers)) return true;
-
-  if (command?.args.some((arg) => /^mcp-remote@\d/.test(arg))) {
-    const hasEndpoint = command.args.some(isDosuEndpoint);
-    const hasHeaderArgument = command.args.some((arg) => arg.startsWith("X-Dosu-API-Key:"));
-    return hasEndpoint && hasHeaderArgument && isRecord(value.env) && "X_DOSU_API_KEY" in value.env;
-  }
   return false;
 }
 
@@ -107,8 +96,12 @@ export interface ProjectProxyDependencies {
 const SAFE_DEPLOYMENT_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
 const WINDOWS_SHELL_METACHARACTERS = /[\s"&|<>()^%!]/;
 
+export function isSafeDeploymentID(value: unknown): value is string {
+  return typeof value === "string" && SAFE_DEPLOYMENT_ID.test(value);
+}
+
 function requireSafeDeploymentID(value: unknown): string {
-  if (typeof value !== "string" || !SAFE_DEPLOYMENT_ID.test(value)) {
+  if (!isSafeDeploymentID(value)) {
     throw new Error("Invalid project deployment ID. Re-run `dosu setup` in this project.");
   }
   return value;
@@ -140,13 +133,13 @@ function requireSafeEndpoint(value: string): string {
 
 /** Build the exact, secretless command written into project MCP files. */
 export function buildProjectProxyCommand(cfg: Config): ProjectProxyCommand {
-  const args = ["-y", `@dosu/cli@${VERSION}`, "mcp", "proxy"];
+  const args = ["mcp", "proxy"];
   if (cfg.mode === MODE_OSS) {
     args.push("--oss");
   } else {
     args.push("--deployment", requireSafeDeploymentID(cfg.active_account?.target?.deployment_id));
   }
-  return { command: "npx", args };
+  return { command: "dosu", args };
 }
 
 /** Resolve runtime secrets only from the one active, private Dosu config. */
@@ -166,12 +159,17 @@ export function resolveProjectProxyRuntime(
     endpoint = requireSafeEndpoint(mcpBaseURL());
   } else {
     const deploymentID = requireSafeDeploymentID(options.deploymentID);
-    if (cfg.mode === MODE_OSS || cfg.active_account?.target?.deployment_id !== deploymentID) {
+    const target = targetForDeployment(cfg, deploymentID);
+    if (!target)
       throw new Error(
-        "This project's Dosu MCP does not match the active Dosu MCP. Re-run `dosu setup` in this project.",
+        "No credential is stored for this project's Dosu MCP. Re-run `dosu setup` in this project.",
       );
-    }
     endpoint = requireSafeEndpoint(mcpURL(deploymentID));
+    const apiKey = target.api_key;
+    if (!apiKey) {
+      throw new Error("Dosu API key is missing. Re-run `dosu setup` in this project.");
+    }
+    return { endpoint, apiKey };
   }
 
   const apiKey = cfg.active_account?.target?.api_key;
@@ -199,6 +197,7 @@ export async function runProjectProxy(
       shell: platform === "win32",
       env: {
         ...process.env,
+        ...(platform === "win32" ? { NoDefaultCurrentDirectoryInExePath: "1" } : {}),
         PATH: npxPathEnv(npx),
         ...remote.env,
       },

--- a/src/mcp/project-proxy.ts
+++ b/src/mcp/project-proxy.ts
@@ -1,0 +1,221 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { win32 } from "node:path";
+import { type Config, loadConfig, MODE_OSS } from "../config/config";
+import { VERSION } from "../version/version";
+import { mcpBaseURL, mcpRemoteServer, mcpURL } from "./config-helpers";
+import { findNpx, npxPathEnv } from "./detect";
+
+export interface ProjectProxyOptions {
+  deploymentID?: string;
+  oss?: boolean;
+}
+
+export interface ProjectProxyCommand {
+  command: "npx";
+  args: string[];
+}
+
+export interface ProjectProxyRuntime {
+  endpoint: string;
+  apiKey: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function projectCommand(value: unknown): { command: string; args: string[] } | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.command === "string" && Array.isArray(value.args)) {
+    return value.args.every((arg) => typeof arg === "string")
+      ? { command: value.command, args: value.args }
+      : null;
+  }
+  if (Array.isArray(value.command) && value.command.every((arg) => typeof arg === "string")) {
+    const [command, ...args] = value.command;
+    return command ? { command, args } : null;
+  }
+  return null;
+}
+
+function isDosuEndpoint(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const path = new URL(value, "https://dosu.invalid").pathname;
+    return path === "/v1/mcp" || path.startsWith("/v1/mcp/");
+  } catch {
+    return false;
+  }
+}
+
+function hasDosuHeader(value: unknown): boolean {
+  return (
+    isRecord(value) && Object.keys(value).some((key) => key.toLowerCase() === "x-dosu-api-key")
+  );
+}
+
+/** True only for an MCP entry shape written by a released Dosu CLI flow. */
+export function isDosuOwnedMcpServer(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+
+  const command = projectCommand(value);
+  if (command?.command === "npx") {
+    const [yes, cliPackage, mcp, proxy, targetFlag, targetValue] = command.args;
+    const projectProxy =
+      yes === "-y" &&
+      typeof cliPackage === "string" &&
+      /^@dosu\/cli@[^\s]+$/.test(cliPackage) &&
+      mcp === "mcp" &&
+      proxy === "proxy" &&
+      ((targetFlag === "--oss" && targetValue === undefined) ||
+        (targetFlag === "--deployment" &&
+          targetValue !== undefined &&
+          SAFE_DEPLOYMENT_ID.test(targetValue)));
+    if (projectProxy) return true;
+  }
+
+  if (isDosuEndpoint(value.url) && hasDosuHeader(value.headers)) return true;
+
+  if (command?.args.some((arg) => /^mcp-remote@\d/.test(arg))) {
+    const hasEndpoint = command.args.some(isDosuEndpoint);
+    const hasHeaderArgument = command.args.some((arg) => arg.startsWith("X-Dosu-API-Key:"));
+    return hasEndpoint && hasHeaderArgument && isRecord(value.env) && "X_DOSU_API_KEY" in value.env;
+  }
+  return false;
+}
+
+interface SpawnedProxy {
+  once(event: "error", listener: (error: Error) => void): unknown;
+  once(event: "close", listener: (code: number | null) => void): unknown;
+}
+
+type SpawnProxy = (
+  command: string,
+  args: string[],
+  options: { stdio: "inherit"; shell: boolean; env: NodeJS.ProcessEnv },
+) => SpawnedProxy;
+
+export interface ProjectProxyDependencies {
+  loadConfig?: () => Config;
+  findNpx?: () => string;
+  platform?: NodeJS.Platform;
+  spawn?: SpawnProxy;
+}
+
+// This ID crosses a shell boundary on Windows because npx.cmd requires one.
+// Keep project-controlled input narrower than cmd.exe's metacharacter set.
+const SAFE_DEPLOYMENT_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const WINDOWS_SHELL_METACHARACTERS = /[\s"&|<>()^%!]/;
+
+function requireSafeDeploymentID(value: unknown): string {
+  if (typeof value !== "string" || !SAFE_DEPLOYMENT_ID.test(value)) {
+    throw new Error("Invalid project deployment ID. Re-run `dosu setup` in this project.");
+  }
+  return value;
+}
+
+function requireOneTarget(options: ProjectProxyOptions): void {
+  if (Boolean(options.deploymentID) === Boolean(options.oss)) {
+    throw new Error("Exactly one project MCP target is required.");
+  }
+}
+
+function requireSafeEndpoint(value: string): string {
+  let endpoint: URL;
+  try {
+    endpoint = new URL(value);
+  } catch {
+    throw new Error("Invalid Dosu MCP endpoint. Re-run `dosu setup`.");
+  }
+  if (
+    (endpoint.protocol !== "https:" && endpoint.protocol !== "http:") ||
+    endpoint.username ||
+    endpoint.password ||
+    WINDOWS_SHELL_METACHARACTERS.test(value)
+  ) {
+    throw new Error("Invalid Dosu MCP endpoint. Re-run `dosu setup`.");
+  }
+  return value;
+}
+
+/** Build the exact, secretless command written into project MCP files. */
+export function buildProjectProxyCommand(cfg: Config): ProjectProxyCommand {
+  const args = ["-y", `@dosu/cli@${VERSION}`, "mcp", "proxy"];
+  if (cfg.mode === MODE_OSS) {
+    args.push("--oss");
+  } else {
+    args.push("--deployment", requireSafeDeploymentID(cfg.active_account?.target?.deployment_id));
+  }
+  return { command: "npx", args };
+}
+
+/** Resolve runtime secrets only from the one active, private Dosu config. */
+export function resolveProjectProxyRuntime(
+  cfg: Config,
+  options: ProjectProxyOptions,
+): ProjectProxyRuntime {
+  requireOneTarget(options);
+
+  let endpoint: string;
+  if (options.oss) {
+    if (cfg.mode !== MODE_OSS) {
+      throw new Error(
+        "This project expects OSS mode, but Dosu is not configured for OSS mode. Re-run `dosu setup` in this project.",
+      );
+    }
+    endpoint = requireSafeEndpoint(mcpBaseURL());
+  } else {
+    const deploymentID = requireSafeDeploymentID(options.deploymentID);
+    if (cfg.mode === MODE_OSS || cfg.active_account?.target?.deployment_id !== deploymentID) {
+      throw new Error(
+        "This project's Dosu MCP does not match the active Dosu MCP. Re-run `dosu setup` in this project.",
+      );
+    }
+    endpoint = requireSafeEndpoint(mcpURL(deploymentID));
+  }
+
+  const apiKey = cfg.active_account?.target?.api_key;
+  if (!apiKey) {
+    throw new Error("Dosu API key is missing. Re-run `dosu setup` in this project.");
+  }
+  return { endpoint, apiKey };
+}
+
+/** Run the existing pinned HTTP-to-stdio bridge. */
+export async function runProjectProxy(
+  options: ProjectProxyOptions,
+  dependencies: ProjectProxyDependencies = {},
+): Promise<number> {
+  const runtime = resolveProjectProxyRuntime((dependencies.loadConfig ?? loadConfig)(), options);
+  const npx = (dependencies.findNpx ?? findNpx)();
+  const platform = dependencies.platform ?? process.platform;
+  const remote = mcpRemoteServer(runtime.endpoint, runtime.apiKey);
+  const executable = platform === "win32" ? win32.basename(npx) : npx;
+  const child = (dependencies.spawn ?? (nodeSpawn as unknown as SpawnProxy))(
+    executable,
+    remote.args,
+    {
+      stdio: "inherit",
+      shell: platform === "win32",
+      env: {
+        ...process.env,
+        PATH: npxPathEnv(npx),
+        ...remote.env,
+      },
+    },
+  );
+
+  return await new Promise<number>((resolve, reject) => {
+    let settled = false;
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      resolve(code ?? 1);
+    });
+  });
+}

--- a/src/mcp/providers.test.ts
+++ b/src/mcp/providers.test.ts
@@ -49,7 +49,7 @@ describe("provider registry", () => {
       { id: "cursor", name: "Cursor", local: true },
       { id: "vscode", name: "VS Code", local: true },
       { id: "gemini", name: "Gemini CLI", local: true },
-      { id: "codex", name: "Codex (CLI + Desktop)", local: true },
+      { id: "codex", name: "Codex", local: true },
       { id: "windsurf", name: "Windsurf", local: false },
       { id: "zed", name: "Zed", local: true },
       { id: "cline", name: "Cline", local: false },
@@ -87,6 +87,17 @@ describe("provider registry", () => {
 
         it("isConfigured returns boolean", () => {
           expect(typeof p.isConfigured()).toBe("boolean");
+        });
+
+        it("reports project configuration capability consistently", () => {
+          const projectRoot = "/tmp/dosu-provider-project";
+          if (p.supportsLocal()) {
+            expect(typeof p.projectConfigPath(projectRoot)).toBe("string");
+            expect(typeof p.isProjectConfigured(projectRoot)).toBe("boolean");
+          } else {
+            expect(p.projectConfigPath(projectRoot)).toBeNull();
+            expect(p.isProjectConfigured(projectRoot)).toBe(false);
+          }
         });
       });
     }

--- a/src/mcp/providers.test.ts
+++ b/src/mcp/providers.test.ts
@@ -44,28 +44,29 @@ describe("provider registry", () => {
 
   describe("provider metadata", () => {
     const expectedProviders = [
-      { id: "claude", name: "Claude Code", local: true },
-      { id: "claude-desktop", name: "Claude Desktop", local: false },
-      { id: "cursor", name: "Cursor", local: true },
-      { id: "vscode", name: "VS Code", local: true },
-      { id: "gemini", name: "Gemini CLI", local: true },
-      { id: "codex", name: "Codex", local: true },
-      { id: "windsurf", name: "Windsurf", local: false },
-      { id: "zed", name: "Zed", local: true },
-      { id: "cline", name: "Cline", local: false },
-      { id: "cline-cli", name: "Cline CLI", local: false },
-      { id: "copilot", name: "GitHub Copilot CLI", local: true },
-      { id: "opencode", name: "OpenCode", local: true },
-      { id: "antigravity", name: "Antigravity", local: false },
-      { id: "mcporter", name: "MCPorter", local: true },
-      { id: "manual", name: "Manual Configuration", local: false },
+      { id: "claude", name: "Claude Code", kind: "project" },
+      { id: "claude-desktop", name: "Claude Desktop", kind: "global-connector" },
+      { id: "cursor", name: "Cursor", kind: "project" },
+      { id: "vscode", name: "VS Code", kind: "project" },
+      { id: "gemini", name: "Gemini CLI", kind: "project" },
+      { id: "codex", name: "Codex", kind: "project" },
+      { id: "windsurf", name: "Windsurf", kind: "unsupported" },
+      { id: "zed", name: "Zed", kind: "project" },
+      { id: "cline", name: "Cline", kind: "unsupported" },
+      { id: "cline-cli", name: "Cline CLI", kind: "unsupported" },
+      { id: "copilot", name: "GitHub Copilot CLI", kind: "project" },
+      { id: "opencode", name: "OpenCode", kind: "project" },
+      { id: "antigravity", name: "Antigravity", kind: "unsupported" },
+      { id: "mcporter", name: "MCPorter", kind: "project" },
+      { id: "factory", name: "Factory", kind: "project" },
+      { id: "manual", name: "Manual Configuration", kind: "global-connector" },
     ];
 
     for (const expected of expectedProviders) {
-      it(`${expected.id}: name="${expected.name}", local=${expected.local}`, () => {
+      it(`${expected.id}: name="${expected.name}", kind=${expected.kind}`, () => {
         const p = getProvider(expected.id);
         expect(p.name()).toBe(expected.name);
-        expect(p.supportsLocal()).toBe(expected.local);
+        expect(p.configurationKind()).toBe(expected.kind);
       });
     }
   });
@@ -91,7 +92,7 @@ describe("provider registry", () => {
 
         it("reports project configuration capability consistently", () => {
           const projectRoot = "/tmp/dosu-provider-project";
-          if (p.supportsLocal()) {
+          if (p.configurationKind() === "project") {
             expect(typeof p.projectConfigPath(projectRoot)).toBe("string");
             expect(typeof p.isProjectConfigured(projectRoot)).toBe("boolean");
           } else {

--- a/src/mcp/providers.ts
+++ b/src/mcp/providers.ts
@@ -9,6 +9,13 @@ import type { Config } from "../config/config";
  */
 export interface ProviderInstallOptions {
   showSecret?: boolean;
+  /** Verified Git root used for project-scoped configuration. */
+  projectRoot?: string;
+}
+
+interface ProviderRemoveOptions {
+  /** Verified Git root used for project-scoped configuration. */
+  projectRoot?: string;
 }
 
 export interface Provider {
@@ -16,7 +23,7 @@ export interface Provider {
   id(): string;
   supportsLocal(): boolean;
   install(cfg: Config, global: boolean, opts?: ProviderInstallOptions): void;
-  remove(global: boolean): void;
+  remove(global: boolean, opts?: ProviderRemoveOptions): void;
 }
 
 /**
@@ -27,6 +34,8 @@ export interface SetupProvider extends Provider {
   isInstalled(): boolean;
   isConfigured(): boolean;
   globalConfigPath(): string;
+  projectConfigPath(projectRoot: string): string | null;
+  isProjectConfigured(projectRoot: string): boolean;
   priority(): number;
 }
 

--- a/src/mcp/providers.ts
+++ b/src/mcp/providers.ts
@@ -7,13 +7,17 @@ import type { Config } from "../config/config";
 /**
  * Provider is the base interface for MCP tool providers.
  */
+export type ProviderConfigurationKind = "project" | "global-connector" | "unsupported";
+
 export interface ProviderInstallOptions {
+  scope: "project" | "global";
   showSecret?: boolean;
   /** Verified Git root used for project-scoped configuration. */
   projectRoot?: string;
 }
 
 interface ProviderRemoveOptions {
+  scope: "project" | "global";
   /** Verified Git root used for project-scoped configuration. */
   projectRoot?: string;
 }
@@ -21,9 +25,9 @@ interface ProviderRemoveOptions {
 export interface Provider {
   name(): string;
   id(): string;
-  supportsLocal(): boolean;
-  install(cfg: Config, global: boolean, opts?: ProviderInstallOptions): void;
-  remove(global: boolean, opts?: ProviderRemoveOptions): void;
+  configurationKind(): ProviderConfigurationKind;
+  install(cfg: Config, opts: ProviderInstallOptions): void;
+  remove(opts: ProviderRemoveOptions): void;
 }
 
 /**
@@ -37,6 +41,37 @@ export interface SetupProvider extends Provider {
   projectConfigPath(projectRoot: string): string | null;
   isProjectConfigured(projectRoot: string): boolean;
   priority(): number;
+}
+
+function enforceDeclaredScope<T extends Provider>(provider: T): T {
+  const assertScope = (scope: "project" | "global", operation: string): void => {
+    const kind = provider.configurationKind();
+    if (kind === "unsupported") {
+      throw new Error(`${provider.name()} does not support Dosu MCP configuration`);
+    }
+    if (kind === "project" && scope !== "project") {
+      throw new Error(
+        `${provider.name()} is project-scoped and cannot perform global ${operation}`,
+      );
+    }
+    if (kind === "global-connector" && scope !== "global") {
+      throw new Error(
+        `${provider.name()} is an explicit global connector and cannot perform project ${operation}`,
+      );
+    }
+  };
+
+  return {
+    ...provider,
+    install(cfg, opts): void {
+      assertScope(opts.scope, "installation");
+      provider.install(cfg, opts);
+    },
+    remove(opts): void {
+      assertScope(opts.scope, "removal");
+      provider.remove(opts);
+    },
+  };
 }
 
 import { AntigravityProvider } from "./providers/antigravity";
@@ -78,7 +113,7 @@ export function allProviders(): Provider[] {
     MCPorterProvider(),
     FactoryProvider(),
     ManualProvider(),
-  ];
+  ].map(enforceDeclaredScope);
 }
 
 /**

--- a/src/mcp/providers/antigravity.ts
+++ b/src/mcp/providers/antigravity.ts
@@ -5,7 +5,7 @@ export const AntigravityProvider = () =>
   createJSONProvider({
     providerName: "Antigravity",
     providerID: "antigravity",
-    local: false,
+    configurationKind: "unsupported",
     priorityValue: 15,
     paths: ["~/.gemini"],
     globalPath: "~/.gemini/antigravity/mcp_config.json",

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -20,12 +20,12 @@ import {
   isDosuOwnedMcpServer,
   type ProjectProxyCommand,
 } from "../project-proxy";
-import type { SetupProvider } from "../providers";
+import type { ProviderConfigurationKind, SetupProvider } from "../providers";
 
 export interface BaseProviderConfig {
   providerName: string;
   providerID: string;
-  local: boolean;
+  configurationKind: ProviderConfigurationKind;
   priorityValue: number;
   paths: string[];
   globalPath: string;
@@ -79,7 +79,7 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
   return {
     name: () => opts.providerName,
     id: () => opts.providerID,
-    supportsLocal: () => opts.local,
+    configurationKind: () => opts.configurationKind,
     priority: () => opts.priorityValue,
     detectPaths: () => opts.paths,
     isInstalled: () => isInstalled(opts.paths),
@@ -97,9 +97,10 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
       }
     },
 
-    install(cfg: Config, global: boolean, installOpts = {}): void {
+    install(cfg: Config, installOpts): void {
       if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
         throw new Error("deployment ID is required");
+      const global = installOpts.scope === "global";
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
@@ -128,7 +129,8 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
       }
     },
 
-    remove(global: boolean, removeOpts = {}): void {
+    remove(removeOpts): void {
+      const global = removeOpts.scope === "global";
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -4,7 +4,9 @@
  */
 
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-root";
 import {
+  getJSONServer,
   installJSONServer,
   isJSONKeyConfigured,
   mcpBaseURL,
@@ -13,6 +15,11 @@ import {
   removeJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import {
+  buildProjectProxyCommand,
+  isDosuOwnedMcpServer,
+  type ProjectProxyCommand,
+} from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 export interface BaseProviderConfig {
@@ -26,6 +33,8 @@ export interface BaseProviderConfig {
   /** Override the server entry shape if needed */
   // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
   buildServer?: (cfg: Config) => Record<string, any>;
+  /** Exact provider-specific stdio shape for a secretless project entry. */
+  buildProjectServer?: (command: ProjectProxyCommand) => Record<string, unknown>;
   /** For providers that use a different local config path pattern */
   localConfigPath?: (cwd: string) => string;
 }
@@ -47,6 +56,25 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
   });
 
   const buildServer = opts.buildServer ?? defaultBuildServer;
+  const buildProjectServer =
+    opts.buildProjectServer ??
+    ((command: ProjectProxyCommand): Record<string, unknown> => ({
+      type: "stdio",
+      command: command.command,
+      args: command.args,
+    }));
+
+  const projectConfigPath = (projectRoot: string): string | null =>
+    opts.localConfigPath ? opts.localConfigPath(projectRoot) : null;
+
+  const requireProjectRoot = (projectRoot: string | undefined): string => {
+    if (!projectRoot) {
+      throw new Error(
+        `${opts.providerName} project installation requires an explicit project root`,
+      );
+    }
+    return projectRoot;
+  };
 
   return {
     name: () => opts.providerName,
@@ -57,30 +85,71 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     isInstalled: () => isInstalled(opts.paths),
     globalConfigPath: () => expandHome(opts.globalPath),
     isConfigured: () => isJSONKeyConfigured(expandHome(opts.globalPath), opts.topKey),
+    projectConfigPath,
+    isProjectConfigured: (projectRoot: string) => {
+      const path = projectConfigPath(projectRoot);
+      if (path) assertSafeProjectPath(projectRoot, path);
+      if (!path) return false;
+      try {
+        return isDosuOwnedMcpServer(getJSONServer(path, opts.topKey));
+      } catch {
+        return false;
+      }
+    },
 
-    install(cfg: Config, global: boolean): void {
+    install(cfg: Config, global: boolean, installOpts = {}): void {
       if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
         throw new Error("deployment ID is required");
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
       } else if (opts.localConfigPath) {
-        configPath = opts.localConfigPath(process.cwd());
+        const projectRoot = requireProjectRoot(installOpts.projectRoot);
+        configPath = opts.localConfigPath(projectRoot);
+        assertSafeProjectPath(projectRoot, configPath);
       } else {
         throw new Error(`${opts.providerName} does not support local installation`);
       }
-      const serverBuilder = cfg.mode === MODE_OSS ? defaultBuildOSSServer : buildServer;
-      installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
+      if (global) {
+        const serverBuilder = cfg.mode === MODE_OSS ? defaultBuildOSSServer : buildServer;
+        installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
+      } else {
+        const existing = getJSONServer(configPath, opts.topKey);
+        if (existing !== undefined && !isDosuOwnedMcpServer(existing)) {
+          throw new Error(
+            `${opts.providerName} already has a non-Dosu MCP server named "dosu"; refusing to overwrite it`,
+          );
+        }
+        installJSONServer(
+          configPath,
+          opts.topKey,
+          buildProjectServer(buildProjectProxyCommand(cfg)),
+        );
+      }
     },
 
-    remove(global: boolean): void {
+    remove(global: boolean, removeOpts = {}): void {
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
       } else if (opts.localConfigPath) {
-        configPath = opts.localConfigPath(process.cwd());
+        const projectRoot = removeOpts.projectRoot;
+        if (!projectRoot) {
+          throw new Error(`${opts.providerName} project removal requires an explicit project root`);
+        }
+        configPath = opts.localConfigPath(projectRoot);
+        assertSafeProjectPath(projectRoot, configPath);
       } else {
         throw new Error(`${opts.providerName} does not support local removal`);
+      }
+      if (!global) {
+        const existing = getJSONServer(configPath, opts.topKey);
+        if (existing === undefined) return;
+        if (!isDosuOwnedMcpServer(existing)) {
+          throw new Error(
+            `${opts.providerName} has a non-Dosu MCP server named "dosu"; refusing to remove it`,
+          );
+        }
       }
       removeJSONServer(configPath, opts.topKey);
     },

--- a/src/mcp/providers/claude-desktop.ts
+++ b/src/mcp/providers/claude-desktop.ts
@@ -18,7 +18,7 @@ function configPath(): string {
 export const ClaudeDesktopProvider = (): SetupProvider => ({
   name: () => "Claude Desktop",
   id: () => "claude-desktop",
-  supportsLocal: () => false,
+  configurationKind: () => "global-connector",
   priority: () => 2,
   detectPaths: () => [join(appSupportDir(), "Claude")],
   isInstalled: () => isInstalled([join(appSupportDir(), "Claude")]),
@@ -27,8 +27,9 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
   projectConfigPath: () => null,
   isProjectConfigured: () => false,
 
-  install(cfg: Config, global: boolean): void {
-    if (!global) throw new Error("Claude Desktop does not support local installation");
+  install(cfg: Config, opts): void {
+    if (opts.scope !== "global")
+      throw new Error("Claude Desktop does not support project installation");
     if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
       throw new Error("deployment ID is required");
     const url =
@@ -52,8 +53,8 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
     });
   },
 
-  remove(global: boolean): void {
-    if (!global) throw new Error("Claude Desktop does not support local removal");
+  remove(opts): void {
+    if (opts.scope !== "global") throw new Error("Claude Desktop does not support project removal");
     removeJSONServer(configPath(), "mcpServers");
   },
 });

--- a/src/mcp/providers/claude-desktop.ts
+++ b/src/mcp/providers/claude-desktop.ts
@@ -24,6 +24,8 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
   isInstalled: () => isInstalled([join(appSupportDir(), "Claude")]),
   globalConfigPath: () => configPath(),
   isConfigured: () => isJSONKeyConfigured(configPath(), "mcpServers"),
+  projectConfigPath: () => null,
+  isProjectConfigured: () => false,
 
   install(cfg: Config, global: boolean): void {
     if (!global) throw new Error("Claude Desktop does not support local installation");

--- a/src/mcp/providers/claude.ts
+++ b/src/mcp/providers/claude.ts
@@ -5,7 +5,7 @@ export const ClaudeProvider = () =>
   createJSONProvider({
     providerName: "Claude Code",
     providerID: "claude",
-    local: true,
+    configurationKind: "project",
     priorityValue: 1,
     paths: ["~/.claude"],
     globalPath: "~/.claude.json",

--- a/src/mcp/providers/cline-cli.ts
+++ b/src/mcp/providers/cline-cli.ts
@@ -11,7 +11,7 @@ export const ClineCliProvider = () =>
   createJSONProvider({
     providerName: "Cline CLI",
     providerID: "cline-cli",
-    local: false,
+    configurationKind: "unsupported",
     priorityValue: 12,
     paths: [clineDir()],
     globalPath: join(clineDir(), "data", "settings", "cline_mcp_settings.json"),

--- a/src/mcp/providers/cline.ts
+++ b/src/mcp/providers/cline.ts
@@ -10,7 +10,7 @@ export const ClineProvider = () =>
   createJSONProvider({
     providerName: "Cline",
     providerID: "cline",
-    local: false,
+    configurationKind: "unsupported",
     priorityValue: 11,
     paths: [extensionDir()],
     globalPath: join(extensionDir(), "settings", "cline_mcp_settings.json"),

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -1,11 +1,8 @@
-/**
- * Codex provider — CLI and desktop app share ~/.codex/config.toml (TOML format).
- * Simplified: we write JSON-style to a TOML-like structure using manual serialization.
- * For full parity, we'd need a TOML library. For now, use JSON config as Codex also supports it.
- */
+/** Codex provider — CLI and desktop app share TOML configuration. */
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { type AST, parseTOML } from "toml-eslint-parser";
 import { type Config, MODE_OSS } from "../../config/config";
 import { assertSafeProjectPath } from "../../setup/project-root";
 import { mcpBaseURL, mcpRemoteServer, mcpURL, writeSecureFile } from "../config-helpers";
@@ -27,10 +24,6 @@ function getConfigPath(global: boolean, projectRoot?: string): string {
   return path;
 }
 
-/**
- * Minimal TOML read/write for the Codex mcp_servers section.
- * We parse just enough to add/remove the [mcp_servers.dosu] entry.
- */
 function readTOML(path: string): string {
   if (!existsSync(path)) return "";
   return readFileSync(path, "utf-8");
@@ -50,43 +43,140 @@ function tomlString(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function hasDosuSection(content: string): boolean {
-  return content.split("\n").some((line) => /^\[mcp_servers\.dosu(?:\..*)?]$/.test(line.trim()));
+function parseConfigTOML(content: string): AST.TOMLProgram {
+  try {
+    return parseTOML(content);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid Codex TOML: ${detail}`);
+  }
 }
 
-function isOwnedProjectSection(content: string): boolean {
-  const lines = content.split("\n");
-  const start = lines.findIndex((line) => line.trim() === "[mcp_servers.dosu]");
-  if (start < 0) return false;
-  const body: string[] = [];
-  for (const line of lines.slice(start + 1)) {
-    if (line.trim().startsWith("[")) break;
-    body.push(line);
+function tableNodes(program: AST.TOMLProgram): AST.TOMLTable[] {
+  return program.body[0].body.filter((node): node is AST.TOMLTable => node.type === "TOMLTable");
+}
+
+function isDosuTable(table: AST.TOMLTable): boolean {
+  return table.resolvedKey[0] === "mcp_servers" && table.resolvedKey[1] === "dosu";
+}
+
+function dosuTables(program: AST.TOMLProgram): AST.TOMLTable[] {
+  return tableNodes(program).filter(isDosuTable);
+}
+
+function keyParts(node: AST.TOMLKeyValue): string[] {
+  return node.key.keys.map((key) => String(key.type === "TOMLBare" ? key.name : key.value));
+}
+
+function isDosuKey(parts: readonly string[]): boolean {
+  return parts[0] === "mcp_servers" && parts[1] === "dosu";
+}
+
+/** Detect valid TOML forms that would collide with `[mcp_servers.dosu]`. */
+function hasAlternateDosuDefinition(program: AST.TOMLProgram): boolean {
+  for (const node of program.body[0].body) {
+    if (node.type === "TOMLKeyValue") {
+      const parts = keyParts(node);
+      if (isDosuKey(parts)) return true;
+      // TOML inline tables are closed: appending `[mcp_servers.dosu]` after
+      // `mcp_servers = { ... }` would redefine the root key and corrupt an
+      // otherwise valid config, whether or not we can inspect its children.
+      if (
+        parts.length === 1 &&
+        parts[0] === "mcp_servers" &&
+        node.value.type === "TOMLInlineTable"
+      ) {
+        return true;
+      }
+    }
+    if (node.type !== "TOMLTable" || isDosuTable(node)) continue;
+    for (const entry of node.body) {
+      if (isDosuKey([...node.resolvedKey.map(String), ...keyParts(entry)])) return true;
+    }
   }
-  const text = body.join("\n");
-  const commandMatch = text.match(/^command\s*=\s*("(?:\\.|[^"])*")\s*$/m);
-  const argsMatch = text.match(/^args\s*=\s*(\[[^\n]*])\s*$/m);
-  if (!commandMatch || !argsMatch) return false;
-  try {
-    return isDosuOwnedMcpServer({
-      command: JSON.parse(commandMatch[1]),
-      args: JSON.parse(argsMatch[1]),
-    });
-  } catch {
-    return false;
+  return false;
+}
+
+function keyName(node: AST.TOMLKeyValue): string | undefined {
+  if (node.key.keys.length !== 1) return undefined;
+  const key = node.key.keys[0];
+  return key.type === "TOMLBare" ? key.name : key.value;
+}
+
+function stringValue(node: AST.TOMLContentNode): string | undefined {
+  return node.type === "TOMLValue" && node.kind === "string" ? node.value : undefined;
+}
+
+function stringArray(node: AST.TOMLContentNode): string[] | undefined {
+  if (node.type !== "TOMLArray") return undefined;
+  const values = node.elements.map(stringValue);
+  return values.every((value): value is string => value !== undefined) ? values : undefined;
+}
+
+function isOwnedProjectSection(program: AST.TOMLProgram): boolean {
+  const base = dosuTables(program).find((table) => table.resolvedKey.length === 2);
+  if (!base) return false;
+  const commandNode = base.body.find((node) => keyName(node) === "command");
+  const argsNode = base.body.find((node) => keyName(node) === "args");
+  if (!commandNode || !argsNode) return false;
+  const command = stringValue(commandNode.value);
+  const args = stringArray(argsNode.value);
+  return Boolean(command && args && isDosuOwnedMcpServer({ command, args }));
+}
+
+function removeDosuTables(content: string, tables: readonly AST.TOMLTable[]): string {
+  let result = content;
+  for (const table of [...tables].sort((left, right) => right.range[0] - left.range[0])) {
+    let end = table.range[1];
+    if (result.startsWith("\r\n", end)) end += 2;
+    else if (result.startsWith("\n", end)) end += 1;
+    result = result.slice(0, table.range[0]) + result.slice(end);
   }
+  return result;
+}
+
+function lineEndingFor(content: string): "\r\n" | "\n" {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function upsertDosuTables(
+  content: string,
+  tables: readonly AST.TOMLTable[],
+  section: string,
+  lineEnding: "\r\n" | "\n",
+): string {
+  if (tables.length === 0) {
+    if (!content) return section;
+    const separator = content.endsWith(`${lineEnding}${lineEnding}`)
+      ? ""
+      : content.endsWith(lineEnding)
+        ? lineEnding
+        : `${lineEnding}${lineEnding}`;
+    return `${content}${separator}${section}`;
+  }
+
+  const insertion = Math.min(...tables.map((table) => table.range[0]));
+  const withoutDosu = removeDosuTables(content, tables);
+  return `${withoutDosu.slice(0, insertion)}${section}${withoutDosu.slice(insertion)}`;
 }
 
 function installDosuToTOML(path: string, cfg: Config, global: boolean): void {
   let content = readTOML(path);
-  if (!global && hasDosuSection(content) && !isOwnedProjectSection(content)) {
+  const lineEnding = lineEndingFor(content);
+  const parsed = parseConfigTOML(content);
+  if (hasAlternateDosuDefinition(parsed)) {
+    throw new Error(
+      'Codex already declares "mcp_servers.dosu" in an alternate TOML form; refusing to overwrite it',
+    );
+  }
+  const existingTables = dosuTables(parsed);
+  if (!global && existingTables.length > 0 && !isOwnedProjectSection(parsed)) {
     throw new Error(
       'Codex already has a non-Dosu MCP server named "dosu"; refusing to overwrite it',
     );
   }
   // Remove existing [mcp_servers.dosu] section if present (including the
   // legacy [mcp_servers.dosu.http_headers] subtable from the remote-HTTP form)
-  content = removeDosuFromTOML(content);
   // Codex desktop only renders MCP Apps (the Session Knowledge card) for
   // locally spawned stdio servers — a remote-HTTP entry serves tools fine
   // but never shows the card — so proxy the endpoint through `npx
@@ -104,40 +194,23 @@ function installDosuToTOML(path: string, cfg: Config, global: boolean): void {
     const env: Record<string, string> = { PATH: npxPathEnv(npx), ...remote.env };
     const envEntries = Object.entries(env)
       .map(([key, value]) => `${key} = ${tomlString(value)}`)
-      .join("\n");
+      .join(lineEnding);
     const args = remote.args.map(tomlString).join(", ");
     section =
-      `\n[mcp_servers.dosu]\ncommand = ${tomlString(npx)}\nargs = [${args}]\n` +
-      `\n[mcp_servers.dosu.env]\n${envEntries}\n`;
+      `[mcp_servers.dosu]${lineEnding}` +
+      `command = ${tomlString(npx)}${lineEnding}` +
+      `args = [${args}]${lineEnding}${lineEnding}` +
+      `[mcp_servers.dosu.env]${lineEnding}${envEntries}${lineEnding}`;
   } else {
     const command = buildProjectProxyCommand(cfg);
     const args = command.args.map(tomlString).join(", ");
-    section = `\n[mcp_servers.dosu]\ncommand = ${tomlString(command.command)}\nargs = [${args}]\n`;
+    section =
+      `[mcp_servers.dosu]${lineEnding}` +
+      `command = ${tomlString(command.command)}${lineEnding}` +
+      `args = [${args}]${lineEnding}`;
   }
-  content += section;
+  content = upsertDosuTables(content, existingTables, section, lineEnding);
   writeTOML(path, content);
-}
-
-function removeDosuFromTOML(content: string): string {
-  // Remove [mcp_servers.dosu] and [mcp_servers.dosu.*] sections
-  const lines = content.split("\n");
-  const result: string[] = [];
-  let inDosuSection = false;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed.match(/^\[mcp_servers\.dosu(\..*)?]$/)) {
-      inDosuSection = true;
-      continue;
-    }
-    if (inDosuSection && trimmed.startsWith("[")) {
-      inDosuSection = false;
-    }
-    if (!inDosuSection) {
-      result.push(line);
-    }
-  }
-  return result.join("\n");
 }
 
 export const CodexProvider = (): SetupProvider => ({
@@ -145,30 +218,48 @@ export const CodexProvider = (): SetupProvider => ({
   // Do not imply that Codex Desktop currently honors project MCP configuration.
   name: () => "Codex",
   id: () => "codex",
-  supportsLocal: () => true,
+  configurationKind: () => "project",
   priority: () => 8,
   detectPaths: () => ["~/.codex"],
   isInstalled: () => isInstalled(["~/.codex"]),
   globalConfigPath: () => join(codexHome(), "config.toml"),
   isConfigured: () => {
     const content = readTOML(join(codexHome(), "config.toml"));
-    return content.includes("[mcp_servers.dosu]");
+    try {
+      return dosuTables(parseConfigTOML(content)).length > 0;
+    } catch {
+      return false;
+    }
   },
   projectConfigPath: (projectRoot: string) => join(projectRoot, ".codex", "config.toml"),
-  isProjectConfigured: (projectRoot: string) =>
-    isOwnedProjectSection(readTOML(getConfigPath(false, projectRoot))),
-  install(cfg: Config, global: boolean, opts = {}): void {
+  isProjectConfigured: (projectRoot: string) => {
+    try {
+      return isOwnedProjectSection(parseConfigTOML(readTOML(getConfigPath(false, projectRoot))));
+    } catch {
+      return false;
+    }
+  },
+  install(cfg: Config, opts): void {
     if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
       throw new Error("deployment ID is required");
+    const global = opts.scope === "global";
     installDosuToTOML(getConfigPath(global, opts.projectRoot), cfg, global);
   },
-  remove(global: boolean, opts = {}): void {
+  remove(opts): void {
+    const global = opts.scope === "global";
     const path = getConfigPath(global, opts.projectRoot);
     const content = readTOML(path);
     if (!content) return;
-    if (!global && hasDosuSection(content) && !isOwnedProjectSection(content)) {
+    const parsed = parseConfigTOML(content);
+    if (hasAlternateDosuDefinition(parsed)) {
+      throw new Error(
+        'Codex declares "mcp_servers.dosu" in an alternate TOML form; refusing to remove it',
+      );
+    }
+    const existingTables = dosuTables(parsed);
+    if (!global && existingTables.length > 0 && !isOwnedProjectSection(parsed)) {
       throw new Error('Codex has a non-Dosu MCP server named "dosu"; refusing to remove it');
     }
-    if (hasDosuSection(content)) writeTOML(path, removeDosuFromTOML(content));
+    if (existingTables.length > 0) writeTOML(path, removeDosuTables(content, existingTables));
   },
 });

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -7,17 +7,24 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-root";
 import { mcpBaseURL, mcpRemoteServer, mcpURL, writeSecureFile } from "../config-helpers";
 import { expandHome, findNpx, isInstalled, npxPathEnv } from "../detect";
+import { buildProjectProxyCommand, isDosuOwnedMcpServer } from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function codexHome(): string {
   return process.env.CODEX_HOME ?? expandHome("~/.codex");
 }
 
-function getConfigPath(global: boolean): string {
+function getConfigPath(global: boolean, projectRoot?: string): string {
   if (global) return join(codexHome(), "config.toml");
-  return join(process.cwd(), ".codex", "config.toml");
+  if (!projectRoot) {
+    throw new Error("Codex project installation requires an explicit project root");
+  }
+  const path = join(projectRoot, ".codex", "config.toml");
+  assertSafeProjectPath(projectRoot, path);
+  return path;
 }
 
 /**
@@ -43,8 +50,40 @@ function tomlString(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function installDosuToTOML(path: string, cfg: Config): void {
+function hasDosuSection(content: string): boolean {
+  return content.split("\n").some((line) => /^\[mcp_servers\.dosu(?:\..*)?]$/.test(line.trim()));
+}
+
+function isOwnedProjectSection(content: string): boolean {
+  const lines = content.split("\n");
+  const start = lines.findIndex((line) => line.trim() === "[mcp_servers.dosu]");
+  if (start < 0) return false;
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim().startsWith("[")) break;
+    body.push(line);
+  }
+  const text = body.join("\n");
+  const commandMatch = text.match(/^command\s*=\s*("(?:\\.|[^"])*")\s*$/m);
+  const argsMatch = text.match(/^args\s*=\s*(\[[^\n]*])\s*$/m);
+  if (!commandMatch || !argsMatch) return false;
+  try {
+    return isDosuOwnedMcpServer({
+      command: JSON.parse(commandMatch[1]),
+      args: JSON.parse(argsMatch[1]),
+    });
+  } catch {
+    return false;
+  }
+}
+
+function installDosuToTOML(path: string, cfg: Config, global: boolean): void {
   let content = readTOML(path);
+  if (!global && hasDosuSection(content) && !isOwnedProjectSection(content)) {
+    throw new Error(
+      'Codex already has a non-Dosu MCP server named "dosu"; refusing to overwrite it',
+    );
+  }
   // Remove existing [mcp_servers.dosu] section if present (including the
   // legacy [mcp_servers.dosu.http_headers] subtable from the remote-HTTP form)
   content = removeDosuFromTOML(content);
@@ -58,16 +97,23 @@ function installDosuToTOML(path: string, cfg: Config): void {
   // with an explicit PATH because this config is shared with Codex desktop,
   // which launches from the Dock with the minimal launchd PATH — the same
   // pitfall as Claude Desktop.
-  const npx = findNpx();
-  const remote = mcpRemoteServer(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
-  const env: Record<string, string> = { PATH: npxPathEnv(npx), ...remote.env };
-  const envEntries = Object.entries(env)
-    .map(([key, value]) => `${key} = ${tomlString(value)}`)
-    .join("\n");
-  const args = remote.args.map(tomlString).join(", ");
-  const section =
-    `\n[mcp_servers.dosu]\ncommand = ${tomlString(npx)}\nargs = [${args}]\n` +
-    `\n[mcp_servers.dosu.env]\n${envEntries}\n`;
+  let section: string;
+  if (global) {
+    const npx = findNpx();
+    const remote = mcpRemoteServer(mcpEndpoint(cfg), cfg.active_account?.target?.api_key);
+    const env: Record<string, string> = { PATH: npxPathEnv(npx), ...remote.env };
+    const envEntries = Object.entries(env)
+      .map(([key, value]) => `${key} = ${tomlString(value)}`)
+      .join("\n");
+    const args = remote.args.map(tomlString).join(", ");
+    section =
+      `\n[mcp_servers.dosu]\ncommand = ${tomlString(npx)}\nargs = [${args}]\n` +
+      `\n[mcp_servers.dosu.env]\n${envEntries}\n`;
+  } else {
+    const command = buildProjectProxyCommand(cfg);
+    const args = command.args.map(tomlString).join(", ");
+    section = `\n[mcp_servers.dosu]\ncommand = ${tomlString(command.command)}\nargs = [${args}]\n`;
+  }
   content += section;
   writeTOML(path, content);
 }
@@ -95,7 +141,9 @@ function removeDosuFromTOML(content: string): string {
 }
 
 export const CodexProvider = (): SetupProvider => ({
-  name: () => "Codex (CLI + Desktop)",
+  // Project .codex/config.toml is documented for Codex CLI and the IDE extension.
+  // Do not imply that Codex Desktop currently honors project MCP configuration.
+  name: () => "Codex",
   id: () => "codex",
   supportsLocal: () => true,
   priority: () => 8,
@@ -106,14 +154,21 @@ export const CodexProvider = (): SetupProvider => ({
     const content = readTOML(join(codexHome(), "config.toml"));
     return content.includes("[mcp_servers.dosu]");
   },
-  install(cfg: Config, global: boolean): void {
+  projectConfigPath: (projectRoot: string) => join(projectRoot, ".codex", "config.toml"),
+  isProjectConfigured: (projectRoot: string) =>
+    isOwnedProjectSection(readTOML(getConfigPath(false, projectRoot))),
+  install(cfg: Config, global: boolean, opts = {}): void {
     if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
       throw new Error("deployment ID is required");
-    installDosuToTOML(getConfigPath(global), cfg);
+    installDosuToTOML(getConfigPath(global, opts.projectRoot), cfg, global);
   },
-  remove(global: boolean): void {
-    const path = getConfigPath(global);
+  remove(global: boolean, opts = {}): void {
+    const path = getConfigPath(global, opts.projectRoot);
     const content = readTOML(path);
-    if (content) writeTOML(path, removeDosuFromTOML(content));
+    if (!content) return;
+    if (!global && hasDosuSection(content) && !isOwnedProjectSection(content)) {
+      throw new Error('Codex has a non-Dosu MCP server named "dosu"; refusing to remove it');
+    }
+    if (hasDosuSection(content)) writeTOML(path, removeDosuFromTOML(content));
   },
 });

--- a/src/mcp/providers/copilot.ts
+++ b/src/mcp/providers/copilot.ts
@@ -61,7 +61,7 @@ function assertReplaceableProjectEntry(configPath: string): void {
 export const CopilotProvider = (): SetupProvider => ({
   name: () => "GitHub Copilot CLI",
   id: () => "copilot",
-  supportsLocal: () => true,
+  configurationKind: () => "project",
   priority: () => 13,
   detectPaths: () => [expandHome("~/.copilot")],
   isInstalled: () => isInstalled([expandHome("~/.copilot")]),
@@ -70,7 +70,8 @@ export const CopilotProvider = (): SetupProvider => ({
   projectConfigPath: (projectRoot: string) => join(projectRoot, ".mcp.json"),
   isProjectConfigured,
 
-  install(cfg: Config, global: boolean, opts = {}): void {
+  install(cfg: Config, opts): void {
+    const global = opts.scope === "global";
     if (global) {
       const url = mcpEndpoint(cfg);
       const server = {
@@ -94,7 +95,8 @@ export const CopilotProvider = (): SetupProvider => ({
     }
   },
 
-  remove(global: boolean, opts = {}): void {
+  remove(opts): void {
+    const global = opts.scope === "global";
     if (global) {
       removeJSONServer(globalPath(), "mcpServers");
     } else {

--- a/src/mcp/providers/copilot.ts
+++ b/src/mcp/providers/copilot.ts
@@ -1,6 +1,8 @@
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-root";
 import {
+  getJSONServer,
   installJSONServer,
   isJSONKeyConfigured,
   mcpBaseURL,
@@ -9,6 +11,7 @@ import {
   removeJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import { buildProjectProxyCommand, isDosuOwnedMcpServer } from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function globalPath(): string {
@@ -24,6 +27,37 @@ function mcpEndpoint(cfg: Config): string {
   return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
+function requireProjectRoot(projectRoot: string | undefined): string {
+  if (!projectRoot) {
+    throw new Error("GitHub Copilot CLI project installation requires an explicit project root");
+  }
+  return projectRoot;
+}
+
+function projectPath(projectRoot: string | undefined): string {
+  const root = requireProjectRoot(projectRoot);
+  const path = join(root, ".mcp.json");
+  assertSafeProjectPath(root, path);
+  return path;
+}
+
+function isProjectConfigured(projectRoot: string): boolean {
+  try {
+    return isDosuOwnedMcpServer(getJSONServer(projectPath(projectRoot), "mcpServers"));
+  } catch {
+    return false;
+  }
+}
+
+function assertReplaceableProjectEntry(configPath: string): void {
+  const existing = getJSONServer(configPath, "mcpServers");
+  if (existing !== undefined && !isDosuOwnedMcpServer(existing)) {
+    throw new Error(
+      'GitHub Copilot CLI already has a non-Dosu MCP server named "dosu"; refusing to overwrite it',
+    );
+  }
+}
+
 export const CopilotProvider = (): SetupProvider => ({
   name: () => "GitHub Copilot CLI",
   id: () => "copilot",
@@ -33,11 +67,12 @@ export const CopilotProvider = (): SetupProvider => ({
   isInstalled: () => isInstalled([expandHome("~/.copilot")]),
   globalConfigPath: () => globalPath(),
   isConfigured: () => isJSONKeyConfigured(globalPath(), "mcpServers"),
+  projectConfigPath: (projectRoot: string) => join(projectRoot, ".mcp.json"),
+  isProjectConfigured,
 
-  install(cfg: Config, global: boolean): void {
-    const url = mcpEndpoint(cfg);
-
+  install(cfg: Config, global: boolean, opts = {}): void {
     if (global) {
+      const url = mcpEndpoint(cfg);
       const server = {
         type: "http",
         url,
@@ -47,23 +82,31 @@ export const CopilotProvider = (): SetupProvider => ({
       };
       installJSONServer(globalPath(), "mcpServers", server);
     } else {
-      const configPath = join(process.cwd(), ".vscode", "mcp.json");
+      const configPath = projectPath(opts.projectRoot);
+      assertReplaceableProjectEntry(configPath);
+      const command = buildProjectProxyCommand(cfg);
       const server = {
-        type: "http",
-        url,
-        // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-        headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+        type: "stdio",
+        command: command.command,
+        args: command.args,
       };
-      installJSONServer(configPath, "servers", server);
+      installJSONServer(configPath, "mcpServers", server);
     }
   },
 
-  remove(global: boolean): void {
+  remove(global: boolean, opts = {}): void {
     if (global) {
       removeJSONServer(globalPath(), "mcpServers");
     } else {
-      const configPath = join(process.cwd(), ".vscode", "mcp.json");
-      removeJSONServer(configPath, "servers");
+      const configPath = projectPath(opts.projectRoot);
+      const existing = getJSONServer(configPath, "mcpServers");
+      if (existing === undefined) return;
+      if (!isDosuOwnedMcpServer(existing)) {
+        throw new Error(
+          'GitHub Copilot CLI has a non-Dosu MCP server named "dosu"; refusing to remove it',
+        );
+      }
+      removeJSONServer(configPath, "mcpServers");
     }
   },
 });

--- a/src/mcp/providers/cursor.ts
+++ b/src/mcp/providers/cursor.ts
@@ -6,7 +6,7 @@ export const CursorProvider = () =>
   createJSONProvider({
     providerName: "Cursor",
     providerID: "cursor",
-    local: true,
+    configurationKind: "project",
     priorityValue: 5,
     paths: ["~/.cursor"],
     globalPath: "~/.cursor/mcp.json",

--- a/src/mcp/providers/factory.ts
+++ b/src/mcp/providers/factory.ts
@@ -5,7 +5,7 @@ export const FactoryProvider = () =>
   createJSONProvider({
     providerName: "Factory",
     providerID: "factory",
-    local: true,
+    configurationKind: "project",
     priorityValue: 17,
     paths: ["~/.factory"],
     globalPath: "~/.factory/mcp.json",

--- a/src/mcp/providers/gemini.ts
+++ b/src/mcp/providers/gemini.ts
@@ -5,7 +5,7 @@ export const GeminiProvider = () =>
   createJSONProvider({
     providerName: "Gemini CLI",
     providerID: "gemini",
-    local: true,
+    configurationKind: "project",
     priorityValue: 7,
     paths: ["~/.gemini"],
     globalPath: "~/.gemini/settings.json",

--- a/src/mcp/providers/gemini.ts
+++ b/src/mcp/providers/gemini.ts
@@ -10,5 +10,6 @@ export const GeminiProvider = () =>
     paths: ["~/.gemini"],
     globalPath: "~/.gemini/settings.json",
     topKey: "mcpServers",
+    buildProjectServer: (command) => ({ command: command.command, args: command.args }),
     localConfigPath: (cwd) => join(cwd, ".gemini", "settings.json"),
   });

--- a/src/mcp/providers/manual.ts
+++ b/src/mcp/providers/manual.ts
@@ -17,9 +17,10 @@ function maskSecret(secret: string): string {
 export const ManualProvider = (): Provider => ({
   name: () => "Manual Configuration",
   id: () => "manual",
-  supportsLocal: () => false,
+  configurationKind: () => "global-connector",
 
-  install(cfg: Config, _global: boolean, opts: ProviderInstallOptions = {}): void {
+  install(cfg: Config, opts: ProviderInstallOptions): void {
+    if (opts.scope !== "global") throw new Error("Manual configuration is a global connector");
     const url = mcpEndpoint(cfg);
     const apiKey = mcpHeaders(cfg.active_account?.target?.api_key)["X-Dosu-API-Key"];
     const headerValue = opts.showSecret ? apiKey : maskSecret(apiKey);

--- a/src/mcp/providers/mcporter.ts
+++ b/src/mcp/providers/mcporter.ts
@@ -1,7 +1,9 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
+import { assertSafeProjectPath } from "../../setup/project-root";
 import {
+  getJSONServer,
   installJSONServer,
   isJSONKeyConfigured,
   mcpBaseURL,
@@ -10,6 +12,7 @@ import {
   removeJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
+import { buildProjectProxyCommand, isDosuOwnedMcpServer } from "../project-proxy";
 import type { SetupProvider } from "../providers";
 
 function resolveGlobalConfigPath(): string {
@@ -26,6 +29,37 @@ function mcpEndpoint(cfg: Config): string {
   return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
+function requireProjectRoot(projectRoot: string | undefined): string {
+  if (!projectRoot) {
+    throw new Error("MCPorter project installation requires an explicit project root");
+  }
+  return projectRoot;
+}
+
+function projectPath(projectRoot: string | undefined): string {
+  const root = requireProjectRoot(projectRoot);
+  const path = join(root, "config", "mcporter.json");
+  assertSafeProjectPath(root, path);
+  return path;
+}
+
+function isProjectConfigured(projectRoot: string): boolean {
+  try {
+    return isDosuOwnedMcpServer(getJSONServer(projectPath(projectRoot), "mcpServers"));
+  } catch {
+    return false;
+  }
+}
+
+function assertReplaceableProjectEntry(configPath: string): void {
+  const existing = getJSONServer(configPath, "mcpServers");
+  if (existing !== undefined && !isDosuOwnedMcpServer(existing)) {
+    throw new Error(
+      'MCPorter already has a non-Dosu MCP server named "dosu"; refusing to overwrite it',
+    );
+  }
+}
+
 export const MCPorterProvider = (): SetupProvider => ({
   name: () => "MCPorter",
   id: () => "mcporter",
@@ -35,24 +69,32 @@ export const MCPorterProvider = (): SetupProvider => ({
   isInstalled: () => isInstalled(["~/.mcporter"]),
   globalConfigPath: () => resolveGlobalConfigPath(),
   isConfigured: () => isJSONKeyConfigured(resolveGlobalConfigPath(), "mcpServers"),
+  projectConfigPath: (projectRoot: string) => join(projectRoot, "config", "mcporter.json"),
+  isProjectConfigured,
 
-  install(cfg: Config, global: boolean): void {
-    const configPath = global
-      ? resolveGlobalConfigPath()
-      : join(process.cwd(), "config", "mcporter.json");
-    const server = {
-      type: "http",
-      url: mcpEndpoint(cfg),
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
-    };
+  install(cfg: Config, global: boolean, opts = {}): void {
+    const configPath = global ? resolveGlobalConfigPath() : projectPath(opts.projectRoot);
+    if (!global) assertReplaceableProjectEntry(configPath);
+    const server = global
+      ? {
+          type: "http",
+          url: mcpEndpoint(cfg),
+          // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
+          headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+        }
+      : buildProjectProxyCommand(cfg);
     installJSONServer(configPath, "mcpServers", server);
   },
 
-  remove(global: boolean): void {
-    const configPath = global
-      ? resolveGlobalConfigPath()
-      : join(process.cwd(), "config", "mcporter.json");
+  remove(global: boolean, opts = {}): void {
+    const configPath = global ? resolveGlobalConfigPath() : projectPath(opts.projectRoot);
+    if (!global) {
+      const existing = getJSONServer(configPath, "mcpServers");
+      if (existing === undefined) return;
+      if (!isDosuOwnedMcpServer(existing)) {
+        throw new Error('MCPorter has a non-Dosu MCP server named "dosu"; refusing to remove it');
+      }
+    }
     removeJSONServer(configPath, "mcpServers");
   },
 });

--- a/src/mcp/providers/mcporter.ts
+++ b/src/mcp/providers/mcporter.ts
@@ -63,7 +63,7 @@ function assertReplaceableProjectEntry(configPath: string): void {
 export const MCPorterProvider = (): SetupProvider => ({
   name: () => "MCPorter",
   id: () => "mcporter",
-  supportsLocal: () => true,
+  configurationKind: () => "project",
   priority: () => 16,
   detectPaths: () => ["~/.mcporter"],
   isInstalled: () => isInstalled(["~/.mcporter"]),
@@ -72,7 +72,8 @@ export const MCPorterProvider = (): SetupProvider => ({
   projectConfigPath: (projectRoot: string) => join(projectRoot, "config", "mcporter.json"),
   isProjectConfigured,
 
-  install(cfg: Config, global: boolean, opts = {}): void {
+  install(cfg: Config, opts): void {
+    const global = opts.scope === "global";
     const configPath = global ? resolveGlobalConfigPath() : projectPath(opts.projectRoot);
     if (!global) assertReplaceableProjectEntry(configPath);
     const server = global
@@ -86,7 +87,8 @@ export const MCPorterProvider = (): SetupProvider => ({
     installJSONServer(configPath, "mcpServers", server);
   },
 
-  remove(global: boolean, opts = {}): void {
+  remove(opts): void {
+    const global = opts.scope === "global";
     const configPath = global ? resolveGlobalConfigPath() : projectPath(opts.projectRoot);
     if (!global) {
       const existing = getJSONServer(configPath, "mcpServers");

--- a/src/mcp/providers/opencode.ts
+++ b/src/mcp/providers/opencode.ts
@@ -19,5 +19,10 @@ export const OpenCodeProvider = () =>
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
+    buildProjectServer: (command) => ({
+      type: "local",
+      command: [command.command, ...command.args],
+      enabled: true,
+    }),
     localConfigPath: (cwd) => join(cwd, "opencode.json"),
   });

--- a/src/mcp/providers/opencode.ts
+++ b/src/mcp/providers/opencode.ts
@@ -6,7 +6,7 @@ export const OpenCodeProvider = () =>
   createJSONProvider({
     providerName: "OpenCode",
     providerID: "opencode",
-    local: true,
+    configurationKind: "project",
     priorityValue: 14,
     paths: ["~/.config/opencode"],
     globalPath: "~/.config/opencode/opencode.json",

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../../config/config.test-utils";
 import { loadJSONConfig, MCP_REMOTE_VERSION } from "../config-helpers";
+import { allSetupProviders } from "../providers";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -127,7 +128,24 @@ describe("createJSONProvider (base)", () => {
     expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
   });
 
-  it("local install writes to localConfigPath when provided", async () => {
+  it("project install requires an explicit project root", async () => {
+    const { createJSONProvider } = await import("./base");
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: true,
+      priorityValue: 1,
+      paths: [],
+      globalPath: join(tempDir, "g.json"),
+      topKey: "mcpServers",
+      localConfigPath: (projectRoot) => join(projectRoot, "local", "mcp.json"),
+    });
+
+    expect(() => provider.install(makeCfg(), false)).toThrow("explicit project root");
+    expect(() => provider.remove(false)).toThrow("explicit project root");
+  });
+
+  it("project install writes a secretless proxy entry to the explicit project root", async () => {
     const { createJSONProvider } = await import("./base");
     const localPath = join(tempDir, "local", "mcp.json");
     const provider = createJSONProvider({
@@ -141,11 +159,17 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: () => localPath,
     });
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const cfg = loadJSONConfig(localPath);
-    expect(cfg.mcpServers.dosu).toBeDefined();
-    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+    expect(cfg.mcpServers.dosu).toMatchObject({
+      type: "stdio",
+      command: "npx",
+    });
+    expect(cfg.mcpServers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
+    expect(provider.projectConfigPath(tempDir)).toBe(localPath);
+    expect(provider.isProjectConfigured(tempDir)).toBe(true);
   });
 
   it("global remove deletes dosu entry from JSON config", async () => {
@@ -193,9 +217,6 @@ describe("createJSONProvider (base)", () => {
   it("local remove deletes dosu entry when localConfigPath is provided", async () => {
     const { createJSONProvider } = await import("./base");
     const localPath = join(tempDir, "local-rm", "mcp.json");
-    mkdirSync(join(tempDir, "local-rm"), { recursive: true });
-    writeFileSync(localPath, JSON.stringify({ mcpServers: { dosu: { url: "x" } } }));
-
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
@@ -207,10 +228,36 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: () => localPath,
     });
 
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const cfg = loadJSONConfig(localPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
+  });
+
+  it("refuses to overwrite or remove a foreign project entry named dosu", async () => {
+    const { createJSONProvider } = await import("./base");
+    const localPath = join(tempDir, "foreign", "mcp.json");
+    mkdirSync(dirname(localPath), { recursive: true });
+    const foreign = { command: "other-server", args: ["serve"] };
+    writeFileSync(localPath, JSON.stringify({ mcpServers: { dosu: foreign } }));
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: true,
+      priorityValue: 1,
+      paths: [],
+      globalPath: join(tempDir, "g.json"),
+      topKey: "mcpServers",
+      localConfigPath: () => localPath,
+    });
+
+    expect(provider.isProjectConfigured(tempDir)).toBe(false);
+    expect(() => provider.install(makeCfg(), false, { projectRoot: tempDir })).toThrow(
+      "refusing to overwrite",
+    );
+    expect(() => provider.remove(false, { projectRoot: tempDir })).toThrow("refusing to remove");
+    expect(loadJSONConfig(localPath).mcpServers.dosu).toEqual(foreign);
   });
 
   it("install with custom buildServer uses that shape", async () => {
@@ -303,16 +350,22 @@ describe("CodexProvider", () => {
     expect(content).not.toContain("http_headers");
   });
 
-  it("local install writes TOML config to .codex/config.toml in cwd", async () => {
+  it("project install writes a secretless TOML config to the explicit project root", async () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".codex", "config.toml");
     expect(existsSync(configPath)).toBe(true);
     const content = readFileSync(configPath, "utf-8");
     expect(content).toContain("[mcp_servers.dosu]");
+    expect(content).toContain('command = "npx"');
+    expect(content).toContain('"mcp", "proxy"');
+    expect(content).toContain("dep-123");
+    expect(content).not.toContain("key-abc");
+    expect(provider.projectConfigPath(tempDir)).toBe(configPath);
+    expect(provider.isProjectConfigured(tempDir)).toBe(true);
   });
 
   it("OSS mode install writes base MCP URL to TOML config", async () => {
@@ -431,12 +484,28 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".codex", "config.toml");
     const content = readFileSync(configPath, "utf-8");
     expect(content).not.toContain("[mcp_servers.dosu]");
+  });
+
+  it("refuses to overwrite or remove a foreign local dosu section", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+    const configPath = join(tempDir, ".codex", "config.toml");
+    mkdirSync(dirname(configPath), { recursive: true });
+    const foreign = '[mcp_servers.dosu]\ncommand = "other-server"\nargs = ["serve"]\n';
+    writeFileSync(configPath, foreign);
+
+    expect(provider.isProjectConfigured(tempDir)).toBe(false);
+    expect(() => provider.install(makeCfg(), false, { projectRoot: tempDir })).toThrow(
+      "refusing to overwrite",
+    );
+    expect(() => provider.remove(false, { projectRoot: tempDir })).toThrow("refusing to remove");
+    expect(readFileSync(configPath, "utf-8")).toBe(foreign);
   });
 
   it("remove does nothing when config file does not exist", async () => {
@@ -515,21 +584,20 @@ describe("CopilotProvider", () => {
     expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
-  it("local install writes to cwd/.vscode/mcp.json with servers key", async () => {
+  it("project install writes a secretless entry to root .mcp.json", async () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
-    const configPath = join(tempDir, ".vscode", "mcp.json");
+    const configPath = join(tempDir, ".mcp.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.servers).toBeDefined();
-    expect(cfg.servers.dosu).toBeDefined();
-    expect(cfg.servers.dosu.type).toBe("http");
-    expect(cfg.servers.dosu.url).toContain("dep-123");
-    // local config should not have tools key
-    expect(cfg.servers.dosu.tools).toBeUndefined();
+    expect(cfg.mcpServers.dosu).toMatchObject({ type: "stdio", command: "npx" });
+    expect(cfg.mcpServers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
+    expect(provider.projectConfigPath(tempDir)).toBe(configPath);
+    expect(provider.isProjectConfigured(tempDir)).toBe(true);
   });
 
   it("OSS mode install writes base MCP URL for global and local Copilot configs", async () => {
@@ -537,15 +605,17 @@ describe("CopilotProvider", () => {
     const provider = CopilotProvider();
 
     provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), false);
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), false, {
+      projectRoot: tempDir,
+    });
 
     const globalCfg = loadJSONConfig(join(tempDir, "xdg-config", "mcp-config.json"));
     expect(globalCfg.mcpServers.dosu.url).toContain("/v1/mcp");
     expect(globalCfg.mcpServers.dosu.url).not.toContain("/deployments/");
 
-    const localCfg = loadJSONConfig(join(tempDir, ".vscode", "mcp.json"));
-    expect(localCfg.servers.dosu.url).toContain("/v1/mcp");
-    expect(localCfg.servers.dosu.url).not.toContain("/deployments/");
+    const localCfg = loadJSONConfig(join(tempDir, ".mcp.json"));
+    expect(localCfg.mcpServers.dosu.args).toContain("--oss");
+    expect(JSON.stringify(localCfg)).not.toContain("key-abc");
   });
 
   it("install throws when deployment_id is missing", async () => {
@@ -573,12 +643,12 @@ describe("CopilotProvider", () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
-    const configPath = join(tempDir, ".vscode", "mcp.json");
+    const configPath = join(tempDir, ".mcp.json");
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.servers.dosu).toBeUndefined();
+    expect(cfg.mcpServers.dosu).toBeUndefined();
   });
 
   it("install preserves existing entries", async () => {
@@ -665,16 +735,20 @@ describe("MCPorterProvider", () => {
     expect(cfg.mcpServers.dosu).toBeDefined();
   });
 
-  it("local install writes to cwd/config/mcporter.json", async () => {
+  it("project install writes a secretless entry under the explicit project root", async () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "config", "mcporter.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
+    expect(provider.projectConfigPath(tempDir)).toBe(configPath);
+    expect(provider.isProjectConfigured(tempDir)).toBe(true);
   });
 
   it("OSS mode install writes base MCP URL for MCPorter", async () => {
@@ -714,8 +788,8 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "config", "mcporter.json");
     const cfg = loadJSONConfig(configPath);
@@ -999,16 +1073,18 @@ describe("CursorProvider", () => {
     expect(cfg.mcpServers.dosu.type).toBeUndefined();
   });
 
-  it("local install writes to cwd/.cursor/mcp.json", async () => {
+  it("project install writes a secretless entry to the explicit project root", async () => {
     const { CursorProvider } = await import("./cursor");
     const provider = CursorProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".cursor", "mcp.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.mcpServers.dosu).toBeDefined();
+    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
   it("remove deletes dosu entry", async () => {
@@ -1058,16 +1134,18 @@ describe("OpenCodeProvider", () => {
     expect(cfg.mcp.dosu.url).toContain("dep-123");
   });
 
-  it("local install writes to cwd/opencode.json", async () => {
+  it("project install writes OpenCode's local command shape without a secret", async () => {
     const { OpenCodeProvider } = await import("./opencode");
     const provider = OpenCodeProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, "opencode.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.mcp.dosu).toBeDefined();
+    expect(cfg.mcp.dosu).toMatchObject({ type: "local", enabled: true });
+    expect(cfg.mcp.dosu.command.join(" ")).toContain("mcp proxy --deployment dep-123");
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
   it("remove deletes dosu entry", async () => {
@@ -1230,16 +1308,19 @@ describe("ZedProvider", () => {
     expect(cfg.context_servers.dosu.url).toContain("dep-123");
   });
 
-  it("local install writes to cwd/.zed/settings.json", async () => {
+  it("project install writes Zed's command shape without a secret", async () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".zed", "settings.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.context_servers.dosu).toBeDefined();
+    expect(cfg.context_servers.dosu.command).toBe("npx");
+    expect(cfg.context_servers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
+    expect(cfg.context_servers.dosu.env).toEqual({});
+    expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
 
   it("remove deletes dosu entry globally", async () => {
@@ -1258,11 +1339,79 @@ describe("ZedProvider", () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), false);
-    provider.remove(false);
+    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.remove(false, { projectRoot: tempDir });
 
     const configPath = join(tempDir, ".zed", "settings.json");
     const cfg = loadJSONConfig(configPath);
     expect(cfg.context_servers.dosu).toBeUndefined();
+  });
+});
+
+describe("project-scoped provider matrix", () => {
+  let tempDir: string;
+  let originalHome: string | undefined;
+  let originalCodexHome: string | undefined;
+  let originalXdgConfigHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-project-provider-matrix-"));
+    originalHome = process.env.HOME;
+    originalCodexHome = process.env.CODEX_HOME;
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.HOME = join(tempDir, "home");
+    process.env.CODEX_HOME = join(tempDir, "codex-home");
+    process.env.XDG_CONFIG_HOME = join(tempDir, "xdg-home");
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
+    if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes every supported project provider under the explicit root without the API key", () => {
+    const providers = allSetupProviders();
+    const localProviders = providers.filter((provider) => provider.supportsLocal());
+    expect(localProviders.map((provider) => provider.id())).toEqual([
+      "claude",
+      "cursor",
+      "vscode",
+      "gemini",
+      "codex",
+      "zed",
+      "copilot",
+      "opencode",
+      "mcporter",
+      "factory",
+    ]);
+
+    for (const provider of localProviders) {
+      const projectRoot = join(tempDir, "projects", provider.id());
+      provider.install(makeCfg(), false, { projectRoot });
+
+      const configPath = provider.projectConfigPath(projectRoot);
+      expect(configPath, provider.id()).not.toBeNull();
+      expect(configPath?.startsWith(`${projectRoot}/`), provider.id()).toBe(true);
+      expect(provider.isProjectConfigured(projectRoot), provider.id()).toBe(true);
+      expect(readFileSync(configPath as string, "utf-8"), provider.id()).not.toContain("key-abc");
+
+      provider.remove(false, { projectRoot });
+      expect(provider.isProjectConfigured(projectRoot), provider.id()).toBe(false);
+    }
+  });
+
+  it("keeps global-only providers global-only", () => {
+    const projectRoot = join(tempDir, "project");
+    for (const provider of allSetupProviders().filter((candidate) => !candidate.supportsLocal())) {
+      expect(provider.projectConfigPath(projectRoot), provider.id()).toBeNull();
+      expect(provider.isProjectConfigured(projectRoot), provider.id()).toBe(false);
+      expect(() => provider.install(makeCfg(), false, { projectRoot }), provider.id()).toThrow(
+        /does not support local installation/,
+      );
+    }
   });
 });

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -56,14 +56,14 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: false,
+      configurationKind: "unsupported",
       priorityValue: 1,
       paths: [],
       globalPath,
       topKey: "mcpServers",
     });
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const cfg = loadJSONConfig(globalPath);
     expect(cfg.mcpServers).toBeDefined();
@@ -79,14 +79,14 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: false,
+      configurationKind: "unsupported",
       priorityValue: 1,
       paths: [],
       globalPath,
       topKey: "mcpServers",
     });
 
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), { scope: "global" });
 
     const cfg = loadJSONConfig(globalPath);
     expect(cfg.mcpServers.dosu).toBeDefined();
@@ -101,16 +101,16 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: false,
+      configurationKind: "unsupported",
       priorityValue: 1,
       paths: [],
       globalPath: join(tempDir, "nope.json"),
       topKey: "mcpServers",
     });
 
-    expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
-      "deployment ID is required",
-    );
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), { scope: "global" }),
+    ).toThrow("deployment ID is required");
   });
 
   it("local install throws when localConfigPath is not provided", async () => {
@@ -118,14 +118,16 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: false,
+      configurationKind: "unsupported",
       priorityValue: 1,
       paths: [],
       globalPath: join(tempDir, "g.json"),
       topKey: "mcpServers",
     });
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), { scope: "project" })).toThrow(
+      "does not support local installation",
+    );
   });
 
   it("project install requires an explicit project root", async () => {
@@ -133,7 +135,7 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: true,
+      configurationKind: "project",
       priorityValue: 1,
       paths: [],
       globalPath: join(tempDir, "g.json"),
@@ -141,8 +143,10 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: (projectRoot) => join(projectRoot, "local", "mcp.json"),
     });
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("explicit project root");
-    expect(() => provider.remove(false)).toThrow("explicit project root");
+    expect(() => provider.install(makeCfg(), { scope: "project" })).toThrow(
+      "explicit project root",
+    );
+    expect(() => provider.remove({ scope: "project" })).toThrow("explicit project root");
   });
 
   it("project install writes a secretless proxy entry to the explicit project root", async () => {
@@ -151,7 +155,7 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: true,
+      configurationKind: "project",
       priorityValue: 1,
       paths: [],
       globalPath: join(tempDir, "g.json"),
@@ -159,12 +163,12 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: () => localPath,
     });
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
 
     const cfg = loadJSONConfig(localPath);
     expect(cfg.mcpServers.dosu).toMatchObject({
       type: "stdio",
-      command: "npx",
+      command: "dosu",
     });
     expect(cfg.mcpServers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
     expect(JSON.stringify(cfg)).not.toContain("key-abc");
@@ -185,14 +189,14 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: false,
+      configurationKind: "unsupported",
       priorityValue: 1,
       paths: [],
       globalPath,
       topKey: "mcpServers",
     });
 
-    provider.remove(true);
+    provider.remove({ scope: "global" });
 
     const cfg = loadJSONConfig(globalPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
@@ -204,14 +208,14 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: false,
+      configurationKind: "unsupported",
       priorityValue: 1,
       paths: [],
       globalPath: join(tempDir, "g.json"),
       topKey: "mcpServers",
     });
 
-    expect(() => provider.remove(false)).toThrow("does not support local removal");
+    expect(() => provider.remove({ scope: "project" })).toThrow("does not support local removal");
   });
 
   it("local remove deletes dosu entry when localConfigPath is provided", async () => {
@@ -220,7 +224,7 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: true,
+      configurationKind: "project",
       priorityValue: 1,
       paths: [],
       globalPath: join(tempDir, "g.json"),
@@ -228,8 +232,8 @@ describe("createJSONProvider (base)", () => {
       localConfigPath: () => localPath,
     });
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
-    provider.remove(false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+    provider.remove({ scope: "project", projectRoot: tempDir });
 
     const cfg = loadJSONConfig(localPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
@@ -244,7 +248,7 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
-      local: true,
+      configurationKind: "project",
       priorityValue: 1,
       paths: [],
       globalPath: join(tempDir, "g.json"),
@@ -253,10 +257,12 @@ describe("createJSONProvider (base)", () => {
     });
 
     expect(provider.isProjectConfigured(tempDir)).toBe(false);
-    expect(() => provider.install(makeCfg(), false, { projectRoot: tempDir })).toThrow(
+    expect(() => provider.install(makeCfg(), { scope: "project", projectRoot: tempDir })).toThrow(
       "refusing to overwrite",
     );
-    expect(() => provider.remove(false, { projectRoot: tempDir })).toThrow("refusing to remove");
+    expect(() => provider.remove({ scope: "project", projectRoot: tempDir })).toThrow(
+      "refusing to remove",
+    );
     expect(loadJSONConfig(localPath).mcpServers.dosu).toEqual(foreign);
   });
 
@@ -267,7 +273,7 @@ describe("createJSONProvider (base)", () => {
     const provider = createJSONProvider({
       providerName: "Custom",
       providerID: "custom",
-      local: false,
+      configurationKind: "unsupported",
       priorityValue: 1,
       paths: [],
       globalPath,
@@ -277,7 +283,7 @@ describe("createJSONProvider (base)", () => {
       }),
     });
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const cfg = loadJSONConfig(globalPath);
     expect(cfg.servers.dosu).toEqual({ myUrl: "custom-dep-123" });
@@ -324,7 +330,7 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const configPath = join(tempDir, "codex-home", "config.toml");
     expect(existsSync(configPath)).toBe(true);
@@ -354,13 +360,13 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, ".codex", "config.toml");
     expect(existsSync(configPath)).toBe(true);
     const content = readFileSync(configPath, "utf-8");
     expect(content).toContain("[mcp_servers.dosu]");
-    expect(content).toContain('command = "npx"');
+    expect(content).toContain('command = "dosu"');
     expect(content).toContain('"mcp", "proxy"');
     expect(content).toContain("dep-123");
     expect(content).not.toContain("key-abc");
@@ -372,7 +378,7 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), { scope: "global" });
 
     const configPath = join(tempDir, "codex-home", "config.toml");
     const content = readFileSync(configPath, "utf-8");
@@ -384,9 +390,9 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
-      "deployment ID is required",
-    );
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), { scope: "global" }),
+    ).toThrow("deployment ID is required");
   });
 
   it("install throws a clear error when npx is not on PATH", async () => {
@@ -395,7 +401,7 @@ describe("CodexProvider", () => {
 
     process.env.PATH = join(tempDir, "no-bin");
 
-    expect(() => provider.install(makeCfg(), true)).toThrow(/npx/);
+    expect(() => provider.install(makeCfg(), { scope: "global" })).toThrow(/npx/);
   });
 
   it("install replaces existing dosu section", async () => {
@@ -403,10 +409,14 @@ describe("CodexProvider", () => {
     const provider = CodexProvider();
 
     // First install
-    provider.install(makeCfg({ deployment_id: "old-dep", api_key: "old-key" }), true);
+    provider.install(makeCfg({ deployment_id: "old-dep", api_key: "old-key" }), {
+      scope: "global",
+    });
 
     // Second install should replace
-    provider.install(makeCfg({ deployment_id: "new-dep", api_key: "new-key" }), true);
+    provider.install(makeCfg({ deployment_id: "new-dep", api_key: "new-key" }), {
+      scope: "global",
+    });
 
     const configPath = join(tempDir, "codex-home", "config.toml");
     const content = readFileSync(configPath, "utf-8");
@@ -428,7 +438,7 @@ describe("CodexProvider", () => {
       '[mcp_servers.dosu]\ntype = "http"\nurl = "https://old.example"\n\n[mcp_servers.dosu.http_headers]\nX-Dosu-API-Key = "old-key"\n',
     );
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const content = readFileSync(configPath, "utf-8");
     expect(content).not.toContain('type = "http"');
@@ -446,7 +456,7 @@ describe("CodexProvider", () => {
     mkdirSync(join(tempDir, "codex-home"), { recursive: true });
     writeFileSync(configPath, '[other_section]\nkey = "value"\n');
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const content = readFileSync(configPath, "utf-8");
     expect(content).toContain("[other_section]");
@@ -462,7 +472,7 @@ describe("CodexProvider", () => {
     mkdirSync(join(tempDir, "codex-home"), { recursive: true });
     writeFileSync(configPath, '[other_section]\nkey = "value"\n', { mode: 0o644 });
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     expect(readFileSync(configPath, "utf-8")).toContain("[mcp_servers.dosu]");
     expect(statSync(configPath).mode & 0o777).toBe(0o600);
@@ -472,8 +482,8 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const configPath = join(tempDir, "codex-home", "config.toml");
     const content = readFileSync(configPath, "utf-8");
@@ -484,8 +494,8 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
-    provider.remove(false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+    provider.remove({ scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, ".codex", "config.toml");
     const content = readFileSync(configPath, "utf-8");
@@ -501,10 +511,107 @@ describe("CodexProvider", () => {
     writeFileSync(configPath, foreign);
 
     expect(provider.isProjectConfigured(tempDir)).toBe(false);
-    expect(() => provider.install(makeCfg(), false, { projectRoot: tempDir })).toThrow(
+    expect(() => provider.install(makeCfg(), { scope: "project", projectRoot: tempDir })).toThrow(
       "refusing to overwrite",
     );
-    expect(() => provider.remove(false, { projectRoot: tempDir })).toThrow("refusing to remove");
+    expect(() => provider.remove({ scope: "project", projectRoot: tempDir })).toThrow(
+      "refusing to remove",
+    );
+    expect(readFileSync(configPath, "utf-8")).toBe(foreign);
+  });
+
+  it("recognizes and replaces an owned multiline project section without rewriting neighbors", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+    const configPath = join(tempDir, ".codex", "config.toml");
+    mkdirSync(dirname(configPath), { recursive: true });
+    const existing = [
+      "# keep this heading",
+      "[mcp_servers.dosu]",
+      'command = "dosu"',
+      "args = [",
+      '  "mcp",',
+      '  "proxy",',
+      '  "--deployment",',
+      '  "old-deployment",',
+      "]",
+      "",
+      "[features]",
+      "# keep this comment",
+      "apps = true",
+      "",
+    ].join("\n");
+    writeFileSync(configPath, existing);
+
+    expect(provider.isProjectConfigured(tempDir)).toBe(true);
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).toContain("# keep this heading");
+    expect(content).toContain("# keep this comment");
+    expect(content).toContain("[features]");
+    expect(content).toContain("dep-123");
+    expect(content).not.toContain("old-deployment");
+  });
+
+  it("is byte-idempotent when the project target is unchanged", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+    const configPath = join(tempDir, ".codex", "config.toml");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, "[features]\n# keep\napps = true\n");
+
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+    const first = readFileSync(configPath, "utf-8");
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+
+    expect(readFileSync(configPath, "utf-8")).toBe(first);
+  });
+
+  it("preserves CRLF throughout a project config", async () => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+    const configPath = join(tempDir, ".codex", "config.toml");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, "[features]\r\n# keep\r\napps = true\r\n");
+
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+    const first = readFileSync(configPath, "utf-8");
+    expect(first.replaceAll("\r\n", "")).not.toContain("\n");
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+    expect(readFileSync(configPath, "utf-8")).toBe(first);
+  });
+
+  it.each([
+    "[features\napps = true\n",
+    '[mcp_servers.dosu]\ncommand = "dosu"\nargs = ["mcp"]\n\n[mcp_servers.dosu]\ncommand = "dosu"\n',
+  ])("refuses malformed or duplicate TOML without changing bytes", async (invalid) => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+    const configPath = join(tempDir, ".codex", "config.toml");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, invalid);
+
+    expect(() => provider.install(makeCfg(), { scope: "project", projectRoot: tempDir })).toThrow(
+      /invalid|duplicate/i,
+    );
+    expect(readFileSync(configPath, "utf-8")).toBe(invalid);
+  });
+
+  it.each([
+    '[mcp_servers]\ndosu = { command = "other", args = [] }\n',
+    'mcp_servers.dosu.command = "other"\nmcp_servers.dosu.args = []\n',
+    'mcp_servers = { dosu = { command = "other", args = [] } }\n',
+  ])("refuses alternate TOML declarations of a foreign dosu entry", async (foreign) => {
+    const { CodexProvider } = await import("./codex");
+    const provider = CodexProvider();
+    const configPath = join(tempDir, ".codex", "config.toml");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, foreign);
+
+    expect(() => provider.install(makeCfg(), { scope: "project", projectRoot: tempDir })).toThrow(
+      /non-Dosu|alternate/i,
+    );
     expect(readFileSync(configPath, "utf-8")).toBe(foreign);
   });
 
@@ -513,7 +620,7 @@ describe("CodexProvider", () => {
     const provider = CodexProvider();
 
     const configPath = join(tempDir, "codex-home", "config.toml");
-    expect(() => provider.remove(true)).not.toThrow();
+    expect(() => provider.remove({ scope: "global" })).not.toThrow();
     expect(existsSync(configPath)).toBe(false);
   });
 
@@ -521,7 +628,7 @@ describe("CodexProvider", () => {
     const { CodexProvider } = await import("./codex");
     const provider = CodexProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
     expect(provider.isConfigured()).toBe(true);
   });
 
@@ -571,7 +678,7 @@ describe("CopilotProvider", () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const configPath = join(tempDir, "xdg-config", "mcp-config.json");
     expect(existsSync(configPath)).toBe(true);
@@ -588,12 +695,12 @@ describe("CopilotProvider", () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, ".mcp.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.mcpServers.dosu).toMatchObject({ type: "stdio", command: "npx" });
+    expect(cfg.mcpServers.dosu).toMatchObject({ type: "stdio", command: "dosu" });
     expect(cfg.mcpServers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
     expect(JSON.stringify(cfg)).not.toContain("key-abc");
     expect(provider.projectConfigPath(tempDir)).toBe(configPath);
@@ -604,8 +711,9 @@ describe("CopilotProvider", () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), false, {
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), { scope: "global" });
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), {
+      scope: "project",
       projectRoot: tempDir,
     });
 
@@ -622,17 +730,17 @@ describe("CopilotProvider", () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
-      "deployment ID is required",
-    );
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), { scope: "global" }),
+    ).toThrow("deployment ID is required");
   });
 
   it("global remove deletes dosu entry from mcpServers", async () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const configPath = join(tempDir, "xdg-config", "mcp-config.json");
     const cfg = loadJSONConfig(configPath);
@@ -643,8 +751,8 @@ describe("CopilotProvider", () => {
     const { CopilotProvider } = await import("./copilot");
     const provider = CopilotProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
-    provider.remove(false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+    provider.remove({ scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, ".mcp.json");
     const cfg = loadJSONConfig(configPath);
@@ -659,7 +767,7 @@ describe("CopilotProvider", () => {
     mkdirSync(join(tempDir, "xdg-config"), { recursive: true });
     writeFileSync(configPath, JSON.stringify({ mcpServers: { other: { url: "http://other" } } }));
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const cfg = loadJSONConfig(configPath);
     expect(cfg.mcpServers.other).toEqual({ url: "http://other" });
@@ -694,7 +802,7 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const configPath = join(tempDir, ".mcporter", "mcporter.json");
     expect(existsSync(configPath)).toBe(true);
@@ -713,7 +821,7 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const cfg = loadJSONConfig(jsoncPath);
     expect(cfg.mcpServers.dosu).toBeDefined();
@@ -729,7 +837,7 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const cfg = loadJSONConfig(jsonPath);
     expect(cfg.mcpServers.dosu).toBeDefined();
@@ -739,12 +847,12 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, "config", "mcporter.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.command).toBe("dosu");
     expect(cfg.mcpServers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
     expect(JSON.stringify(cfg)).not.toContain("key-abc");
     expect(provider.projectConfigPath(tempDir)).toBe(configPath);
@@ -755,7 +863,7 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), { scope: "global" });
 
     const configPath = join(tempDir, ".mcporter", "mcporter.json");
     const cfg = loadJSONConfig(configPath);
@@ -767,17 +875,17 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
-      "deployment ID is required",
-    );
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), { scope: "global" }),
+    ).toThrow("deployment ID is required");
   });
 
   it("global remove deletes dosu entry", async () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const configPath = join(tempDir, ".mcporter", "mcporter.json");
     const cfg = loadJSONConfig(configPath);
@@ -788,8 +896,8 @@ describe("MCPorterProvider", () => {
     const { MCPorterProvider } = await import("./mcporter");
     const provider = MCPorterProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
-    provider.remove(false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+    provider.remove({ scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, "config", "mcporter.json");
     const cfg = loadJSONConfig(configPath);
@@ -808,7 +916,7 @@ describe("ManualProvider", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    provider.install(makeCfg(), false);
+    provider.install(makeCfg(), { scope: "global" });
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("dep-123");
@@ -825,7 +933,7 @@ describe("ManualProvider", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    provider.install(makeCfg(), false, { showSecret: true });
+    provider.install(makeCfg(), { scope: "global", showSecret: true });
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("key-abc");
@@ -839,7 +947,7 @@ describe("ManualProvider", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    provider.install(makeCfg({ api_key: "shortkey" }), false);
+    provider.install(makeCfg({ api_key: "shortkey" }), { scope: "global" });
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("X-Dosu-API-Key: [hidden]");
@@ -854,7 +962,7 @@ describe("ManualProvider", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    provider.install(makeCfg({ api_key: "abcdefghijkl" }), false);
+    provider.install(makeCfg({ api_key: "abcdefghijkl" }), { scope: "global" });
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("X-Dosu-API-Key: abc...jkl");
@@ -870,7 +978,7 @@ describe("ManualProvider", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), false);
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), { scope: "global" });
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("/v1/mcp");
@@ -885,7 +993,7 @@ describe("ManualProvider", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    provider.remove(false);
+    provider.remove({ scope: "global" });
 
     const allOutput = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(allOutput).toContain("remove");
@@ -934,7 +1042,7 @@ describe("ClaudeDesktopProvider", () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const cfg = loadJSONConfig(provider.globalConfigPath());
     const dosu = cfg.mcpServers.dosu;
@@ -959,7 +1067,7 @@ describe("ClaudeDesktopProvider", () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), { scope: "global" });
 
     const cfg = loadJSONConfig(provider.globalConfigPath());
     const args = cfg.mcpServers.dosu.args.join(" ");
@@ -971,9 +1079,9 @@ describe("ClaudeDesktopProvider", () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
-      "deployment ID is required",
-    );
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), { scope: "global" }),
+    ).toThrow("deployment ID is required");
   });
 
   it("install throws a clear error when npx is not on PATH", async () => {
@@ -982,22 +1090,24 @@ describe("ClaudeDesktopProvider", () => {
 
     process.env.PATH = join(tempDir, "no-bin");
 
-    expect(() => provider.install(makeCfg(), true)).toThrow(/npx/);
+    expect(() => provider.install(makeCfg(), { scope: "global" })).toThrow(/npx/);
   });
 
   it("local install throws because Claude Desktop is global-only", async () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), { scope: "project" })).toThrow(
+      "does not support project installation",
+    );
   });
 
   it("remove deletes the dosu entry", async () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const cfg = loadJSONConfig(provider.globalConfigPath());
     expect(cfg.mcpServers.dosu).toBeUndefined();
@@ -1007,7 +1117,7 @@ describe("ClaudeDesktopProvider", () => {
     const { ClaudeDesktopProvider } = await import("./claude-desktop");
     const provider = ClaudeDesktopProvider();
 
-    expect(() => provider.remove(false)).toThrow("does not support local removal");
+    expect(() => provider.remove({ scope: "project" })).toThrow("does not support project removal");
   });
 
   it("install skips empty PATH segments when resolving npx", async () => {
@@ -1015,7 +1125,7 @@ describe("ClaudeDesktopProvider", () => {
     const provider = ClaudeDesktopProvider();
 
     process.env.PATH = `:${dirname(npxPath)}`;
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const cfg = loadJSONConfig(provider.globalConfigPath());
     expect(cfg.mcpServers.dosu.command).toBe(npxPath);
@@ -1026,7 +1136,7 @@ describe("ClaudeDesktopProvider", () => {
     const provider = ClaudeDesktopProvider();
 
     expect(provider.isConfigured()).toBe(false);
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
     expect(provider.isConfigured()).toBe(true);
   });
 });
@@ -1061,7 +1171,7 @@ describe("CursorProvider", () => {
     const { CursorProvider } = await import("./cursor");
     const provider = CursorProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const configPath = join(tempDir, ".cursor", "mcp.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1077,12 +1187,12 @@ describe("CursorProvider", () => {
     const { CursorProvider } = await import("./cursor");
     const provider = CursorProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, ".cursor", "mcp.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.mcpServers.dosu.command).toBe("npx");
+    expect(cfg.mcpServers.dosu.command).toBe("dosu");
     expect(cfg.mcpServers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
     expect(JSON.stringify(cfg)).not.toContain("key-abc");
   });
@@ -1091,8 +1201,8 @@ describe("CursorProvider", () => {
     const { CursorProvider } = await import("./cursor");
     const provider = CursorProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const configPath = join(tempDir, ".cursor", "mcp.json");
     const cfg = loadJSONConfig(configPath);
@@ -1123,7 +1233,7 @@ describe("OpenCodeProvider", () => {
     const { OpenCodeProvider } = await import("./opencode");
     const provider = OpenCodeProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const configPath = join(tempDir, ".config", "opencode", "opencode.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1138,7 +1248,7 @@ describe("OpenCodeProvider", () => {
     const { OpenCodeProvider } = await import("./opencode");
     const provider = OpenCodeProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, "opencode.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1152,8 +1262,8 @@ describe("OpenCodeProvider", () => {
     const { OpenCodeProvider } = await import("./opencode");
     const provider = OpenCodeProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const configPath = join(tempDir, ".config", "opencode", "opencode.json");
     const cfg = loadJSONConfig(configPath);
@@ -1184,7 +1294,7 @@ describe("ClineCliProvider", () => {
     const { ClineCliProvider } = await import("./cline-cli");
     const provider = ClineCliProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const configPath = join(tempDir, "cline-home", "data", "settings", "cline_mcp_settings.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1199,17 +1309,17 @@ describe("ClineCliProvider", () => {
     const { ClineCliProvider } = await import("./cline-cli");
     const provider = ClineCliProvider();
 
-    expect(() => provider.install(makeCfg({ deployment_id: undefined }), true)).toThrow(
-      "deployment ID is required",
-    );
+    expect(() =>
+      provider.install(makeCfg({ deployment_id: undefined }), { scope: "global" }),
+    ).toThrow("deployment ID is required");
   });
 
   it("remove deletes dosu entry", async () => {
     const { ClineCliProvider } = await import("./cline-cli");
     const provider = ClineCliProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const configPath = join(tempDir, "cline-home", "data", "settings", "cline_mcp_settings.json");
     const cfg = loadJSONConfig(configPath);
@@ -1220,7 +1330,9 @@ describe("ClineCliProvider", () => {
     const { ClineCliProvider } = await import("./cline-cli");
     const provider = ClineCliProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), { scope: "project" })).toThrow(
+      "does not support local installation",
+    );
   });
 });
 
@@ -1243,7 +1355,7 @@ describe("AntigravityProvider", () => {
     const { AntigravityProvider } = await import("./antigravity");
     const provider = AntigravityProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const configPath = join(tempDir, ".gemini", "antigravity", "mcp_config.json");
     expect(existsSync(configPath)).toBe(true);
@@ -1258,15 +1370,17 @@ describe("AntigravityProvider", () => {
     const { AntigravityProvider } = await import("./antigravity");
     const provider = AntigravityProvider();
 
-    expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
+    expect(() => provider.install(makeCfg(), { scope: "project" })).toThrow(
+      "does not support local installation",
+    );
   });
 
   it("remove deletes dosu entry", async () => {
     const { AntigravityProvider } = await import("./antigravity");
     const provider = AntigravityProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const configPath = join(tempDir, ".gemini", "antigravity", "mcp_config.json");
     const cfg = loadJSONConfig(configPath);
@@ -1297,7 +1411,7 @@ describe("ZedProvider", () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), true);
+    provider.install(makeCfg(), { scope: "global" });
 
     const globalCfgPath = provider.globalConfigPath();
     expect(existsSync(globalCfgPath)).toBe(true);
@@ -1312,12 +1426,12 @@ describe("ZedProvider", () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, ".zed", "settings.json");
     expect(existsSync(configPath)).toBe(true);
     const cfg = loadJSONConfig(configPath);
-    expect(cfg.context_servers.dosu.command).toBe("npx");
+    expect(cfg.context_servers.dosu.command).toBe("dosu");
     expect(cfg.context_servers.dosu.args.join(" ")).toContain("mcp proxy --deployment dep-123");
     expect(cfg.context_servers.dosu.env).toEqual({});
     expect(JSON.stringify(cfg)).not.toContain("key-abc");
@@ -1327,8 +1441,8 @@ describe("ZedProvider", () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), true);
-    provider.remove(true);
+    provider.install(makeCfg(), { scope: "global" });
+    provider.remove({ scope: "global" });
 
     const globalCfgPath = provider.globalConfigPath();
     const cfg = loadJSONConfig(globalCfgPath);
@@ -1339,8 +1453,8 @@ describe("ZedProvider", () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();
 
-    provider.install(makeCfg(), false, { projectRoot: tempDir });
-    provider.remove(false, { projectRoot: tempDir });
+    provider.install(makeCfg(), { scope: "project", projectRoot: tempDir });
+    provider.remove({ scope: "project", projectRoot: tempDir });
 
     const configPath = join(tempDir, ".zed", "settings.json");
     const cfg = loadJSONConfig(configPath);
@@ -1375,7 +1489,9 @@ describe("project-scoped provider matrix", () => {
 
   it("writes every supported project provider under the explicit root without the API key", () => {
     const providers = allSetupProviders();
-    const localProviders = providers.filter((provider) => provider.supportsLocal());
+    const localProviders = providers.filter(
+      (provider) => provider.configurationKind() === "project",
+    );
     expect(localProviders.map((provider) => provider.id())).toEqual([
       "claude",
       "cursor",
@@ -1391,7 +1507,7 @@ describe("project-scoped provider matrix", () => {
 
     for (const provider of localProviders) {
       const projectRoot = join(tempDir, "projects", provider.id());
-      provider.install(makeCfg(), false, { projectRoot });
+      provider.install(makeCfg(), { scope: "project", projectRoot });
 
       const configPath = provider.projectConfigPath(projectRoot);
       expect(configPath, provider.id()).not.toBeNull();
@@ -1399,19 +1515,47 @@ describe("project-scoped provider matrix", () => {
       expect(provider.isProjectConfigured(projectRoot), provider.id()).toBe(true);
       expect(readFileSync(configPath as string, "utf-8"), provider.id()).not.toContain("key-abc");
 
-      provider.remove(false, { projectRoot });
+      provider.remove({ scope: "project", projectRoot });
       expect(provider.isProjectConfigured(projectRoot), provider.id()).toBe(false);
+    }
+  });
+
+  it("prevents project providers from creating or deleting global MCP entries", () => {
+    for (const provider of allSetupProviders().filter(
+      (candidate) => candidate.configurationKind() === "project",
+    )) {
+      expect(() => provider.install(makeCfg(), { scope: "global" }), provider.id()).toThrow(
+        /project-scoped/,
+      );
+      expect(() => provider.remove({ scope: "global" }), provider.id()).toThrow(/project-scoped/);
+    }
+  });
+
+  it("prevents unsupported providers from mutating either scope", () => {
+    const projectRoot = join(tempDir, "project");
+    for (const provider of allSetupProviders().filter(
+      (candidate) => candidate.configurationKind() === "unsupported",
+    )) {
+      expect(() => provider.install(makeCfg(), { scope: "global" }), provider.id()).toThrow(
+        /does not support Dosu MCP configuration/,
+      );
+      expect(() => provider.remove({ scope: "project", projectRoot }), provider.id()).toThrow(
+        /does not support Dosu MCP configuration/,
+      );
     }
   });
 
   it("keeps global-only providers global-only", () => {
     const projectRoot = join(tempDir, "project");
-    for (const provider of allSetupProviders().filter((candidate) => !candidate.supportsLocal())) {
+    for (const provider of allSetupProviders().filter(
+      (candidate) => candidate.configurationKind() !== "project",
+    )) {
       expect(provider.projectConfigPath(projectRoot), provider.id()).toBeNull();
       expect(provider.isProjectConfigured(projectRoot), provider.id()).toBe(false);
-      expect(() => provider.install(makeCfg(), false, { projectRoot }), provider.id()).toThrow(
-        /does not support local installation/,
-      );
+      expect(
+        () => provider.install(makeCfg(), { scope: "project", projectRoot }),
+        provider.id(),
+      ).toThrow(/does not support|cannot perform/);
     }
   });
 });

--- a/src/mcp/providers/vscode.ts
+++ b/src/mcp/providers/vscode.ts
@@ -6,7 +6,7 @@ export const VSCodeProvider = () =>
   createJSONProvider({
     providerName: "VS Code",
     providerID: "vscode",
-    local: true,
+    configurationKind: "project",
     priorityValue: 6,
     paths: [join(appSupportDir(), "Code")],
     globalPath: join(appSupportDir(), "Code", "User", "mcp.json"),

--- a/src/mcp/providers/windsurf.ts
+++ b/src/mcp/providers/windsurf.ts
@@ -6,7 +6,7 @@ export const WindsurfProvider = () =>
   createJSONProvider({
     providerName: "Windsurf",
     providerID: "windsurf",
-    local: false,
+    configurationKind: "unsupported",
     priorityValue: 9,
     paths: [join(homedir(), ".codeium", "windsurf")],
     globalPath: join(homedir(), ".codeium", "windsurf", "mcp_config.json"),

--- a/src/mcp/providers/zed.ts
+++ b/src/mcp/providers/zed.ts
@@ -29,5 +29,10 @@ export const ZedProvider = () =>
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
     }),
+    buildProjectServer: (command) => ({
+      command: command.command,
+      args: command.args,
+      env: {},
+    }),
     localConfigPath: (cwd) => join(cwd, ".zed", "settings.json"),
   });

--- a/src/mcp/providers/zed.ts
+++ b/src/mcp/providers/zed.ts
@@ -16,7 +16,7 @@ export const ZedProvider = () =>
   createJSONProvider({
     providerName: "Zed",
     providerID: "zed",
-    local: true,
+    configurationKind: "project",
     priorityValue: 10,
     paths: [zedConfigDir()],
     globalPath: join(zedConfigDir(), "settings.json"),

--- a/src/rules/installer.test.ts
+++ b/src/rules/installer.test.ts
@@ -8,6 +8,7 @@ import {
   DOSU_RULE_URLS,
   FALLBACK_DOSU_RULE,
   fetchDosuRule,
+  GLOBAL_DOSU_SKILLS_GUIDANCE,
   installRuleForAgent,
   isRuleAgent,
   removeRuleForAgent,
@@ -51,7 +52,9 @@ describe("rule template", () => {
       .fn<typeof fetch>()
       .mockResolvedValueOnce(new Response("remote rule", { status: 200 }));
 
-    await expect(fetchDosuRule(fetchImpl)).resolves.toBe("remote rule\n");
+    await expect(fetchDosuRule(fetchImpl)).resolves.toBe(
+      `remote rule\n\n${GLOBAL_DOSU_SKILLS_GUIDANCE}\n`,
+    );
     expect(fetchImpl).toHaveBeenCalledWith(DOSU_RULE_URLS[0]);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
@@ -62,7 +65,9 @@ describe("rule template", () => {
       .mockResolvedValueOnce(new Response("", { status: 404 }))
       .mockResolvedValueOnce(new Response("backup rule", { status: 200 }));
 
-    await expect(fetchDosuRule(fetchImpl)).resolves.toBe("backup rule\n");
+    await expect(fetchDosuRule(fetchImpl)).resolves.toBe(
+      `backup rule\n\n${GLOBAL_DOSU_SKILLS_GUIDANCE}\n`,
+    );
     expect(fetchImpl).toHaveBeenNthCalledWith(2, DOSU_RULE_URLS[1]);
   });
 
@@ -136,8 +141,35 @@ describe("standalone rule files", () => {
     const installed = installRuleForAgent("claude", "project rule", root);
 
     expect(installed?.path).toBe(join(root, ".claude", "rules", "dosu.md"));
-    expect(readFileSync(installed?.path ?? "", "utf-8")).toBe("project rule\n");
+    expect(readFileSync(installed?.path ?? "", "utf-8")).toContain("project rule\n");
     expect(existsSync(join(tempDir, ".claude", "rules", "dosu.md"))).toBe(false);
+  });
+
+  it.each([
+    "claude",
+    "cursor",
+  ])("preserves a foreign project rule for %s during install and removal", (agent) => {
+    const root = join(tempDir, "repo");
+    const path = rulePathForAgent(agent, root) ?? "";
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "user-authored rule\n");
+
+    expect(() => installRuleForAgent(agent, "Dosu rule", root)).toThrow(/non-Dosu|refusing/);
+    expect(() => removeRuleForAgent(agent, root)).toThrow(/non-Dosu|refusing/);
+    expect(readFileSync(path, "utf-8")).toBe("user-authored rule\n");
+  });
+
+  it.each([
+    "claude",
+    "cursor",
+  ])("recognizes and removes its own CRLF project rule for %s", (agent) => {
+    const root = join(tempDir, "repo");
+    const installed = installRuleForAgent(agent, "Dosu rule", root);
+    const path = installed?.path ?? "";
+    writeFileSync(path, readFileSync(path, "utf-8").replaceAll("\n", "\r\n"));
+
+    expect(removeRuleForAgent(agent, root)?.action).toBe("removed");
+    expect(existsSync(path)).toBe(false);
   });
 
   it("removes a standalone rule idempotently", () => {
@@ -167,7 +199,7 @@ describe("marker-delimited instruction sections", () => {
     const updated = readFileSync(path ?? "", "utf-8");
     expect(updated).not.toContain("first rule");
     expect(updated).toContain("second rule");
-    expect(updated.match(/<!-- dosu:rules:start v1 -->/g)).toHaveLength(1);
+    expect(updated.match(new RegExp(DOSU_RULE_SECTION_START, "g"))).toHaveLength(1);
     expect(updated.match(/<!-- dosu:rules:end -->/g)).toHaveLength(1);
 
     expect(installRuleForAgent("codex", "second rule")?.action).toBe("unchanged");
@@ -180,7 +212,7 @@ describe("marker-delimited instruction sections", () => {
     expect(gemini?.path).toBe(antigravity?.path);
     expect(antigravity?.action).toBe("unchanged");
     const content = readFileSync(gemini?.path ?? "", "utf-8");
-    expect(content.match(/<!-- dosu:rules:start v1 -->/g)).toHaveLength(1);
+    expect(content.match(new RegExp(DOSU_RULE_SECTION_START, "g"))).toHaveLength(1);
   });
 
   it("removes only the marked section and preserves surrounding content", () => {

--- a/src/rules/installer.test.ts
+++ b/src/rules/installer.test.ts
@@ -94,6 +94,17 @@ describe("agent registry", () => {
     expect(rulePathForAgent("antigravity")).toBe(join(tempDir, ".gemini", "GEMINI.md"));
     expect(rulePathForAgent("windsurf")).toBeNull();
   });
+
+  it("keeps project rules inside the repository", () => {
+    const root = join(tempDir, "repo");
+
+    expect(rulePathForAgent("claude", root)).toBe(join(root, ".claude", "rules", "dosu.md"));
+    expect(rulePathForAgent("cursor", root)).toBe(join(root, ".cursor", "rules", "dosu.mdc"));
+    expect(rulePathForAgent("gemini", root)).toBe(join(root, "GEMINI.md"));
+    expect(rulePathForAgent("codex", root)).toBeNull();
+    expect(rulePathForAgent("opencode", root)).toBeNull();
+    expect(rulePathForAgent("antigravity", root)).toBeNull();
+  });
 });
 
 describe("standalone rule files", () => {
@@ -118,6 +129,15 @@ describe("standalone rule files", () => {
       "---\nalwaysApply: true\n---\n\nshared rule\n",
     );
     expect(readFileSync(claude?.path ?? "", "utf-8")).toBe("shared rule\n");
+  });
+
+  it("writes project rules without touching global rule paths", () => {
+    const root = join(tempDir, "repo");
+    const installed = installRuleForAgent("claude", "project rule", root);
+
+    expect(installed?.path).toBe(join(root, ".claude", "rules", "dosu.md"));
+    expect(readFileSync(installed?.path ?? "", "utf-8")).toBe("project rule\n");
+    expect(existsSync(join(tempDir, ".claude", "rules", "dosu.md"))).toBe(false);
   });
 
   it("removes a standalone rule idempotently", () => {

--- a/src/rules/installer.ts
+++ b/src/rules/installer.ts
@@ -36,17 +36,21 @@ export interface RuleResult {
   action: RuleAction;
 }
 
-const DOSU_RULE_SECTION_VERSION = 1;
+const DOSU_RULE_SECTION_VERSION = 2;
 export const DOSU_RULE_SECTION_START = `<!-- dosu:rules:start v${DOSU_RULE_SECTION_VERSION} -->`;
 export const DOSU_RULE_SECTION_END = "<!-- dosu:rules:end -->";
 
 const DOSU_RULE_SECTION_START_RE = /<!-- dosu:rules:start(?: v\d+)? -->/;
 const CURSOR_FRONTMATTER = "---\nalwaysApply: true\n---\n\n";
+const PROJECT_RULE_FILE_MARKER = "<!-- dosu:project-rule v1 -->\n";
 
 export const DOSU_RULE_URLS = [
   "https://raw.githubusercontent.com/dosu-ai/dosu-cli/main/rules/dosu.md",
   "https://raw.githubusercontent.com/dosu-ai/dosu-cli/master/rules/dosu.md",
 ] as const;
+
+export const GLOBAL_DOSU_SKILLS_GUIDANCE =
+  "Use globally installed Dosu skills when their descriptions match the task. A skill does not make an unavailable MCP tool callable.";
 
 export const FALLBACK_DOSU_RULE = `The team you are assisting maintains shared knowledge in Dosu: consult it to build on prior work, and contribute durable knowledge so future teammates and agents do not have to rediscover it. Always use only tools currently listed by the server.
 
@@ -57,6 +61,8 @@ When \`write_knowledge\` is listed, use it after the task for durable, non-obvio
 Use \`review_knowledge\` only when the user asks to inspect or manage pending knowledge. Preview one item at a time and require explicit confirmation before making changes.
 
 When \`read_knowledge\` or \`write_knowledge\` returned a \`receipt_item_id\` this turn, call \`finalize_session_knowledge\` exactly once at the end of the turn — after completing the task, immediately before your final reply — passing all receipt_item_ids from this turn. Never call it when the current turn produced no receipt_item_id, and never call it more than once per turn.
+
+${GLOBAL_DOSU_SKILLS_GUIDANCE}
 `;
 
 function claudeConfigDir(): string {
@@ -115,6 +121,14 @@ function normalizeRule(content: string): string {
   return `${content.trim()}\n`;
 }
 
+function normalizeCanonicalRule(content: string): string {
+  const normalized = content.trim();
+  const canonical = normalized.includes(GLOBAL_DOSU_SKILLS_GUIDANCE)
+    ? normalized
+    : `${normalized}\n\n${GLOBAL_DOSU_SKILLS_GUIDANCE}`;
+  return `${canonical}\n`;
+}
+
 export async function fetchDosuRule(
   fetchImpl: typeof globalThis.fetch = globalThis.fetch,
 ): Promise<string> {
@@ -123,12 +137,12 @@ export async function fetchDosuRule(
       const response = await fetchImpl(url);
       if (!response.ok) continue;
       const content = await response.text();
-      if (content.trim()) return normalizeRule(content);
+      if (content.trim()) return normalizeCanonicalRule(content);
     } catch {
       // Try the next source, then fall back to the bundled rule.
     }
   }
-  return normalizeRule(FALLBACK_DOSU_RULE);
+  return normalizeCanonicalRule(FALLBACK_DOSU_RULE);
 }
 
 function ensureParent(path: string): void {
@@ -145,6 +159,20 @@ function writeIfChanged(path: string, content: string): RuleAction {
   if (readFileSync(path, "utf-8") === content) return "unchanged";
   writeFileSync(path, content, "utf-8");
   return "updated";
+}
+
+function renderStandaloneRule(
+  normalized: string,
+  cursorFrontmatter: boolean,
+  projectOwned: boolean,
+): string {
+  const marker = projectOwned ? PROJECT_RULE_FILE_MARKER : "";
+  return `${cursorFrontmatter ? CURSOR_FRONTMATTER : ""}${marker}${normalized}`;
+}
+
+function isOwnedProjectRuleFile(content: string, cursorFrontmatter: boolean): boolean {
+  const prefix = `${cursorFrontmatter ? CURSOR_FRONTMATTER : ""}${PROJECT_RULE_FILE_MARKER}`;
+  return content.replaceAll("\r\n", "\n").startsWith(prefix);
 }
 
 function findSection(content: string): { start: number; end: number } | null {
@@ -214,13 +242,23 @@ export function installRuleForAgent(
   if (!path) return null;
   if (projectRoot) assertSafeProjectPath(projectRoot, path);
   const normalized = normalizeRule(content);
-  const action =
-    target.kind === "file"
-      ? writeIfChanged(
-          path,
-          target.cursorFrontmatter ? `${CURSOR_FRONTMATTER}${normalized}` : normalized,
-        )
-      : upsertSection(path, normalized);
+  let action: RuleAction;
+  if (target.kind === "file") {
+    const cursorFrontmatter = Boolean(target.cursorFrontmatter);
+    if (
+      projectRoot &&
+      existsSync(path) &&
+      !isOwnedProjectRuleFile(readFileSync(path, "utf-8"), cursorFrontmatter)
+    ) {
+      throw new Error(`${path} contains a non-Dosu project rule; refusing to overwrite it`);
+    }
+    action = writeIfChanged(
+      path,
+      renderStandaloneRule(normalized, cursorFrontmatter, Boolean(projectRoot)),
+    );
+  } else {
+    action = upsertSection(path, normalized);
+  }
 
   return { agent, path, action };
 }
@@ -235,6 +273,12 @@ export function removeRuleForAgent(agent: string, projectRoot?: string): RuleRes
   if (!existsSync(path)) return { agent, path, action: "not_found" };
 
   if (target.kind === "file") {
+    if (
+      projectRoot &&
+      !isOwnedProjectRuleFile(readFileSync(path, "utf-8"), Boolean(target.cursorFrontmatter))
+    ) {
+      throw new Error(`${path} contains a non-Dosu project rule; refusing to remove it`);
+    }
     unlinkSync(path);
     return { agent, path, action: "removed" };
   }

--- a/src/rules/installer.ts
+++ b/src/rules/installer.ts
@@ -13,18 +13,19 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { assertSafeProjectPath } from "../setup/project-root";
 
 export type RuleAgentID = "claude" | "cursor" | "codex" | "opencode" | "gemini" | "antigravity";
 
 type RuleTarget =
   | {
       kind: "file";
-      path: () => string;
+      path: (projectRoot?: string) => string | null;
       cursorFrontmatter?: boolean;
     }
   | {
       kind: "section";
-      path: () => string;
+      path: (projectRoot?: string) => string | null;
     };
 
 export type RuleAction = "created" | "updated" | "unchanged" | "removed" | "not_found";
@@ -69,28 +70,36 @@ function codexHome(): string {
 const RULE_TARGETS: Record<RuleAgentID, RuleTarget> = {
   claude: {
     kind: "file",
-    path: () => join(claudeConfigDir(), "rules", "dosu.md"),
+    path: (root) =>
+      root
+        ? join(root, ".claude", "rules", "dosu.md")
+        : join(claudeConfigDir(), "rules", "dosu.md"),
   },
   cursor: {
     kind: "file",
-    path: () => join(homedir(), ".cursor", "rules", "dosu.mdc"),
+    path: (root) =>
+      root
+        ? join(root, ".cursor", "rules", "dosu.mdc")
+        : join(homedir(), ".cursor", "rules", "dosu.mdc"),
     cursorFrontmatter: true,
   },
   codex: {
     kind: "section",
-    path: () => join(codexHome(), "AGENTS.md"),
+    // Project setup writes the canonical root AGENTS.md separately.
+    path: (root) => (root ? null : join(codexHome(), "AGENTS.md")),
   },
   opencode: {
     kind: "section",
-    path: () => join(homedir(), ".config", "opencode", "AGENTS.md"),
+    // OpenCode also reads the canonical project AGENTS.md.
+    path: (root) => (root ? null : join(homedir(), ".config", "opencode", "AGENTS.md")),
   },
   gemini: {
     kind: "section",
-    path: () => join(homedir(), ".gemini", "GEMINI.md"),
+    path: (root) => (root ? join(root, "GEMINI.md") : join(homedir(), ".gemini", "GEMINI.md")),
   },
   antigravity: {
     kind: "section",
-    path: () => join(homedir(), ".gemini", "GEMINI.md"),
+    path: (root) => (root ? null : join(homedir(), ".gemini", "GEMINI.md")),
   },
 };
 
@@ -98,8 +107,8 @@ export function isRuleAgent(agent: string): agent is RuleAgentID {
   return Object.hasOwn(RULE_TARGETS, agent);
 }
 
-export function rulePathForAgent(agent: string): string | null {
-  return isRuleAgent(agent) ? RULE_TARGETS[agent].path() : null;
+export function rulePathForAgent(agent: string, projectRoot?: string): string | null {
+  return isRuleAgent(agent) ? RULE_TARGETS[agent].path(projectRoot) : null;
 }
 
 function normalizeRule(content: string): string {
@@ -193,11 +202,17 @@ function upsertSection(path: string, content: string): RuleAction {
   return "updated";
 }
 
-export function installRuleForAgent(agent: string, content: string): RuleResult | null {
+export function installRuleForAgent(
+  agent: string,
+  content: string,
+  projectRoot?: string,
+): RuleResult | null {
   if (!isRuleAgent(agent)) return null;
 
   const target = RULE_TARGETS[agent];
-  const path = target.path();
+  const path = target.path(projectRoot);
+  if (!path) return null;
+  if (projectRoot) assertSafeProjectPath(projectRoot, path);
   const normalized = normalizeRule(content);
   const action =
     target.kind === "file"
@@ -210,11 +225,13 @@ export function installRuleForAgent(agent: string, content: string): RuleResult 
   return { agent, path, action };
 }
 
-export function removeRuleForAgent(agent: string): RuleResult | null {
+export function removeRuleForAgent(agent: string, projectRoot?: string): RuleResult | null {
   if (!isRuleAgent(agent)) return null;
 
   const target = RULE_TARGETS[agent];
-  const path = target.path();
+  const path = target.path(projectRoot);
+  if (!path) return null;
+  if (projectRoot) assertSafeProjectPath(projectRoot, path);
   if (!existsSync(path)) return { agent, path, action: "not_found" };
 
   if (target.kind === "file") {

--- a/src/setup/agents-md-step.test.ts
+++ b/src/setup/agents-md-step.test.ts
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,7 +7,6 @@ import {
   buildDosuAgentsSection,
   DOSU_SECTION_END,
   DOSU_SECTION_START,
-  inGitWorkTree,
   stepUpdateAgentsMd,
   upsertDosuAgentsSection,
 } from "./agents-md-step";
@@ -45,27 +43,6 @@ describe("buildDosuAgentsSection", () => {
     expect(buildDosuAgentsSection()).toBe(
       `${DOSU_SECTION_START}\n${canonical}\n${DOSU_SECTION_END}`,
     );
-  });
-});
-
-describe("inGitWorkTree", () => {
-  it("returns false outside a git repo", () => {
-    expect(inGitWorkTree(dir)).toBe(false);
-  });
-
-  it("returns true inside a git repo", () => {
-    execSync("git init", { cwd: dir, stdio: "ignore" });
-    expect(inGitWorkTree(dir)).toBe(true);
-  });
-
-  it("returns false inside the .git directory (rev-parse exits 0 but prints false)", () => {
-    execSync("git init", { cwd: dir, stdio: "ignore" });
-    expect(inGitWorkTree(join(dir, ".git"))).toBe(false);
-  });
-
-  it("returns false in a bare repository", () => {
-    execSync("git init --bare", { cwd: dir, stdio: "ignore" });
-    expect(inGitWorkTree(dir)).toBe(false);
   });
 });
 

--- a/src/setup/agents-md-step.test.ts
+++ b/src/setup/agents-md-step.test.ts
@@ -7,6 +7,8 @@ import {
   buildDosuAgentsSection,
   DOSU_SECTION_END,
   DOSU_SECTION_START,
+  removeDosuAgentsSection,
+  stepRemoveAgentsMd,
   stepUpdateAgentsMd,
   upsertDosuAgentsSection,
 } from "./agents-md-step";
@@ -15,6 +17,7 @@ vi.mock("@clack/prompts", () => ({
   log: {
     success: vi.fn(),
     error: vi.fn(),
+    info: vi.fn(),
   },
 }));
 
@@ -126,6 +129,53 @@ describe("upsertDosuAgentsSection", () => {
     );
     expect(readFileSync(path, "utf-8")).toBe(existing);
   });
+
+  it("refuses to modify duplicate Dosu sections", () => {
+    const path = join(dir, "AGENTS.md");
+    const section = buildDosuAgentsSection("instruction");
+    const existing = `${section}\n\n${section}\n`;
+    writeFileSync(path, existing);
+
+    expect(() => upsertDosuAgentsSection(dir, "new instruction")).toThrow(/refusing/);
+    expect(readFileSync(path, "utf-8")).toBe(existing);
+  });
+});
+
+describe("removeDosuAgentsSection", () => {
+  it("removes only the owned section and preserves surrounding user instructions", () => {
+    const path = join(dir, "AGENTS.md");
+    writeFileSync(path, `# Before\n\n${buildDosuAgentsSection("instruction")}\n\n# After\n`);
+
+    expect(removeDosuAgentsSection(dir).action).toBe("removed");
+    expect(readFileSync(path, "utf-8")).toBe("# Before\n\n# After\n");
+  });
+
+  it("deletes AGENTS.md when the generated Dosu section is the only content", () => {
+    const path = join(dir, "AGENTS.md");
+    writeFileSync(path, `${buildDosuAgentsSection("instruction")}\n`);
+
+    expect(removeDosuAgentsSection(dir).action).toBe("removed");
+    expect(() => readFileSync(path, "utf-8")).toThrow();
+  });
+
+  it("leaves a foreign AGENTS.md byte-for-byte unchanged", () => {
+    const path = join(dir, "AGENTS.md");
+    const existing = "# User instructions\r\n";
+    writeFileSync(path, existing);
+
+    expect(removeDosuAgentsSection(dir).action).toBe("not_found");
+    expect(readFileSync(path, "utf-8")).toBe(existing);
+  });
+
+  it("refuses malformed or duplicate markers without changing the file", () => {
+    const path = join(dir, "AGENTS.md");
+    const section = buildDosuAgentsSection("instruction");
+    const existing = `${section}\n${section}\n`;
+    writeFileSync(path, existing);
+
+    expect(() => removeDosuAgentsSection(dir)).toThrow(/refusing/);
+    expect(readFileSync(path, "utf-8")).toBe(existing);
+  });
 });
 
 describe("stepUpdateAgentsMd", () => {
@@ -147,5 +197,14 @@ describe("stepUpdateAgentsMd", () => {
       stepUpdateAgentsMd(join(dir, "does-not-exist"), "canonical instruction"),
     ).resolves.toBe(false);
     expect(p.log.error).toHaveBeenCalled();
+  });
+});
+
+describe("stepRemoveAgentsMd", () => {
+  it("reports a safe removal and treats an absent section as success", () => {
+    upsertDosuAgentsSection(dir, "instruction");
+    expect(stepRemoveAgentsMd(dir)).toBe(true);
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("removed"));
+    expect(stepRemoveAgentsMd(dir)).toBe(true);
   });
 });

--- a/src/setup/agents-md-step.ts
+++ b/src/setup/agents-md-step.ts
@@ -8,7 +8,7 @@
  * rest of the file.
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { logger } from "../debug/logger";
@@ -20,7 +20,7 @@ import { formatSetupSummary } from "./styles";
  * Bump when the section content changes meaningfully. The version is stamped
  * into the start marker for compatibility across section revisions.
  */
-const DOSU_SECTION_VERSION = 2;
+const DOSU_SECTION_VERSION = 3;
 
 export const DOSU_SECTION_START = `<!-- dosu:mcp:start v${DOSU_SECTION_VERSION} -->`;
 export const DOSU_SECTION_END = "<!-- dosu:mcp:end -->";
@@ -29,10 +29,16 @@ export const DOSU_SECTION_END = "<!-- dosu:mcp:end -->";
 const SECTION_START_RE = /<!-- dosu:mcp:start(?: v(\d+))? -->/;
 
 type AgentsMdAction = "created" | "updated" | "unchanged";
+type AgentsMdRemoveAction = "removed" | "not_found";
 
 export interface AgentsMdResult {
   path: string;
   action: AgentsMdAction;
+}
+
+export interface AgentsMdRemoveResult {
+  path: string;
+  action: AgentsMdRemoveAction;
 }
 
 interface SectionLocation {
@@ -54,15 +60,13 @@ export function buildDosuAgentsSection(content: string = FALLBACK_DOSU_RULE): st
 }
 
 function findSection(content: string): SectionLocation | null {
-  const startMatch = content.match(SECTION_START_RE);
-  const start = startMatch?.index ?? -1;
-  const end = content.indexOf(DOSU_SECTION_END, Math.max(start, 0));
-
-  if (start === -1 && end === -1) return null;
-  if (start === -1 || end < start) {
+  const starts = [...content.matchAll(new RegExp(SECTION_START_RE.source, "g"))];
+  const ends = [...content.matchAll(new RegExp(DOSU_SECTION_END, "g"))];
+  if (starts.length === 0 && ends.length === 0) return null;
+  if (starts.length !== 1 || ends.length !== 1 || (ends[0]?.index ?? -1) < starts[0].index) {
     throw new Error("Dosu AGENTS.md markers are incomplete; refusing to overwrite the file");
   }
-  return { start, end };
+  return { start: starts[0].index, end: ends[0].index };
 }
 
 /**
@@ -102,6 +106,29 @@ export function upsertDosuAgentsSection(
   return { path, action: "updated" };
 }
 
+/** Remove only the marker-delimited Dosu section; preserve all user content. */
+export function removeDosuAgentsSection(cwd: string = process.cwd()): AgentsMdRemoveResult {
+  const path = join(cwd, "AGENTS.md");
+  assertSafeProjectPath(cwd, path);
+  if (!existsSync(path)) return { path, action: "not_found" };
+
+  const existing = readFileSync(path, "utf-8");
+  const location = findSection(existing);
+  if (!location) return { path, action: "not_found" };
+
+  const lineEnding = lineEndingFor(existing);
+  const next = (
+    existing.slice(0, location.start) + existing.slice(location.end + DOSU_SECTION_END.length)
+  )
+    .replace(/(?:\r?\n){3,}/g, `${lineEnding}${lineEnding}`)
+    .replace(/^(?:\r?\n)+/, "")
+    .trimEnd();
+
+  if (!next) unlinkSync(path);
+  else writeFileSync(path, `${next}${lineEnding}`);
+  return { path, action: "removed" };
+}
+
 /**
  * Setup-flow wrapper: upsert the section and report via clack. Returns
  * `true` when AGENTS.md ends up carrying the Dosu section (including the
@@ -123,6 +150,23 @@ export async function stepUpdateAgentsMd(
     const msg = err instanceof Error ? err.message : String(err);
     logger.error("setup", `AGENTS.md update failed: ${msg}`);
     p.log.error(`Could not update AGENTS.md: ${msg}`);
+    return false;
+  }
+}
+
+/** Setup-flow wrapper for removing an obsolete project instruction section. */
+export function stepRemoveAgentsMd(cwd: string = process.cwd()): boolean {
+  logger.info("setup", "Step: remove AGENTS.md section");
+  try {
+    const result = removeDosuAgentsSection(cwd);
+    if (result.action === "removed") {
+      p.log.info(formatSetupSummary("AGENTS.md", [{ path: result.path, status: "removed" }]));
+    }
+    return true;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("setup", `AGENTS.md removal failed: ${msg}`);
+    p.log.error(`Could not remove the Dosu AGENTS.md section: ${msg}`);
     return false;
   }
 }

--- a/src/setup/agents-md-step.ts
+++ b/src/setup/agents-md-step.ts
@@ -8,12 +8,12 @@
  * rest of the file.
  */
 
-import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { logger } from "../debug/logger";
 import { FALLBACK_DOSU_RULE, fetchDosuRule } from "../rules/installer";
+import { assertSafeProjectPath } from "./project-root";
 import { formatSetupSummary } from "./styles";
 
 /**
@@ -38,25 +38,6 @@ export interface AgentsMdResult {
 interface SectionLocation {
   start: number;
   end: number;
-}
-
-/**
- * True when `cwd` is inside a git work tree. Gates whether setup offers the
- * AGENTS.md step at all — writing an AGENTS.md into an arbitrary directory
- * (home dir, /tmp) would just be litter.
- */
-export function inGitWorkTree(cwd: string = process.cwd()): boolean {
-  try {
-    // Exits 0 but prints "false" in bare repos and inside .git itself, so
-    // the stdout check matters — exit code alone is not enough.
-    const stdout = execSync("git rev-parse --is-inside-work-tree", {
-      cwd,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return stdout.toString().trim() === "true";
-  } catch {
-    return false;
-  }
 }
 
 function lineEndingFor(content: string): "\r\n" | "\n" {
@@ -93,6 +74,7 @@ export function upsertDosuAgentsSection(
   content: string = FALLBACK_DOSU_RULE,
 ): AgentsMdResult {
   const path = join(cwd, "AGENTS.md");
+  assertSafeProjectPath(cwd, path);
 
   if (!existsSync(path)) {
     const section = buildDosuAgentsSection(content);

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -196,6 +196,7 @@ import { loadJSONConfig, saveJSONConfig } from "../mcp/config-helpers";
 import * as providersModule from "../mcp/providers";
 import { ClaudeProvider } from "../mcp/providers/claude";
 import { ClaudeDesktopProvider } from "../mcp/providers/claude-desktop";
+import { CopilotProvider } from "../mcp/providers/copilot";
 import { CursorProvider } from "../mcp/providers/cursor";
 import { OpenCodeProvider } from "../mcp/providers/opencode";
 import {
@@ -471,6 +472,47 @@ describe("stepConfigureTools", () => {
 
     // Verify the dosu entry was removed from disk
     written = loadJSONConfig(configPath);
+    expect(written.mcpServers.dosu).toBeUndefined();
+  });
+
+  it.each([
+    ["GitHub Copilot CLI", CopilotProvider, ClaudeProvider],
+    ["Claude Code", ClaudeProvider, CopilotProvider],
+  ])("preserves the shared project MCP config when keeping %s and removing the other provider", (_retainedName, retainedProvider, removedProvider) => {
+    const cfg = makeCfg();
+    const retained = retainedProvider();
+    const removed = removedProvider();
+    const selection: ToolSelection = {
+      toInstall: [retained],
+      toRemove: [removed],
+      skipped: [],
+    };
+
+    const results = stepConfigureTools(cfg, selection, tempDir);
+
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => result.action)).toEqual(["install", "remove"]);
+    expect(results.every((result) => result.error === undefined)).toBe(true);
+    const written = loadJSONConfig(join(tempDir, ".mcp.json"));
+    expect(written.mcpServers.dosu).toBeDefined();
+  });
+
+  it("removes the shared project MCP config when neither provider is retained", () => {
+    const cfg = makeCfg();
+    const claude = ClaudeProvider();
+    const copilot = CopilotProvider();
+    claude.install(cfg, false, { projectRoot: tempDir });
+    const selection: ToolSelection = {
+      toInstall: [],
+      toRemove: [claude, copilot],
+      skipped: [],
+    };
+
+    const results = stepConfigureTools(cfg, selection, tempDir);
+
+    expect(results).toHaveLength(2);
+    expect(results.every((result) => result.error === undefined)).toBe(true);
+    const written = loadJSONConfig(join(tempDir, ".mcp.json"));
     expect(written.mcpServers.dosu).toBeUndefined();
   });
 

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -122,7 +122,14 @@ vi.mock("../commands/skill", () => ({
           ({ claude: "claude-code", cursor: "cursor" })[providerID as "claude" | "cursor"],
       )
       .filter(Boolean),
-  skillInstallTargetForProvider: (providerID: string) => {
+  skillInstallTargetForProvider: (providerID: string, projectRoot?: string) => {
+    if (projectRoot) {
+      const target = {
+        claude: { path: `${projectRoot}/.claude/skills/dosu`, symlink: false },
+        cursor: { path: `${projectRoot}/.agents/skills/dosu`, symlink: false },
+      }[providerID as "claude" | "cursor"];
+      return target ?? null;
+    }
     const target = {
       claude: { path: "/skills/claude/dosu", symlink: true },
       cursor: { path: "/skills/cursor/dosu", symlink: false },
@@ -139,12 +146,10 @@ const { mockStepConnectGitHubRepo } = vi.hoisted(() => ({
 // AGENTS.md step: mocked so flow tests never write an AGENTS.md into the real
 // repo cwd. Defaults (not in a git work tree) are installed by
 // `installSetupStepDefaults()`.
-const { mockInGitWorkTree, mockStepUpdateAgentsMd } = vi.hoisted(() => ({
-  mockInGitWorkTree: vi.fn(),
+const { mockStepUpdateAgentsMd } = vi.hoisted(() => ({
   mockStepUpdateAgentsMd: vi.fn(),
 }));
 vi.mock("./agents-md-step", () => ({
-  inGitWorkTree: (...args: unknown[]) => mockInGitWorkTree(...args),
   stepUpdateAgentsMd: (...args: unknown[]) => mockStepUpdateAgentsMd(...args),
 }));
 
@@ -167,6 +172,13 @@ const { mockStepConfigureAgentRules } = vi.hoisted(() => ({
 }));
 vi.mock("./rules-step", () => ({
   stepConfigureAgentRules: (...args: unknown[]) => mockStepConfigureAgentRules(...args),
+}));
+const { mockRequireProjectRoot } = vi.hoisted(() => ({
+  mockRequireProjectRoot: vi.fn(),
+}));
+vi.mock("./project-root", () => ({
+  assertSafeProjectPath: vi.fn(),
+  requireProjectRoot: (...args: unknown[]) => mockRequireProjectRoot(...args),
 }));
 vi.mock("./github-step", () => ({
   stepConnectGitHubRepo: (...args: unknown[]) => mockStepConnectGitHubRepo(...args),
@@ -212,10 +224,10 @@ function mockToolSelection(selection: string[]) {
 
 function installSetupStepDefaults() {
   mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
-  mockInGitWorkTree.mockReturnValue(false);
   mockStepUpdateAgentsMd.mockReturnValue(true);
   mockStepConfigureAgentRules.mockResolvedValue([]);
   mockOfferLogsHandoff.mockResolvedValue({ plan: null });
+  mockRequireProjectRoot.mockImplementation(() => tempDir);
 }
 
 function installRemoteSetupDefaults() {
@@ -255,6 +267,7 @@ function setupTempEnv() {
 }
 
 function teardownTempEnv() {
+  process.exitCode = undefined;
   process.env.HOME = origHome;
   if (origXdg !== undefined) {
     process.env.XDG_CONFIG_HOME = origXdg;
@@ -285,6 +298,8 @@ function throwingProvider(): providersModule.SetupProvider {
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => join(tempDir, "broken.json"),
+    projectConfigPath: (root) => join(root, "broken.json"),
+    isProjectConfigured: () => false,
     install() {
       throw new Error("boom: provider failure");
     },
@@ -351,7 +366,7 @@ describe("stepDetectTools", () => {
     expect(detected[0].id()).toBe("cursor");
   });
 
-  it("includes Claude Desktop when its app dir exists", () => {
+  it("excludes installed agents that have no project-scoped config", () => {
     const desktop = ClaudeDesktopProvider();
     for (const detectPath of desktop.detectPaths()) {
       mkdirSync(detectPath, { recursive: true });
@@ -362,7 +377,7 @@ describe("stepDetectTools", () => {
     });
 
     const detected = stepDetectTools();
-    expect(detected.map((p2) => p2.id())).toEqual(["claude-desktop"]);
+    expect(detected).toEqual([]);
   });
 
   it("returns empty array when no providers are installed", () => {
@@ -413,21 +428,23 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, tempDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("install");
     expect(results[0].error).toBeUndefined();
 
     // Verify the file was actually written to disk
-    const configPath = cursor.globalConfigPath();
-    expect(existsSync(configPath)).toBe(true);
+    const configPath = cursor.projectConfigPath(tempDir);
+    expect(configPath).not.toBeNull();
+    expect(existsSync(configPath ?? "")).toBe(true);
 
-    const written = loadJSONConfig(configPath);
+    const written = loadJSONConfig(configPath ?? "");
     expect(written.mcpServers).toBeDefined();
     expect(written.mcpServers.dosu).toBeDefined();
-    expect(written.mcpServers.dosu.url).toContain("dep-123");
-    expect(written.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+    expect(written.mcpServers.dosu.command).toBe("npx");
+    expect(written.mcpServers.dosu.args).toContain("dep-123");
+    expect(JSON.stringify(written)).not.toContain("key-abc");
   });
 
   it("removes a provider and deletes the dosu entry from disk", () => {
@@ -435,8 +452,8 @@ describe("stepConfigureTools", () => {
     const cursor = CursorProvider();
 
     // First install so there's something to remove
-    cursor.install(cfg, true);
-    const configPath = cursor.globalConfigPath();
+    cursor.install(cfg, false, { projectRoot: tempDir });
+    const configPath = cursor.projectConfigPath(tempDir) ?? "";
     let written = loadJSONConfig(configPath);
     expect(written.mcpServers.dosu).toBeDefined();
 
@@ -446,7 +463,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, tempDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("remove");
@@ -466,13 +483,13 @@ describe("stepConfigureTools", () => {
       skipped: [cursor],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, tempDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("skip");
     expect(results[0].error).toBeUndefined();
     // No file should have been created
-    expect(existsSync(cursor.globalConfigPath())).toBe(false);
+    expect(existsSync(cursor.projectConfigPath(tempDir) ?? "")).toBe(false);
   });
 
   it("handles install errors and records them in results", () => {
@@ -484,7 +501,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, tempDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("install");
@@ -503,7 +520,7 @@ describe("stepConfigureTools", () => {
       skipped: [],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, tempDir);
 
     expect(results).toHaveLength(1);
     expect(results[0].action).toBe("remove");
@@ -517,11 +534,11 @@ describe("stepConfigureTools", () => {
     const opencode = OpenCodeProvider();
 
     // Pre-install opencode so we can remove it
-    opencode.install(cfg, true);
+    opencode.install(cfg, false, { projectRoot: tempDir });
 
     const cursorForSkip = CursorProvider();
     // Pre-install cursor so the skip entry refers to an installed provider
-    cursorForSkip.install(cfg, true);
+    cursorForSkip.install(cfg, false, { projectRoot: tempDir });
 
     // Fresh providers for this call
     const freshCursor = CursorProvider();
@@ -534,7 +551,7 @@ describe("stepConfigureTools", () => {
       skipped: [anotherCursor],
     };
 
-    const results = stepConfigureTools(cfg, selection);
+    const results = stepConfigureTools(cfg, selection, tempDir);
 
     expect(results).toHaveLength(3);
 
@@ -549,11 +566,11 @@ describe("stepConfigureTools", () => {
     expect(skipResult).toBeDefined();
 
     // Verify cursor config was written
-    const cursorConfig = loadJSONConfig(freshCursor.globalConfigPath());
+    const cursorConfig = loadJSONConfig(freshCursor.projectConfigPath(tempDir) ?? "");
     expect(cursorConfig.mcpServers.dosu).toBeDefined();
 
     // Verify opencode dosu entry was removed
-    const opencodeConfig = loadJSONConfig(freshOpencode.globalConfigPath());
+    const opencodeConfig = loadJSONConfig(freshOpencode.projectConfigPath(tempDir) ?? "");
     expect(opencodeConfig.mcp.dosu).toBeUndefined();
   });
 });
@@ -573,11 +590,15 @@ describe("stepShowSummary", () => {
   it("logs configured tools count and paths for installs", () => {
     const cursor = CursorProvider();
     const results: ConfigResult[] = [{ provider: cursor, action: "install" }];
+    const projectRoot = join(tempDir, "repo");
 
-    stepShowSummary(results);
+    stepShowSummary(results, projectRoot);
 
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Cursor"));
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining(join(projectRoot, ".cursor", "mcp.json")),
+    );
     // The summary itself never prints extra messages.
     expect(p.log.message).not.toHaveBeenCalled();
   });
@@ -586,7 +607,7 @@ describe("stepShowSummary", () => {
     const cursor = CursorProvider();
     const results: ConfigResult[] = [{ provider: cursor, action: "remove" }];
 
-    stepShowSummary(results);
+    stepShowSummary(results, tempDir);
 
     expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 agent"));
     expect(p.log.message).not.toHaveBeenCalled();
@@ -596,7 +617,7 @@ describe("stepShowSummary", () => {
     const cursor = CursorProvider();
     const results: ConfigResult[] = [{ provider: cursor, action: "skip" }];
 
-    stepShowSummary(results);
+    stepShowSummary(results, tempDir);
 
     expect(p.log.success).toHaveBeenCalledWith(
       expect.stringContaining("All agents already configured"),
@@ -612,7 +633,7 @@ describe("stepShowSummary", () => {
       { provider: opencode, action: "remove" },
     ];
 
-    stepShowSummary(results);
+    stepShowSummary(results, tempDir);
 
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
     expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 1 agent"));
@@ -626,7 +647,7 @@ describe("stepShowSummary", () => {
       { provider: opencode, action: "install", error: new Error("failed") },
     ];
 
-    stepShowSummary(results);
+    stepShowSummary(results, tempDir);
 
     // Only 1 successful install
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
@@ -640,7 +661,7 @@ describe("stepShowSummary", () => {
       { provider: opencode, action: "remove" },
     ];
 
-    stepShowSummary(results);
+    stepShowSummary(results, tempDir);
 
     expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Removed from 2 agent"));
     expect(p.log.message).not.toHaveBeenCalled();
@@ -654,7 +675,7 @@ describe("stepShowSummary", () => {
       { provider: opencode, action: "skip" },
     ];
 
-    stepShowSummary(results);
+    stepShowSummary(results, tempDir);
 
     // Should show install summary, NOT "all configured"
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
@@ -665,7 +686,7 @@ describe("stepShowSummary", () => {
   });
 
   it("prints nothing when results are empty", () => {
-    stepShowSummary([]);
+    stepShowSummary([], tempDir);
 
     expect(p.log.success).not.toHaveBeenCalled();
     expect(p.log.info).not.toHaveBeenCalled();
@@ -854,13 +875,16 @@ describe("runSetup integration", () => {
     expect(existsSync(cursorConfigPath)).toBe(true);
     const cursorConfig = loadJSONConfig(cursorConfigPath);
     expect(cursorConfig.mcpServers.dosu).toBeDefined();
-    expect(cursorConfig.mcpServers.dosu.url).toContain("d1");
+    expect(cursorConfig.mcpServers.dosu.command).toBe("npx");
+    expect(cursorConfig.mcpServers.dosu.args).toContain("d1");
+    expect(JSON.stringify(cursorConfig)).not.toContain("key-abc");
 
     // Verify summary was shown
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Configured 1 agent"));
     expect(mockStepConfigureAgentRules).toHaveBeenCalledWith(
       expect.objectContaining({ toInstall: [expect.objectContaining({})] }),
       [expect.objectContaining({ action: "install" })],
+      tempDir,
     );
   });
 
@@ -963,8 +987,9 @@ describe("runSetup integration", () => {
     expect(savedCfg.active_account?.target?.api_key).toBe("key-abc");
 
     const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
-    expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp/deployments/d2");
-    expect(cursorConfig.mcpServers.dosu.url).not.toBe(ossConfig.mcpServers.dosu.url);
+    expect(cursorConfig.mcpServers.dosu.args).toContain("d2");
+    expect(cursorConfig.mcpServers.dosu.args).not.toContain("--oss");
+    expect(JSON.stringify(cursorConfig)).not.toContain("key-abc");
   });
 
   it("creates new API key when existing one is invalid", async () => {
@@ -1005,9 +1030,11 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    // Cursor should have been reinstalled (not skipped) because api_key changed
+    // The project command is reinstalled but remains secretless when the key changes.
     const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
-    expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("new-key");
+    expect(cursorConfig.mcpServers.dosu.args).toContain("d1");
+    expect(JSON.stringify(cursorConfig)).not.toContain("old-key");
+    expect(JSON.stringify(cursorConfig)).not.toContain("new-key");
   });
 
   it("reinstalls configured tools when setup is re-run with the same target", async () => {
@@ -1038,8 +1065,10 @@ describe("runSetup integration", () => {
     await runSetup();
 
     const cursorConfig = loadJSONConfig(cursorConfigPath);
-    expect(cursorConfig.mcpServers.dosu.url).toContain("/v1/mcp/deployments/d1");
-    expect(cursorConfig.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+    expect(cursorConfig.mcpServers.dosu.command).toBe("npx");
+    expect(cursorConfig.mcpServers.dosu.args).toContain("d1");
+    expect(JSON.stringify(cursorConfig)).not.toContain("stale-key");
+    expect(JSON.stringify(cursorConfig)).not.toContain("key-abc");
   });
 
   it("shows error when OAuth fails", async () => {
@@ -1467,9 +1496,9 @@ describe("runSetup integration", () => {
       OpenCodeProvider(),
     ]);
 
-    // Pre-configure both providers so isConfigured() returns true
-    CursorProvider().install(cfg, true);
-    OpenCodeProvider().install(cfg, true);
+    // Pre-configure both providers in this project.
+    CursorProvider().install(cfg, false, { projectRoot: tempDir });
+    OpenCodeProvider().install(cfg, false, { projectRoot: tempDir });
 
     // User deselects opencode but keeps cursor
     mockToolSelection(["cursor"]);
@@ -1494,7 +1523,6 @@ describe("runSetup integration", () => {
 
     setupAuthenticatedClient();
     // Every other gate is open, so OSS mode is the only reason it stays quiet.
-    mockInGitWorkTree.mockReturnValue(true);
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection(["cursor"]);
@@ -1516,9 +1544,14 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], {
+      quiet: true,
+      projectRoot: tempDir,
+    });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/skills/cursor/dosu"));
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining(`${tempDir}/.agents/skills/dosu`),
+    );
   });
 
   it("does not install the skill when no agent is selected", async () => {
@@ -1547,7 +1580,10 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], {
+      quiet: true,
+      projectRoot: tempDir,
+    });
   });
 
   it("goes directly to agent selection without a component-selection prompt", async () => {
@@ -1568,19 +1604,18 @@ describe("runSetup integration", () => {
     expect(messages.some((message) => message.includes("Dosu will set"))).toBe(false);
   });
 
-  it("automatically updates AGENTS.md after configuring an agent in a git work tree", async () => {
+  it("updates AGENTS.md at the verified project root after configuring an agent", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    mockInGitWorkTree.mockReturnValue(true);
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection(["cursor"]);
 
     await runSetup();
 
-    expect(mockStepUpdateAgentsMd).toHaveBeenCalledTimes(1);
+    expect(mockStepUpdateAgentsMd).toHaveBeenCalledWith(tempDir);
 
     const completed = trackedCliOnboardingEvents().find(
       (e) => e.event === "cli_onboarding_completed",
@@ -1593,7 +1628,6 @@ describe("runSetup integration", () => {
     saveConfig(cfg);
 
     setupAuthenticatedClient();
-    mockInGitWorkTree.mockReturnValue(true);
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection([]);
@@ -1603,18 +1637,21 @@ describe("runSetup integration", () => {
     expect(mockStepUpdateAgentsMd).not.toHaveBeenCalled();
   });
 
-  it("does not update AGENTS.md outside a git work tree", async () => {
+  it("stops before authentication outside a Git project", async () => {
     const cfg = makeCfg();
     saveConfig(cfg);
 
-    setupAuthenticatedClient();
-    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
-    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    mockToolSelection(["cursor"]);
+    mockRequireProjectRoot.mockImplementationOnce(() => {
+      throw new Error("Run Dosu setup inside a Git project.");
+    });
 
     await runSetup();
 
     expect(mockStepUpdateAgentsMd).not.toHaveBeenCalled();
+    expect(mockOfferLogsHandoff).not.toHaveBeenCalled();
+    expect(Client).not.toHaveBeenCalled();
+    expect(p.log.error).toHaveBeenCalledWith("Run Dosu setup inside a Git project.");
+    expect(process.exitCode).toBe(1);
   });
 });
 
@@ -1636,23 +1673,28 @@ describe("runInstallSkill", () => {
   it("calls installSkill and returns true on success", async () => {
     mockInstallSkill.mockResolvedValue({ success: true, sha: "abc" });
 
-    const result = await runInstallSkill([ClaudeProvider()]);
+    const result = await runInstallSkill([ClaudeProvider()], tempDir);
     const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(true);
     expect(spinner?.start).toHaveBeenCalledWith("Installing skill for 1 agent");
     expect(spinner?.clear).toHaveBeenCalledOnce();
-    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], {
+      quiet: true,
+      projectRoot: tempDir,
+    });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Claude Code"));
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/skills/claude/dosu"));
-    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("(symlink)"));
+    expect(p.log.success).toHaveBeenCalledWith(
+      expect.stringContaining(`${tempDir}/.claude/skills/dosu`),
+    );
+    expect(p.log.success).not.toHaveBeenCalledWith(expect.stringContaining("(symlink)"));
   });
 
   it("uses plural loading copy for multiple selected agents", async () => {
     mockInstallSkill.mockResolvedValue({ success: true });
 
-    await runInstallSkill([ClaudeProvider(), CursorProvider()]);
+    await runInstallSkill([ClaudeProvider(), CursorProvider()], tempDir);
     const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(spinner?.start).toHaveBeenCalledWith("Installing skill for 2 agents");
@@ -1662,7 +1704,7 @@ describe("runInstallSkill", () => {
   it("returns false and logs error when installSkill reports failure", async () => {
     mockInstallSkill.mockResolvedValue({ success: false });
 
-    const result = await runInstallSkill([ClaudeProvider()]);
+    const result = await runInstallSkill([ClaudeProvider()], tempDir);
     const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(false);
@@ -1674,7 +1716,7 @@ describe("runInstallSkill", () => {
   it("returns false and logs error when installSkill throws", async () => {
     mockInstallSkill.mockRejectedValue(new Error("boom"));
 
-    const result = await runInstallSkill([ClaudeProvider()]);
+    const result = await runInstallSkill([ClaudeProvider()], tempDir);
     const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(false);
@@ -1739,7 +1781,6 @@ describe("runSetup checkpoint behavior", () => {
   it("does not offer the logs handoff when the user selects no agents", async () => {
     saveConfig(makeCfg());
     setupAuthed();
-    mockInGitWorkTree.mockReturnValue(true);
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection([]);
@@ -1754,7 +1795,6 @@ describe("runSetup checkpoint behavior", () => {
     // returns an empty array (nothing to configure), so the handoff would be useless.
     saveConfig(makeCfg());
     setupAuthed();
-    mockInGitWorkTree.mockReturnValue(true);
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
@@ -1768,7 +1808,6 @@ describe("runSetup checkpoint behavior", () => {
   it("does not offer the logs handoff when every MCP install errors", async () => {
     saveConfig(makeCfg());
     setupAuthed();
-    mockInGitWorkTree.mockReturnValue(true);
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     const cursor = CursorProvider();
     vi.spyOn(cursor, "install").mockImplementation(() => {
@@ -1783,25 +1822,9 @@ describe("runSetup checkpoint behavior", () => {
     expect(mockOfferLogsHandoff).not.toHaveBeenCalled();
   });
 
-  it("does not offer the logs handoff outside a git work tree", async () => {
-    // `npx @dosu/cli setup` is routinely run from $HOME; the handoff hands the
-    // terminal to a coding agent rooted at cwd, so it stays inside a repo.
-    saveConfig(makeCfg());
-    setupAuthed();
-    mockInGitWorkTree.mockReturnValue(false);
-    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
-    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
-    mockToolSelection(["cursor"]);
-
-    await runSetup();
-
-    expect(mockOfferLogsHandoff).not.toHaveBeenCalled();
-  });
-
   it("offers the logs handoff with the configured agents and launches after the outro", async () => {
     saveConfig(makeCfg());
     setupAuthed();
-    mockInGitWorkTree.mockReturnValue(true);
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection(["cursor"]);
@@ -1832,7 +1855,6 @@ describe("runSetup checkpoint behavior", () => {
   it("records a declined logs handoff without launching the agent", async () => {
     saveConfig(makeCfg());
     setupAuthed();
-    mockInGitWorkTree.mockReturnValue(true);
     mkdirSync(join(tempDir, ".cursor"), { recursive: true });
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection(["cursor"]);

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -146,10 +146,12 @@ const { mockStepConnectGitHubRepo } = vi.hoisted(() => ({
 // AGENTS.md step: mocked so flow tests never write an AGENTS.md into the real
 // repo cwd. Defaults (not in a git work tree) are installed by
 // `installSetupStepDefaults()`.
-const { mockStepUpdateAgentsMd } = vi.hoisted(() => ({
+const { mockStepRemoveAgentsMd, mockStepUpdateAgentsMd } = vi.hoisted(() => ({
+  mockStepRemoveAgentsMd: vi.fn(),
   mockStepUpdateAgentsMd: vi.fn(),
 }));
 vi.mock("./agents-md-step", () => ({
+  stepRemoveAgentsMd: (...args: unknown[]) => mockStepRemoveAgentsMd(...args),
   stepUpdateAgentsMd: (...args: unknown[]) => mockStepUpdateAgentsMd(...args),
 }));
 
@@ -225,6 +227,7 @@ function mockToolSelection(selection: string[]) {
 
 function installSetupStepDefaults() {
   mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
+  mockStepRemoveAgentsMd.mockReturnValue(true);
   mockStepUpdateAgentsMd.mockReturnValue(true);
   mockStepConfigureAgentRules.mockResolvedValue([]);
   mockOfferLogsHandoff.mockResolvedValue({ plan: null });
@@ -293,7 +296,7 @@ function throwingProvider(): providersModule.SetupProvider {
   return {
     name: () => "Broken Tool",
     id: () => "broken",
-    supportsLocal: () => false,
+    configurationKind: () => "unsupported",
     priority: () => 99,
     detectPaths: () => [],
     isInstalled: () => true,
@@ -443,7 +446,7 @@ describe("stepConfigureTools", () => {
     const written = loadJSONConfig(configPath ?? "");
     expect(written.mcpServers).toBeDefined();
     expect(written.mcpServers.dosu).toBeDefined();
-    expect(written.mcpServers.dosu.command).toBe("npx");
+    expect(written.mcpServers.dosu.command).toBe("dosu");
     expect(written.mcpServers.dosu.args).toContain("dep-123");
     expect(JSON.stringify(written)).not.toContain("key-abc");
   });
@@ -453,7 +456,7 @@ describe("stepConfigureTools", () => {
     const cursor = CursorProvider();
 
     // First install so there's something to remove
-    cursor.install(cfg, false, { projectRoot: tempDir });
+    cursor.install(cfg, { scope: "project", projectRoot: tempDir });
     const configPath = cursor.projectConfigPath(tempDir) ?? "";
     let written = loadJSONConfig(configPath);
     expect(written.mcpServers.dosu).toBeDefined();
@@ -501,7 +504,7 @@ describe("stepConfigureTools", () => {
     const cfg = makeCfg();
     const claude = ClaudeProvider();
     const copilot = CopilotProvider();
-    claude.install(cfg, false, { projectRoot: tempDir });
+    claude.install(cfg, { scope: "project", projectRoot: tempDir });
     const selection: ToolSelection = {
       toInstall: [],
       toRemove: [claude, copilot],
@@ -576,11 +579,11 @@ describe("stepConfigureTools", () => {
     const opencode = OpenCodeProvider();
 
     // Pre-install opencode so we can remove it
-    opencode.install(cfg, false, { projectRoot: tempDir });
+    opencode.install(cfg, { scope: "project", projectRoot: tempDir });
 
     const cursorForSkip = CursorProvider();
     // Pre-install cursor so the skip entry refers to an installed provider
-    cursorForSkip.install(cfg, false, { projectRoot: tempDir });
+    cursorForSkip.install(cfg, { scope: "project", projectRoot: tempDir });
 
     // Fresh providers for this call
     const freshCursor = CursorProvider();
@@ -917,7 +920,7 @@ describe("runSetup integration", () => {
     expect(existsSync(cursorConfigPath)).toBe(true);
     const cursorConfig = loadJSONConfig(cursorConfigPath);
     expect(cursorConfig.mcpServers.dosu).toBeDefined();
-    expect(cursorConfig.mcpServers.dosu.command).toBe("npx");
+    expect(cursorConfig.mcpServers.dosu.command).toBe("dosu");
     expect(cursorConfig.mcpServers.dosu.args).toContain("d1");
     expect(JSON.stringify(cursorConfig)).not.toContain("key-abc");
 
@@ -1007,11 +1010,15 @@ describe("runSetup integration", () => {
       validateAPIKey: vi.fn().mockResolvedValue(true),
     });
 
-    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(join(projectRoot, ".cursor"), { recursive: true });
+    mockRequireProjectRoot.mockReturnValue(projectRoot);
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection(["cursor"]);
 
-    CursorProvider().install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+    CursorProvider().install(makeCfg({ mode: "oss", deployment_id: undefined }), {
+      scope: "global",
+    });
     const ossConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
     expect(ossConfig.mcpServers.dosu.url).toContain("/v1/mcp");
     expect(ossConfig.mcpServers.dosu.url).not.toContain("/deployments/");
@@ -1026,9 +1033,12 @@ describe("runSetup integration", () => {
     const savedCfg = loadConfig();
     expect(savedCfg.mode).toBeUndefined();
     expect(savedCfg.active_account?.target?.deployment_id).toBe("d2");
-    expect(savedCfg.active_account?.target?.api_key).toBe("key-abc");
+    // An OSS key is not valid evidence for a different Cloud deployment.
+    // Switching scopes must mint a deployment-specific key instead of
+    // carrying the old credential across the boundary.
+    expect(savedCfg.active_account?.target?.api_key).toBe("new-key");
 
-    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    const cursorConfig = loadJSONConfig(join(projectRoot, ".cursor", "mcp.json"));
     expect(cursorConfig.mcpServers.dosu.args).toContain("d2");
     expect(cursorConfig.mcpServers.dosu.args).not.toContain("--oss");
     expect(JSON.stringify(cursorConfig)).not.toContain("key-abc");
@@ -1056,10 +1066,12 @@ describe("runSetup integration", () => {
 
   it("reinstalls configured tools when only the API key changes", async () => {
     // Use deployment_id "d1" to match the mock so deployment doesn't change
-    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    const projectRoot = join(tempDir, "repo");
+    mkdirSync(join(projectRoot, ".cursor"), { recursive: true });
+    mockRequireProjectRoot.mockReturnValue(projectRoot);
     const cfg = makeCfg({ deployment_id: "d1", deployment_name: "Deploy1", api_key: "old-key" });
     saveConfig(cfg);
-    CursorProvider().install(cfg, true);
+    CursorProvider().install(cfg, { scope: "global" });
 
     // The old key is "invalid", so the flow will mint a new one
     setupAuthenticatedClient({
@@ -1073,7 +1085,7 @@ describe("runSetup integration", () => {
     await runSetup();
 
     // The project command is reinstalled but remains secretless when the key changes.
-    const cursorConfig = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    const cursorConfig = loadJSONConfig(join(projectRoot, ".cursor", "mcp.json"));
     expect(cursorConfig.mcpServers.dosu.args).toContain("d1");
     expect(JSON.stringify(cursorConfig)).not.toContain("old-key");
     expect(JSON.stringify(cursorConfig)).not.toContain("new-key");
@@ -1088,11 +1100,9 @@ describe("runSetup integration", () => {
     saveJSONConfig(cursorConfigPath, {
       mcpServers: {
         dosu: {
-          type: "http",
-          url: "https://stale.example/v1/mcp/deployments/old-deployment",
-          headers: {
-            "X-Dosu-API-Key": "stale-key",
-          },
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "@dosu/cli@0.49.4", "mcp", "proxy", "--deployment", "d1"],
         },
       },
     });
@@ -1107,9 +1117,9 @@ describe("runSetup integration", () => {
     await runSetup();
 
     const cursorConfig = loadJSONConfig(cursorConfigPath);
-    expect(cursorConfig.mcpServers.dosu.command).toBe("npx");
+    expect(cursorConfig.mcpServers.dosu.command).toBe("dosu");
     expect(cursorConfig.mcpServers.dosu.args).toContain("d1");
-    expect(JSON.stringify(cursorConfig)).not.toContain("stale-key");
+    expect(JSON.stringify(cursorConfig)).not.toContain("@dosu/cli@0.49.4");
     expect(JSON.stringify(cursorConfig)).not.toContain("key-abc");
   });
 
@@ -1539,8 +1549,8 @@ describe("runSetup integration", () => {
     ]);
 
     // Pre-configure both providers in this project.
-    CursorProvider().install(cfg, false, { projectRoot: tempDir });
-    OpenCodeProvider().install(cfg, false, { projectRoot: tempDir });
+    CursorProvider().install(cfg, { scope: "project", projectRoot: tempDir });
+    OpenCodeProvider().install(cfg, { scope: "project", projectRoot: tempDir });
 
     // User deselects opencode but keeps cursor
     mockToolSelection(["cursor"]);
@@ -1586,14 +1596,9 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], {
-      quiet: true,
-      projectRoot: tempDir,
-    });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
-    expect(p.log.success).toHaveBeenCalledWith(
-      expect.stringContaining(`${tempDir}/.agents/skills/dosu`),
-    );
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/skills/cursor/dosu"));
   });
 
   it("does not install the skill when no agent is selected", async () => {
@@ -1622,10 +1627,7 @@ describe("runSetup integration", () => {
 
     await runSetup();
 
-    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], {
-      quiet: true,
-      projectRoot: tempDir,
-    });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["cursor"], { quiet: true });
   });
 
   it("goes directly to agent selection without a component-selection prompt", async () => {
@@ -1677,6 +1679,43 @@ describe("runSetup integration", () => {
     await runSetup();
 
     expect(mockStepUpdateAgentsMd).not.toHaveBeenCalled();
+    expect(mockStepRemoveAgentsMd).not.toHaveBeenCalled();
+  });
+
+  it("removes only the Dosu AGENTS.md section after the last configured agent is removed", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    const cursor = CursorProvider();
+    cursor.install(cfg, { scope: "project", projectRoot: tempDir });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [cursor]);
+    mockToolSelection([]);
+
+    await runSetup();
+
+    expect(mockStepUpdateAgentsMd).not.toHaveBeenCalled();
+    expect(mockStepRemoveAgentsMd).toHaveBeenCalledWith(tempDir);
+  });
+
+  it("keeps AGENTS.md when removing the last agent fails", async () => {
+    const cfg = makeCfg();
+    saveConfig(cfg);
+
+    setupAuthenticatedClient();
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    const cursor = CursorProvider();
+    cursor.install(cfg, { scope: "project", projectRoot: tempDir });
+    vi.spyOn(cursor, "remove").mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [cursor]);
+    mockToolSelection([]);
+
+    await runSetup();
+
+    expect(mockStepRemoveAgentsMd).not.toHaveBeenCalled();
   });
 
   it("stops before authentication outside a Git project", async () => {
@@ -1693,6 +1732,31 @@ describe("runSetup integration", () => {
     expect(mockOfferLogsHandoff).not.toHaveBeenCalled();
     expect(Client).not.toHaveBeenCalled();
     expect(p.log.error).toHaveBeenCalledWith("Run Dosu setup inside a Git project.");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("stops before project or credential writes when setup runs through temporary npx", async () => {
+    const originalNpmCommand = process.env.npm_command;
+    const originalArgv = process.argv;
+    process.env.npm_command = "exec";
+    process.argv = [
+      process.execPath,
+      "/home/user/.npm/_npx/abc123/node_modules/.bin/dosu",
+      "setup",
+    ];
+    try {
+      await runSetup();
+    } finally {
+      if (originalNpmCommand === undefined) delete process.env.npm_command;
+      else process.env.npm_command = originalNpmCommand;
+      process.argv = originalArgv;
+    }
+
+    expect(mockRequireProjectRoot).not.toHaveBeenCalled();
+    expect(Client).not.toHaveBeenCalled();
+    expect(p.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("globally installed Dosu CLI"),
+    );
     expect(process.exitCode).toBe(1);
   });
 });
@@ -1715,28 +1779,23 @@ describe("runInstallSkill", () => {
   it("calls installSkill and returns true on success", async () => {
     mockInstallSkill.mockResolvedValue({ success: true, sha: "abc" });
 
-    const result = await runInstallSkill([ClaudeProvider()], tempDir);
+    const result = await runInstallSkill([ClaudeProvider()]);
     const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(true);
     expect(spinner?.start).toHaveBeenCalledWith("Installing skill for 1 agent");
     expect(spinner?.clear).toHaveBeenCalledOnce();
-    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], {
-      quiet: true,
-      projectRoot: tempDir,
-    });
+    expect(mockInstallSkill).toHaveBeenCalledWith(["claude"], { quiet: true });
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Skill ready for 1 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Claude Code"));
-    expect(p.log.success).toHaveBeenCalledWith(
-      expect.stringContaining(`${tempDir}/.claude/skills/dosu`),
-    );
-    expect(p.log.success).not.toHaveBeenCalledWith(expect.stringContaining("(symlink)"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("/skills/claude/dosu"));
+    expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("(symlink)"));
   });
 
   it("uses plural loading copy for multiple selected agents", async () => {
     mockInstallSkill.mockResolvedValue({ success: true });
 
-    await runInstallSkill([ClaudeProvider(), CursorProvider()], tempDir);
+    await runInstallSkill([ClaudeProvider(), CursorProvider()]);
     const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(spinner?.start).toHaveBeenCalledWith("Installing skill for 2 agents");
@@ -1746,7 +1805,7 @@ describe("runInstallSkill", () => {
   it("returns false and logs error when installSkill reports failure", async () => {
     mockInstallSkill.mockResolvedValue({ success: false });
 
-    const result = await runInstallSkill([ClaudeProvider()], tempDir);
+    const result = await runInstallSkill([ClaudeProvider()]);
     const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(false);
@@ -1758,7 +1817,7 @@ describe("runInstallSkill", () => {
   it("returns false and logs error when installSkill throws", async () => {
     mockInstallSkill.mockRejectedValue(new Error("boom"));
 
-    const result = await runInstallSkill([ClaudeProvider()], tempDir);
+    const result = await runInstallSkill([ClaudeProvider()]);
     const spinner = vi.mocked(p.spinner).mock.results[0]?.value;
 
     expect(result).toBe(false);

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -20,7 +20,7 @@ import {
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
-import { inGitWorkTree, stepUpdateAgentsMd } from "./agents-md-step";
+import { stepUpdateAgentsMd } from "./agents-md-step";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
 import {
   type LogsHandoffDecision,
@@ -28,6 +28,7 @@ import {
   launchLogsAgent,
   offerLogsHandoff,
 } from "./logs-handoff";
+import { requireProjectRoot } from "./project-root";
 import { stepConfigureAgentRules } from "./rules-step";
 import { browserFallbackHint, dim, formatSetupSummary, IconRemove, info } from "./styles";
 
@@ -100,6 +101,14 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
       mode_option: opts.mode,
     }),
   );
+  let projectRoot: string;
+  try {
+    projectRoot = requireProjectRoot();
+  } catch (err: unknown) {
+    p.log.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+    return;
+  }
 
   let cfg = loadConfig();
 
@@ -235,7 +244,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
 
   // Agent selection is the only install choice. Every successfully configured
   // agent receives the full supported bundle: MCP, rules, and skill.
-  const configured = await stepConfigureMcpTools(cfg);
+  const configured = await stepConfigureMcpTools(cfg, projectRoot);
   if (configured === null) {
     trackInBackground(
       trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_cancelled", {
@@ -264,9 +273,9 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   let skillCompleted = false;
   const skillProviders = configuredProviders
     .map((result) => result.provider)
-    .filter((provider) => skillInstallTargetForProvider(provider.id()) !== null);
+    .filter((provider) => skillInstallTargetForProvider(provider.id(), projectRoot) !== null);
   if (skillProviders.length > 0) {
-    skillCompleted = await runInstallSkill(skillProviders);
+    skillCompleted = await runInstallSkill(skillProviders, projectRoot);
     if (skillCompleted) {
       trackInBackground(
         trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_skill_installed"),
@@ -274,21 +283,19 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     }
   }
 
-  // Project instructions are part of the bundle when setup runs inside a git
-  // work tree and at least one agent was configured.
+  // Project instructions are part of every successfully configured project bundle.
   let agentsMdCompleted = false;
-  if (mcpCompleted && inGitWorkTree()) {
-    agentsMdCompleted = await stepUpdateAgentsMd();
+  if (mcpCompleted) {
+    agentsMdCompleted = await stepUpdateAgentsMd(projectRoot);
   }
 
   // Post-setup log mining (cloud mode only): replaces the old codebase-audit
   // CTA. Kickoff prefers agents the user just configured (Cursor / Claude / Codex).
-  // Gated on a git work tree, like the audit CTA it replaces: the handoff gives
-  // the terminal to a coding agent rooted at cwd, and `npx @dosu/cli setup` is
-  // routinely run straight from $HOME or a scratch directory.
+  // Project-root validation at setup launch guarantees this handoff stays in a
+  // Git project before it gives the terminal to a coding agent.
   let logsPlan: LogsHandoffPlan | null = null;
   let logsHandoff: LogsHandoffDecision | undefined;
-  if (mcpCompleted && cfg.mode !== MODE_OSS && inGitWorkTree()) {
+  if (mcpCompleted && cfg.mode !== MODE_OSS) {
     const preferredAgents = configuredProviders.map((result) => result.provider.id());
     const offer = await offerLogsHandoff({ preferredAgents });
     logsPlan = offer.plan;
@@ -353,7 +360,10 @@ function applyModeOverride(cfg: Config, opts: SetupOptions): void {
  * Returns the ConfigResult array on success, or null if the user cancelled.
  * An empty detection pool is treated as success (nothing to do).
  */
-async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null> {
+async function stepConfigureMcpTools(
+  cfg: Config,
+  projectRoot: string,
+): Promise<ConfigResult[] | null> {
   const detected = stepDetectTools();
   if (detected.length === 0) {
     p.log.warn(
@@ -361,11 +371,11 @@ async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null
     );
     return [];
   }
-  const selection = await stepSelectTools(detected);
+  const selection = await stepSelectTools(detected, projectRoot);
   if (!selection) return null;
-  const results = stepConfigureTools(cfg, selection);
-  stepShowSummary(results);
-  await stepConfigureAgentRules(selection, results);
+  const results = stepConfigureTools(cfg, selection, projectRoot);
+  stepShowSummary(results, projectRoot);
+  await stepConfigureAgentRules(selection, results, projectRoot);
   return results;
 }
 
@@ -373,7 +383,10 @@ async function stepConfigureMcpTools(cfg: Config): Promise<ConfigResult[] | null
  * Install the skill for the same providers selected during MCP setup.
  * Returns `true` on success.
  */
-export async function runInstallSkill(providers: readonly SetupProvider[]): Promise<boolean> {
+export async function runInstallSkill(
+  providers: readonly SetupProvider[],
+  projectRoot: string,
+): Promise<boolean> {
   logger.info("setup", "Step: install skill");
   const spinner = p.spinner();
   const agentLabel = providers.length === 1 ? "agent" : "agents";
@@ -385,12 +398,12 @@ export async function runInstallSkill(providers: readonly SetupProvider[]): Prom
     // verbose.
     const result = await installSkill(
       providers.map((provider) => provider.id()),
-      { quiet: true },
+      { quiet: true, projectRoot },
     );
     if (result.success) {
       logger.info("setup", `Skill installed${result.sha ? ` sha=${result.sha}` : ""}`);
       const items = providers.flatMap((provider) => {
-        const target = skillInstallTargetForProvider(provider.id());
+        const target = skillInstallTargetForProvider(provider.id(), projectRoot);
         if (!target) return [];
         return [
           {
@@ -822,13 +835,18 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
 }
 
 export function stepDetectTools(): SetupProvider[] {
-  return allSetupProviders().filter((p) => p.isInstalled());
+  return allSetupProviders().filter((p) => p.supportsLocal() && p.isInstalled());
 }
 
-async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection | null> {
+async function stepSelectTools(
+  detected: SetupProvider[],
+  projectRoot: string,
+): Promise<ToolSelection | null> {
   const configuredMap = new Map<string, boolean>();
+  const legacyGlobalMap = new Map<string, boolean>();
   for (const p of detected) {
-    configuredMap.set(p.id(), p.isConfigured());
+    configuredMap.set(p.id(), p.isProjectConfigured(projectRoot));
+    legacyGlobalMap.set(p.id(), p.isConfigured());
   }
 
   const options = detected.map((p) => {
@@ -836,11 +854,17 @@ async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection
     return {
       label: p.name(),
       value: p.id(),
-      hint: configured ? "configured — untick to remove" : undefined,
+      hint: configured
+        ? "configured in this project — untick to remove"
+        : legacyGlobalMap.get(p.id())
+          ? "global config found — ticked to configure this project"
+          : undefined,
     };
   });
 
-  const preselected = detected.filter((p) => configuredMap.get(p.id())).map((p) => p.id());
+  const preselected = detected
+    .filter((p) => configuredMap.get(p.id()) || legacyGlobalMap.get(p.id()))
+    .map((p) => p.id());
 
   const selected = await p.multiselect({
     message: "Select agents — tick to configure, untick to remove",
@@ -864,12 +888,16 @@ async function stepSelectTools(detected: SetupProvider[]): Promise<ToolSelection
   return result;
 }
 
-export function stepConfigureTools(cfg: Config, selection: ToolSelection): ConfigResult[] {
+export function stepConfigureTools(
+  cfg: Config,
+  selection: ToolSelection,
+  projectRoot: string,
+): ConfigResult[] {
   const results: ConfigResult[] = [];
 
   for (const provider of selection.toInstall) {
     try {
-      provider.install(cfg, true);
+      provider.install(cfg, false, { projectRoot });
       logger.info("setup", `Configured ${provider.name()}`);
       results.push({ provider, action: "install" });
     } catch (err: unknown) {
@@ -886,7 +914,7 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
 
   for (const provider of selection.toRemove) {
     try {
-      provider.remove(true);
+      provider.remove(false, { projectRoot });
       logger.info("setup", `Removed ${provider.name()}`);
       results.push({ provider, action: "remove" });
     } catch (err: unknown) {
@@ -908,7 +936,7 @@ export function stepConfigureTools(cfg: Config, selection: ToolSelection): Confi
   return results;
 }
 
-export function stepShowSummary(results: ConfigResult[]): void {
+export function stepShowSummary(results: ConfigResult[], projectRoot: string): void {
   const installed = results.filter((r) => r.action === "install" && !r.error);
   const removed = results.filter((r) => r.action === "remove" && !r.error);
   const skipped = results.filter((r) => r.action === "skip");
@@ -919,7 +947,7 @@ export function stepShowSummary(results: ConfigResult[]): void {
         `Configured ${installed.length} agent(s):`,
         installed.map((result) => ({
           label: result.provider.name(),
-          path: result.provider.globalConfigPath(),
+          path: result.provider.projectConfigPath(projectRoot) ?? "project configuration",
         })),
       ),
     );
@@ -931,7 +959,7 @@ export function stepShowSummary(results: ConfigResult[]): void {
         `Removed from ${removed.length} agent(s):`,
         removed.map((result) => ({
           label: result.provider.name(),
-          path: result.provider.globalConfigPath(),
+          path: result.provider.projectConfigPath(projectRoot) ?? "project configuration",
         })),
         IconRemove,
       ),

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -20,8 +20,9 @@ import {
 import { logger } from "../debug/logger";
 import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
-import { stepUpdateAgentsMd } from "./agents-md-step";
+import { stepRemoveAgentsMd, stepUpdateAgentsMd } from "./agents-md-step";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
+import { GLOBAL_INSTALL_REQUIRED_MESSAGE, setupNeedsGlobalInstall } from "./global-install";
 import {
   type LogsHandoffDecision,
   type LogsHandoffPlan,
@@ -87,6 +88,11 @@ function trackInBackground(tracking: Promise<void>): void {
 }
 
 export async function runSetup(opts: SetupOptions = {}): Promise<void> {
+  if (setupNeedsGlobalInstall()) {
+    p.log.error(GLOBAL_INSTALL_REQUIRED_MESSAGE);
+    process.exitCode = 1;
+    return;
+  }
   const onboardingRunID = randomUUID();
   logger.info(
     "setup",
@@ -273,9 +279,9 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   let skillCompleted = false;
   const skillProviders = configuredProviders
     .map((result) => result.provider)
-    .filter((provider) => skillInstallTargetForProvider(provider.id(), projectRoot) !== null);
+    .filter((provider) => skillInstallTargetForProvider(provider.id()) !== null);
   if (skillProviders.length > 0) {
-    skillCompleted = await runInstallSkill(skillProviders, projectRoot);
+    skillCompleted = await runInstallSkill(skillProviders);
     if (skillCompleted) {
       trackInBackground(
         trackCliOnboardingEvent(cfg, onboardingRunID, "cli_onboarding_skill_installed"),
@@ -283,10 +289,17 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
     }
   }
 
-  // Project instructions are part of every successfully configured project bundle.
+  // Project instructions exist iff this project still has a Dosu MCP. Removing
+  // the last selected agent reconciles the exact marker-owned section too.
   let agentsMdCompleted = false;
   if (mcpCompleted) {
     agentsMdCompleted = await stepUpdateAgentsMd(projectRoot);
+  } else if (
+    configured.length > 0 &&
+    configured.every((result) => result.action === "remove" && !result.error) &&
+    !hasConfiguredProjectProvider(projectRoot)
+  ) {
+    agentsMdCompleted = stepRemoveAgentsMd(projectRoot);
   }
 
   // Post-setup log mining (cloud mode only): replaces the old codebase-audit
@@ -326,6 +339,13 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   if (logsPlan) {
     launchLogsAgent(logsPlan);
   }
+}
+
+function hasConfiguredProjectProvider(projectRoot: string): boolean {
+  return allSetupProviders().some(
+    (provider) =>
+      provider.configurationKind() === "project" && provider.isProjectConfigured(projectRoot),
+  );
 }
 
 /**
@@ -383,10 +403,7 @@ async function stepConfigureMcpTools(
  * Install the skill for the same providers selected during MCP setup.
  * Returns `true` on success.
  */
-export async function runInstallSkill(
-  providers: readonly SetupProvider[],
-  projectRoot: string,
-): Promise<boolean> {
+export async function runInstallSkill(providers: readonly SetupProvider[]): Promise<boolean> {
   logger.info("setup", "Step: install skill");
   const spinner = p.spinner();
   const agentLabel = providers.length === 1 ? "agent" : "agents";
@@ -398,12 +415,12 @@ export async function runInstallSkill(
     // verbose.
     const result = await installSkill(
       providers.map((provider) => provider.id()),
-      { quiet: true, projectRoot },
+      { quiet: true },
     );
     if (result.success) {
       logger.info("setup", `Skill installed${result.sha ? ` sha=${result.sha}` : ""}`);
       const items = providers.flatMap((provider) => {
-        const target = skillInstallTargetForProvider(provider.id(), projectRoot);
+        const target = skillInstallTargetForProvider(provider.id());
         if (!target) return [];
         return [
           {
@@ -835,7 +852,9 @@ async function stepMintAPIKey(apiClient: Client, cfg: Config): Promise<string | 
 }
 
 export function stepDetectTools(): SetupProvider[] {
-  return allSetupProviders().filter((p) => p.supportsLocal() && p.isInstalled());
+  return allSetupProviders().filter(
+    (provider) => provider.configurationKind() === "project" && provider.isInstalled(),
+  );
 }
 
 async function stepSelectTools(
@@ -898,7 +917,7 @@ export function stepConfigureTools(
 
   for (const provider of selection.toInstall) {
     try {
-      provider.install(cfg, false, { projectRoot });
+      provider.install(cfg, { scope: "project", projectRoot });
       const projectConfigPath = provider.projectConfigPath(projectRoot);
       if (projectConfigPath) retainedProjectConfigPaths.add(projectConfigPath);
       logger.info("setup", `Configured ${provider.name()}`);
@@ -919,7 +938,7 @@ export function stepConfigureTools(
     try {
       const projectConfigPath = provider.projectConfigPath(projectRoot);
       if (!projectConfigPath || !retainedProjectConfigPaths.has(projectConfigPath)) {
-        provider.remove(false, { projectRoot });
+        provider.remove({ scope: "project", projectRoot });
       }
       logger.info("setup", `Removed ${provider.name()}`);
       results.push({ provider, action: "remove" });

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -894,10 +894,13 @@ export function stepConfigureTools(
   projectRoot: string,
 ): ConfigResult[] {
   const results: ConfigResult[] = [];
+  const retainedProjectConfigPaths = new Set<string>();
 
   for (const provider of selection.toInstall) {
     try {
       provider.install(cfg, false, { projectRoot });
+      const projectConfigPath = provider.projectConfigPath(projectRoot);
+      if (projectConfigPath) retainedProjectConfigPaths.add(projectConfigPath);
       logger.info("setup", `Configured ${provider.name()}`);
       results.push({ provider, action: "install" });
     } catch (err: unknown) {
@@ -914,7 +917,10 @@ export function stepConfigureTools(
 
   for (const provider of selection.toRemove) {
     try {
-      provider.remove(false, { projectRoot });
+      const projectConfigPath = provider.projectConfigPath(projectRoot);
+      if (!projectConfigPath || !retainedProjectConfigPaths.has(projectConfigPath)) {
+        provider.remove(false, { projectRoot });
+      }
       logger.info("setup", `Removed ${provider.name()}`);
       results.push({ provider, action: "remove" });
     } catch (err: unknown) {

--- a/src/setup/global-install.test.ts
+++ b/src/setup/global-install.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { setupNeedsGlobalInstall } from "./global-install";
+
+describe("setupNeedsGlobalInstall", () => {
+  it("recognizes @dosu/cli launched ephemerally by npm exec", () => {
+    expect(
+      setupNeedsGlobalInstall(
+        "npm",
+        {
+          npm_command: "exec",
+          npm_execpath: "/opt/node/lib/node_modules/npm/bin/npm-cli.js",
+        },
+        "/home/user/.npm/_npx/abc123/node_modules/.bin/dosu",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores inherited npm exec variables from a parent process", () => {
+    expect(
+      setupNeedsGlobalInstall(
+        "npm",
+        {
+          npm_command: "exec",
+          npm_execpath: "/opt/node/lib/node_modules/npm/bin/npm-cli.js",
+        },
+        "/usr/local/lib/node_modules/@dosu/cli/bin/dosu.js",
+      ),
+    ).toBe(false);
+  });
+
+  it("blocks a project-local @dosu/cli even when launched from a subdirectory", () => {
+    expect(
+      setupNeedsGlobalInstall(
+        "npm",
+        {},
+        "/workspace/node_modules/@dosu/cli/bin/dosu.js",
+        "/workspace/packages/app",
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    "/home/user/.cache/pnpm/dlx-123/node_modules/@dosu/cli/bin/dosu.js",
+    "/home/user/.bun/install/cache/@dosu/cli@0.49.4/bin/dosu.js",
+    "C:\\repo\\node_modules\\.bin\\dosu.cmd",
+  ])("blocks a temporary package runner entrypoint at %s", (entrypoint) => {
+    expect(setupNeedsGlobalInstall("npm", {}, entrypoint, "/repo")).toBe(true);
+  });
+
+  it("does not mistake a global nvm package for a local install when run from home", () => {
+    expect(
+      setupNeedsGlobalInstall(
+        "npm",
+        {},
+        "/home/user/.nvm/versions/node/v22/lib/node_modules/@dosu/cli/bin/dosu.js",
+        "/home/user",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not mistake bunx test execution for an npx Dosu invocation", () => {
+    expect(
+      setupNeedsGlobalInstall(
+        "npm",
+        {
+          npm_lifecycle_event: "npx",
+          npm_execpath: "/opt/homebrew/bin/bun",
+        },
+        "/workspace/node_modules/vitest/vitest.mjs",
+      ),
+    ).toBe(false);
+  });
+
+  it("never treats non-npm builds as temporary npx installs", () => {
+    expect(
+      setupNeedsGlobalInstall(
+        "homebrew",
+        {
+          npm_command: "exec",
+          npm_execpath: "/opt/node/lib/node_modules/npm/bin/npm-cli.js",
+        },
+        "C:\\Users\\me\\AppData\\Local\\npm-cache\\_npx\\abc\\node_modules\\.bin\\dosu.cmd",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/setup/global-install.ts
+++ b/src/setup/global-install.ts
@@ -1,0 +1,38 @@
+import { INSTALL_CHANNEL } from "../version/version";
+
+export const GLOBAL_INSTALL_REQUIRED_MESSAGE =
+  "Project setup requires a globally installed Dosu CLI. Install Dosu globally with `curl -fsSL https://cli.dosu.dev/install | sh`, npm, or Homebrew, then run `dosu setup` again.";
+
+/** A project MCP calls `dosu`, so an ephemeral npx-only setup would create a broken project. */
+export function setupNeedsGlobalInstall(
+  channel: string = INSTALL_CHANNEL,
+  _env: Readonly<Record<string, string | undefined>> = process.env,
+  entrypoint: string | undefined = process.argv[1],
+  cwd: string = process.cwd(),
+): boolean {
+  if (channel !== "npm") return false;
+
+  // npm lifecycle variables are inherited and therefore are not proof that
+  // this CLI itself is temporary. Classify only the entrypoint locations used
+  // by npm exec, pnpm dlx, bunx, or a project-local node_modules install.
+  const normalizedEntrypoint = (entrypoint ?? "").replaceAll("\\", "/");
+  const normalizedCwd = cwd.replaceAll("\\", "/").replace(/\/$/, "");
+  const lowerEntrypoint = normalizedEntrypoint.toLowerCase();
+  const lowerCwd = normalizedCwd.toLowerCase();
+
+  if (
+    /\/_npx\/[^/]+\/node_modules\//.test(lowerEntrypoint) ||
+    /\/(?:pnpm|npm)(?:-cache)?\/(?:.*\/)?(?:dlx|tmp\/dlx-)[^/]*\//.test(lowerEntrypoint) ||
+    /\/\.bun\/install\/(?:cache|tmp)\//.test(lowerEntrypoint) ||
+    /\/node_modules\/\.bin\/dosu(?:\.(?:cmd|ps1))?$/.test(lowerEntrypoint)
+  ) {
+    return true;
+  }
+
+  const packageSegment = "/node_modules/@dosu/cli/";
+  const packageIndex = lowerEntrypoint.indexOf(packageSegment);
+  if (packageIndex === -1) return false;
+
+  const projectRoot = lowerEntrypoint.slice(0, packageIndex);
+  return lowerCwd === projectRoot || lowerCwd.startsWith(`${projectRoot}/`);
+}

--- a/src/setup/project-root.test.ts
+++ b/src/setup/project-root.test.ts
@@ -1,0 +1,98 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { assertSafeProjectPath, requireProjectRoot, resolveProjectRoot } from "./project-root";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const path = mkdtempSync(join(tmpdir(), "dosu-project-root-"));
+  tempDirs.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("resolveProjectRoot", () => {
+  it("returns the Git root when called from a nested directory", () => {
+    const root = tempDir();
+    execFileSync("git", ["init", "--quiet", root]);
+    const nested = join(root, "packages", "cli");
+    mkdirSync(nested, { recursive: true });
+
+    expect(resolveProjectRoot(nested)).toBe(realpathSync(root));
+  });
+
+  it("returns null outside a Git work tree", () => {
+    expect(resolveProjectRoot(tempDir())).toBeNull();
+  });
+});
+
+describe("requireProjectRoot", () => {
+  it("fails before setup can write outside a project", () => {
+    expect(() => requireProjectRoot(tempDir())).toThrow("inside a Git project");
+  });
+});
+
+describe("assertSafeProjectPath", () => {
+  it("allows a new nested path under the verified root", () => {
+    const root = realpathSync(tempDir());
+
+    expect(() => assertSafeProjectPath(root, join(root, ".cursor", "mcp.json"))).not.toThrow();
+  });
+
+  it("allows existing regular directories and files", () => {
+    const root = realpathSync(tempDir());
+    const target = join(root, ".cursor", "mcp.json");
+    mkdirSync(join(root, ".cursor"));
+    writeFileSync(target, "{}\n");
+
+    expect(() => assertSafeProjectPath(root, target)).not.toThrow();
+  });
+
+  it.each([
+    ["the root itself", (root: string) => root],
+    ["a parent escape", (root: string) => join(root, "..", "outside.json")],
+    ["a sibling with the same prefix", (root: string) => `${root}-outside/mcp.json`],
+  ])("rejects %s", (_name, targetForRoot) => {
+    const root = realpathSync(tempDir());
+
+    expect(() => assertSafeProjectPath(root, targetForRoot(root))).toThrow(
+      "outside the verified Git project",
+    );
+  });
+
+  it("rejects an existing symlink directory even when it points inside the root", () => {
+    const root = realpathSync(tempDir());
+    const realDirectory = join(root, "real-config");
+    mkdirSync(realDirectory);
+    symlinkSync(realDirectory, join(root, ".cursor"));
+
+    expect(() => assertSafeProjectPath(root, join(root, ".cursor", "mcp.json"))).toThrow(
+      "symbolic link",
+    );
+  });
+
+  it("rejects a symlink directory that escapes the root", () => {
+    const root = realpathSync(tempDir());
+    const outside = tempDir();
+    symlinkSync(outside, join(root, ".cursor"));
+
+    expect(() => assertSafeProjectPath(root, join(root, ".cursor", "mcp.json"))).toThrow(
+      "symbolic link",
+    );
+  });
+
+  it("rejects the target file itself when it is a symlink", () => {
+    const root = realpathSync(tempDir());
+    const outside = join(tempDir(), "outside.json");
+    writeFileSync(outside, "do not touch\n");
+    symlinkSync(outside, join(root, ".mcp.json"));
+
+    expect(() => assertSafeProjectPath(root, join(root, ".mcp.json"))).toThrow("symbolic link");
+  });
+});

--- a/src/setup/project-root.ts
+++ b/src/setup/project-root.ts
@@ -1,0 +1,58 @@
+import { execFileSync } from "node:child_process";
+import { lstatSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+
+/** Resolve the repository root that project-scoped setup is allowed to modify. */
+export function resolveProjectRoot(cwd: string = process.cwd()): string | null {
+  try {
+    const output = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!output) return null;
+    return realpathSync(isAbsolute(output) ? output : resolve(cwd, output));
+  } catch {
+    return null;
+  }
+}
+
+export function requireProjectRoot(cwd: string = process.cwd()): string {
+  const root = resolveProjectRoot(cwd);
+  if (!root) {
+    throw new Error("Run Dosu setup inside a Git project.");
+  }
+  return root;
+}
+
+/**
+ * Refuse project mutations that escape the verified root or traverse a
+ * pre-existing symbolic link. Call immediately before reading or writing a
+ * project-owned path.
+ */
+export function assertSafeProjectPath(projectRoot: string, targetPath: string): void {
+  const root = resolve(projectRoot);
+  const target = resolve(targetPath);
+  const targetRelative = relative(root, target);
+  if (
+    !targetRelative ||
+    targetRelative === ".." ||
+    targetRelative.startsWith(`..${sep}`) ||
+    isAbsolute(targetRelative)
+  ) {
+    throw new Error(`Refusing to access a path outside the verified Git project: ${target}`);
+  }
+
+  let current = root;
+  for (const segment of targetRelative.split(sep)) {
+    current = join(current, segment);
+    try {
+      if (lstatSync(current).isSymbolicLink()) {
+        throw new Error(`Refusing to access a symbolic link in the project path: ${current}`);
+      }
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+  }
+}

--- a/src/setup/rules-step.test.ts
+++ b/src/setup/rules-step.test.ts
@@ -44,7 +44,7 @@ function makeProvider(id: string): SetupProvider {
   return {
     id: () => id,
     name: () => `Agent ${id}`,
-    supportsLocal: () => true,
+    configurationKind: () => "project",
     install: vi.fn(),
     remove: vi.fn(),
     detectPaths: () => [],

--- a/src/setup/rules-step.test.ts
+++ b/src/setup/rules-step.test.ts
@@ -51,6 +51,8 @@ function makeProvider(id: string): SetupProvider {
     isInstalled: () => true,
     isConfigured: () => false,
     globalConfigPath: () => `/config/${id}`,
+    projectConfigPath: (root) => `${root}/config/${id}`,
+    isProjectConfigured: () => false,
     priority: () => 0,
   };
 }
@@ -77,6 +79,32 @@ beforeEach(() => {
 });
 
 describe("stepConfigureAgentRules", () => {
+  it("leaves Codex project instructions to the canonical AGENTS.md step", async () => {
+    const codex = makeProvider("codex");
+    mockRulePathForAgent.mockReturnValue(null);
+
+    const results = await stepConfigureAgentRules(
+      { toInstall: [codex], toRemove: [] },
+      [{ provider: codex, action: "install" }],
+      "/repo",
+    );
+
+    expect(results).toEqual([]);
+    expect(mockFetchDosuRule).not.toHaveBeenCalled();
+  });
+
+  it("passes the verified project root to rule installation", async () => {
+    const claude = makeProvider("claude");
+
+    await stepConfigureAgentRules(
+      { toInstall: [claude], toRemove: [] },
+      [{ provider: claude, action: "install" }],
+      "/repo",
+    );
+
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n", "/repo");
+  });
+
   it("installs one fetched rule for every successfully configured supported agent", async () => {
     const claude = makeProvider("claude");
     const cursor = makeProvider("cursor");
@@ -95,8 +123,8 @@ describe("stepConfigureAgentRules", () => {
 
     expect(mockFetchDosuRule).toHaveBeenCalledTimes(1);
     expect(mockInstallRuleForAgent).toHaveBeenCalledTimes(2);
-    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n");
-    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("cursor", "canonical rule\n");
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("claude", "canonical rule\n", undefined);
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("cursor", "canonical rule\n", undefined);
     expect(results).toHaveLength(2);
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Rules ready for 2 agent"));
     expect(p.log.success).toHaveBeenCalledWith(expect.stringContaining("Agent claude"));
@@ -122,7 +150,7 @@ describe("stepConfigureAgentRules", () => {
       { provider: codex, action: "remove" },
     ]);
 
-    expect(mockRemoveRuleForAgent).toHaveBeenCalledWith("codex");
+    expect(mockRemoveRuleForAgent).toHaveBeenCalledWith("codex", undefined);
     expect(results).toEqual([
       expect.objectContaining({ provider: codex, action: "removed", path: "/rules/codex.md" }),
     ]);
@@ -138,7 +166,7 @@ describe("stepConfigureAgentRules", () => {
       { provider: antigravity, action: "remove" },
     ]);
 
-    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("gemini", "canonical rule\n");
+    expect(mockInstallRuleForAgent).toHaveBeenCalledWith("gemini", "canonical rule\n", undefined);
     expect(mockRemoveRuleForAgent).not.toHaveBeenCalled();
   });
 

--- a/src/setup/rules-step.ts
+++ b/src/setup/rules-step.ts
@@ -76,14 +76,21 @@ function logRuleResults(results: AgentRuleSetupResult[]): void {
 export async function stepConfigureAgentRules(
   selection: SetupSelection,
   mcpResults: McpResult[],
+  projectRoot?: string,
 ): Promise<AgentRuleSetupResult[]> {
   const successfulInstalls = successfulAgentIDs(mcpResults, "install");
   const successfulRemovals = successfulAgentIDs(mcpResults, "remove");
   const toInstall = selection.toInstall.filter(
-    (provider) => successfulInstalls.has(provider.id()) && isRuleAgent(provider.id()),
+    (provider) =>
+      successfulInstalls.has(provider.id()) &&
+      isRuleAgent(provider.id()) &&
+      rulePathForAgent(provider.id(), projectRoot) !== null,
   );
   const toRemove = selection.toRemove.filter(
-    (provider) => successfulRemovals.has(provider.id()) && isRuleAgent(provider.id()),
+    (provider) =>
+      successfulRemovals.has(provider.id()) &&
+      isRuleAgent(provider.id()) &&
+      rulePathForAgent(provider.id(), projectRoot) !== null,
   );
   const results: AgentRuleSetupResult[] = [];
 
@@ -91,7 +98,7 @@ export async function stepConfigureAgentRules(
     const content = await fetchDosuRule();
     for (const provider of toInstall) {
       try {
-        const installed = installRuleForAgent(provider.id(), content);
+        const installed = installRuleForAgent(provider.id(), content, projectRoot);
         if (installed) results.push({ provider, action: installed.action, path: installed.path });
       } catch (err: unknown) {
         const error = err instanceof Error ? err : new Error(String(err));
@@ -103,7 +110,7 @@ export async function stepConfigureAgentRules(
         results.push({
           provider,
           action: "not_found",
-          path: rulePathForAgent(provider.id()) ?? "",
+          path: rulePathForAgent(provider.id(), projectRoot) ?? "",
           error,
         });
       }
@@ -114,16 +121,16 @@ export async function stepConfigureAgentRules(
   // Keep the shared section if either selected agent still needs it.
   const retainedPaths = new Set(
     toInstall
-      .map((provider) => rulePathForAgent(provider.id()))
+      .map((provider) => rulePathForAgent(provider.id(), projectRoot))
       .filter((path): path is string => path !== null),
   );
 
   for (const provider of toRemove) {
-    const path = rulePathForAgent(provider.id());
+    const path = rulePathForAgent(provider.id(), projectRoot);
     if (path && retainedPaths.has(path)) continue;
 
     try {
-      const removed = removeRuleForAgent(provider.id());
+      const removed = removeRuleForAgent(provider.id(), projectRoot);
       if (removed) results.push({ provider, action: removed.action, path: removed.path });
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
## Summary

- make `dosu setup` activate only the current Git project: project MCP, owned rules, and the marker-owned root `AGENTS.md` section
- migrate private config to v3 so one account can retain a separate API key for every Library; switching accounts clears the previous account aggregate
- write secretless project MCP commands as `dosu mcp proxy --deployment <id>`; the proxy selects the matching saved credential and fails closed when it is absent
- install every reviewed skill from `dosu-ai/dosu-skill` globally for the selected agents; project directories receive no skill copies
- make `dosu upgrade` refresh only an installed official skill set, preserving its existing agent targets and leaving a user-deleted set deleted
- separate provider policy into `project`, `global-connector`, and `unsupported`; project agents cannot be installed globally
- parse Codex TOML with `toml-eslint-parser`, preserving unrelated content, comments, and line endings while rejecting malformed, duplicate, or foreign Dosu definitions

This is independently releasable stack **1/3**. [#170](https://github.com/dosu-ai/dosu-cli/pull/170) adds exact historical-global cleanup; [#193](https://github.com/dosu-ai/dosu-cli/pull/193) adds bulk project selection.

## Scope

| Global | Current project |
| --- | --- |
| CLI and login session | secretless MCP entry |
| one API key per Library | owned agent rule where supported |
| all official Dosu skills for selected agents | marker-owned root `AGENTS.md` section |

Claude Desktop and manual configuration remain explicit `--global` connectors. Cline, Windsurf, and Antigravity remain unchanged where the CLI cannot safely write a project config this release.

## Safety boundaries

- temporary `npx`, local `node_modules`, `pnpm dlx`, and `bunx` setup invocations stop before auth or writes and direct the user to install the global CLI
- project paths reject symlinks and path escape; malformed config and foreign same-named entries are preserved byte-for-byte
- deselecting an agent removes only exact Dosu-owned project content; the root `AGENTS.md` section is removed only after every selected removal succeeds and no project provider remains configured
- Codex edits only one unambiguous `[mcp_servers.dosu]` table and retains surrounding TOML formatting and comments
- skill commands use an absolute `npx`, argument arrays, a neutral HOME working directory, and hardened Windows execution instead of a project shell string
- native binaries are compiled with Bun 1.4.0+ and disable cwd `.env` / `bunfig.toml` loading; CI runs an adversarial cwd smoke. This follows [Bun's executable config-isolation contract](https://bun.com/docs/bundler/executables#disabling-config-loading-at-runtime).

## Primary product evidence

- Claude project MCP and rules: [MCP scopes](https://code.claude.com/docs/en/mcp#mcp-installation-scopes), [rules](https://code.claude.com/docs/en/memory#organize-rules-with-clauderules)
- Cursor project MCP and rules: [MCP configuration](https://docs.cursor.com/context/model-context-protocol#configuration-locations), [project rules](https://docs.cursor.com/context/rules#project-rules)
- VS Code workspace MCP: [official configuration](https://code.visualstudio.com/docs/agent-customization/mcp-servers)
- Gemini CLI workspace settings and MCP: [settings](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/settings.md), [MCP](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)
- Codex project config and instructions: [config layers](https://developers.openai.com/codex/config-basic), [`AGENTS.md`](https://developers.openai.com/codex/guides/agents-md)
- Zed project MCP: [secure project settings](https://zed.dev/blog/secure-by-default), [custom MCP servers](https://zed.dev/docs/ai/mcp#as-custom-servers)
- GitHub Copilot CLI workspace MCP: [CLI reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference), [config directories](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference)
- OpenCode project config and MCP: [config locations](https://opencode.ai/v2/docs/config#locations), [MCP servers](https://opencode.ai/docs/mcp-servers/)
- Factory and MCPorter: [Factory MCP](https://docs.factory.ai/harness/mcp#configuration-file), [MCPorter config](https://github.com/openclaw/mcporter/blob/main/docs/config.md)
- global skill installation behavior: [`skills` README](https://github.com/vercel-labs/skills/blob/main/README.md)

## Red / green verification

- red contract commit: `71d605c`
- green implementation commits: `6a4211a`, `f15b921`
- `bun run check`
- `bun run deadcode`
- `bun run typecheck`
- `bun run test` — 74 files, 1,797 tests passed on Bun 1.4.0
- `bun run build:npm` and `npm pack --dry-run`
- `bun run build` plus adversarial project `.env` smoke
- `bun run build:all` — all 7 platform binaries built
- installed packed npm CLI in an isolated prefix and verified:
  - temporary `npm exec` setup stopped before credentials or project writes
  - a v2 config migrated on disk to v3 without losing its key
  - active Library B coexisted with Library A, while the Library A project proxy selected only Library A's key
  - a missing deployment credential failed closed
  - `mcp add cursor` wrote only project `.cursor/mcp.json`, contained no key, and created no project skill directory

No merge or release is included.

## 2026-08-27 refresh

- merged current main at v0.51.0 (7b52fd9) without force-pushing
- resolved the setup-flow overlap by retaining both the project-scoped install guard and main's GitHub-connect offer
- exact head: 4aaf42e
- full local gate: 76 files / 1,851 tests, 90.14% branch coverage, check, dead-code, typecheck, native build, seven-platform build, and npm pack
- exact-head GitHub CI passed: https://github.com/dosu-ai/dosu-cli/actions/runs/33115996233