### PR TITLE
fix: remove every skill installed from the dosu-skill repo

### DIFF
--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -161,6 +161,19 @@ describe("skill remove", () => {
     });
   });
 
+  // `skills list` echoes the front-matter name without validating it, and
+  // `skills remove --all` deletes every skill from every source.
+  it("skips flag-shaped names so they cannot be re-parsed as options", async () => {
+    stubInventory([
+      { name: "dosu", source: "dosu-ai/dosu-skill" },
+      { name: "--all", source: "dosu-ai/dosu-skill" },
+    ]);
+    await run("remove");
+    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
+      stdio: "inherit",
+    });
+  });
+
   it("falls back to the known skill when the inventory is unreadable", async () => {
     mockExecSync.mockImplementation((command: string) => {
       if (command.includes("skills list")) throw new Error("npx unavailable");

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecSync = vi.fn();
@@ -168,6 +168,40 @@ describe("skill remove", () => {
       { name: "dosu", source: "dosu-ai/dosu-skill" },
       { name: "--all", source: "dosu-ai/dosu-skill" },
     ]);
+    await run("remove");
+    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
+      stdio: "inherit",
+    });
+  });
+
+  it("does nothing when the inventory holds no skills of ours", async () => {
+    stubInventory([{ name: "web-design", source: "vercel-labs/agent-skills" }]);
+    await run("remove");
+    expect(mockExecSync).not.toHaveBeenCalledWith(
+      expect.stringContaining("skills remove"),
+      expect.anything(),
+    );
+    expect(allOutput()).toContain("No skills from dosu-ai/dosu-skill are installed");
+  });
+
+  it("stops the update notice by forgetting the installed SHA", async () => {
+    const cachePath = join(tempDir, "dosu-cli", "skill-update-check.json");
+    mkdirSync(dirname(cachePath), { recursive: true });
+    writeFileSync(
+      cachePath,
+      JSON.stringify({ lastCheck: 1, latestSha: "new-sha", installedSha: "old-sha" }),
+    );
+
+    stubInventory([{ name: "dosu", source: "dosu-ai/dosu-skill" }]);
+    await run("remove");
+
+    const cache = JSON.parse(readFileSync(cachePath, "utf-8"));
+    expect(cache.installedSha).toBe("");
+    expect(cache.latestSha).toBe("new-sha");
+  });
+
+  it("treats a non-array inventory as unreadable", async () => {
+    stubInventory({ unexpected: "shape" } as unknown as unknown[]);
     await run("remove");
     expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
       stdio: "inherit",

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -120,9 +120,54 @@ describe("skill install", () => {
 });
 
 describe("skill remove", () => {
-  it("runs npx skills remove with correct args", async () => {
+  /** Make `npx skills list -g --json` resolve to the given inventory. */
+  function stubInventory(entries: unknown[]): void {
+    mockExecSync.mockImplementation((command: string) =>
+      command.includes("skills list") ? JSON.stringify(entries) : undefined,
+    );
+  }
+
+  it("removes every skill installed from the Dosu repo", async () => {
+    stubInventory([
+      { name: "dosu", source: "dosu-ai/dosu-skill" },
+      { name: "dosu-review", source: "dosu-ai/dosu-skill" },
+    ]);
     await run("remove");
-    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g -s dosu -y", {
+    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu dosu-review -y", {
+      stdio: "inherit",
+    });
+  });
+
+  it("leaves skills from other sources alone", async () => {
+    stubInventory([
+      { name: "dosu", source: "dosu-ai/dosu-skill" },
+      { name: "web-design", source: "vercel-labs/agent-skills" },
+      { name: "local-skill", source: null },
+    ]);
+    await run("remove");
+    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
+      stdio: "inherit",
+    });
+  });
+
+  it("skips names that are unsafe to interpolate into a shell command", async () => {
+    stubInventory([
+      { name: "dosu", source: "dosu-ai/dosu-skill" },
+      { name: "evil; rm -rf /", source: "dosu-ai/dosu-skill" },
+    ]);
+    await run("remove");
+    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
+      stdio: "inherit",
+    });
+  });
+
+  it("falls back to the known skill when the inventory is unreadable", async () => {
+    mockExecSync.mockImplementation((command: string) => {
+      if (command.includes("skills list")) throw new Error("npx unavailable");
+      return undefined;
+    });
+    await run("remove");
+    expect(mockExecSync).toHaveBeenCalledWith("npx skills remove -g dosu -y", {
       stdio: "inherit",
     });
   });

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import { Command } from "commander";
 import pc from "picocolors";
 import { logger } from "../debug/logger";
-import { fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
+import { clearInstalledSha, fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
 const SKILL_NAME = "dosu";
@@ -150,24 +150,35 @@ export async function installSkill(
  * as reported by the skills CLI's own inventory.
  *
  * `skills remove` resolves exact names and has no wildcard, so removing our
- * whole set means enumerating it first. Returns an empty list if the inventory
- * cannot be read.
+ * whole set means enumerating it first. An empty array means none of ours are
+ * installed; `null` means the inventory could not be read, which is a different
+ * situation and gets a different fallback.
  */
-function installedSkillNames(): string[] {
+function installedSkillNames(): string[] | null {
+  let entries: { name?: unknown; source?: unknown }[];
   try {
     const json = execSync("npx skills list -g --json", {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
     });
-    const entries = JSON.parse(json) as { name?: unknown; source?: unknown }[];
-    return entries
-      .filter((entry) => entry.source === SKILL_REPO)
-      .map((entry) => entry.name)
-      .filter((name): name is string => typeof name === "string" && SAFE_SKILL_NAME.test(name));
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) throw new Error("expected a JSON array");
+    entries = parsed;
   } catch (err) {
     logger.debug("skill", `Could not list installed skills: ${err}`);
-    return [];
+    return null;
   }
+
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (entry.source !== SKILL_REPO || typeof entry.name !== "string") continue;
+    if (!SAFE_SKILL_NAME.test(entry.name)) {
+      logger.warn("skill", `Skipping skill with an unsupported name: ${entry.name}`);
+      continue;
+    }
+    names.push(entry.name);
+  }
+  return names;
 }
 
 export function skillCommand(): Command {
@@ -191,17 +202,21 @@ export function skillCommand(): Command {
     .command("remove")
     .description("Remove the Dosu skills")
     .action(() => {
-      // Names go in positionally: the remove parser silently drops `-s`, and
-      // passing none at all opens an interactive picker. Falling back to the
-      // original skill keeps the command non-interactive when the inventory
-      // is unreadable.
       const installed = installedSkillNames();
-      const targets = installed.length > 0 ? installed : [SKILL_NAME];
+      if (installed?.length === 0) {
+        console.log(`No skills from ${SKILL_REPO} are installed.`);
+        return;
+      }
+      // Names go in positionally: the remove parser silently drops `-s`, and
+      // passing none at all opens an interactive picker. When the inventory is
+      // unreadable, fall back to the one name we have always shipped.
+      const targets = installed ?? [SKILL_NAME];
       console.log(`Removing skills from ${SKILL_REPO}...`);
       try {
         execSync(`npx skills remove -g ${targets.join(" ")} -y`, {
           stdio: "inherit",
         });
+        clearInstalledSha();
         console.log(pc.green(`\n✓ Skills removed.`));
       } catch {
         console.error(pc.red(`\nFailed to remove skills.`));

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -12,6 +12,8 @@ import { fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
 const SKILL_NAME = "dosu";
+/** Names are interpolated into a shell command, so keep them boring. */
+const SAFE_SKILL_NAME = /^[a-zA-Z0-9._-]+$/;
 const SUPPORTED_SKILL_AGENTS = [
   "claude-code",
   "cursor",
@@ -137,6 +139,31 @@ export async function installSkill(
   return { success: true };
 }
 
+/**
+ * Names of the globally installed skills that came from {@link SKILL_REPO},
+ * as reported by the skills CLI's own inventory.
+ *
+ * `skills remove` resolves exact names and has no wildcard, so removing our
+ * whole set means enumerating it first. Returns an empty list if the inventory
+ * cannot be read.
+ */
+function installedSkillNames(): string[] {
+  try {
+    const json = execSync("npx skills list -g --json", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const entries = JSON.parse(json) as { name?: unknown; source?: unknown }[];
+    return entries
+      .filter((entry) => entry.source === SKILL_REPO)
+      .map((entry) => entry.name)
+      .filter((name): name is string => typeof name === "string" && SAFE_SKILL_NAME.test(name));
+  } catch (err) {
+    logger.debug("skill", `Could not list installed skills: ${err}`);
+    return [];
+  }
+}
+
 export function skillCommand(): Command {
   const cmd = new Command("skill").description("Manage the Dosu agent skill");
 
@@ -156,16 +183,22 @@ export function skillCommand(): Command {
 
   cmd
     .command("remove")
-    .description("Remove the Dosu skill")
+    .description("Remove the Dosu skills")
     .action(() => {
-      console.log(`Removing ${SKILL_NAME} skill...`);
+      // Names go in positionally: the remove parser silently drops `-s`, and
+      // passing none at all opens an interactive picker. Falling back to the
+      // original skill keeps the command non-interactive when the inventory
+      // is unreadable.
+      const installed = installedSkillNames();
+      const targets = installed.length > 0 ? installed : [SKILL_NAME];
+      console.log(`Removing skills from ${SKILL_REPO}...`);
       try {
-        execSync(`npx skills remove -g -s ${SKILL_NAME} -y`, {
+        execSync(`npx skills remove -g ${targets.join(" ")} -y`, {
           stdio: "inherit",
         });
-        console.log(pc.green(`\n✓ Skill "${SKILL_NAME}" removed.`));
+        console.log(pc.green(`\n✓ Skills removed.`));
       } catch {
-        console.error(pc.red(`\nFailed to remove skill.`));
+        console.error(pc.red(`\nFailed to remove skills.`));
         process.exit(1);
       }
     });

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -12,8 +12,14 @@ import { fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
 const SKILL_NAME = "dosu";
-/** Names are interpolated into a shell command, so keep them boring. */
-const SAFE_SKILL_NAME = /^[a-zA-Z0-9._-]+$/;
+/**
+ * Names are interpolated into a shell command as positional arguments, so keep
+ * them boring. The leading character must be alphanumeric: `skills list` echoes
+ * the SKILL.md front-matter name verbatim without validating its shape, and a
+ * name like `--all` would be re-parsed as an option by `skills remove`, which
+ * treats it as "delete every installed skill from every source".
+ */
+const SAFE_SKILL_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 const SUPPORTED_SKILL_AGENTS = [
   "claude-code",
   "cursor",

--- a/src/version/skill-update-check.ts
+++ b/src/version/skill-update-check.ts
@@ -61,6 +61,17 @@ export function writeSkillCache(cache: SkillUpdateCache): void {
   }
 }
 
+/**
+ * Forget which SHA is installed, so the update notice stops firing.
+ *
+ * An empty `installedSha` is this cache's "unknown" state: `checkForSkillUpdates`
+ * stays quiet until the next install or update repopulates it.
+ */
+export function clearInstalledSha(): void {
+  const cache = readSkillCache();
+  if (cache) writeSkillCache({ ...cache, installedSha: "" });
+}
+
 /** Fetch the latest commit SHA from the dosu-skill GitHub repo. */
 export async function fetchLatestSha(): Promise<string | null> {
   const controller = new AbortController();


### PR DESCRIPTION
Follow-up to #172, which made `dosu skill install` install every skill the repo exposes. `remove` was left behind.

## Problem

```
npx skills remove -g -s dosu -y
```

The name is hardcoded, so a second skill shipped from `dosu-ai/dosu-skill` would install fine and then be orphaned on the user's machine forever — `remove` would never touch it.

Two things about the `skills` CLI constrain the fix:

- **`remove` has no wildcard.** `resolveSkillsToRemove()` does exact (sanitized) name matching. `-s '*'` resolves to nothing and silently removes zero skills.
- **`remove` doesn't parse `-s`/`--skill` at all**, despite documenting it in `--help`. The flag falls through every branch of `parseRemoveOptions` and is dropped; `dosu` only works today because it lands as a positional argument.

So the set has to be enumerated, and the names passed positionally.

## Change

Read the installed set from `npx skills list -g --json`, keep the entries whose `source` is `dosu-ai/dosu-skill`, and pass those names to `remove`.

Skills from other sources are untouched — that's what the `source` filter is for. Names are checked against `/^[a-zA-Z0-9._-]+$/` before being interpolated into the shell command.

If the inventory can't be read, fall back to `dosu`. Passing no names at all opens an interactive picker, which would hang the non-TTY callers.

## Also fixed here

Two defects review turned up in the same command. Both predate this branch, but both sit in the code it already touches:

- `remove` never cleared `installedSha` in the update cache, so the CLI kept advertising "Dosu skill update available" for a skill the user had deleted. It is now cleared on a successful removal — an empty `installedSha` is the cache's documented "unknown" state, so the notice stays quiet until the next install repopulates it.
- A readable inventory holding none of our skills was indistinguishable from an unreadable one, so `remove` fell back to the literal name `dosu` and would delete an unrelated skill that happened to share it. `installedSkillNames()` now returns `null` for "could not read" and `[]` for "none installed"; only the former falls back. A non-array payload counts as unreadable, and names skipped for being unsafe are logged rather than dropped silently.

## Not in scope

`skill update` still doesn't prune skills deleted or renamed upstream — it reinstalls the current set and leaves stale copies behind. That only happens when we change the skill repo ourselves, and detecting it needs the repo's current skill list, which the CLI only exposes as unparseable TUI output. Worth doing when we first delete a skill, not before.

## Hardening from review

The name filter originally accepted anything matching `/^[a-zA-Z0-9._-]+$/`, which includes `--all`. Since names are passed positionally, `skills remove` would have re-parsed that as its "delete every installed skill from every source" flag — and `skills list` echoes the SKILL.md front-matter name verbatim without validating its shape, so nothing upstream prevents such a name. The pattern is now anchored on an alphanumeric first character; a name we cannot pass safely is skipped, which at worst orphans that one skill.

## Verification

- `bun run test` — 1710 passed, including new cases for multi-skill removal, cross-source isolation, unsafe names, and the fallback
- End-to-end against the real installer with an isolated `HOME` holding two skills from different sources: `dosu skill remove` removed `dosu` and left the unrelated skill installed
- Confirmed against the real CLI that `-s "*"` removes nothing (`No matching skills found for: *`) and that multi-name positional removal works



Each new safety behaviour was mutation-tested: deleting the cache clear, the empty-inventory guard, or the regex anchor each fails exactly one test and no others.
