### PR TITLE
fix(handoff): telemetry on handoff

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -166,7 +166,9 @@ Authenticated events may also include `org_id`, `deployment_id`, and `space_id`.
 Current common setup properties are `cli_version`, `install_channel`, `platform`, `arch`, and `mode`.
 Current callers also use only these workflow properties: `onboarding_run_id`,
 `has_deployment_option`, `mode_option`, `flow_kind`, `reason`, `provider_count`, `providers`,
-`completed_mcp`, `completed_skill`, and `completed_agents_md`. Setup events use stable names in the
+`completed_mcp`, `completed_skill`, `completed_agents_md`, `completed_logs_handoff`, and
+`logs_handoff` (`accepted` / `declined` / `cancelled`, only when the post-setup log-mining
+confirm was shown). Setup events use stable names in the
 `cli_onboarding_*` family. They do not include raw authentication errors. This path uses a dedicated
 no-refresh client, runs without blocking setup, refuses redirects, and aborts its request after
 500ms. The public API input remains a generic property record for generated-client compatibility,

--- a/src/setup/analytics.test.ts
+++ b/src/setup/analytics.test.ts
@@ -257,6 +257,25 @@ describe("setup analytics", () => {
     expect(JSON.stringify(input)).not.toContain("/Users/alice");
   });
 
+  it("allowlists logs-handoff outcomes and drops unknown values", async () => {
+    await trackCliOnboardingEvent(makeConfig(), RUN_ID, "cli_onboarding_completed", {
+      completed_logs_handoff: true,
+      logs_handoff: "accepted",
+    });
+    expect(mutate.mock.calls[0]?.[0].properties).toMatchObject({
+      completed_logs_handoff: true,
+      logs_handoff: "accepted",
+    });
+
+    mutate.mockClear();
+    await trackCliOnboardingEvent(makeConfig(), RUN_ID, "cli_onboarding_completed", {
+      logs_handoff: "maybe-later",
+      prompt: "Please bootstrap my knowledge",
+    } as never);
+    expect(mutate.mock.calls[0]?.[0].properties).not.toHaveProperty("logs_handoff");
+    expect(mutate.mock.calls[0]?.[0].properties).not.toHaveProperty("prompt");
+  });
+
   it("logs and swallows pre-auth client setup failures", async () => {
     mockGetWebAppURL.mockReturnValueOnce("");
 

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -38,6 +38,8 @@ interface CliOnboardingProperties {
   completed_mcp?: boolean;
   completed_skill?: boolean;
   completed_agents_md?: boolean;
+  completed_logs_handoff?: boolean;
+  logs_handoff?: "accepted" | "declined" | "cancelled";
 }
 
 type SafePropertyValue = string | number | boolean | string[] | undefined;
@@ -202,8 +204,20 @@ function allowlistedWorkflowProperties(properties: CliOnboardingProperties): Saf
       )
       .slice(0, 50);
   }
-  for (const key of ["completed_mcp", "completed_skill", "completed_agents_md"] as const) {
+  for (const key of [
+    "completed_mcp",
+    "completed_skill",
+    "completed_agents_md",
+    "completed_logs_handoff",
+  ] as const) {
     if (typeof input[key] === "boolean") safe[key] = input[key];
+  }
+  if (
+    input.logs_handoff === "accepted" ||
+    input.logs_handoff === "declined" ||
+    input.logs_handoff === "cancelled"
+  ) {
+    safe.logs_handoff = input.logs_handoff;
   }
   return safe;
 }

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -215,7 +215,7 @@ function installSetupStepDefaults() {
   mockInGitWorkTree.mockReturnValue(false);
   mockStepUpdateAgentsMd.mockReturnValue(true);
   mockStepConfigureAgentRules.mockResolvedValue([]);
-  mockOfferLogsHandoff.mockResolvedValue(null);
+  mockOfferLogsHandoff.mockResolvedValue({ plan: null });
 }
 
 function installRemoteSetupDefaults() {
@@ -1806,7 +1806,7 @@ describe("runSetup checkpoint behavior", () => {
     vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
     mockToolSelection(["cursor"]);
     const plan = { agent: "cursor", sources: ["cursor"] };
-    mockOfferLogsHandoff.mockResolvedValue(plan);
+    mockOfferLogsHandoff.mockResolvedValue({ plan, decision: "accepted" });
 
     await runSetup();
 
@@ -1815,6 +1815,42 @@ describe("runSetup checkpoint behavior", () => {
     // The agent must take over a finished clack session, never mid-session.
     expect(vi.mocked(p.outro).mock.invocationCallOrder[0]).toBeLessThan(
       mockLaunchLogsAgent.mock.invocationCallOrder[0],
+    );
+    expect(trackedCliOnboardingEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "cli_onboarding_completed",
+          properties: expect.objectContaining({
+            completed_logs_handoff: true,
+            logs_handoff: "accepted",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("records a declined logs handoff without launching the agent", async () => {
+    saveConfig(makeCfg());
+    setupAuthed();
+    mockInGitWorkTree.mockReturnValue(true);
+    mkdirSync(join(tempDir, ".cursor"), { recursive: true });
+    vi.spyOn(providersModule, "allSetupProviders").mockImplementation(() => [CursorProvider()]);
+    mockToolSelection(["cursor"]);
+    mockOfferLogsHandoff.mockResolvedValue({ plan: null, decision: "declined" });
+
+    await runSetup();
+
+    expect(mockLaunchLogsAgent).not.toHaveBeenCalled();
+    expect(trackedCliOnboardingEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "cli_onboarding_completed",
+          properties: expect.objectContaining({
+            completed_logs_handoff: false,
+            logs_handoff: "declined",
+          }),
+        }),
+      ]),
     );
   });
 

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -22,7 +22,12 @@ import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
 import { inGitWorkTree, stepUpdateAgentsMd } from "./agents-md-step";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
-import { type LogsHandoffPlan, launchLogsAgent, offerLogsHandoff } from "./logs-handoff";
+import {
+  type LogsHandoffDecision,
+  type LogsHandoffPlan,
+  launchLogsAgent,
+  offerLogsHandoff,
+} from "./logs-handoff";
 import { stepConfigureAgentRules } from "./rules-step";
 import { browserFallbackHint, dim, formatSetupSummary, IconRemove, info } from "./styles";
 
@@ -282,9 +287,12 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   // the terminal to a coding agent rooted at cwd, and `npx @dosu/cli setup` is
   // routinely run straight from $HOME or a scratch directory.
   let logsPlan: LogsHandoffPlan | null = null;
+  let logsHandoff: LogsHandoffDecision | undefined;
   if (mcpCompleted && cfg.mode !== MODE_OSS && inGitWorkTree()) {
     const preferredAgents = configuredProviders.map((result) => result.provider.id());
-    logsPlan = await offerLogsHandoff({ preferredAgents });
+    const offer = await offerLogsHandoff({ preferredAgents });
+    logsPlan = offer.plan;
+    logsHandoff = offer.decision;
   }
 
   if (mcpCompleted || skillCompleted || agentsMdCompleted) {
@@ -293,6 +301,8 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
         completed_mcp: mcpCompleted,
         completed_skill: skillCompleted,
         completed_agents_md: agentsMdCompleted,
+        completed_logs_handoff: logsHandoff === "accepted",
+        ...(logsHandoff ? { logs_handoff: logsHandoff } : {}),
       }),
     );
   }

--- a/src/setup/logs-handoff.test.ts
+++ b/src/setup/logs-handoff.test.ts
@@ -136,9 +136,9 @@ describe("buildLogsHandoffPrompt", () => {
 });
 
 describe("offerLogsHandoff", () => {
-  it("returns null when no log sources are present", async () => {
+  it("returns no plan when no log sources are present", async () => {
     const home = makeHome("dosu-logs-none-");
-    await expect(offerLogsHandoff({ home })).resolves.toBeNull();
+    await expect(offerLogsHandoff({ home })).resolves.toEqual({ plan: null });
     expect(p.confirm).not.toHaveBeenCalled();
   });
 
@@ -149,8 +149,8 @@ describe("offerLogsHandoff", () => {
     vi.mocked(p.confirm).mockResolvedValue(true);
 
     await expect(offerLogsHandoff({ home, preferredAgents: ["cursor"] })).resolves.toEqual({
-      agent: "cursor",
-      sources: ["cursor", "claude", "codex"],
+      plan: { agent: "cursor", sources: ["cursor", "claude", "codex"] },
+      decision: "accepted",
     });
     expect(p.log.success).toHaveBeenCalledWith(
       expect.stringContaining("MCP setup successful! Found logs:"),
@@ -172,8 +172,8 @@ describe("offerLogsHandoff", () => {
     vi.mocked(p.confirm).mockResolvedValue(true);
 
     await expect(offerLogsHandoff({ home, preferredAgents: ["cursor"] })).resolves.toEqual({
-      agent: "cursor",
-      sources: ["cursor", "claude", "codex"],
+      plan: { agent: "cursor", sources: ["cursor", "claude", "codex"] },
+      decision: "accepted",
     });
     expect(p.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -188,7 +188,10 @@ describe("offerLogsHandoff", () => {
     mockWhich({ claude: true });
     vi.mocked(p.confirm).mockResolvedValue(false);
 
-    await expect(offerLogsHandoff({ home, preferredAgents: ["claude"] })).resolves.toBeNull();
+    await expect(offerLogsHandoff({ home, preferredAgents: ["claude"] })).resolves.toEqual({
+      plan: null,
+      decision: "declined",
+    });
     expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("bootstrap my knowledge"));
   });
 
@@ -199,7 +202,10 @@ describe("offerLogsHandoff", () => {
     vi.mocked(p.confirm).mockResolvedValue(true);
     vi.mocked(p.isCancel).mockReturnValue(true);
 
-    await expect(offerLogsHandoff({ home, preferredAgents: ["claude"] })).resolves.toBeNull();
+    await expect(offerLogsHandoff({ home, preferredAgents: ["claude"] })).resolves.toEqual({
+      plan: null,
+      decision: "cancelled",
+    });
     expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("bootstrap my knowledge"));
   });
 
@@ -208,7 +214,7 @@ describe("offerLogsHandoff", () => {
     seedLogs(home);
     mockWhich({});
 
-    await expect(offerLogsHandoff({ home })).resolves.toBeNull();
+    await expect(offerLogsHandoff({ home })).resolves.toEqual({ plan: null });
     expect(p.confirm).not.toHaveBeenCalled();
     expect(p.log.message).toHaveBeenCalledWith(expect.stringContaining("bootstrap my knowledge"));
   });

--- a/src/setup/logs-handoff.ts
+++ b/src/setup/logs-handoff.ts
@@ -164,21 +164,30 @@ export interface OfferLogsHandoffOptions {
   home?: string;
 }
 
+/** Set only when the continue prompt was shown. */
+export type LogsHandoffDecision = "accepted" | "declined" | "cancelled";
+
+export interface OfferLogsHandoffResult {
+  plan: LogsHandoffPlan | null;
+  decision?: LogsHandoffDecision;
+}
+
 /**
- * Detect log sources and offer a single continue to mine them all. Returns a
- * plan to launch after outro, or null when skipped / declined / no logs.
+ * Detect log sources and offer a single continue to mine them all. `decision`
+ * is set only when the user saw the confirm — skipped offers omit it so
+ * analytics can tell "asked" from "never asked".
  */
 export async function offerLogsHandoff(
   options: OfferLogsHandoffOptions = {},
-): Promise<LogsHandoffPlan | null> {
+): Promise<OfferLogsHandoffResult> {
   const hits = detectLogSources(options.home);
-  if (hits.length === 0) return null;
+  if (hits.length === 0) return { plan: null };
 
   const sources = hits.map((hit) => hit.source);
   const agent = resolveKickoffAgent(options.preferredAgents ?? []);
   if (!agent) {
     printManualLogsNudge();
-    return null;
+    return { plan: null };
   }
 
   p.log.success(`MCP setup successful! Found logs: ${formatLogSourceSummary(hits)}`);
@@ -187,12 +196,16 @@ export async function offerLogsHandoff(
     message: confirmLogsHandoffMessage(agent),
     initialValue: true,
   });
-  if (p.isCancel(go) || !go) {
+  if (p.isCancel(go)) {
     printManualLogsNudge();
-    return null;
+    return { plan: null, decision: "cancelled" };
+  }
+  if (!go) {
+    printManualLogsNudge();
+    return { plan: null, decision: "declined" };
   }
 
-  return { agent, sources };
+  return { plan: { agent, sources }, decision: "accepted" };
 }
 
 /** Launch the chosen agent with the log-mining prompt. */


### PR DESCRIPTION
seeing a lot of downloads and want to get data on this. adds posthog telemetry for logs parsing handoff:

logs_handoff = accepted — they said yes (CLI then launches the log-mining agent after the outro)
logs_handoff = declined — they said no
logs_handoff = cancelled — they hit Ctrl+C on the confirm
logs_handoff missing — they were never asked (no logs, no kickoff agent, OSS, or not in a git repo)
completed_logs_handoff — true only on accept, on every completed event