### PR TITLE
chore: sync vendored CLI contract (de4d34216f45)

### DIFF
--- a/src/client/contract.ts
+++ b/src/client/contract.ts
@@ -1,2 +1,2 @@
 export const CLI_CONTRACT_HASH: typeof import("../generated/dosu-api-types").CLI_CONTRACT_HASH =
-  "22c5cd2ce534";
+  "de4d34216f45";

--- a/src/generated/dosu-api-types.d.ts
+++ b/src/generated/dosu-api-types.d.ts
@@ -397,6 +397,7 @@ export type CliMessage = {
 		user_id: string | null
 	}>
 	resolves_thread: boolean | null
+	retention_redacted_at: string | null
 	thread_id: string
 	title: string | null
 	url_descriptions: unknown | null
@@ -477,7 +478,7 @@ export type CliSlackChannelRow = {
 	topic?: string | null
 }
 
-export declare const CLI_CONTRACT_HASH: '22c5cd2ce534'
+export declare const CLI_CONTRACT_HASH: 'de4d34216f45'
 
 export type AnalyticsGetUsageStatsInput = {
 	days?: number
@@ -791,6 +792,7 @@ export type MessagesGetMessageOutput = {
 	posted: boolean
 	quality_checklist_problems: Array<string> | null
 	resolves_thread: boolean | null
+	retention_redacted_at: string | null
 	thread_id: string
 	title: string | null
 	url_descriptions: unknown | null
@@ -859,6 +861,7 @@ export type OrganizationGetOrganizationByIdOutput = {
 	overage_enabled: boolean
 	overage_monthly_cap_cents: number
 	pro_trial_used_at: string | null
+	slack_retention_days: number | null
 	updated_at: string
 } | null
 


### PR DESCRIPTION
Automated sync of the vendored CLI contract from dosu-ai/dosu@10a73296975318f35e3ecb7a05b61602afe2a81b (contract hash `de4d34216f45`).

- `src/generated/dosu-api-types.d.ts` — full copy of `frontend/packages/api/generated/cli-contract.d.ts`
- `src/client/contract.ts` — pinned `CLI_CONTRACT_HASH` updated to match

**Green CI** on this PR means the contract change is compatible with current CLI code — safe to merge.
**Red typecheck** means the CLI needs adapting before this can land.