### PR TITLE
feat(install): github setup

### DIFF
--- a/src/agent/flow.test.ts
+++ b/src/agent/flow.test.ts
@@ -24,6 +24,7 @@ const {
   mockSkillAgentIDsForProviders,
   mockInGitWorkTree,
   mockUpsertDosuAgentsSection,
+  mockConnectGitHubForAgent,
 } = vi.hoisted(() => {
   return {
     mockMintTicket: vi.fn(),
@@ -46,6 +47,7 @@ const {
     mockSkillAgentIDsForProviders: vi.fn(),
     mockInGitWorkTree: vi.fn(),
     mockUpsertDosuAgentsSection: vi.fn(),
+    mockConnectGitHubForAgent: vi.fn(),
   };
 });
 
@@ -78,6 +80,11 @@ vi.mock("../commands/skill", () => ({
 vi.mock("../setup/agents-md-step", () => ({
   inGitWorkTree: mockInGitWorkTree,
   upsertDosuAgentsSection: mockUpsertDosuAgentsSection,
+}));
+
+vi.mock("../setup/github-step", () => ({
+  connectGitHubForAgent: (...args: unknown[]) => mockConnectGitHubForAgent(...args),
+  GITHUB_APP_INSTALL_URL: "https://github.com/apps/dosubot/installations/select_target",
 }));
 
 vi.mock("../client/client", () => ({
@@ -137,6 +144,11 @@ describe("buildResumeCommand", () => {
       "npx @dosu/cli@latest setup --agent --tool cursor --login-ticket tkt-2 --deployment dep-9",
     );
   });
+
+  it("omits --login-ticket when resuming after a GitHub App install", () => {
+    const cmd = buildResumeCommand("claude", undefined, "dep-1");
+    expect(cmd).toBe("npx @dosu/cli@latest setup --agent --tool claude --deployment dep-1");
+  });
 });
 
 describe("listAgentSupportedToolIDs", () => {
@@ -175,6 +187,8 @@ describe("runAgentSetup", () => {
     mockSkillAgentIDsForProviders.mockReset();
     mockInGitWorkTree.mockReset();
     mockUpsertDosuAgentsSection.mockReset();
+    mockConnectGitHubForAgent.mockReset();
+    mockConnectGitHubForAgent.mockResolvedValue({ status: "already_connected" });
     for (const fn of Object.values(mockClient)) fn.mockReset();
 
     claudeProvider = makeProvider("claude", { name: () => "Claude Code" });
@@ -959,5 +973,116 @@ describe("runAgentSetup", () => {
       }),
     ]);
     expect(claudeProvider.install).not.toHaveBeenCalled();
+  });
+
+  function seedReadyAgentSession() {
+    mockExchangeTicket.mockResolvedValue({
+      status: "authenticated",
+      access_token: ticketAccessToken,
+      refresh_token: "ref",
+      expires_in: 3600,
+      email: "user@example.com",
+    });
+    mockClient.getDeployments.mockResolvedValue([
+      {
+        deployment_id: "dep-1",
+        name: "acme/main",
+        description: "",
+        provider_slug: "dosu_mcp",
+        enabled: true,
+        org_id: "org-1",
+        org_name: "acme",
+        space_id: "space-1",
+      },
+    ]);
+    mockClient.validateAPIKey.mockResolvedValue(false);
+    mockClient.createAPIKey.mockResolvedValue({
+      api_key: "sk_user_x",
+      id: "k1",
+      name: "dosu-cli",
+      key_prefix: "sk_user_x",
+    });
+  }
+
+  it("asks the user to install the GitHub App when no repos are available", async () => {
+    seedReadyAgentSession();
+    mockConnectGitHubForAgent.mockResolvedValue({ status: "needs_install" });
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt-good" });
+
+    expect(code).toBe(0);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "github",
+      status: "need_user_action",
+      url: "https://github.com/apps/dosubot/installations/select_target",
+      resume_command: "npx @dosu/cli@latest setup --agent --tool claude --deployment dep-1",
+    });
+    expect(emittedEvents().map((e) => e.step)).not.toContain("done");
+  });
+
+  it("emits multiple_repos when several undeployed repos exist", async () => {
+    seedReadyAgentSession();
+    mockConnectGitHubForAgent.mockResolvedValue({
+      status: "needs_repo_choice",
+      candidates: [
+        { slug: "acme/api", repository_id: 1 },
+        { slug: "acme/core", repository_id: 2 },
+      ],
+    });
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt-good" });
+
+    expect(code).toBe(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "github",
+      status: "error",
+      reason: "multiple_repos",
+      candidates: [
+        { slug: "acme/api", repository_id: 1 },
+        { slug: "acme/core", repository_id: 2 },
+      ],
+    });
+  });
+
+  it("emits connect_failed when GitHub attach fails", async () => {
+    seedReadyAgentSession();
+    mockConnectGitHubForAgent.mockResolvedValue({
+      status: "failed",
+      message: "missing org/space context",
+    });
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt-good" });
+
+    expect(code).toBe(1);
+    expect(emittedEvents().at(-1)).toMatchObject({
+      step: "github",
+      status: "error",
+      reason: "connect_failed",
+    });
+  });
+
+  it("emits a github step when a repo is attached automatically", async () => {
+    seedReadyAgentSession();
+    mockConnectGitHubForAgent.mockResolvedValue({
+      status: "connected",
+      slugs: ["acme/api"],
+    });
+
+    const code = await runAgentSetup({ tool: "claude", loginTicket: "tkt-good" });
+
+    expect(code).toBe(0);
+    expect(emittedEvents().map((e) => e.step)).toEqual([
+      "auth",
+      "deployment",
+      "api_key",
+      "mcp_install",
+      "rule_install",
+      "skill_install",
+      "github",
+      "done",
+    ]);
+    expect(emittedEvents()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ step: "github", slugs: ["acme/api"] })]),
+    );
   });
 });

--- a/src/agent/flow.ts
+++ b/src/agent/flow.ts
@@ -28,6 +28,7 @@ import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders } from "../mcp/providers";
 import { fetchDosuRule, installRuleForAgent, isRuleAgent } from "../rules/installer";
 import { inGitWorkTree, upsertDosuAgentsSection } from "../setup/agents-md-step";
+import { connectGitHubForAgent, GITHUB_APP_INSTALL_URL } from "../setup/github-step";
 import { emitError, emitNeedUserAction, emitStep } from "./output";
 
 export interface AgentSetupOptions {
@@ -188,6 +189,48 @@ export async function runAgentSetup(opts: AgentSetupOptions): Promise<number> {
       });
       return 1;
     }
+  }
+
+  const github = await connectGitHubForAgent(cfg);
+  if (github.status === "needs_install") {
+    const resume = buildResumeCommand(
+      opts.tool,
+      undefined,
+      opts.deploymentID ?? cfg.active_account?.target?.deployment_id,
+    );
+    emitNeedUserAction({
+      step: "github",
+      url: GITHUB_APP_INSTALL_URL,
+      resume_command: resume,
+      agent_next_steps:
+        "No GitHub repository is connected. Give the user this URL to install the Dosu GitHub App " +
+        "on their org and select the repos Dosu should access. After they confirm, wait about a " +
+        "minute for the install to sync, then re-run resume_command — the CLI will attach the " +
+        "local repo (or the only available repo) as a source.",
+    });
+    return 0;
+  }
+  if (github.status === "needs_repo_choice") {
+    emitError({
+      step: "github",
+      reason: "multiple_repos",
+      candidates: github.candidates,
+      agent_next_steps:
+        `User has ${github.candidates.length} GitHub repos available and none connected. ` +
+        "Show the slugs and have them run interactive `dosu setup` to pick one, then re-run this command.",
+    });
+    return 1;
+  }
+  if (github.status === "failed") {
+    emitError({
+      step: "github",
+      reason: "connect_failed",
+      agent_next_steps: `Could not connect GitHub: ${github.message}. Have the user run interactive \`dosu setup\` or retry.`,
+    });
+    return 1;
+  }
+  if (github.status === "connected") {
+    emitStep({ step: "github", slugs: github.slugs });
   }
 
   emitStep({
@@ -484,8 +527,11 @@ async function ensureAPIKey(client: Client, cfg: Config): Promise<{ code: number
  * Build the exact command the agent should run after the user signs in.
  * Mirrors the marketing one-liner so the agent can copy/paste it back.
  */
-export function buildResumeCommand(tool: string, ticket: string, deploymentID?: string): string {
-  const parts = [NPX_INVOCATION, "setup", "--agent", "--tool", tool, "--login-ticket", ticket];
+export function buildResumeCommand(tool: string, ticket?: string, deploymentID?: string): string {
+  const parts = [NPX_INVOCATION, "setup", "--agent", "--tool", tool];
+  if (ticket) {
+    parts.push("--login-ticket", ticket);
+  }
   if (deploymentID) {
     parts.push("--deployment", deploymentID);
   }

--- a/src/agent/output.test.ts
+++ b/src/agent/output.test.ts
@@ -45,6 +45,23 @@ describe("agent/output", () => {
     });
   });
 
+  it("omits ticket fields when emitNeedUserAction is used for GitHub install", () => {
+    emitNeedUserAction({
+      step: "github",
+      url: "https://github.com/apps/dosubot/installations/select_target",
+      resume_command: "npx @dosu/cli@latest setup --agent --tool claude",
+      agent_next_steps: "Give the user the install URL.",
+    });
+
+    expect(lastEmittedJSON()).toEqual({
+      step: "github",
+      status: "need_user_action",
+      url: "https://github.com/apps/dosubot/installations/select_target",
+      resume_command: "npx @dosu/cli@latest setup --agent --tool claude",
+      agent_next_steps: "Give the user the install URL.",
+    });
+  });
+
   it("emitError emits a structured error with reason + next steps", () => {
     emitError({
       step: "deployment",

--- a/src/agent/output.ts
+++ b/src/agent/output.ts
@@ -31,18 +31,18 @@ export function emitJSONLine(value: unknown): void {
 export function emitNeedUserAction(opts: {
   step: string;
   url: string;
-  ticket: string;
-  resume_command: string;
-  expires_in: number;
   agent_next_steps: string;
+  ticket?: string;
+  resume_command?: string;
+  expires_in?: number;
 }): void {
   emitJSONLine({
     step: opts.step,
     status: "need_user_action",
     url: opts.url,
-    ticket: opts.ticket,
-    resume_command: opts.resume_command,
-    expires_in: opts.expires_in,
+    ...(opts.ticket !== undefined ? { ticket: opts.ticket } : {}),
+    ...(opts.resume_command !== undefined ? { resume_command: opts.resume_command } : {}),
+    ...(opts.expires_in !== undefined ? { expires_in: opts.expires_in } : {}),
     agent_next_steps: opts.agent_next_steps,
   });
 }

--- a/src/setup/flow.test.ts
+++ b/src/setup/flow.test.ts
@@ -132,8 +132,9 @@ vi.mock("../commands/skill", () => ({
   skillCommand: vi.fn(),
 }));
 
-const { mockStepConnectGitHubRepo } = vi.hoisted(() => ({
+const { mockStepConnectGitHubRepo, mockOrgHasGitHubSource } = vi.hoisted(() => ({
   mockStepConnectGitHubRepo: vi.fn(),
+  mockOrgHasGitHubSource: vi.fn(),
 }));
 
 // AGENTS.md step: mocked so flow tests never write an AGENTS.md into the real
@@ -170,6 +171,7 @@ vi.mock("./rules-step", () => ({
 }));
 vi.mock("./github-step", () => ({
   stepConnectGitHubRepo: (...args: unknown[]) => mockStepConnectGitHubRepo(...args),
+  orgHasGitHubSource: (...args: unknown[]) => mockOrgHasGitHubSource(...args),
   detectGitRepo: vi.fn(() => null),
 }));
 
@@ -212,6 +214,9 @@ function mockToolSelection(selection: string[]) {
 
 function installSetupStepDefaults() {
   mockStepConnectGitHubRepo.mockResolvedValue({ advance: false, has_connected_repo: false });
+  // Already-onboarded + already-connected is the everyday path. Tests that
+  // exercise the TTY GitHub step flip this to false.
+  mockOrgHasGitHubSource.mockResolvedValue(true);
   mockInGitWorkTree.mockReturnValue(false);
   mockStepUpdateAgentsMd.mockReturnValue(true);
   mockStepConfigureAgentRules.mockResolvedValue([]);
@@ -1942,13 +1947,37 @@ describe("runSetup checkpoint behavior", () => {
     expect(mockTrpc.user.updateProfile.mutate).not.toHaveBeenCalled();
   });
 
-  it("keeps ordinary setup free of GitHub when the remote profile is already onboarded", async () => {
-    saveConfig(makeCfg());
+  it("keeps ordinary setup free of GitHub when a GitHub source already exists", async () => {
+    saveConfig(makeCfg({ org_id: "o1", space_id: "s1" }));
     setupAuthed();
     vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
 
     await runSetup();
 
+    expect(mockOrgHasGitHubSource).toHaveBeenCalled();
+    expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
+  });
+
+  it("runs the TTY GitHub step for an already-onboarded org with no GitHub source", async () => {
+    mockOrgHasGitHubSource.mockResolvedValue(false);
+    saveConfig(makeCfg({ org_id: "o1", space_id: "s1" }));
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockStepConnectGitHubRepo).toHaveBeenCalledOnce();
+  });
+
+  it("never runs the TTY GitHub step in OSS mode", async () => {
+    mockOrgHasGitHubSource.mockResolvedValue(false);
+    saveConfig(makeCfg({ mode: "oss", org_id: "o1", space_id: "s1" }));
+    setupAuthed();
+    vi.spyOn(providersModule, "allSetupProviders").mockReturnValue([]);
+
+    await runSetup();
+
+    expect(mockOrgHasGitHubSource).not.toHaveBeenCalled();
     expect(mockStepConnectGitHubRepo).not.toHaveBeenCalled();
   });
 

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -22,6 +22,7 @@ import { MCP_PROVIDER_SLUG } from "../mcp/constants";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
 import { inGitWorkTree, stepUpdateAgentsMd } from "./agents-md-step";
 import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analytics";
+import { orgHasGitHubSource, stepConnectGitHubRepo } from "./github-step";
 import {
   type LogsHandoffDecision,
   type LogsHandoffPlan,
@@ -232,6 +233,21 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   }
   updateTarget(cfg, { api_key: apiKey });
   saveConfig(cfg);
+
+  // Already-onboarded cloud orgs with no GitHub source used to complete
+  // setup silently — `stepConnectGitHubRepo` only lived on `dosu audit`.
+  // First-run users still connect via the web wizard on the auth hop;
+  // this is the fallback for everyone else (and for a wizard that was skipped).
+  if (
+    cfg.mode !== MODE_OSS &&
+    cfg.active_account?.target?.org_id &&
+    cfg.active_account?.target?.space_id
+  ) {
+    const hasGithub = await orgHasGitHubSource(cfg);
+    if (!hasGithub) {
+      await stepConnectGitHubRepo(cfg);
+    }
+  }
 
   // Agent selection is the only install choice. Every successfully configured
   // agent receives the full supported bundle: MCP, rules, and skill.

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -95,7 +95,14 @@ vi.mock("../client/trpc", () => ({
 import * as p from "@clack/prompts";
 import type { Config } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
-import { detectGitRepo, stepConnectGitHubRepo, verifyDataSourcesPersist } from "./github-step";
+import {
+  connectGitHubForAgent,
+  detectGitRepo,
+  GITHUB_APP_INSTALL_URL,
+  orgHasGitHubSource,
+  stepConnectGitHubRepo,
+  verifyDataSourcesPersist,
+} from "./github-step";
 
 // Skip the post-connect verify-poll budget so each test resolves in real
 // time without needing fake timers to coexist with the install-flow promise
@@ -1094,5 +1101,163 @@ describe("verifyDataSourcesPersist", () => {
     expect(result.dropped.size).toBe(0);
     // Looped more than once (re-polled after sleeping) before the budget ran out.
     expect(mockTrpc.dataSource.list.query.mock.calls.length).toBeGreaterThan(1);
+  });
+});
+
+describe("orgHasGitHubSource", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockTrpc.dataSource.list.query.mockResolvedValue([]);
+  });
+
+  it("returns false when cfg has no org_id", async () => {
+    await expect(orgHasGitHubSource(makeCfg({ org_id: undefined }))).resolves.toBe(false);
+    expect(mockTrpc.dataSource.list.query).not.toHaveBeenCalled();
+  });
+
+  it("returns true when a github data source exists", async () => {
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-1", provider_slug: "github" },
+    ]);
+    await expect(orgHasGitHubSource(makeCfg())).resolves.toBe(true);
+  });
+
+  it("returns false when only non-github sources exist", async () => {
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-1", provider_slug: "confluence" },
+    ]);
+    await expect(orgHasGitHubSource(makeCfg())).resolves.toBe(false);
+  });
+
+  it("returns false when the list query fails", async () => {
+    mockTrpc.dataSource.list.query.mockRejectedValue(new Error("boom"));
+    await expect(orgHasGitHubSource(makeCfg())).resolves.toBe(false);
+  });
+});
+
+describe("connectGitHubForAgent", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockTrpc.dataSource.list.query.mockResolvedValue([]);
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({ deployment_id: "dep-1" });
+    mockTrpc.dataSource.create.mutate.mockResolvedValue({ data_source_id: "ds-1" });
+    mockTrpc.dataSource.syncDataSource.mutate.mockResolvedValue({});
+    mockTrpc.dataSource.attachToSpace.mutate.mockResolvedValue({});
+    mockTrpc.workspaces.listForSpace.query.mockResolvedValue([{ deployment_id: "dep-1" }]);
+    mockTrpc.deploymentDataSource.create.mutate.mockResolvedValue({});
+  });
+
+  it("points at the production Dosu GitHub App", () => {
+    expect(GITHUB_APP_INSTALL_URL).toContain("github.com/apps/dosubot/installations/select_target");
+  });
+
+  it("fails when cfg is missing org or space", async () => {
+    await expect(connectGitHubForAgent(makeCfg({ org_id: undefined }), null)).resolves.toEqual({
+      status: "failed",
+      message: "missing org/space context",
+    });
+  });
+
+  it("returns already_connected when a github source exists", async () => {
+    mockTrpc.dataSource.list.query.mockResolvedValue([
+      { data_source_id: "ds-1", provider_slug: "github" },
+    ]);
+    await expect(connectGitHubForAgent(makeCfg(), null)).resolves.toEqual({
+      status: "already_connected",
+    });
+    expect(mockTrpc.githubRepository.listForOrg.query).not.toHaveBeenCalled();
+  });
+
+  it("returns needs_install when the App has no repos for the org", async () => {
+    await expect(connectGitHubForAgent(makeCfg(), null)).resolves.toEqual({
+      status: "needs_install",
+    });
+  });
+
+  it("returns already_connected when every listed repo is already deployed", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: true },
+    ]);
+    await expect(connectGitHubForAgent(makeCfg(), null)).resolves.toEqual({
+      status: "already_connected",
+    });
+  });
+
+  it("returns needs_repo_choice when several undeployed repos exist and none match cwd", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+      { repository_id: 2, name: "core", slug: "acme/core", is_deployed: false },
+    ]);
+    await expect(connectGitHubForAgent(makeCfg(), null)).resolves.toEqual({
+      status: "needs_repo_choice",
+      candidates: [
+        { slug: "acme/api", repository_id: 1 },
+        { slug: "acme/core", repository_id: 2 },
+      ],
+    });
+  });
+
+  it("connects the lone undeployed repo", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockTrpc.dataSource.list.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ data_source_id: "ds-1", provider_slug: "github" }]);
+
+    await expect(
+      connectGitHubForAgent(makeCfg(), null, { verify: { timeoutMs: 0, intervalMs: 0 } }),
+    ).resolves.toEqual({
+      status: "connected",
+      slugs: ["acme/api"],
+    });
+    expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers the local git origin among several undeployed repos", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+      { repository_id: 2, name: "core", slug: "acme/core", is_deployed: false },
+    ]);
+    mockTrpc.dataSource.list.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ data_source_id: "ds-1", provider_slug: "github" }]);
+
+    await expect(
+      connectGitHubForAgent(
+        makeCfg(),
+        { owner: "Acme", name: "API", slug: "Acme/API" },
+        { verify: { timeoutMs: 0, intervalMs: 0 } },
+      ),
+    ).resolves.toEqual({ status: "connected", slugs: ["acme/api"] });
+    expect(mockTrpc.workspaces.create.mutate).toHaveBeenCalledTimes(1);
+    expect(mockTrpc.workspaces.create.mutate.mock.calls[0][0].name).toBe("acme/api");
+  });
+
+  it("fails when createDeploymentForRepo cannot attach the repo", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockTrpc.workspaces.create.mutate.mockResolvedValue({});
+
+    await expect(connectGitHubForAgent(makeCfg(), null)).resolves.toEqual({
+      status: "failed",
+      message: "could not attach any GitHub repository as a source",
+    });
+  });
+
+  it("fails when the created source is deleted during sync", async () => {
+    mockTrpc.githubRepository.listForOrg.query.mockResolvedValue([
+      { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+    ]);
+    mockTrpc.dataSource.list.query.mockResolvedValue([]);
+
+    await expect(
+      connectGitHubForAgent(makeCfg(), null, { verify: { timeoutMs: 0, intervalMs: 0 } }),
+    ).resolves.toEqual({
+      status: "failed",
+      message: "GitHub source was created then removed during sync",
+    });
   });
 });

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -100,6 +100,18 @@ export interface GithubStepResult {
   created_repository_slugs?: string[];
 }
 
+/** Production Dosu GitHub App. Override with DOSU_GITHUB_APP_INSTALL_URL_OVERRIDE. */
+export const GITHUB_APP_INSTALL_URL =
+  process.env.DOSU_GITHUB_APP_INSTALL_URL_OVERRIDE ??
+  "https://github.com/apps/dosubot/installations/select_target";
+
+export type AgentGitHubConnectResult =
+  | { status: "already_connected" }
+  | { status: "connected"; slugs: string[] }
+  | { status: "needs_install" }
+  | { status: "needs_repo_choice"; candidates: { slug: string; repository_id: number }[] }
+  | { status: "failed"; message: string };
+
 // Shape returned by tRPC `githubRepository.listForOrg`. Backend spreads
 // `...github.repository` so `created_at` rides along even though the
 // router type doesn't surface it explicitly.
@@ -133,6 +145,23 @@ export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null 
 
   const [, owner, name] = m;
   return { owner, name, slug: `${owner}/${name}` };
+}
+
+export async function orgHasGitHubSource(cfg: Config): Promise<boolean> {
+  const orgID = cfg.active_account?.target?.org_id;
+  if (!orgID) return false;
+  const trpc = createTypedClient(cfg);
+  try {
+    const listed = await trpc.dataSource.list.query({
+      org_id: orgID,
+      excluded_provider_slugs: [],
+    });
+    return listed.some((d) => d.provider_slug === "github");
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("setup", `dataSource.list github check failed: ${msg}`);
+    return false;
+  }
 }
 
 async function fetchListForOrg(trpc: TypedClient, orgID: string): Promise<AvailableRepo[]> {
@@ -465,6 +494,74 @@ async function deleteOrphanDeployment(
     const msg = err instanceof Error ? err.message : String(err);
     logger.warn("setup", `Failed to revert orphan deployment for ${slug}: ${msg}`);
   }
+}
+
+/**
+ * Non-interactive GitHub connect for `dosu setup --agent`.
+ *
+ * Never opens a browser or prompts. If the App is not installed, the caller
+ * emits a need_user_action ticket with GITHUB_APP_INSTALL_URL. After the user
+ * installs, a later invocation attaches the local origin (or the lone
+ * undeployed repo) via the same tRPC path as the TTY step.
+ */
+export async function connectGitHubForAgent(
+  cfg: Config,
+  detected: DetectedRepo | null = detectGitRepo(),
+  opts: StepConnectGitHubRepoOptions = {},
+): Promise<AgentGitHubConnectResult> {
+  if (!cfg.active_account?.target?.org_id || !cfg.active_account?.target?.space_id) {
+    return { status: "failed", message: "missing org/space context" };
+  }
+  const orgID = cfg.active_account.target.org_id;
+  const spaceID = cfg.active_account.target.space_id;
+
+  if (await orgHasGitHubSource(cfg)) {
+    return { status: "already_connected" };
+  }
+
+  const trpc = createTypedClient(cfg);
+  const repos = await fetchListForOrg(trpc, orgID);
+  if (repos.length === 0) {
+    return { status: "needs_install" };
+  }
+
+  const undeployed = repos.filter((r) => !r.is_deployed);
+  if (undeployed.length === 0) {
+    return { status: "already_connected" };
+  }
+
+  const detectedMatch =
+    detected && undeployed.find((r) => r.slug.toLowerCase() === detected.slug.toLowerCase());
+  const toConnect = detectedMatch ? [detectedMatch] : undeployed.length === 1 ? undeployed : null;
+  if (!toConnect) {
+    return {
+      status: "needs_repo_choice",
+      candidates: undeployed.map((r) => ({ slug: r.slug, repository_id: r.repository_id })),
+    };
+  }
+
+  const created: { data_source_id: string; slug: string }[] = [];
+  for (const repo of toConnect) {
+    const result = await createDeploymentForRepo(trpc, orgID, spaceID, repo);
+    if (result) {
+      created.push({ data_source_id: result.data_source_id, slug: repo.slug });
+    }
+  }
+  if (created.length === 0) {
+    return { status: "failed", message: "could not attach any GitHub repository as a source" };
+  }
+
+  const survivors = await verifyDataSourcesPersist(
+    trpc,
+    orgID,
+    created.map((c) => c.data_source_id),
+    opts.verify,
+  );
+  const survived = created.filter((c) => survivors.alive.has(c.data_source_id));
+  if (survived.length === 0) {
+    return { status: "failed", message: "GitHub source was created then removed during sync" };
+  }
+  return { status: "connected", slugs: survived.map((c) => c.slug) };
 }
 
 export async function stepConnectGitHubRepo(


### PR DESCRIPTION
Interactive dosu setup
If there is no GitHub source, the terminal shows the repo picker. “Add repositories…” opens the browser to Dosu’s bounce page /cli/connect-github, which sets a cookie and sends you to GitHub’s App install UI (github.com/apps/dosubot/...). After GitHub finishes, /cli/connect-github-done pings the CLI. You pick the repo in the terminal; the CLI creates the source over tRPC. You never go through /onboarding/connections.

dosu setup --agent
No Dosu page at all. The process exits in seconds and prints need_user_action with GitHub’s install URL directly:

https://github.com/apps/dosubot/installations/select_target
