### PR TITLE
test: assert the release sourcemap upload by ordering and fail-open

### DIFF
--- a/scripts/build-npm.test.ts
+++ b/scripts/build-npm.test.ts
@@ -110,7 +110,16 @@ describe("build-npm script", () => {
     const releaseConfig = readFileSync("release.config.js", "utf8");
     const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
 
-    expect(releaseConfig).toContain("bun run build:npm && bun run upload:sourcemaps");
+    // Ordering: the upload runs against the freshly built npm bundle, before
+    // the release tarballs are cut.
+    expect(releaseConfig).toMatch(
+      /bun run build:npm &&.*bun run upload:sourcemaps.*&& bash scripts\/build-release\.sh/,
+    );
+    // ...but fail-open. `sentry-cli --wait` gave up on Sentry's server-side
+    // processing mid-release once and took the whole 0.48.0 publish down with
+    // it, even though the upload had succeeded. Source maps are observability,
+    // not a release artifact, so they must never gate shipping to npm.
+    expect(releaseConfig).toContain("(bun run upload:sourcemaps ||");
     expect(workflow).toContain(`SENTRY_AUTH_TOKEN: \${{ secrets.DOSU_CLI_SENTRY_AUTH_TOKEN }}`);
     expect(workflow).toContain('NPM_CONFIG_IGNORE_SCRIPTS: "true"');
   });


### PR DESCRIPTION
Fixes the `test` failure I introduced in #177. `main` is currently red and the `release` job is being skipped, so **0.48.0 is still unpublished**.

## What broke

#177 changed `release.config.js` to make the Sentry sourcemap upload fail-open:

```diff
-"bun run build:npm && bun run upload:sourcemaps && bash scripts/build-release.sh ..."
+"bun run build:npm && (bun run upload:sourcemaps || echo '::warning::...') && bash scripts/build-release.sh ..."
```

`scripts/build-npm.test.ts:113` guarded that command with a literal substring:

```ts
expect(releaseConfig).toContain("bun run build:npm && bun run upload:sourcemaps");
```

The added parenthesis broke the match. `build` / `lint` / `typecheck` / `windows-npm-smoke` all stayed green, which is why it slipped through — `scripts/**` is not in `tsconfig.json`'s `include`, so `typecheck` never looks at it, and only `vitest` covers this file.

## The fix

Assert the *intent* rather than the exact spelling:

| assertion | guards |
|---|---|
| `/bun run build:npm &&.*bun run upload:sourcemaps.*&& bash scripts\/build-release\.sh/` | the upload runs against the freshly built bundle, before the tarballs are cut |
| `toContain("(bun run upload:sourcemaps \|\|")` | it stays fail-open |

Strictly stronger than the old check, which pinned neither the ordering against `build-release.sh` nor the fail-open property.

## Verification

Full CI-equivalent run locally: `bunx vitest run --coverage` 1578 passed / 68 files, 97.14% stmts · 91.71% branches; `tsc --noEmit` clean; `biome check` clean; `knip` (both configs) clean.

Mutation-tested — the new assertions actually bite:

| mutation | result |
|---|---|
| revert the fail-open wrapper | ❌ test fails |
| delete the sourcemap upload entirely | ❌ test fails |
| unmodified | ✅ 11 passed |

## Release impact

`test:` triggers no bump on its own, but `feat(setup): ... (#176)` is still unreleased on `main`, so merging this cuts **0.48.0**.