### PR TITLE
fix(setup): align GitHub deployment config with hosted schema

### DIFF
--- a/src/setup/default-deployment-config.test.ts
+++ b/src/setup/default-deployment-config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_DEPLOYMENT_CONFIG_GITHUB } from "./default-deployment-config";
+
+describe("DEFAULT_DEPLOYMENT_CONFIG_GITHUB", () => {
+  it("omits fields removed from the hosted deployment schema", () => {
+    expect(DEFAULT_DEPLOYMENT_CONFIG_GITHUB).not.toHaveProperty("stale_bot");
+    expect(DEFAULT_DEPLOYMENT_CONFIG_GITHUB).not.toHaveProperty("pull_requests.stale_doc_check");
+    expect(DEFAULT_DEPLOYMENT_CONFIG_GITHUB).not.toHaveProperty(
+      "issues.auto_label_config.custom_instructions",
+    );
+    expect(DEFAULT_DEPLOYMENT_CONFIG_GITHUB).not.toHaveProperty(
+      "pull_requests.auto_label_config.custom_instructions",
+    );
+  });
+});

--- a/src/setup/default-deployment-config.ts
+++ b/src/setup/default-deployment-config.ts
@@ -4,11 +4,9 @@
  * `DEFAULT_DEPLOYMENT_CONFIG_GITHUB_TEST` from
  * `frontend/packages/core/src/utils/deployments.ts` in the Dosu main repo.
  *
- * The CLI copies it verbatim so that CLI-created deployments get the same
- * sensible feature defaults (auto-reply on issues, stale-doc check on PRs,
- * etc.) that web-created deployments do. If this ever drifts from the web
- * default, we should fix by publishing a shared config package rather than
- * by keeping two copies — tracked as a V2 cleanup.
+ * The CLI copies it verbatim so CLI-created deployments use the same supported
+ * feature defaults as web-created deployments. The hosted schema rejects
+ * unknown fields, so keep this copy synchronized with the web default.
  */
 export const DEFAULT_DEPLOYMENT_CONFIG_GITHUB: Readonly<Record<string, unknown>> = {
   default_maintainer: "",
@@ -32,7 +30,6 @@ export const DEFAULT_DEPLOYMENT_CONFIG_GITHUB: Readonly<Record<string, unknown>>
       include: [] as string[],
       exclude: [] as string[],
       separator: null,
-      custom_instructions: null,
     },
     voting: {
       enabled: false,
@@ -59,7 +56,6 @@ export const DEFAULT_DEPLOYMENT_CONFIG_GITHUB: Readonly<Record<string, unknown>>
       include: [] as string[],
       exclude: [] as string[],
       separator: null,
-      custom_instructions: null,
     },
     lgtm_label: {
       enabled: false,
@@ -77,10 +73,6 @@ export const DEFAULT_DEPLOYMENT_CONFIG_GITHUB: Readonly<Record<string, unknown>>
       name: "auto-merge",
       color: "FFA500",
       description: "This PR is set to be merged",
-    },
-    stale_doc_check: {
-      enabled: true,
-      monitored_paths: [] as string[],
     },
     diff_review_policies: [] as unknown[],
   },
@@ -100,14 +92,6 @@ export const DEFAULT_DEPLOYMENT_CONFIG_GITHUB: Readonly<Record<string, unknown>>
     },
     included_categories: ["Q&A", "Questions"],
     quality_checklist: null,
-  },
-  stale_bot: {
-    enabled: false,
-    days_before_stale: 90,
-    days_before_close: 7,
-    max_issues_close_per_day: 25,
-    excluded_label_ids: [] as string[],
-    tag_maintainer_response: false,
   },
   changelogs: {
     visibility: false,


### PR DESCRIPTION
## Summary

- Remove deprecated GitHub deployment fields rejected by the hosted schema.
- Align the CLI deployment default with Dosu's current web default.
- Add regression coverage for every removed field.

## Why

The CLI config copy still contains `stale_bot`, `pull_requests.stale_doc_check`, and two `custom_instructions` fields that the hosted schema no longer accepts, causing `workspaces.create` to fail with PostgreSQL error `23514` on `deploy_config_valid`.

## Test plan

- [x] `bun run test` — 1,633 tests
- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `bun run build`
