### PR TITLE
ci: make sentry sourcemap upload fail-open during release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -16,8 +16,14 @@ export default {
     [
       "@semantic-release/exec",
       {
+        // Sourcemap upload is observability, not a release artifact, so it is
+        // deliberately fail-open: `sentry-cli --wait` blocks on Sentry's
+        // server-side processing and gives up with `Failed to process files in
+        // 300s`, which took down the whole 0.48.0 publish even though the
+        // upload itself had already succeeded. A Sentry hiccup must never stop
+        // us shipping to npm — the run log still carries the failure.
         prepareCmd:
-          "bun run build:npm && bun run upload:sourcemaps && bash scripts/build-release.sh ${nextRelease.version} ${nextRelease.gitHead}",
+          "bun run build:npm && (bun run upload:sourcemaps || echo '::warning::sentry sourcemap upload failed (non-fatal)') && bash scripts/build-release.sh ${nextRelease.version} ${nextRelease.gitHead}",
         successCmd:
           "echo 'released=true' >> $GITHUB_OUTPUT && echo 'version=${nextRelease.version}' >> $GITHUB_OUTPUT",
       },


### PR DESCRIPTION
## What happened

The 0.48.0 release ([run 31732622088](https://github.com/dosu-ai/dosu-cli/actions/runs/31732622088/job/94556825961)) failed in semantic-release's `prepare`:

```
> Uploaded files to Sentry              <- the upload succeeded
> Bundle ID: 8866a5ad-1c10-5010-ac6c-eda415fb0d62
error: Failed to process files in 300s   <- --wait gave up on server-side processing
error: script "upload:sourcemaps" exited with code 1
durationMs: 301747
```

`sentry-cli sourcemaps upload --wait` blocks until Sentry finishes processing the bundle, capped at 300s. The files were already uploaded; only the *wait* timed out. But the non-zero exit broke the `&&` chain in `prepareCmd`, so `build-release.sh` never ran and `prepare` failed.

Because semantic-release aborts before `publish`, **nothing shipped**: npm `latest` is still 0.47.0, there is no `v0.48.0` tag and no GitHub release. The state is clean, just unreleased.

## Why fix it structurally instead of just re-running

As written, Sentry's availability is a hard dependency of publishing to npm. This time it cost 5 minutes; a longer Sentry incident would mean we cannot ship at all. Sourcemaps are observability, not a release artifact.

## The change

Wrap the upload so it is fail-open. `build:npm` and `build-release.sh` stay fatal.

Verified against `/bin/sh` (`@semantic-release/exec` runs `execa(script, { shell: true })`):

| case | result |
|---|---|
| sourcemap upload fails | warning printed, `build-release.sh` still runs, exit 0 |
| sourcemap upload succeeds | no warning, exit 0 |
| `build:npm` fails | exit 1 (still fatal) |

`result.stdout` is piped straight to the job log, so `::warning::` surfaces as a workflow annotation rather than being swallowed.

## Release impact

This commit is `ci:` and triggers no bump on its own — but `feat(setup): replace audit CTA with log-to-dosu-knowledge handoff (#176)` is still sitting unreleased on `main`, so merging this will cut **0.48.0** on the way through.