### PR TITLE
feat: install every skill in the dosu-skill repo

### DIFF
--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -90,7 +90,7 @@ describe("skill install", () => {
         "npx skills add dosu-ai/dosu-skill -g",
         "-a claude-code -a cursor -a gemini-cli -a codex -a windsurf",
         "-a zed -a cline -a github-copilot -a opencode -a antigravity",
-        "-s dosu -y",
+        "-s '*' -y",
       ].join(" "),
       {
         stdio: "inherit",
@@ -190,7 +190,7 @@ describe("installSkill helper", () => {
 
     expect(result.success).toBe(true);
     expect(mockExecSync).toHaveBeenCalledWith(
-      "npx skills add dosu-ai/dosu-skill -g -a claude-code -a codex -s dosu -y",
+      "npx skills add dosu-ai/dosu-skill -g -a claude-code -a codex -s '*' -y",
       { stdio: "inherit" },
     );
   });

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -90,7 +90,7 @@ describe("skill install", () => {
         "npx skills add dosu-ai/dosu-skill -g",
         "-a claude-code -a cursor -a gemini-cli -a codex -a windsurf",
         "-a zed -a cline -a github-copilot -a opencode -a antigravity",
-        "-s '*' -y",
+        '-s "*" -y',
       ].join(" "),
       {
         stdio: "inherit",
@@ -190,7 +190,7 @@ describe("installSkill helper", () => {
 
     expect(result.success).toBe(true);
     expect(mockExecSync).toHaveBeenCalledWith(
-      "npx skills add dosu-ai/dosu-skill -g -a claude-code -a codex -s '*' -y",
+      'npx skills add dosu-ai/dosu-skill -g -a claude-code -a codex -s "*" -y',
       { stdio: "inherit" },
     );
   });

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -110,10 +110,13 @@ export async function installSkill(
   }
 
   try {
-    // `-s '*'` installs every skill the repo exposes, so adding one upstream
-    // does not require a CLI release. The quotes matter: the command runs
-    // through a shell, and a bare `*` would be glob-expanded against cwd.
-    const command = `npx skills add ${SKILL_REPO} -g ${agentArgs} -s '*' -y`;
+    // `-s "*"` installs every skill the repo exposes, so adding one upstream
+    // does not require a CLI release. The quoting is load-bearing and must be
+    // double quotes: this string is run through a shell, so on POSIX a bare `*`
+    // would glob-expand against cwd, while on Windows the shell is cmd.exe,
+    // which does not treat single quotes as delimiters and would forward a
+    // literal `'*'` that matches no skill name.
+    const command = `npx skills add ${SKILL_REPO} -g ${agentArgs} -s "*" -y`;
     if (options.quiet) await execQuiet(command);
     else execSync(command, { stdio: "inherit" });
   } catch (err) {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -110,7 +110,10 @@ export async function installSkill(
   }
 
   try {
-    const command = `npx skills add ${SKILL_REPO} -g ${agentArgs} -s ${SKILL_NAME} -y`;
+    // `-s '*'` installs every skill the repo exposes, so adding one upstream
+    // does not require a CLI release. The quotes matter: the command runs
+    // through a shell, and a bare `*` would be glob-expanded against cwd.
+    const command = `npx skills add ${SKILL_REPO} -g ${agentArgs} -s '*' -y`;
     if (options.quiet) await execQuiet(command);
     else execSync(command, { stdio: "inherit" });
   } catch (err) {
@@ -138,10 +141,10 @@ export function skillCommand(): Command {
     .command("install")
     .description("Install the Dosu skill for AI coding agents")
     .action(async () => {
-      console.log(`Installing ${SKILL_NAME} skill from ${SKILL_REPO}...`);
+      console.log(`Installing skills from ${SKILL_REPO}...`);
       const result = await installSkill();
       if (result.success) {
-        console.log(pc.green(`\n✓ Skill "${SKILL_NAME}" installed successfully.`));
+        console.log(pc.green(`\n✓ Skills installed successfully.`));
       } else {
         console.error(pc.red(`\nFailed to install skill. Make sure npx is available.`));
         process.exit(1);
@@ -168,7 +171,7 @@ export function skillCommand(): Command {
     .command("update")
     .description("Update the Dosu skill to the latest version")
     .action(async () => {
-      console.log(`Updating ${SKILL_NAME} skill...`);
+      console.log(`Updating skills from ${SKILL_REPO}...`);
       // Reinstall rather than `npx skills update`: update matches on the
       // skillPath recorded in the skills lockfile, so it can't follow the
       // skill across a repo-layout move (it reports "deleted upstream"
@@ -179,7 +182,7 @@ export function skillCommand(): Command {
         console.error(pc.red(`\nFailed to update skill.`));
         process.exit(1);
       }
-      console.log(pc.green(`\n✓ Skill "${SKILL_NAME}" updated.`));
+      console.log(pc.green(`\n✓ Skills updated.`));
     });
 
   return cmd;


### PR DESCRIPTION
## Problem

`installSkill()` shells out to:

```
npx skills add dosu-ai/dosu-skill -g <agents…> -s dosu -y
```

`-s dosu` is an exact-name filter. The `skills` CLI discovers everything under `skills/` in the source repo, then drops anything whose `SKILL.md` `name` isn't `dosu`. So a second skill added to `dosu-ai/dosu-skill` would silently never install, and shipping it would require a CLI release in lockstep.

Dropping `-s` entirely is not an option either: with two or more skills the CLI falls through to an interactive multiselect (nothing pre-selected), which hangs in the non-TTY paths — `setup --agent` and the quiet install used by the setup wizard.

## Change

Replace the filter with `-s '*'`, the CLI's documented "install all skills" selector. Upstream can now add skills without a coordinated CLI release.

The quoting is load-bearing: the command is run through a shell, so a bare `*` would glob-expand against cwd.

Install/update console output no longer names a single skill.

## Not in scope

`dosu skill remove` still targets `-s dosu` only, so a second skill would be orphaned. Fixed in #173.

> **Correction:** this section originally claimed `-s '*'` on `remove` would delete every globally installed skill from every source. That is wrong. `remove` never parses `-s` at all, and its name resolution has no wildcard, so `-s '*'` silently removes nothing. The conclusion (enumerate the names instead) still holds; the stated reason did not.

## Verification

- `bun run test` — 1574 passed
- `bun run typecheck`, `bun run check` — clean
- Confirmed via `sh -c` that `-s '*'` reaches the child as a literal `*` while a bare `-s *` expands to filenames
