### PR TITLE
fix: make session refresh persistence safe

### DIFF
--- a/src/auth/session-errors.ts
+++ b/src/auth/session-errors.ts
@@ -1,0 +1,39 @@
+const SESSION_EXPIRED_CODE = "SESSION_EXPIRED";
+const SESSION_PERSISTENCE_ERROR_CODE = "SESSION_PERSISTENCE_ERROR";
+const SESSION_REFRESH_ERROR_CODE = "SESSION_REFRESH_ERROR";
+
+export class SessionExpiredError extends Error {
+  readonly code = SESSION_EXPIRED_CODE;
+
+  constructor(options?: ErrorOptions) {
+    super("Your Dosu session has expired. Run 'dosu login' to re-authenticate.", options);
+    this.name = "SessionExpiredError";
+  }
+}
+
+export class SessionPersistenceError extends Error {
+  readonly code = SESSION_PERSISTENCE_ERROR_CODE;
+
+  constructor(options?: ErrorOptions) {
+    super(
+      "Could not safely save refreshed Dosu credentials. Ensure the Dosu config directory is writable, then retry.",
+      options,
+    );
+    this.name = "SessionPersistenceError";
+  }
+}
+
+/** Unexpected refresh failures remain observable and must not be reported as an expired session. */
+export class SessionRefreshError extends Error {
+  readonly code = SESSION_REFRESH_ERROR_CODE;
+  readonly status?: number;
+
+  constructor(options: ErrorOptions & { status?: number } = {}) {
+    const message = options.status
+      ? `Could not refresh the Dosu session (authentication server returned status ${options.status}). Retry the command.`
+      : "Could not reach the authentication server to refresh the Dosu session. Retry the command.";
+    super(message, options);
+    this.name = "SessionRefreshError";
+    this.status = options.status;
+  }
+}

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,16 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Config } from "../config/config";
+import { type Config, saveConfig } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { Client, SessionExpiredError } from "./client";
-
-// Mock saveConfig to avoid filesystem writes (hoisted; applies to the whole file)
-vi.mock("../config/config", async () => {
-  const actual = await vi.importActual("../config/config");
-  return {
-    ...actual,
-    saveConfig: vi.fn(),
-  };
-});
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -88,6 +79,7 @@ describe("Client", () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ data: "success" }));
 
       const cfg = makeConfig();
+      saveConfig(cfg);
 
       const client = new Client(cfg);
       const resp = await client.get("/test");
@@ -99,7 +91,9 @@ describe("Client", () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
       mockFetch.mockResolvedValueOnce(jsonResponse({ error_code: "refresh_token_not_found" }, 400)); // refresh fails
 
-      const client = new Client(makeConfig());
+      const cfg = makeConfig();
+      saveConfig(cfg);
+      const client = new Client(cfg);
       await expect(client.get("/test")).rejects.toBeInstanceOf(SessionExpiredError);
     });
 
@@ -118,6 +112,7 @@ describe("Client", () => {
       const cfg = makeConfig({
         expires_at: Math.floor(Date.now() / 1000) - 100, // already expired
       });
+      saveConfig(cfg);
       const client = new Client(cfg);
       const resp = await client.get("/test");
 
@@ -129,6 +124,26 @@ describe("Client", () => {
       // Config should be updated with new tokens
       expect(cfg.active_account?.session.access_token).toBe("refreshed-token");
       expect(cfg.active_account?.session.refresh_token).toBe("refreshed-refresh");
+    });
+
+    it("does not refresh again when credentials changed while a 401 was in flight", async () => {
+      const cfg = makeConfig({ access_token: "old-access", refresh_token: "old-refresh" });
+      saveConfig(cfg);
+      mockFetch.mockImplementationOnce(async () => {
+        if (cfg.active_account) {
+          cfg.active_account.session.access_token = "new-access";
+          cfg.active_account.session.refresh_token = "new-refresh";
+        }
+        saveConfig(cfg);
+        return jsonResponse({}, 401);
+      });
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "success" }));
+
+      const resp = await new Client(cfg).get("/test");
+
+      expect(resp.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1]?.[1]?.headers["Supabase-Access-Token"]).toBe("new-access");
     });
 
     it("throws when refresh_token is missing and token is expired", async () => {
@@ -262,13 +277,16 @@ describe("Client", () => {
         }),
       );
 
-      const client = new Client(makeConfig());
+      const cfg = makeConfig();
+      saveConfig(cfg);
+      const client = new Client(cfg);
       await client.refreshToken();
 
       const [url, options] = mockFetch.mock.calls[0];
       expect(url).toContain("/auth/v1/token");
       expect(options.headers).toHaveProperty("apikey");
       expect(options.headers.apikey).toBeTruthy();
+      expect(options.signal).toBeInstanceOf(AbortSignal);
     });
   });
 
@@ -291,7 +309,9 @@ describe("Client", () => {
       // Retry still returns 500
       mockFetch.mockResolvedValueOnce(new Response("Server Error", { status: 500 }));
 
-      const client = new Client(makeConfig());
+      const cfg = makeConfig();
+      saveConfig(cfg);
+      const client = new Client(cfg);
       await expect(client.createAPIKey("dep-1", "cli")).rejects.toThrow("failed to create API key");
     });
   });

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -97,7 +97,7 @@ describe("Client", () => {
 
     it("throws SessionExpiredError when refresh fails", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
-      mockFetch.mockResolvedValueOnce(jsonResponse({}, 400)); // refresh fails
+      mockFetch.mockResolvedValueOnce(jsonResponse({ error_code: "refresh_token_not_found" }, 400)); // refresh fails
 
       const client = new Client(makeConfig());
       await expect(client.get("/test")).rejects.toBeInstanceOf(SessionExpiredError);
@@ -138,7 +138,11 @@ describe("Client", () => {
           expires_at: Math.floor(Date.now() / 1000) - 100,
         }),
       );
-      await expect(client.get("/test")).rejects.toThrow("no refresh token available");
+      await expect(client.get("/test")).rejects.toMatchObject({
+        name: "SessionExpiredError",
+        code: "SESSION_EXPIRED",
+        message: expect.stringContaining("dosu login"),
+      });
     });
   });
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -21,6 +21,8 @@ import { getAccessTokenOAuthClientID } from "../config/identity";
 
 export { SessionExpiredError };
 
+const REFRESH_REQUEST_TIMEOUT_MS = 10_000;
+
 export interface Deployment {
   deployment_id: string;
   name: string;
@@ -66,11 +68,15 @@ export class Client {
       await this.refreshToken();
     }
 
+    const requestAccessToken = this.config.active_account?.session.access_token;
     let resp = await this.doRequestOnce(method, path, body);
 
     // If backend says unauthorized, try refresh + retry once
     if (resp.status === 401 || resp.status === 403) {
-      await this.refreshToken();
+      const currentAccessToken = this.config.active_account?.session.access_token;
+      if (!currentAccessToken || currentAccessToken === requestAccessToken) {
+        await this.refreshToken();
+      }
       resp = await this.doRequestOnce(method, path, body);
     }
 
@@ -140,17 +146,15 @@ export class Client {
       const disk = loadConfig();
       this.assertSameActiveAccount(disk);
       const diskRefreshToken = disk.active_account?.session.refresh_token;
-      const diskHasNewerSession = Boolean(
-        diskRefreshToken && diskRefreshToken !== refreshTokenAtStart,
-      );
+      if (!diskRefreshToken) throw new SessionExpiredError();
+      const diskHasNewerSession = diskRefreshToken !== refreshTokenAtStart;
 
       if (diskHasNewerSession && !isTokenExpired(disk)) {
         this.adoptConfig(disk);
         return;
       }
 
-      const source = diskRefreshToken ? disk : this.config;
-      const candidate = await this.refreshTokenOnce(source);
+      const candidate = await this.refreshTokenOnce(disk);
       try {
         saveConfig(candidate);
       } catch (cause) {
@@ -180,20 +184,25 @@ export class Client {
         }).toString()
       : JSON.stringify({ refresh_token: session.refresh_token });
 
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REFRESH_REQUEST_TIMEOUT_MS);
     let resp: Response;
     try {
       resp = await fetch(endpoint, {
         method: "POST",
         headers,
         body,
+        signal: controller.signal,
       });
     } catch (cause) {
       throw new SessionRefreshError({ cause });
+    } finally {
+      clearTimeout(timeout);
     }
 
     if (resp.status !== 200) {
       const errorCode = await readAuthErrorCode(resp);
-      if (resp.status === 401 || REAUTHENTICATION_ERROR_CODES.has(errorCode ?? "")) {
+      if (REAUTHENTICATION_ERROR_CODES.has(errorCode ?? "")) {
         throw new SessionExpiredError();
       }
       throw new SessionRefreshError({ status: resp.status });
@@ -207,12 +216,12 @@ export class Client {
     const latest = loadConfig();
     this.assertSameActiveAccount(latest);
     const latestSession = latest.active_account?.session;
-    if (latestSession?.refresh_token && latestSession.refresh_token !== session.refresh_token) {
+    if (!latestSession?.refresh_token) throw new SessionExpiredError();
+    if (latestSession.refresh_token !== session.refresh_token) {
       return latest;
     }
 
-    const base = latestSession?.refresh_token ? latest : source;
-    return configWithSession(base, {
+    return configWithSession(latest, {
       access_token: data.access_token,
       refresh_token: data.refresh_token,
       expires_at: Math.floor(Date.now() / 1000) + data.expires_in,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,6 +2,11 @@
  * HTTP client for making authenticated requests to the Dosu backend.
  */
 
+import {
+  SessionExpiredError,
+  SessionPersistenceError,
+  SessionRefreshError,
+} from "../auth/session-errors";
 import type { Config } from "../config/config";
 import {
   getConfigUserID,
@@ -10,15 +15,11 @@ import {
   loadConfig,
   saveConfig,
 } from "../config/config";
+import { withConfigRefreshLock } from "../config/config-lock";
 import { getBackendURL, getSupabaseAnonKey, getSupabaseURL } from "../config/constants";
 import { getAccessTokenOAuthClientID } from "../config/identity";
 
-export class SessionExpiredError extends Error {
-  constructor() {
-    super("session expired");
-    this.name = "SessionExpiredError";
-  }
-}
+export { SessionExpiredError };
 
 export interface Deployment {
   deployment_id: string;
@@ -69,11 +70,7 @@ export class Client {
 
     // If backend says unauthorized, try refresh + retry once
     if (resp.status === 401 || resp.status === 403) {
-      try {
-        await this.refreshToken();
-      } catch {
-        throw new SessionExpiredError();
-      }
+      await this.refreshToken();
       resp = await this.doRequestOnce(method, path, body);
     }
 
@@ -129,58 +126,43 @@ export class Client {
   /**
    * Public method to refresh token externally (used during auth step).
    *
-   * Multi-process self-healing: sibling CLI processes rotate the refresh
-   * token through the shared config file, and GoTrue refresh tokens are
-   * single-use — replaying a stale one outside the reuse interval can revoke
-   * the ENTIRE session for every client holding it. So: adopt the newest
-   * on-disk tokens before refreshing (a long-lived process may hold a stale
-   * in-memory copy), and on failure re-read the config once in case a
-   * sibling rotated mid-flight.
+   * The lock covers the complete read -> remote refresh -> atomic save cycle,
+   * so sibling processes cannot rotate the same refresh token concurrently.
+   * Refreshed credentials become visible in memory only after they are durable.
    */
   async refreshToken(): Promise<void> {
-    this.adoptNewerDiskTokens();
-    if (!this.config.active_account?.session.refresh_token) {
-      throw new Error("no refresh token available");
+    const refreshTokenAtStart = this.config.active_account?.session.refresh_token;
+    if (!refreshTokenAtStart) {
+      throw new SessionExpiredError();
     }
 
-    try {
-      await this.refreshTokenOnce();
-    } catch (err) {
-      // A sibling may have rotated the token between our config read and the
-      // request landing. If the file now holds a different token, retry once
-      // with it before declaring the session dead.
-      if (!this.adoptNewerDiskTokens()) {
-        throw err;
+    await withConfigRefreshLock(async () => {
+      const disk = loadConfig();
+      this.assertSameActiveAccount(disk);
+      const diskRefreshToken = disk.active_account?.session.refresh_token;
+      const diskHasNewerSession = Boolean(
+        diskRefreshToken && diskRefreshToken !== refreshTokenAtStart,
+      );
+
+      if (diskHasNewerSession && !isTokenExpired(disk)) {
+        this.adoptConfig(disk);
+        return;
       }
-      await this.refreshTokenOnce();
-    }
+
+      const source = diskRefreshToken ? disk : this.config;
+      const candidate = await this.refreshTokenOnce(source);
+      try {
+        saveConfig(candidate);
+      } catch (cause) {
+        throw new SessionPersistenceError({ cause });
+      }
+      this.adoptConfig(candidate);
+    });
   }
 
-  /**
-   * Sync in-memory tokens from the config file when a sibling process saved
-   * a different refresh token. Returns true when tokens were adopted.
-   */
-  private adoptNewerDiskTokens(): boolean {
-    const disk = loadConfig();
-    this.assertSameActiveAccount(disk);
-    const diskSession = disk.active_account?.session;
-    const memorySession = this.config.active_account?.session;
-    if (
-      !diskSession?.refresh_token ||
-      !memorySession ||
-      diskSession.refresh_token === memorySession.refresh_token
-    ) {
-      return false;
-    }
-    memorySession.access_token = diskSession.access_token;
-    memorySession.refresh_token = diskSession.refresh_token;
-    memorySession.expires_at = diskSession.expires_at;
-    return true;
-  }
-
-  private async refreshTokenOnce(): Promise<void> {
-    const session = this.config.active_account?.session;
-    if (!session?.refresh_token) throw new Error("no refresh token available");
+  private async refreshTokenOnce(source: Config): Promise<Config> {
+    const session = source.active_account?.session;
+    if (!session?.refresh_token) throw new SessionExpiredError();
 
     const supabaseURL = getSupabaseURL();
     const oauthClientID = getAccessTokenOAuthClientID(session.access_token);
@@ -198,32 +180,54 @@ export class Client {
         }).toString()
       : JSON.stringify({ refresh_token: session.refresh_token });
 
-    const resp = await fetch(endpoint, {
-      method: "POST",
-      headers,
-      body,
-    });
-
-    if (resp.status !== 200) {
-      throw new Error(`refresh failed with status ${resp.status}`);
+    let resp: Response;
+    try {
+      resp = await fetch(endpoint, {
+        method: "POST",
+        headers,
+        body,
+      });
+    } catch (cause) {
+      throw new SessionRefreshError({ cause });
     }
 
-    const data = (await resp.json()) as {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-    };
+    if (resp.status !== 200) {
+      const errorCode = await readAuthErrorCode(resp);
+      if (resp.status === 401 || REAUTHENTICATION_ERROR_CODES.has(errorCode ?? "")) {
+        throw new SessionExpiredError();
+      }
+      throw new SessionRefreshError({ status: resp.status });
+    }
+
+    const data = await readRefreshResponse(resp);
 
     // A browser login in another process may have switched accounts while the
     // refresh request was in flight. Never let this stale client overwrite the
     // new account aggregate with tokens from the previous account.
-    this.assertSameActiveAccount(loadConfig());
+    const latest = loadConfig();
+    this.assertSameActiveAccount(latest);
+    const latestSession = latest.active_account?.session;
+    if (latestSession?.refresh_token && latestSession.refresh_token !== session.refresh_token) {
+      return latest;
+    }
 
-    session.access_token = data.access_token;
-    session.refresh_token = data.refresh_token;
-    session.expires_at = Math.floor(Date.now() / 1000) + data.expires_in;
+    const base = latestSession?.refresh_token ? latest : source;
+    return configWithSession(base, {
+      access_token: data.access_token,
+      refresh_token: data.refresh_token,
+      expires_at: Math.floor(Date.now() / 1000) + data.expires_in,
+    });
+  }
 
-    saveConfig(this.config);
+  private adoptConfig(source: Config): void {
+    this.config.mode = source.mode;
+    this.config.active_account = source.active_account
+      ? {
+          ...source.active_account,
+          session: { ...source.active_account.session },
+          target: source.active_account.target ? { ...source.active_account.target } : undefined,
+        }
+      : undefined;
   }
 
   private assertSameActiveAccount(disk: Config): void {
@@ -289,6 +293,74 @@ export class Client {
     }
     return resp.json() as Promise<APIKeyResponse>;
   }
+}
+
+const REAUTHENTICATION_ERROR_CODES = new Set([
+  "invalid_grant",
+  "refresh_token_already_used",
+  "refresh_token_not_found",
+  "session_expired",
+  "session_not_found",
+]);
+
+interface RefreshResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}
+
+async function readAuthErrorCode(resp: Response): Promise<string | undefined> {
+  try {
+    const data = (await resp.json()) as unknown;
+    if (!isRecord(data)) return undefined;
+    const code = typeof data.error_code === "string" ? data.error_code : data.error;
+    return typeof code === "string" ? code : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readRefreshResponse(resp: Response): Promise<RefreshResponse> {
+  let data: unknown;
+  try {
+    data = await resp.json();
+  } catch (cause) {
+    throw new SessionRefreshError({ cause, status: resp.status });
+  }
+  if (
+    !isRecord(data) ||
+    typeof data.access_token !== "string" ||
+    typeof data.refresh_token !== "string" ||
+    typeof data.expires_in !== "number" ||
+    !Number.isFinite(data.expires_in)
+  ) {
+    throw new SessionRefreshError({ status: resp.status });
+  }
+  return {
+    access_token: data.access_token,
+    refresh_token: data.refresh_token,
+    expires_in: data.expires_in,
+  };
+}
+
+function configWithSession(
+  source: Config,
+  session: NonNullable<Config["active_account"]>["session"],
+): Config {
+  const account = source.active_account;
+  if (!account) throw new SessionExpiredError();
+  return {
+    ...source,
+    active_account: {
+      ...account,
+      session,
+      target: account.target ? { ...account.target } : undefined,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function readErrorBody(resp: Response): Promise<string> {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -195,20 +195,26 @@ export class Client {
         signal: controller.signal,
       });
     } catch (cause) {
+      clearTimeout(timeout);
       throw new SessionRefreshError({ cause });
+    }
+
+    let data: RefreshResponse;
+    try {
+      if (resp.status !== 200) {
+        const errorCode = await readAuthErrorCode(resp);
+        if (
+          REAUTHENTICATION_ERROR_CODES.has(errorCode ?? "") ||
+          (!oauthClientID && errorCode === "validation_failed")
+        ) {
+          throw new SessionExpiredError();
+        }
+        throw new SessionRefreshError({ status: resp.status });
+      }
+      data = await readRefreshResponse(resp);
     } finally {
       clearTimeout(timeout);
     }
-
-    if (resp.status !== 200) {
-      const errorCode = await readAuthErrorCode(resp);
-      if (REAUTHENTICATION_ERROR_CODES.has(errorCode ?? "")) {
-        throw new SessionExpiredError();
-      }
-      throw new SessionRefreshError({ status: resp.status });
-    }
-
-    const data = await readRefreshResponse(resp);
 
     // A browser login in another process may have switched accounts while the
     // refresh request was in flight. Never let this stale client overwrite the

--- a/src/client/refresh.test.ts
+++ b/src/client/refresh.test.ts
@@ -6,27 +6,23 @@
  * detection) — killing every client that shares it. Multiple CLI processes
  * (TUI and parallel commands) share one config file, so a
  * process holding a stale in-memory token can kill the session for all of
- * them. These tests pin the client's defenses:
+ * them. These tests pin the client's lock-based defenses:
  *
- * 1. adopt-before-refresh — refresh with the newest on-disk token, never a
- *    stale in-memory copy (long-lived TUI scenario).
- * 2. retry-after-rotation — when a refresh fails because a sibling rotated
- *    the token mid-flight, re-read the config and retry once with the newer
- *    token before declaring the session dead.
- * 3. two-client relay — a stale client adopts its sibling's rotation instead
- *    of replaying the dead token (which, against real GoTrue, would revoke
- *    the session for BOTH).
+ * 1. acquire a config-directory lock before contacting GoTrue;
+ * 2. adopt a valid session persisted by the lock holder instead of rotating
+ *    again; and
+ * 3. persist a candidate session before updating the caller's in-memory copy.
  *
  * The fake GoTrue mirrors hosted behavior outside the reuse interval: only
  * the CURRENT refresh token succeeds; anything else gets a 400
  * (refresh_token_already_used).
  */
 
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { type Config, loadConfig, saveConfig } from "../config/config";
+import { type Config, getConfigDir, getConfigPath, loadConfig, saveConfig } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { Client } from "./client";
 
@@ -121,7 +117,7 @@ describe("refresh self-healing", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("refreshes with the newest on-disk token, not a stale in-memory copy", async () => {
+  it("adopts a newer valid on-disk session without another remote refresh", async () => {
     // A sibling process already rotated the token and saved it.
     saveConfig(makeConfig({ access_token: "at-disk", refresh_token: "rt-disk" }));
     const gotrue = new FakeGoTrue("rt-disk");
@@ -132,10 +128,10 @@ describe("refresh self-healing", () => {
     const cfg = makeConfig({ refresh_token: "rt-stale" });
     await new Client(cfg).refreshToken();
 
-    expect(gotrue.presented).toEqual(["rt-disk"]); // never "rt-stale"
+    expect(gotrue.presented).toEqual([]);
     expect(gotrue.rejections).toBe(0);
-    expect(cfg.active_account?.session.refresh_token).toBe("rt-1");
-    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-1"); // rotation persisted
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-disk");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-disk");
   });
 
   it("refreshes OAuth 2.1 sessions through the OAuth token endpoint", async () => {
@@ -164,33 +160,8 @@ describe("refresh self-healing", () => {
     expect(new URLSearchParams(init.body as string).get("client_id")).toBe("cli-client-id");
   });
 
-  it("retries once with the on-disk token when a sibling rotates mid-flight", async () => {
-    // Memory and disk agree when the refresh starts...
-    saveConfig(makeConfig({ refresh_token: "rt-a" }));
-    const cfg = loadConfig();
-
-    // ...but a sibling has ALREADY rotated rt-a -> rt-b server-side; its
-    // save lands while our (stale) request is in flight.
-    const gotrue = new FakeGoTrue("rt-b");
-    let siblingSaved = false;
-    mockFetch.mockImplementation(async (url: unknown, options?: { body?: string }) => {
-      const resp = await gotrue.handle(url, options);
-      if (!siblingSaved) {
-        siblingSaved = true;
-        saveConfig(makeConfig({ access_token: "at-b", refresh_token: "rt-b" }));
-      }
-      return resp;
-    });
-
-    await new Client(cfg).refreshToken();
-
-    expect(gotrue.presented).toEqual(["rt-a", "rt-b"]); // failed once, healed
-    expect(cfg.active_account?.session.refresh_token).toBe("rt-1");
-    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-1");
-  });
-
-  it("two clients sharing one config file relay the rotation instead of killing it", async () => {
-    saveConfig(makeConfig({ refresh_token: "rt-0" }));
+  it("serializes two concurrent clients so only one rotates and both adopt it", async () => {
+    saveConfig(makeConfig({ refresh_token: "rt-0", expires_at: 1 }));
     const gotrue = new FakeGoTrue("rt-0");
     mockFetch.mockImplementation(gotrue.handle);
 
@@ -198,28 +169,140 @@ describe("refresh self-healing", () => {
     const a = loadConfig();
     const b = loadConfig();
 
-    // ...A refreshes first (rt-0 -> rt-1), then B — whose in-memory token is
-    // now stale — must adopt A's rotation (rt-1 -> rt-2), not replay rt-0.
-    await new Client(a).refreshToken();
-    await new Client(b).refreshToken();
+    await Promise.all([new Client(a).refreshToken(), new Client(b).refreshToken()]);
 
-    expect(gotrue.presented).toEqual(["rt-0", "rt-1"]);
-    expect(gotrue.rejections).toBe(0); // a replayed token would kill the session
-    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-2");
+    expect(gotrue.presented).toEqual(["rt-0"]);
+    expect(gotrue.rejections).toBe(0);
+    expect(a.active_account?.session.refresh_token).toBe("rt-1");
+    expect(b.active_account?.session.refresh_token).toBe("rt-1");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-1");
 
-    // The config dir contains exactly the config file — no stray tmp files.
+    // The config dir contains exactly the config file — no stale lock or temp files.
     expect(readdirSync(join(tempDir, "dosu-cli"))).toEqual(["config.json"]);
   });
 
-  it("still fails cleanly when the session is truly dead (no newer token on disk)", async () => {
+  it("coalesces concurrent refresh calls that share one in-memory config", async () => {
+    saveConfig(makeConfig({ refresh_token: "rt-0", expires_at: 1 }));
+    const gotrue = new FakeGoTrue("rt-0");
+    mockFetch.mockImplementation(gotrue.handle);
+    const cfg = loadConfig();
+    const client = new Client(cfg);
+
+    await Promise.all([client.refreshToken(), client.refreshToken()]);
+
+    expect(gotrue.presented).toEqual(["rt-0"]);
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-1");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-1");
+  });
+
+  it("returns SessionExpiredError when the auth server rejects the refresh", async () => {
     saveConfig(makeConfig({ refresh_token: "rt-dead" }));
     const cfg = loadConfig();
     const gotrue = new FakeGoTrue("rt-elsewhere"); // nothing we hold will work
     mockFetch.mockImplementation(gotrue.handle);
 
-    await expect(new Client(cfg).refreshToken()).rejects.toThrow("refresh failed with status 400");
-    // One attempt only — disk has nothing newer to retry with.
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionExpiredError",
+      code: "SESSION_EXPIRED",
+      message: expect.stringContaining("dosu login"),
+    });
     expect(gotrue.presented).toEqual(["rt-dead"]);
+    expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
+  });
+
+  it("keeps unexpected auth server failures observable and does not mutate credentials", async () => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error_code: "unexpected_failure" }), { status: 503 }),
+    );
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionRefreshError",
+      code: "SESSION_REFRESH_ERROR",
+      status: 503,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+    expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
+  });
+
+  it("keeps network refresh failures observable with their cause", async () => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    const cause = Object.assign(new Error("private network detail"), { code: "ECONNRESET" });
+    mockFetch.mockRejectedValue(cause);
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionRefreshError",
+      code: "SESSION_REFRESH_ERROR",
+      cause,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+  });
+
+  it("does not retry or mutate memory when refreshed credentials cannot be persisted", async () => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    mkdirSync(`${getConfigPath()}.${process.pid}.tmp`);
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "at-new",
+          refresh_token: "rt-new",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const failure = await new Client(cfg).refreshToken().catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      name: "SessionPersistenceError",
+      code: "SESSION_PERSISTENCE_ERROR",
+      message: expect.stringContaining("writable"),
+      cause: { code: "EISDIR" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(cfg.active_account?.session).toMatchObject({
+      access_token: "at-old",
+      refresh_token: "rt-old",
+      expires_at: 1,
+    });
+    expect(loadConfig().active_account?.session).toMatchObject({
+      access_token: "at-old",
+      refresh_token: "rt-old",
+      expires_at: 1,
+    });
+    expect(readdirSync(getConfigDir())).not.toContain("session-refresh.lock");
+  });
+
+  it("fails before contacting Supabase when the config directory is unwritable", async () => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    chmodSync(getConfigDir(), 0o500);
+
+    try {
+      const failure = await new Client(cfg).refreshToken().catch((error: unknown) => error);
+      expect(failure).toMatchObject({
+        name: "SessionPersistenceError",
+        code: "SESSION_PERSISTENCE_ERROR",
+        message: expect.stringContaining("writable"),
+        cause: { code: expect.stringMatching(/^(?:EACCES|EPERM)$/) },
+      });
+    } finally {
+      chmodSync(getConfigDir(), 0o700);
+    }
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
   });
 
   it("does not adopt tokens from a different account on disk", async () => {

--- a/src/client/refresh.test.ts
+++ b/src/client/refresh.test.ts
@@ -92,6 +92,45 @@ function oauthAccessToken(clientID: string): string {
   return `header.${payload}.signature`;
 }
 
+interface StalledJsonResponse {
+  deliver(value: unknown): void;
+  isTerminated(): boolean;
+  response: Response;
+}
+
+function stalledJsonResponse(status: number, signal?: AbortSignal): StalledJsonResponse {
+  let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let terminated = false;
+  const body = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      controller = streamController;
+      signal?.addEventListener(
+        "abort",
+        () => {
+          if (terminated) return;
+          terminated = true;
+          streamController.error(signal.reason);
+        },
+        { once: true },
+      );
+    },
+    cancel() {
+      terminated = true;
+    },
+  });
+
+  return {
+    deliver(value: unknown) {
+      if (terminated || !controller) return;
+      terminated = true;
+      controller.enqueue(new TextEncoder().encode(JSON.stringify(value)));
+      controller.close();
+    },
+    isTerminated: () => terminated,
+    response: new Response(body, { status }),
+  };
+}
+
 describe("refresh self-healing", () => {
   const savedEnv: Record<string, string | undefined> = {};
   let tempDir: string;
@@ -253,6 +292,51 @@ describe("refresh self-healing", () => {
     expect(loadConfig().active_account?.session.refresh_token).toBe("rt-dead");
   });
 
+  it("requires reauthentication for a malformed legacy refresh token", async () => {
+    // Correct base64url shape and encoded length, but an invalid checksum.
+    // A client may reject it locally or let Supabase return validation_failed.
+    const malformedRefreshToken = Buffer.alloc(38).toString("base64url");
+    saveConfig(makeConfig({ refresh_token: malformedRefreshToken, expires_at: 1 }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error_code: "validation_failed" }), { status: 400 }),
+    );
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionExpiredError",
+      code: "SESSION_EXPIRED",
+      message: expect.stringContaining("dosu login"),
+    });
+
+    expect(mockFetch.mock.calls.length).toBeLessThanOrEqual(1);
+    const refreshCall = mockFetch.mock.calls[0] as [string, RequestInit] | undefined;
+    if (refreshCall) {
+      expect(refreshCall[0]).toBe(
+        "https://test.supabase.co/auth/v1/token?grant_type=refresh_token",
+      );
+    }
+    expect(loadConfig().active_account?.session.refresh_token).toBe(malformedRefreshToken);
+  });
+
+  it("keeps an OAuth validation failure observable", async () => {
+    const accessToken = oauthAccessToken("cli-client-id");
+    saveConfig(makeConfig({ access_token: accessToken, refresh_token: "oauth-refresh" }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error_code: "validation_failed" }), { status: 400 }),
+    );
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionRefreshError",
+      code: "SESSION_REFRESH_ERROR",
+      status: 400,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://test.supabase.co/auth/v1/oauth/token");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("oauth-refresh");
+  });
+
   it("keeps unexpected auth server failures observable and does not mutate credentials", async () => {
     saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
     const cfg = loadConfig();
@@ -387,6 +471,84 @@ describe("refresh self-healing", () => {
 
       expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
       expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+      expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    200, 400,
+  ])("bounds response-body consumption and ignores a late body for status %i", async (status) => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    vi.useFakeTimers();
+    try {
+      let stalled: StalledJsonResponse | undefined;
+      let markResponseReady: (() => void) | undefined;
+      const responseReady = new Promise<void>((resolve) => {
+        markResponseReady = resolve;
+      });
+      mockFetch.mockImplementation(async (_url: unknown, options?: RequestInit) => {
+        stalled = stalledJsonResponse(status, options?.signal ?? undefined);
+        markResponseReady?.();
+        return stalled.response;
+      });
+
+      let settled = false;
+      const result = new Client(cfg).refreshToken().then(
+        () => {
+          settled = true;
+          return undefined;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
+      await responseReady;
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      const settledByDeadline = settled;
+      const lockHeldAtDeadline = readdirSync(getConfigDir()).includes("session-refresh.lock");
+      if (!stalled?.isTerminated()) {
+        const responseBody =
+          status === 200
+            ? {
+                access_token: "at-new",
+                refresh_token: "rt-new",
+                expires_in: 3600,
+              }
+            : { error_code: "unexpected_failure" };
+        stalled?.deliver(responseBody);
+      }
+      const outcome = await result;
+
+      // A timeout implemented as an outer race can release the lock while the
+      // losing refresh continues. Give any late body continuation time to run.
+      vi.useRealTimers();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect({ lockHeldAtDeadline, outcome, settledByDeadline }).toMatchObject({
+        lockHeldAtDeadline: false,
+        outcome: {
+          name: "SessionRefreshError",
+          code: "SESSION_REFRESH_ERROR",
+        },
+        settledByDeadline: true,
+      });
+      expect(cfg.active_account?.session).toMatchObject({
+        access_token: "at-old",
+        refresh_token: "rt-old",
+        expires_at: 1,
+      });
+      expect(loadConfig().active_account?.session).toMatchObject({
+        access_token: "at-old",
+        refresh_token: "rt-old",
+        expires_at: 1,
+      });
       expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
     } finally {
       vi.useRealTimers();

--- a/src/client/refresh.test.ts
+++ b/src/client/refresh.test.ts
@@ -167,6 +167,26 @@ describe("refresh self-healing", () => {
     expect(new URLSearchParams(init.body as string).get("client_id")).toBe("cli-client-id");
   });
 
+  it("preserves the selected target while saving refreshed credentials", async () => {
+    saveConfig(makeConfig({ refresh_token: "rt-old", deployment_id: "dep-1" }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "at-new",
+          refresh_token: "rt-new",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await new Client(cfg).refreshToken();
+
+    expect(cfg.active_account?.target?.deployment_id).toBe("dep-1");
+    expect(loadConfig().active_account?.target?.deployment_id).toBe("dep-1");
+  });
+
   it("serializes two concurrent clients so only one rotates and both adopt it", async () => {
     saveConfig(makeConfig({ refresh_token: "rt-0", expires_at: 1 }));
     const gotrue = new FakeGoTrue("rt-0");
@@ -217,6 +237,22 @@ describe("refresh self-healing", () => {
     expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
   });
 
+  it("recognizes the OAuth error field when reauthentication is required", async () => {
+    saveConfig(makeConfig({ refresh_token: "rt-dead" }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+    );
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionExpiredError",
+      code: "SESSION_EXPIRED",
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-dead");
+  });
+
   it("keeps unexpected auth server failures observable and does not mutate credentials", async () => {
     saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
     const cfg = loadConfig();
@@ -252,6 +288,62 @@ describe("refresh self-healing", () => {
     expect(mockFetch).toHaveBeenCalledOnce();
     expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
     expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+  });
+
+  it.each([
+    ["invalid JSON", "not-json"],
+    ["a non-object error", "[]"],
+    ["a non-string error", JSON.stringify({ error: 42 })],
+  ])("keeps an auth-server failure with %s observable", async (_description, body) => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(new Response(body, { status: 502 }));
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionRefreshError",
+      code: "SESSION_REFRESH_ERROR",
+      status: 502,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+  });
+
+  it.each([
+    ["invalid JSON", "{"],
+    ["a non-object body", "[]"],
+    [
+      "a non-string access token",
+      JSON.stringify({ access_token: 1, refresh_token: "rt-new", expires_in: 3600 }),
+    ],
+    [
+      "a non-string refresh token",
+      JSON.stringify({ access_token: "at-new", refresh_token: 1, expires_in: 3600 }),
+    ],
+    [
+      "a non-numeric expiry",
+      JSON.stringify({ access_token: "at-new", refresh_token: "rt-new", expires_in: "3600" }),
+    ],
+    [
+      "a non-finite expiry",
+      '{"access_token":"at-new","refresh_token":"rt-new","expires_in":1e400}',
+    ],
+  ])("rejects a successful refresh response with %s", async (_description, body) => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(new Response(body, { status: 200 }));
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionRefreshError",
+      code: "SESSION_REFRESH_ERROR",
+      status: 200,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+    expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
   });
 
   it("keeps network refresh failures observable with their cause", async () => {
@@ -421,6 +513,35 @@ describe("refresh self-healing", () => {
     expect(cfg.active_account?.session.refresh_token).toBe("rt-a");
     expect(loadConfig().active_account).toBeUndefined();
     expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
+  });
+
+  it("adopts a newer login for the same account instead of overwriting it", async () => {
+    saveConfig(makeAccountConfig("account-a", { refresh_token: "rt-a", deployment_id: "dep-old" }));
+    const cfg = loadConfig();
+    mockFetch.mockImplementation(async () => {
+      saveConfig(
+        makeAccountConfig("account-a", {
+          access_token: "at-login",
+          refresh_token: "rt-login",
+          deployment_id: "dep-login",
+        }),
+      );
+      return new Response(
+        JSON.stringify({
+          access_token: "at-a-refreshed",
+          refresh_token: "rt-a-refreshed",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      );
+    });
+
+    await new Client(cfg).refreshToken();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-login");
+    expect(cfg.active_account?.target?.deployment_id).toBe("dep-login");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-login");
   });
 
   it("does not overwrite a different account that logs in during refresh", async () => {

--- a/src/client/refresh.test.ts
+++ b/src/client/refresh.test.ts
@@ -22,7 +22,14 @@ import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { type Config, getConfigDir, getConfigPath, loadConfig, saveConfig } from "../config/config";
+import {
+  type Config,
+  emptyConfig,
+  getConfigDir,
+  getConfigPath,
+  loadConfig,
+  saveConfig,
+} from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
 import { Client } from "./client";
 
@@ -229,6 +236,24 @@ describe("refresh self-healing", () => {
     expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
   });
 
+  it("does not classify an unknown auth-server 401 as an expired session", async () => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error_code: "invalid_api_key" }), { status: 401 }),
+    );
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionRefreshError",
+      code: "SESSION_REFRESH_ERROR",
+      status: 401,
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
+    expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+  });
+
   it("keeps network refresh failures observable with their cause", async () => {
     saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
     const cfg = loadConfig();
@@ -244,6 +269,36 @@ describe("refresh self-healing", () => {
     expect(mockFetch).toHaveBeenCalledOnce();
     expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
     expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+  });
+
+  it("aborts a hung refresh request and releases the config lock", async () => {
+    saveConfig(makeConfig({ access_token: "at-old", refresh_token: "rt-old", expires_at: 1 }));
+    const cfg = loadConfig();
+    vi.useFakeTimers();
+    try {
+      mockFetch.mockImplementation(
+        async (_url: unknown, options?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            const signal = options?.signal;
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          }),
+      );
+
+      const refresh = new Client(cfg).refreshToken();
+      const rejection = expect(refresh).rejects.toMatchObject({
+        name: "SessionRefreshError",
+        code: "SESSION_REFRESH_ERROR",
+        cause: { name: "AbortError" },
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+      await rejection;
+
+      expect(cfg.active_account?.session.refresh_token).toBe("rt-old");
+      expect(loadConfig().active_account?.session.refresh_token).toBe("rt-old");
+      expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not retry or mutate memory when refreshed credentials cannot be persisted", async () => {
@@ -315,6 +370,57 @@ describe("refresh self-healing", () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(loadConfig().active_account?.user_id).toBe("account-b");
+  });
+
+  it("does not resurrect a session removed before refresh acquires the lock", async () => {
+    saveConfig(makeAccountConfig("account-a", { refresh_token: "rt-a" }));
+    const cfg = loadConfig();
+    saveConfig(emptyConfig());
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "at-resurrected",
+          refresh_token: "rt-resurrected",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionExpiredError",
+      code: "SESSION_EXPIRED",
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-a");
+    expect(loadConfig().active_account).toBeUndefined();
+  });
+
+  it("does not restore a session removed while the refresh request is in flight", async () => {
+    saveConfig(makeAccountConfig("account-a", { refresh_token: "rt-a" }));
+    const cfg = loadConfig();
+    mockFetch.mockImplementation(async () => {
+      saveConfig(emptyConfig());
+      return new Response(
+        JSON.stringify({
+          access_token: "at-resurrected",
+          refresh_token: "rt-resurrected",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      );
+    });
+
+    await expect(new Client(cfg).refreshToken()).rejects.toMatchObject({
+      name: "SessionExpiredError",
+      code: "SESSION_EXPIRED",
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(cfg.active_account?.session.refresh_token).toBe("rt-a");
+    expect(loadConfig().active_account).toBeUndefined();
+    expect(readdirSync(getConfigDir())).toEqual(["config.json"]);
   });
 
   it("does not overwrite a different account that logs in during refresh", async () => {

--- a/src/client/trpc.test.ts
+++ b/src/client/trpc.test.ts
@@ -62,6 +62,10 @@ function trpcError(status: number): Response {
   });
 }
 
+function sessionError(name: string, code: string, message: string): Error {
+  return Object.assign(new Error(message), { name, code });
+}
+
 describe("createTypedClient", () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -107,16 +111,25 @@ describe("createTypedClient", () => {
       expect(fetchOpts.headers["x-dosu-cli-contract"]).toBe(CLI_CONTRACT_HASH);
     });
 
-    it("throws session expired when proactive refresh fails", async () => {
+    it("preserves a typed persistence error when proactive refresh fails", async () => {
       mockIsTokenExpired.mockReturnValue(true);
-      mockRefreshToken.mockRejectedValue(new Error("network error"));
+      const refreshError = sessionError(
+        "SessionPersistenceError",
+        "SESSION_PERSISTENCE_ERROR",
+        "Could not save refreshed credentials. Ensure the Dosu config directory is writable.",
+      );
+      mockRefreshToken.mockRejectedValue(refreshError);
 
       const client = createTypedClient(makeConfig());
 
-      await expect(
+      const request =
         // biome-ignore lint/suspicious/noExplicitAny: testing dynamic tRPC proxy
-        (client as any).thread.list.query({ space_id: "s1" }),
-      ).rejects.toThrow("session expired");
+        (client as any).thread.list.query({ space_id: "s1" });
+      await expect(request).rejects.toMatchObject({
+        name: "TRPCClientError",
+        message: expect.stringContaining("writable"),
+        cause: refreshError,
+      });
     });
   });
 
@@ -143,19 +156,27 @@ describe("createTypedClient", () => {
       expect(retryOpts.headers["x-dosu-cli-contract"]).toBe(CLI_CONTRACT_HASH);
     });
 
-    it("returns original response when 401 refresh fails", async () => {
-      mockRefreshToken.mockRejectedValue(new Error("refresh failed"));
+    it("throws the typed refresh error when a 401 refresh fails", async () => {
+      const refreshError = sessionError(
+        "SessionExpiredError",
+        "SESSION_EXPIRED",
+        "Session expired. Run 'dosu login' to re-authenticate.",
+      );
+      mockRefreshToken.mockRejectedValue(refreshError);
       mockFetch.mockResolvedValue(trpcError(401));
 
       const client = createTypedClient(makeConfig());
 
-      await expect(
+      const request =
         // biome-ignore lint/suspicious/noExplicitAny: testing dynamic tRPC proxy
-        (client as any).thread.list.query({ space_id: "s1" }),
-      ).rejects.toThrow();
+        (client as any).thread.list.query({ space_id: "s1" });
+      await expect(request).rejects.toMatchObject({
+        name: "TRPCClientError",
+        message: expect.stringContaining("dosu login"),
+        cause: refreshError,
+      });
 
       expect(mockRefreshToken).toHaveBeenCalledOnce();
-      // Should NOT have retried — only 1 fetch call
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/client/trpc.test.ts
+++ b/src/client/trpc.test.ts
@@ -179,5 +179,24 @@ describe("createTypedClient", () => {
       expect(mockRefreshToken).toHaveBeenCalledOnce();
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+
+    it("does not refresh again when the request used older credentials", async () => {
+      const cfg = makeConfig({ access_token: "old-access", refresh_token: "old-refresh" });
+      mockFetch.mockImplementationOnce(async () => {
+        testSession(cfg).access_token = "new-access";
+        testSession(cfg).refresh_token = "new-refresh";
+        return trpcError(401);
+      });
+      mockFetch.mockResolvedValueOnce(trpcOk({ retried: true }));
+
+      const client = createTypedClient(cfg);
+      // biome-ignore lint/suspicious/noExplicitAny: testing dynamic tRPC proxy
+      await (client as any).thread.list.query({ space_id: "s1" });
+
+      expect(mockRefreshToken).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [, retryOpts] = mockFetch.mock.calls[1];
+      expect(retryOpts.headers["Supabase-Access-Token"]).toBe("new-access");
+    });
   });
 });

--- a/src/client/trpc.ts
+++ b/src/client/trpc.ts
@@ -50,11 +50,7 @@ export function createTypedClient<TClient extends object = TypedClient>(config: 
         async headers() {
           if (isTokenExpired(config)) {
             logger.debug("trpc", "token expired, refreshing before request");
-            try {
-              await httpClient.refreshToken();
-            } catch {
-              throw new Error("session expired. Run 'dosu login' to re-authenticate");
-            }
+            await httpClient.refreshToken();
           }
           return {
             "Supabase-Access-Token": config.active_account?.session.access_token ?? "",
@@ -66,11 +62,7 @@ export function createTypedClient<TClient extends object = TypedClient>(config: 
 
           if (res.status === 401 || res.status === 403) {
             logger.debug("trpc", "got 401/403, attempting token refresh and retry");
-            try {
-              await httpClient.refreshToken();
-            } catch {
-              return res;
-            }
+            await httpClient.refreshToken();
             return globalThis.fetch(url, {
               ...options,
               headers: {

--- a/src/client/trpc.ts
+++ b/src/client/trpc.ts
@@ -58,11 +58,19 @@ export function createTypedClient<TClient extends object = TypedClient>(config: 
           };
         },
         async fetch(url, options) {
+          const requestAccessToken = new Headers(options?.headers).get("Supabase-Access-Token");
           const res = await globalThis.fetch(url, options);
 
           if (res.status === 401 || res.status === 403) {
             logger.debug("trpc", "got 401/403, attempting token refresh and retry");
-            await httpClient.refreshToken();
+            const currentAccessToken = config.active_account?.session.access_token;
+            if (
+              !currentAccessToken ||
+              requestAccessToken === null ||
+              currentAccessToken === requestAccessToken
+            ) {
+              await httpClient.refreshToken();
+            }
             return globalThis.fetch(url, {
               ...options,
               headers: {

--- a/src/config/config-lock.test.ts
+++ b/src/config/config-lock.test.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   statSync,
   unlinkSync,
@@ -85,6 +86,53 @@ describe("config refresh lock", () => {
 
     expect(task).toHaveBeenCalledOnce();
     expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("does not delete a live successor installed after classifying a stale owner", async () => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    const deadPid = process.pid + 1;
+    writeFileSync(lockPath, JSON.stringify({ owner_id: "dead", pid: deadPid, created_at: 1 }), {
+      mode: 0o600,
+    });
+    const task = vi.fn(async () => "should not run");
+    let installedSuccessor = false;
+
+    const outcome = await withConfigRefreshLock(task, {
+      isProcessAlive: (pid) => {
+        if (pid === deadPid && !installedSuccessor) {
+          installedSuccessor = true;
+          unlinkSync(lockPath);
+          writeFileSync(
+            lockPath,
+            JSON.stringify({
+              owner_id: "successor",
+              pid: process.pid,
+              created_at: Date.now(),
+            }),
+            { mode: 0o600 },
+          );
+        }
+        return pid !== deadPid;
+      },
+      ownerId: "waiting-owner",
+      timeoutMs: 0,
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    const remainingOwner = existsSync(lockPath)
+      ? (JSON.parse(readFileSync(lockPath, "utf8")) as { owner_id?: string }).owner_id
+      : undefined;
+    expect({ outcome, remainingOwner, taskCalls: task.mock.calls.length }).toMatchObject({
+      outcome: {
+        name: "SessionPersistenceError",
+        code: "SESSION_PERSISTENCE_ERROR",
+      },
+      remainingOwner: "successor",
+      taskCalls: 0,
+    });
   });
 
   it("wraps config-directory creation failures before running the task", async () => {

--- a/src/config/config-lock.test.ts
+++ b/src/config/config-lock.test.ts
@@ -1,15 +1,41 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    closeSync: vi.fn(actual.closeSync),
+    mkdirSync: vi.fn(actual.mkdirSync),
+    statSync: vi.fn(actual.statSync),
+    writeFileSync: vi.fn(actual.writeFileSync),
+  };
+});
+
 import { getConfigDir, getConfigPath } from "./config";
 import { CONFIG_REFRESH_LOCK_FILENAME, withConfigRefreshLock } from "./config-lock";
+
+function fsError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(code), { code });
+}
 
 describe("config refresh lock", () => {
   let originalXdg: string | undefined;
   let tempDir: string;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     originalXdg = process.env.XDG_CONFIG_HOME;
     tempDir = mkdtempSync(join(tmpdir(), "dosu-config-lock-test-"));
     process.env.XDG_CONFIG_HOME = tempDir;
@@ -59,6 +85,153 @@ describe("config refresh lock", () => {
 
     expect(task).toHaveBeenCalledOnce();
     expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("wraps config-directory creation failures before running the task", async () => {
+    const cause = fsError("EACCES");
+    vi.mocked(mkdirSync).mockImplementationOnce(() => {
+      throw cause;
+    });
+    const task = vi.fn(async () => "should not run");
+
+    await expect(withConfigRefreshLock(task)).rejects.toMatchObject({
+      name: "SessionPersistenceError",
+      code: "SESSION_PERSISTENCE_ERROR",
+      cause,
+    });
+
+    expect(task).not.toHaveBeenCalled();
+  });
+
+  it("removes the partial lock when writing its metadata fails", async () => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    const cause = fsError("EIO");
+    vi.mocked(writeFileSync).mockImplementationOnce(() => {
+      throw cause;
+    });
+    const task = vi.fn(async () => "should not run");
+
+    await expect(withConfigRefreshLock(task)).rejects.toMatchObject({
+      name: "SessionPersistenceError",
+      cause,
+    });
+
+    expect(task).not.toHaveBeenCalled();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("removes the lock when closing its descriptor fails", async () => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    const cause = fsError("EIO");
+    const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+    vi.mocked(closeSync).mockImplementationOnce((fd) => {
+      actual.closeSync(fd);
+      throw cause;
+    });
+    const task = vi.fn(async () => "should not run");
+
+    await expect(withConfigRefreshLock(task)).rejects.toMatchObject({
+      name: "SessionPersistenceError",
+      cause,
+    });
+
+    expect(task).not.toHaveBeenCalled();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it.each([
+    ["invalid JSON", "{"],
+    ["non-object metadata", "[]"],
+    ["invalid metadata", JSON.stringify({ owner_id: 42, pid: "bad", created_at: null })],
+  ])("reclaims a stale lock with %s", async (_description, contents) => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    writeFileSync(lockPath, contents, { mode: 0o600 });
+    const task = vi.fn(async () => "recovered");
+    const now = Date.now() + 1_000;
+
+    await expect(
+      withConfigRefreshLock(task, {
+        now: () => now,
+        staleAgeMs: 0,
+        ownerId: "new-owner",
+      }),
+    ).resolves.toBe("recovered");
+
+    expect(task).toHaveBeenCalledOnce();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("retries acquisition when a malformed lock disappears during inspection", async () => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    writeFileSync(lockPath, "not-json", { mode: 0o600 });
+    vi.mocked(statSync).mockImplementationOnce((path) => {
+      unlinkSync(path);
+      throw fsError("ENOENT");
+    });
+    const task = vi.fn(async () => "acquired");
+
+    await expect(withConfigRefreshLock(task, { staleAgeMs: 0 })).resolves.toBe("acquired");
+
+    expect(task).toHaveBeenCalledOnce();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("retries acquisition when a stale lock disappears after it is claimed", async () => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    writeFileSync(lockPath, JSON.stringify({ owner_id: "dead", pid: 1234, created_at: 1 }), {
+      mode: 0o600,
+    });
+    vi.mocked(statSync).mockImplementationOnce((path) => {
+      unlinkSync(path);
+      throw fsError("ENOENT");
+    });
+    const task = vi.fn(async () => "acquired");
+
+    await expect(
+      withConfigRefreshLock(task, { isProcessAlive: () => false, ownerId: "new-owner" }),
+    ).resolves.toBe("acquired");
+
+    expect(task).toHaveBeenCalledOnce();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("uses process liveness to reclaim a lock left by a dead owner", async () => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    writeFileSync(lockPath, JSON.stringify({ owner_id: "dead", pid: 1234, created_at: 1 }), {
+      mode: 0o600,
+    });
+    const kill = vi.spyOn(process, "kill").mockImplementationOnce(() => {
+      throw fsError("ESRCH");
+    });
+
+    try {
+      await expect(withConfigRefreshLock(async () => "recovered")).resolves.toBe("recovered");
+    } finally {
+      kill.mockRestore();
+    }
+
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("does not remove a successor lock installed before release", async () => {
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+
+    await withConfigRefreshLock(async () => {
+      unlinkSync(lockPath);
+      writeFileSync(
+        lockPath,
+        JSON.stringify({ owner_id: "successor", pid: process.pid, created_at: Date.now() }),
+        { mode: 0o600 },
+      );
+    });
+
+    expect(existsSync(lockPath)).toBe(true);
   });
 
   it("bounds waiting without deleting a live process lock", async () => {

--- a/src/config/config-lock.test.ts
+++ b/src/config/config-lock.test.ts
@@ -1,0 +1,95 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getConfigDir, getConfigPath } from "./config";
+import { CONFIG_REFRESH_LOCK_FILENAME, withConfigRefreshLock } from "./config-lock";
+
+describe("config refresh lock", () => {
+  let originalXdg: string | undefined;
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalXdg = process.env.XDG_CONFIG_HOME;
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-config-lock-test-"));
+    process.env.XDG_CONFIG_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdg;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it.each([false, true])("cleans up after task failure=%s", async (shouldFail) => {
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    const task = vi.fn(async () => {
+      expect(existsSync(lockPath)).toBe(true);
+      if (shouldFail) throw new Error("task failed");
+      return "done";
+    });
+
+    if (shouldFail) {
+      await expect(withConfigRefreshLock(task)).rejects.toThrow("task failed");
+    } else {
+      await expect(withConfigRefreshLock(task)).resolves.toBe("done");
+    }
+
+    expect(task).toHaveBeenCalledOnce();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("reclaims a stale lock without leaving claim files", async () => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    writeFileSync(lockPath, JSON.stringify({ owner_id: "dead-owner", pid: 1234, created_at: 1 }), {
+      mode: 0o600,
+    });
+    const task = vi.fn(async () => "recovered");
+
+    await expect(
+      withConfigRefreshLock(task, {
+        isProcessAlive: () => false,
+        ownerId: "new-owner",
+      }),
+    ).resolves.toBe("recovered");
+
+    expect(task).toHaveBeenCalledOnce();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("bounds waiting without deleting a live process lock", async () => {
+    getConfigPath();
+    const lockPath = join(getConfigDir(), CONFIG_REFRESH_LOCK_FILENAME);
+    writeFileSync(
+      lockPath,
+      JSON.stringify({ owner_id: "live-owner", pid: process.pid, created_at: 0 }),
+      { mode: 0o600 },
+    );
+    let now = 0;
+    const sleep = vi.fn(async (delayMs: number) => {
+      now += delayMs;
+    });
+    const task = vi.fn(async () => "should not run");
+
+    await expect(
+      withConfigRefreshLock(task, {
+        now: () => now,
+        sleep,
+        timeoutMs: 20,
+        retryDelayMs: 10,
+        ownerId: "waiting-owner",
+      }),
+    ).rejects.toMatchObject({
+      name: "SessionPersistenceError",
+      code: "SESSION_PERSISTENCE_ERROR",
+    });
+
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(task).not.toHaveBeenCalled();
+    expect(existsSync(lockPath)).toBe(true);
+  });
+});

--- a/src/config/config-lock.ts
+++ b/src/config/config-lock.ts
@@ -137,22 +137,18 @@ function claimAndRemoveStaleLock(
   isProcessAlive: (pid: number) => boolean,
   ownerId: string,
 ): boolean {
-  let stale = false;
-  try {
-    const metadata = readLockMetadata(lockPath);
-    if (metadata && Number.isInteger(metadata.pid) && metadata.pid > 0) {
-      stale = !isProcessAlive(metadata.pid);
-    } else {
-      stale = now - statSync(lockPath).mtimeMs >= staleAgeMs;
-    }
-  } catch (cause) {
-    return hasErrorCode(cause, "ENOENT");
-  }
-  if (!stale) return false;
-
   const claimPath = `${lockPath}.stale.${process.pid}.${ownerId}`;
   try {
     linkSync(lockPath, claimPath);
+    const metadata = readLockMetadata(claimPath);
+    let stale = false;
+    if (metadata && Number.isInteger(metadata.pid) && metadata.pid > 0) {
+      stale = !isProcessAlive(metadata.pid);
+    } else {
+      stale = now - statSync(claimPath).mtimeMs >= staleAgeMs;
+    }
+    if (!stale) return false;
+
     const current = statSync(lockPath);
     const claimed = statSync(claimPath);
     if (current.dev !== claimed.dev || current.ino !== claimed.ino) return false;

--- a/src/config/config-lock.ts
+++ b/src/config/config-lock.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { SessionPersistenceError } from "../auth/session-errors";
+import { getConfigDir } from "./config";
+
+export const CONFIG_REFRESH_LOCK_FILENAME = "session-refresh.lock";
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_RETRY_DELAY_MS = 25;
+const DEFAULT_STALE_AGE_MS = 30_000;
+
+interface LockMetadata {
+  owner_id: string;
+  pid: number;
+  created_at: number;
+}
+
+interface ConfigRefreshLockOptions {
+  timeoutMs?: number;
+  retryDelayMs?: number;
+  staleAgeMs?: number;
+  now?: () => number;
+  sleep?: (delayMs: number) => Promise<void>;
+  isProcessAlive?: (pid: number) => boolean;
+  ownerId?: string;
+}
+
+/** Run a complete refresh operation while holding the config-directory lock. */
+export async function withConfigRefreshLock<T>(
+  task: () => Promise<T>,
+  options: ConfigRefreshLockOptions = {},
+): Promise<T> {
+  const release = await acquireConfigRefreshLock(options);
+  try {
+    return await task();
+  } finally {
+    release();
+  }
+}
+
+async function acquireConfigRefreshLock(options: ConfigRefreshLockOptions): Promise<() => void> {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  const staleAgeMs = options.staleAgeMs ?? DEFAULT_STALE_AGE_MS;
+  const isProcessAlive = options.isProcessAlive ?? defaultIsProcessAlive;
+  const ownerId = options.ownerId ?? randomUUID();
+  const configDir = getConfigDir();
+  const lockPath = join(configDir, CONFIG_REFRESH_LOCK_FILENAME);
+
+  try {
+    if (!existsSync(configDir)) mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  } catch (cause) {
+    throw new SessionPersistenceError({ cause });
+  }
+
+  const deadline = now() + Math.max(0, timeoutMs);
+  while (true) {
+    try {
+      createLockFile(lockPath, { owner_id: ownerId, pid: process.pid, created_at: now() });
+      return () => releaseOwnedLock(lockPath, ownerId);
+    } catch (cause) {
+      if (!hasErrorCode(cause, "EEXIST")) {
+        throw new SessionPersistenceError({ cause });
+      }
+    }
+
+    if (claimAndRemoveStaleLock(lockPath, staleAgeMs, now(), isProcessAlive, ownerId)) {
+      continue;
+    }
+    if (now() >= deadline) {
+      throw new SessionPersistenceError({
+        cause: new Error("Timed out waiting for another Dosu session refresh."),
+      });
+    }
+    await sleep(Math.max(1, retryDelayMs));
+  }
+}
+
+function createLockFile(lockPath: string, metadata: LockMetadata): void {
+  const fd = openSync(lockPath, "wx", 0o600);
+  try {
+    writeFileSync(fd, JSON.stringify(metadata));
+  } catch (cause) {
+    try {
+      closeSync(fd);
+    } catch {
+      // Preserve the original write failure.
+    }
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // A failed best-effort cleanup is reclaimed through the stale-lock path.
+    }
+    throw cause;
+  }
+  try {
+    closeSync(fd);
+  } catch (cause) {
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // A failed best-effort cleanup is reclaimed through the stale-lock path.
+    }
+    throw cause;
+  }
+}
+
+function releaseOwnedLock(lockPath: string, ownerId: string): void {
+  try {
+    if (readLockMetadata(lockPath)?.owner_id === ownerId) unlinkSync(lockPath);
+  } catch {
+    // Cleanup must not mask the refresh result. A crashed/failed cleanup is stale-reclaimable.
+  }
+}
+
+/**
+ * Claim a stale inode with a hard link before unlinking the public lock path.
+ * This prevents one waiter from deleting a replacement lock created by another waiter.
+ */
+function claimAndRemoveStaleLock(
+  lockPath: string,
+  staleAgeMs: number,
+  now: number,
+  isProcessAlive: (pid: number) => boolean,
+  ownerId: string,
+): boolean {
+  let stale = false;
+  try {
+    const metadata = readLockMetadata(lockPath);
+    if (metadata && Number.isInteger(metadata.pid) && metadata.pid > 0) {
+      stale = !isProcessAlive(metadata.pid);
+    } else {
+      stale = now - statSync(lockPath).mtimeMs >= staleAgeMs;
+    }
+  } catch (cause) {
+    return hasErrorCode(cause, "ENOENT");
+  }
+  if (!stale) return false;
+
+  const claimPath = `${lockPath}.stale.${process.pid}.${ownerId}`;
+  try {
+    linkSync(lockPath, claimPath);
+    const current = statSync(lockPath);
+    const claimed = statSync(claimPath);
+    if (current.dev !== claimed.dev || current.ino !== claimed.ino) return false;
+    unlinkSync(lockPath);
+    return true;
+  } catch (cause) {
+    return hasErrorCode(cause, "ENOENT");
+  } finally {
+    try {
+      unlinkSync(claimPath);
+    } catch {
+      // The claim is best-effort cleanup and never grants lock ownership by itself.
+    }
+  }
+}
+
+function readLockMetadata(lockPath: string): LockMetadata | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(lockPath, "utf8")) as unknown;
+    if (!isRecord(parsed)) return undefined;
+    if (
+      typeof parsed.owner_id !== "string" ||
+      typeof parsed.pid !== "number" ||
+      typeof parsed.created_at !== "number"
+    ) {
+      return undefined;
+    }
+    return {
+      owner_id: parsed.owner_id,
+      pid: parsed.pid,
+      created_at: parsed.created_at,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (cause) {
+    return !hasErrorCode(cause, "ESRCH");
+  }
+}
+
+function defaultSleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function hasErrorCode(value: unknown, code: string): boolean {
+  return isRecord(value) && value.code === code;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/telemetry/telemetry.test.ts
+++ b/src/telemetry/telemetry.test.ts
@@ -427,6 +427,27 @@ describe("safe payload builders", () => {
   });
 
   it.each([
+    ["SessionExpiredError", "SESSION_EXPIRED"],
+    ["SessionPersistenceError", "SESSION_PERSISTENCE_ERROR"],
+  ])("unwraps a tRPC cause as %s without retaining private details", (name, code) => {
+    const cause = Object.assign(new Error("private /Users/alice/.config/dosu-cli/config.json"), {
+      name,
+      code,
+      path: "/Users/alice/.config/dosu-cli/config.json",
+    });
+    const wrapped = Object.assign(new Error("wrapped private error"), {
+      name: "TRPCClientError",
+      cause,
+    });
+
+    const safeError = sanitizeError(wrapped);
+
+    expect(safeError).toMatchObject({ type: name, code });
+    expect(JSON.stringify(safeError)).not.toContain("alice");
+    expect(JSON.stringify(safeError)).not.toContain("config.json");
+  });
+
+  it.each([
     "EISDIR",
     "ELOOP",
     "EMFILE",
@@ -844,6 +865,71 @@ describe("CommandTelemetry lifecycle", () => {
     expect(payload.properties).toMatchObject({ result: "validation_error", exit_code: 1 });
   });
 
+  it.each([
+    ["SessionExpiredError", "SESSION_EXPIRED", false],
+    ["SessionExpiredError", "SESSION_EXPIRED", true],
+    ["SessionPersistenceError", "SESSION_PERSISTENCE_ERROR", false],
+    ["SessionPersistenceError", "SESSION_PERSISTENCE_ERROR", true],
+  ])("keeps %s (%s) out of Sentry when tRPC wrapped=%s", async (name, code, wrapped) => {
+    const deps = testDependencies();
+    const telemetry = createCommandTelemetry(
+      { install_id: "11111111-1111-4111-8111-111111111111" },
+      deps,
+    );
+    telemetry.start("review list", SAFE_CONTEXT);
+    const cause = Object.assign(new Error("private token and local path"), { name, code });
+    const error = wrapped
+      ? Object.assign(new Error("wrapped private error"), {
+          name: "TRPCClientError",
+          cause,
+        })
+      : cause;
+
+    await telemetry.fail(error);
+
+    expect(deps.fetch).toHaveBeenCalledOnce();
+    expect(deps.randomUUID).not.toHaveBeenCalled();
+    const [url, init] = deps.fetch.mock.calls[0] ?? [];
+    expect(url).toBe("https://dosu.dev/ph-api/i/v0/e/");
+    const payload = JSON.parse(String(init?.body)) as {
+      properties: Record<string, unknown>;
+    };
+    expect(payload.properties).toMatchObject({ result: "failure", error_code: code });
+    expect(JSON.stringify(payload)).not.toContain("private");
+  });
+
+  it("continues sending an unexpected wrapped session refresh failure to Sentry", async () => {
+    const deps = testDependencies();
+    const telemetry = createCommandTelemetry(
+      { install_id: "11111111-1111-4111-8111-111111111111" },
+      deps,
+    );
+    telemetry.start("review list", SAFE_CONTEXT);
+    const cause = Object.assign(new Error("private upstream response"), {
+      name: "SessionRefreshError",
+      code: "SESSION_REFRESH_ERROR",
+      status: 503,
+    });
+    const wrapped = Object.assign(new Error("wrapped private error"), {
+      name: "TRPCClientError",
+      cause,
+    });
+
+    await telemetry.fail(wrapped);
+
+    expect(deps.fetch).toHaveBeenCalledTimes(2);
+    expect(deps.randomUUID).toHaveBeenCalledOnce();
+    const bodies = deps.fetch.mock.calls.map((call) => String(call[1]?.body));
+    const analytics = JSON.parse(bodies.find((body) => body.startsWith("{")) ?? "{}") as {
+      properties: Record<string, unknown>;
+    };
+    const envelope = bodies.find((body) => body.includes("\n")) ?? "";
+    expect(analytics.properties.error_code).toBe("SESSION_REFRESH_ERROR");
+    expect(envelope).toContain('"type":"SessionRefreshError"');
+    expect(envelope).toContain('"http_status":"503"');
+    expect(envelope).not.toContain("private upstream");
+  });
+
   it("reports a non-validation nonzero completion as a message-free Sentry error", async () => {
     const deps = testDependencies();
     const telemetry = createCommandTelemetry({}, deps);
@@ -858,7 +944,7 @@ describe("CommandTelemetry lifecycle", () => {
     expect(envelope).not.toContain('"message"');
   });
 
-  it("sends a safe analytics failure and a manual Sentry envelope only once", async () => {
+  it("still sends an unrelated tRPC failure to analytics and Sentry exactly once", async () => {
     const deps = testDependencies();
     const telemetry = createCommandTelemetry(
       {

--- a/src/telemetry/telemetry.test.ts
+++ b/src/telemetry/telemetry.test.ts
@@ -447,6 +447,19 @@ describe("safe payload builders", () => {
     expect(JSON.stringify(safeError)).not.toContain("config.json");
   });
 
+  it("bounds cyclic cause chains without retaining private details", () => {
+    const error = Object.assign(new Error("private cyclic detail"), {
+      name: "TRPCClientError",
+      code: "NOT_FOUND",
+    }) as Error & { cause?: unknown; code: string };
+    error.cause = error;
+
+    const safeError = sanitizeError(error);
+
+    expect(safeError).toMatchObject({ type: "TRPCClientError", code: "NOT_FOUND" });
+    expect(JSON.stringify(safeError)).not.toContain("private");
+  });
+
   it.each([
     "EISDIR",
     "ELOOP",

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -27,6 +27,8 @@ const SAFE_ERROR_TYPES = new Set([
   "RangeError",
   "ReferenceError",
   "SessionExpiredError",
+  "SessionPersistenceError",
+  "SessionRefreshError",
   "SyntaxError",
   "TRPCClientError",
   "TypeError",
@@ -73,6 +75,9 @@ const SAFE_ERROR_CODES = new Set([
   "PAYMENT_REQUIRED",
   "PRECONDITION_FAILED",
   "SERVICE_UNAVAILABLE",
+  "SESSION_EXPIRED",
+  "SESSION_PERSISTENCE_ERROR",
+  "SESSION_REFRESH_ERROR",
   "TIMEOUT",
   "TOO_MANY_REQUESTS",
   "UNAUTHORIZED",
@@ -423,15 +428,16 @@ function parseOwnedStackLine(
 
 /** Extracts only allowlisted, bounded diagnostics. Raw Error values are never retained. */
 export function sanitizeError(error: unknown): SafeError {
-  const data = safeRead(error, "data");
-  const typeCandidate = safeRead(error, "name");
-  const codeCandidates = [safeRead(data, "code"), safeRead(error, "code")];
+  const normalizedError = domainErrorFromCauseChain(error) ?? error;
+  const data = safeRead(normalizedError, "data");
+  const typeCandidate = safeRead(normalizedError, "name");
+  const codeCandidates = [safeRead(data, "code"), safeRead(normalizedError, "code")];
   const statusCandidates = [
     safeRead(data, "httpStatus"),
-    safeRead(error, "status"),
-    safeRead(error, "statusCode"),
+    safeRead(normalizedError, "status"),
+    safeRead(normalizedError, "statusCode"),
   ];
-  const exitCodeCandidate = safeRead(error, "exitCode");
+  const exitCodeCandidate = safeRead(normalizedError, "exitCode");
   const code = codeCandidates.find(validErrorCode);
   const status = statusCandidates.find(validStatus);
   const exitCode =
@@ -443,9 +449,28 @@ export function sanitizeError(error: unknown): SafeError {
     type: validErrorType(typeCandidate) ? typeCandidate : "Error",
     ...(code ? { code } : {}),
     ...(status ? { status } : {}),
-    frames: parseStack(safeRead(error, "stack")),
+    frames: parseStack(safeRead(normalizedError, "stack")),
     ...(exitCode === undefined ? {} : { exitCode }),
   };
+}
+
+function domainErrorFromCauseChain(error: unknown): unknown {
+  const seen = new Set<object>();
+  let current = error;
+  for (let depth = 0; depth < 5 && objectLike(current); depth += 1) {
+    if (seen.has(current)) return undefined;
+    seen.add(current);
+    const code = safeRead(current, "code");
+    if (
+      code === "SESSION_EXPIRED" ||
+      code === "SESSION_PERSISTENCE_ERROR" ||
+      code === "SESSION_REFRESH_ERROR"
+    ) {
+      return current;
+    }
+    current = safeRead(current, "cause");
+  }
+  return undefined;
 }
 
 export function durationBucket(durationMs: number): string {
@@ -964,7 +989,7 @@ export function createCommandTelemetry(
         }
       }
 
-      if (!disabled && result === "failure" && error && sentryDsn) {
+      if (!disabled && result === "failure" && error && shouldSendToSentry(error) && sentryDsn) {
         const id = eventId(generateUuid);
         const envelope = id
           ? buildSentryEnvelope({
@@ -1040,4 +1065,8 @@ export function createCommandTelemetry(
       await dispatch(result, exitCode, error);
     },
   };
+}
+
+function shouldSendToSentry(error: SafeError): boolean {
+  return !["SESSION_EXPIRED", "SESSION_PERSISTENCE_ERROR"].includes(error.code ?? "");
 }


### PR DESCRIPTION
## Summary

- serialize the complete config reload, token refresh, and atomic save cycle with a config-directory inter-process lock
- persist candidate credentials before updating caller memory and never retry after a successful rotation followed by a save failure
- preserve typed session-expired, persistence, and unexpected refresh errors through tRPC
- keep expected actionable auth failures out of error reporting while retaining safe analytics and reporting unrelated tRPC or refresh failures

## Why

Concurrent CLI commands could refresh the same rotating credential, and a successful refresh followed by a local persistence failure could leave disk and memory out of sync. This makes refresh coordination deterministic and keeps actionable authentication failures distinct from unexpected network or server failures.

## Review follow-up

The PR-style review added deterministic coverage and fixes to:

- prevent a stale in-memory client from recreating a session removed from disk before or during refresh
- avoid a second rotation when a late 401/403 belongs to credentials already replaced by another same-process request
- bound the token request so a live but hung lock owner eventually releases the refresh lock
- classify only recognized reauthentication errors as session expiry instead of blanket-converting every auth-server 401

## Testing

- focused refresh/tRPC/telemetry suite: 125 passed
- full coverage suite: 69 files, 1,601 tests passed
- coverage: 96.74% statements, 91.51% branches, 97.68% functions, 97.5% lines
- `bun run check`
- `bun run typecheck`
- `bun run deadcode`
- `bun run build`
- `./bin/dosu --version` (`v0.48.2`)
