### PR TITLE
fix: align CLI commands with App contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ bun run check                   # Biome lint + format check (used in CI)
 Running `dosu` with no args launches the interactive TUI (`src/tui/tui.ts`). Two broad families of subcommands are registered in `src/cli/cli.ts`:
 
 - **Local / MCP management** — `login`, `logout`, `status`, `setup`, `mcp add|list`, `logs`, `telemetry`.
-- **Dosu platform** (require an authenticated deployment) — `ask`, `knowledge`, `docs`, `suggest`, `threads`, `review`, `sources`, `integrations`, `tags`, `members`, `org`, `deployments`, `analytics`, `insights`, `skill`. Each lives in `src/commands/<name>.ts` and talks to the backend via `src/client/`.
+- **Dosu platform** (require an authenticated deployment) — `ask`, `knowledge`, `docs`, `suggest`, `threads`, `review`, `sources`, `integrations`, `topics`, `members`, `org`, `deployments`, `analytics`, `insights`, `skill`. Each lives in `src/commands/<name>.ts` and talks to the backend via `src/client/`.
 
 Key modules:
 

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ Once authenticated against a deployment, you can drive the Dosu platform without
 | `dosu review` | Document review workflow |
 | `dosu sources` | Manage connected data sources (list, sync, update) |
 | `dosu integrations` | List and inspect platform integrations (Slack, GitHub, …) |
-| `dosu tags` | List knowledge base tags and tagged pages |
-| `dosu members` | Manage team members and access requests |
+| `dosu topics` | List knowledge base topics and their pages |
+| `dosu members` | Invite organization members |
 | `dosu org` | Show organization information |
-| `dosu deployments` | List / show / switch deployments |
+| `dosu deployments` | List / show / switch Dosu MCP deployments |
 | `dosu analytics` | View usage statistics |
 | `dosu insights` | Open a visual report of your Dosu space activity |
 | `dosu skill` | Install / update / remove the Dosu agent skill |

--- a/src/client/supabase.test.ts
+++ b/src/client/supabase.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTestConfig } from "../config/config.test-utils";
+
+vi.mock("../config/constants", () => ({
+  getSupabaseAnonKey: () => "anon-key",
+  getSupabaseURL: () => "https://supabase.test",
+}));
+
+import { listSpaceDataSourceIds } from "./supabase";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("listSpaceDataSourceIds", () => {
+  it("reads the exact space attachment set through Supabase RLS", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify([{ data_source_id: "ds-1" }, { data_source_id: "ds-2" }]), {
+        status: 200,
+      }),
+    );
+    const config = makeTestConfig({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      expires_at: 0,
+    });
+
+    await expect(listSpaceDataSourceIds(config, "space-1")).resolves.toEqual(["ds-1", "ds-2"]);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(
+      "https://supabase.test/rest/v1/space_data_source?select=data_source_id&space_id=eq.space-1",
+    );
+    expect(options.headers).toEqual({
+      apikey: "anon-key",
+      Authorization: "Bearer access-token",
+    });
+  });
+
+  it("rejects an invalid response shape", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify([{ id: "wrong" }]), { status: 200 }),
+    );
+
+    await expect(
+      listSpaceDataSourceIds(
+        makeTestConfig({ access_token: "token", refresh_token: "refresh", expires_at: 0 }),
+        "space-1",
+      ),
+    ).rejects.toThrow("invalid space_data_source response");
+  });
+});

--- a/src/client/supabase.ts
+++ b/src/client/supabase.ts
@@ -1,0 +1,36 @@
+import type { Config } from "../config/config";
+import { getSupabaseAnonKey, getSupabaseURL } from "../config/constants";
+
+export async function listSpaceDataSourceIds(config: Config, spaceId: string): Promise<string[]> {
+  const accessToken = config.active_account?.session.access_token;
+  if (!accessToken) throw new Error("Not logged in. Run 'dosu login' first.");
+
+  const endpoint = new URL("/rest/v1/space_data_source", getSupabaseURL());
+  endpoint.searchParams.set("select", "data_source_id");
+  endpoint.searchParams.set("space_id", `eq.${spaceId}`);
+
+  const response = await fetch(endpoint, {
+    headers: {
+      apikey: getSupabaseAnonKey(),
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to list this deployment's data sources (status ${response.status}).`);
+  }
+
+  const rows: unknown = await response.json();
+  if (!Array.isArray(rows) || rows.some((row) => !isDataSourceLink(row))) {
+    throw new Error("Supabase returned an invalid space_data_source response.");
+  }
+  return rows.map((row) => row.data_source_id);
+}
+
+function isDataSourceLink(value: unknown): value is { data_source_id: string } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "data_source_id" in value &&
+    typeof value.data_source_id === "string"
+  );
+}

--- a/src/commands/analytics.test.ts
+++ b/src/commands/analytics.test.ts
@@ -99,6 +99,17 @@ describe("analytics", () => {
     expect(mockQuery.mock.calls[0][1].days).toBe(7);
   });
 
+  it.each([
+    "0",
+    "-1",
+    "1.5",
+    "nope",
+  ])("rejects invalid --days %s before calling tRPC", async (days) => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("--days", days)).rejects.toThrow();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
   it("outputs valid JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce({

--- a/src/commands/analytics.ts
+++ b/src/commands/analytics.ts
@@ -2,9 +2,10 @@
  * `dosu analytics` — usage statistics.
  */
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 import { createTypedClient } from "../client/trpc";
+import { positiveInteger } from "./arguments";
 import { requireLoginConfig } from "./auth";
 import { printInfo, printResult } from "./output";
 
@@ -20,16 +21,20 @@ function requireConfig() {
 export function analyticsCommand(): Command {
   const cmd = new Command("analytics")
     .description("View usage statistics")
-    .option("--days <n>", "Number of days to analyze (default: 30)", "30")
+    .addOption(
+      new Option("--days <n>", "Number of days to analyze (default: 30)")
+        .argParser(positiveInteger)
+        .default(30),
+    )
     .option("--json", "Output as JSON")
-    .action(async (opts: { days?: string; json?: boolean }) => {
+    .action(async (opts: { days: number; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
       const stats = await client.analytics.getUsageStats.query({
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
         spaceId: cfg.active_account!.target!.space_id!,
-        days: Number.parseInt(opts.days ?? "30", 10),
+        days: opts.days,
       });
 
       if (opts.json) {

--- a/src/commands/arguments.ts
+++ b/src/commands/arguments.ts
@@ -1,0 +1,34 @@
+import { InvalidArgumentError } from "commander";
+
+export function positiveInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError("must be a positive integer");
+  }
+  return parsed;
+}
+
+export function positiveIntegerAtMost(maximum: number): (value: string) => number {
+  return (value: string) => {
+    const parsed = positiveInteger(value);
+    if (parsed > maximum) {
+      throw new InvalidArgumentError(`must be at most ${maximum}`);
+    }
+    return parsed;
+  };
+}
+
+export function messageLimit(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || (parsed !== -1 && parsed <= 0)) {
+    throw new InvalidArgumentError("must be -1 or a positive integer");
+  }
+  return parsed;
+}
+
+export function uuid(value: string): string {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
+    throw new InvalidArgumentError("must be a UUID");
+  }
+  return value;
+}

--- a/src/commands/deployments.test.ts
+++ b/src/commands/deployments.test.ts
@@ -17,6 +17,13 @@ vi.mock("../client/trpc", () => ({
   createTypedClient: vi.fn().mockImplementation(() => createMockProxy()),
 }));
 
+const mockCreateAPIKey = vi.fn();
+vi.mock("../client/client", () => ({
+  Client: class {
+    createAPIKey = mockCreateAPIKey;
+  },
+}));
+
 const mockLoadConfig = vi.fn();
 const mockSaveConfig = vi.fn();
 vi.mock("../config/config", async (importOriginal) => ({
@@ -58,6 +65,8 @@ async function run(...args: string[]) {
 
 beforeEach(() => {
   mockQuery.mockReset();
+  mockCreateAPIKey.mockReset();
+  mockCreateAPIKey.mockResolvedValue({ api_key: "fresh-key" });
   mockLoadConfig.mockReset();
   mockSaveConfig.mockReset();
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -74,6 +83,20 @@ afterEach(() => {
 });
 
 describe("deployments list", () => {
+  it("only returns MCP deployments that the CLI can target", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce([
+      { deployment_id: "github-1", name: "Repo", provider_slug: "github" },
+      { deployment_id: "mcp-1", name: "Dosu MCP", provider_slug: "dosu_mcp" },
+    ]);
+
+    await run("list", "--json");
+
+    expect(JSON.parse(allOutput())).toEqual([
+      { deployment_id: "mcp-1", name: "Dosu MCP", provider_slug: "dosu_mcp" },
+    ]);
+  });
+
   it("calls workspaces.listForOrg when org_id exists", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce([]);
@@ -81,16 +104,29 @@ describe("deployments list", () => {
     expect(mockQuery).toHaveBeenCalledWith("workspaces.listForOrg", "org1");
   });
 
-  it("calls workspaces.listAll when org_id is missing", async () => {
+  it("lists each accessible org when no active org is selected", async () => {
     mockLoadConfig.mockReturnValue(makeValidConfig({ org_id: undefined }));
-    mockQuery.mockResolvedValueOnce([]);
+    mockQuery.mockImplementation((path: string, input: unknown) => {
+      if (path === "organization.getOrganizations") {
+        return Promise.resolve([
+          { org_id: "org1", name: "One" },
+          { org_id: "org2", name: "Two" },
+        ]);
+      }
+      if (path === "workspaces.listForOrg") return Promise.resolve([]);
+      throw new Error(`unexpected query: ${path} ${String(input)}`);
+    });
     await run("list");
-    expect(mockQuery).toHaveBeenCalledWith("workspaces.listAll", {});
+    expect(mockQuery).toHaveBeenCalledWith("workspaces.listForOrg", "org1");
+    expect(mockQuery).toHaveBeenCalledWith("workspaces.listForOrg", "org2");
+    expect(mockQuery).not.toHaveBeenCalledWith("workspaces.listAll", expect.anything());
   });
 
   it("outputs valid JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce([{ deployment_id: "d1", name: "Test" }]);
+    mockQuery.mockResolvedValueOnce([
+      { deployment_id: "d1", name: "Test", provider_slug: "dosu_mcp" },
+    ]);
     await run("list", "--json");
     const output = JSON.parse(allOutput());
     expect(output).toHaveLength(1);
@@ -107,7 +143,13 @@ describe("deployments list", () => {
   it("shows 'active' for enabled=true", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce([
-      { deployment_id: "d1", name: "Prod", enabled: true, org_id: "org1" },
+      {
+        deployment_id: "d1",
+        name: "Prod",
+        enabled: true,
+        org_id: "org1",
+        provider_slug: "dosu_mcp",
+      },
     ]);
     await run("list");
     expect(allOutput()).toContain("active");
@@ -116,7 +158,13 @@ describe("deployments list", () => {
   it("shows 'disabled' for enabled=false", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce([
-      { deployment_id: "d1", name: "Old", enabled: false, org_id: "org1" },
+      {
+        deployment_id: "d1",
+        name: "Old",
+        enabled: false,
+        org_id: "org1",
+        provider_slug: "dosu_mcp",
+      },
     ]);
     await run("list");
     expect(allOutput()).toContain("disabled");
@@ -125,7 +173,13 @@ describe("deployments list", () => {
   it("shows current deployment hint", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce([
-      { deployment_id: "d1", name: "Test", enabled: true, org_id: "org1" },
+      {
+        deployment_id: "d1",
+        name: "Test",
+        enabled: true,
+        org_id: "org1",
+        provider_slug: "dosu_mcp",
+      },
     ]);
     await run("list");
     expect(allOutput()).toContain("Current: My Deploy");
@@ -134,7 +188,13 @@ describe("deployments list", () => {
   it("shows truncated org_id", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce([
-      { deployment_id: "d1", name: "Prod", enabled: true, org_id: "0123456789abcdef" },
+      {
+        deployment_id: "d1",
+        name: "Prod",
+        enabled: true,
+        org_id: "0123456789abcdef",
+        provider_slug: "dosu_mcp",
+      },
     ]);
     await run("list");
     expect(allOutput()).toContain("01234567");
@@ -142,7 +202,9 @@ describe("deployments list", () => {
 
   it("shows '(unnamed)' for missing name and '—' for missing org_id", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce([{ deployment_id: "d1", enabled: true }]);
+    mockQuery.mockResolvedValueOnce([
+      { deployment_id: "d1", enabled: true, provider_slug: "dosu_mcp" },
+    ]);
     await run("list");
     const output = allOutput();
     expect(output).toContain("(unnamed)");
@@ -157,7 +219,13 @@ describe("deployments list", () => {
       }),
     );
     mockQuery.mockResolvedValueOnce([
-      { deployment_id: "d1", name: "Test", enabled: true, org_id: "org1" },
+      {
+        deployment_id: "d1",
+        name: "Test",
+        enabled: true,
+        org_id: "org1",
+        provider_slug: "dosu_mcp",
+      },
     ]);
     await run("list");
     expect(allOutput()).toContain("Current: dep1");
@@ -261,6 +329,7 @@ describe("deployments switch", () => {
     name: "New Deploy",
     org_id: "org2",
     space_id: "sp2",
+    provider_slug: "dosu_mcp",
   };
 
   it("validates deployment via workspaces.get", async () => {
@@ -270,7 +339,7 @@ describe("deployments switch", () => {
     expect(mockQuery).toHaveBeenCalledWith("workspaces.get", "new-dep");
   });
 
-  it("saves all 4 fields to config", async () => {
+  it("saves the deployment fields with a newly scoped API key", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce(deployment);
     await run("switch", "new-dep");
@@ -280,6 +349,8 @@ describe("deployments switch", () => {
     expect(savedTarget.deployment_name).toBe("New Deploy");
     expect(savedTarget.org_id).toBe("org2");
     expect(savedTarget.space_id).toBe("sp2");
+    expect(savedTarget.api_key).toBe("fresh-key");
+    expect(mockCreateAPIKey).toHaveBeenCalledWith("new-dep", "dosu-cli");
   });
 
   it("outputs JSON with --json", async () => {
@@ -303,6 +374,16 @@ describe("deployments switch", () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce(null);
     await expect(run("switch", "missing-dep")).rejects.toThrow("exit");
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-MCP workspace before creating an API key", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockQuery.mockResolvedValueOnce({ ...deployment, provider_slug: "github" });
+
+    await expect(run("switch", "new-dep")).rejects.toThrow("exit");
+
+    expect(mockCreateAPIKey).not.toHaveBeenCalled();
     expect(mockSaveConfig).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -4,13 +4,30 @@
 
 import { Command } from "commander";
 import pc from "picocolors";
-import { createTypedClient } from "../client/trpc";
+import { Client } from "../client/client";
+import { createTypedClient, type TypedClient } from "../client/trpc";
 import { saveConfig, updateTarget } from "../config/config";
+import type { CliDeployment } from "../generated/dosu-api-types";
 import { requireLoginConfig } from "./auth";
 import { formatDate, printInfo, printResult, printTable } from "./output";
 
+const MCP_PROVIDER_SLUG = "dosu_mcp";
+
 function requireConfig() {
   return requireLoginConfig();
+}
+
+async function listAccessibleDeployments(
+  client: TypedClient,
+  activeOrgId: string | undefined,
+): Promise<CliDeployment[]> {
+  if (activeOrgId) return client.workspaces.listForOrg.query(activeOrgId);
+
+  const orgs = await client.organization.getOrganizations.query({});
+  const deployments = await Promise.all(
+    orgs.map((org) => client.workspaces.listForOrg.query(org.org_id)),
+  );
+  return deployments.flat();
 }
 
 export function deploymentsCommand(): Command {
@@ -24,9 +41,13 @@ export function deploymentsCommand(): Command {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      const deployments = cfg.active_account?.target?.org_id
-        ? await client.workspaces.listForOrg.query(cfg.active_account?.target?.org_id)
-        : await client.workspaces.listAll.query({});
+      const allDeployments = await listAccessibleDeployments(
+        client,
+        cfg.active_account?.target?.org_id,
+      );
+      const deployments = allDeployments.filter(
+        (deployment) => deployment.provider_slug === MCP_PROVIDER_SLUG,
+      );
 
       if (opts.json) {
         printResult(deployments, opts);
@@ -119,12 +140,19 @@ export function deploymentsCommand(): Command {
         console.error(pc.red(`Deployment not found: ${id}`));
         process.exit(1);
       }
+      if (deployment.provider_slug !== MCP_PROVIDER_SLUG) {
+        console.error(pc.red(`Not a Dosu MCP deployment: ${id}`));
+        process.exit(1);
+      }
+
+      const apiKey = await new Client(cfg).createAPIKey(deployment.deployment_id, "dosu-cli");
 
       updateTarget(cfg, {
         deployment_id: deployment.deployment_id,
         deployment_name: deployment.name,
         org_id: deployment.org_id,
         space_id: deployment.space_id,
+        api_key: apiKey.api_key,
       });
       saveConfig(cfg);
 

--- a/src/commands/doc-import.ts
+++ b/src/commands/doc-import.ts
@@ -1,0 +1,48 @@
+import type { TypedClient } from "../client/trpc";
+
+export const IMPORT_PLATFORMS = [
+  "github",
+  "gitlab",
+  "azure_devops",
+  "confluence",
+  "notion",
+  "coda",
+] as const;
+
+export type ImportPlatform = (typeof IMPORT_PLATFORMS)[number];
+
+interface ImportContext {
+  knowledgeStoreId: string;
+  spaceId: string;
+}
+
+export async function importDocuments(
+  client: TypedClient,
+  platform: ImportPlatform,
+  context: ImportContext,
+  ids: string[],
+) {
+  const baseInput = {
+    knowledge_store_id: context.knowledgeStoreId,
+    space_id: context.spaceId,
+  };
+
+  switch (platform) {
+    case "github":
+      return client.docImports.importGithubFiles.mutate({ ...baseInput, file_ids: ids });
+    case "gitlab":
+      return client.docImports.importGitlabFiles.mutate({ ...baseInput, file_ids: ids });
+    case "azure_devops":
+      return client.docImports.importAzureDevopsFiles.mutate({ ...baseInput, file_ids: ids });
+    case "confluence":
+      return client.docImports.importConfluencePages.mutate({ ...baseInput, page_ids: ids });
+    case "notion":
+      return client.docImports.importNotionPages.mutate({ ...baseInput, page_ids: ids });
+    case "coda":
+      return client.docImports.importCodaPages.mutate({ ...baseInput, page_ids: ids });
+    default: {
+      const unsupported: never = platform;
+      throw new Error(`Unsupported import platform: ${unsupported}`);
+    }
+  }
+}

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -33,6 +33,13 @@ vi.mock("../client/trpc", () => ({
   createTypedClient: vi.fn().mockImplementation(() => createMockProxy()),
 }));
 
+const mockBackendGet = vi.fn();
+vi.mock("../client/client", () => ({
+  Client: class {
+    get = mockBackendGet;
+  },
+}));
+
 const mockLoadConfig = vi.fn();
 vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
@@ -102,6 +109,7 @@ beforeEach(() => {
   mockQuery.mockReset();
   mockMutate.mockReset();
   mockLoadConfig.mockReset();
+  mockBackendGet.mockReset();
   mockFetch.mockReset();
   mockClackLogError.mockReset();
   mockClackLogInfo.mockReset();
@@ -130,10 +138,10 @@ describe("docs list", () => {
     expect(call[1].knowledge_store_id).toBe("ks1");
   });
 
-  it("passes --search and --tag filters", async () => {
+  it("passes --search and --topic filters", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce({ data: [] });
-    await run("list", "--search", "api", "--tag", "t1");
+    await run("list", "--search", "api", "--topic", "t1");
 
     const input = mockQuery.mock.calls[1][1];
     expect(input.searchTerm).toBe("api");
@@ -192,11 +200,11 @@ describe("docs get", () => {
     });
   });
 
-  it("passes --version to page.get when provided", async () => {
+  it("passes --revision to page.get when provided", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockReset();
     mockQuery.mockResolvedValueOnce({ id: "p1", title: "V2" });
-    await run("get", "p1", "--version", "2");
+    await run("get", "p1", "--revision", "2");
     expect(mockQuery).toHaveBeenCalledWith("page.get", {
       page_id: "p1",
       version: 2,
@@ -281,6 +289,14 @@ describe("docs create", () => {
     }
   });
 
+  it("rejects --body with --body-file before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(
+      run("create", "--title", "Conflict", "--body", "inline", "--body-file", "package.json"),
+    ).rejects.toThrow();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce({ id: "new-p1", title: "T" });
@@ -312,10 +328,10 @@ describe("docs update", () => {
 
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockResolvedValueOnce({ id: "p1", title: "Updated" });
+    mockMutate.mockResolvedValueOnce(undefined);
     await run("update", "--json", "p1", "--title", "Updated");
     const output = JSON.parse(allOutput());
-    expect(output).toMatchObject({ id: "p1", title: "Updated" });
+    expect(output).toEqual({ success: true, id: "p1" });
   });
 
   it("prints human-readable confirmation", async () => {
@@ -323,6 +339,12 @@ describe("docs update", () => {
     mockMutate.mockResolvedValueOnce({});
     await run("update", "p1", "--title", "Updated");
     expect(allOutput()).toContain("Document updated");
+  });
+
+  it("rejects an update with no changes before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("update", "p1")).rejects.toThrow();
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 });
 
@@ -461,7 +483,7 @@ describe("docs restore", () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce({});
     mockQuery.mockReset();
-    await run("restore", "p1", "--version", "3");
+    await run("restore", "p1", "--revision", "3");
     expect(mockMutate).toHaveBeenCalledWith("page.restoreVersion", {
       page_id: "p1",
       version_to_restore: 3,
@@ -472,17 +494,17 @@ describe("docs restore", () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce({});
     mockQuery.mockReset();
-    await run("restore", "--json", "p1", "--version", "3");
+    await run("restore", "--json", "p1", "--revision", "3");
     const output = JSON.parse(allOutput());
     expect(output.success).toBe(true);
-    expect(output.version).toBe("3");
+    expect(output.revision).toBe(3);
   });
 
   it("prints human-readable confirmation", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce({});
     mockQuery.mockReset();
-    await run("restore", "p1", "--version", "3");
+    await run("restore", "p1", "--revision", "3");
     expect(allOutput()).toContain("restored to version 3");
   });
 });
@@ -579,6 +601,11 @@ describe("docs auto-tag", () => {
 });
 
 describe("docs import", () => {
+  it("rejects an empty --files list before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("import", "github", "--files", " , ")).rejects.toThrow();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
   it("calls docImports.importGithubFiles with file_ids", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce({ task_id: "task-1" });
@@ -1054,36 +1081,35 @@ describe("docs import", () => {
 });
 
 describe("docs import-status", () => {
-  it("calls docImports.getImportStatus", async () => {
+  const taskId = "01a03ccd-23fd-70d3-8176-73a87b8fcc26";
+
+  it("calls the task backend with the UUIDv7 returned by import", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockReset();
-    mockQuery.mockResolvedValueOnce({ status: "completed" });
-    await run("import-status", "task-1");
-    expect(mockQuery).toHaveBeenCalledWith("docImports.getImportStatus", "task-1");
+    mockBackendGet.mockResolvedValueOnce(jsonResponse({ status: "completed" }));
+    await run("import-status", taskId);
+    expect(mockBackendGet).toHaveBeenCalledWith(`/doc-imports/status/${taskId}`);
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   it("prints message when task not found", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockReset();
-    mockQuery.mockResolvedValueOnce(null);
-    await run("import-status", "bad-task");
+    mockBackendGet.mockResolvedValueOnce(new Response(null, { status: 404 }));
+    await run("import-status", taskId);
     expect(allOutput()).toContain("Import task not found");
   });
 
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockReset();
-    mockQuery.mockResolvedValueOnce({ status: "completed" });
-    await run("import-status", "--json", "task-1");
+    mockBackendGet.mockResolvedValueOnce(jsonResponse({ status: "completed" }));
+    await run("import-status", "--json", taskId);
     const output = JSON.parse(allOutput());
     expect(output).toMatchObject({ status: "completed" });
   });
 
   it("prints status in human-readable format", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockReset();
-    mockQuery.mockResolvedValueOnce({ status: "completed" });
-    await run("import-status", "task-1");
+    mockBackendGet.mockResolvedValueOnce(jsonResponse({ status: "completed" }));
+    await run("import-status", taskId);
     expect(allOutput()).toContain('Status: {"status":"completed"}');
   });
 });

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -5,12 +5,15 @@
 import { readFileSync } from "node:fs";
 import * as p from "@clack/prompts";
 import { isTRPCClientError } from "@trpc/client";
-import { Command } from "commander";
+import { Argument, Command, Option } from "commander";
 import pc from "picocolors";
+import { Client } from "../client/client";
 import { createTypedClient, type TypedClient } from "../client/trpc";
 import { getBackendURL } from "../config/constants";
 import { logger } from "../debug/logger";
+import { positiveInteger, uuid } from "./arguments";
 import { requireAPIKey, requireLoginConfig } from "./auth";
+import { IMPORT_PLATFORMS, type ImportPlatform, importDocuments } from "./doc-import";
 import { formatDate, printInfo, printResult, printTable, truncate } from "./output";
 
 function requireConfig() {
@@ -129,6 +132,10 @@ async function backendPost(
     headers: { "Content-Type": "application/json", "X-Dosu-API-Key": apiKey },
     body: JSON.stringify(body),
   });
+  return parseBackendResponse(resp);
+}
+
+async function parseBackendResponse(resp: Response): Promise<unknown> {
   if (!resp.ok) {
     let detail = `Request failed with status ${resp.status}`;
     try {
@@ -148,10 +155,10 @@ export function docsCommand(): Command {
     .command("list")
     .description("List documents")
     .option("--search <query>", "Search documents")
-    .option("--tag <id>", "Filter by tag ID")
-    .option("--limit <n>", "Maximum results", "20")
+    .option("--topic <id>", "Filter by topic ID")
+    .addOption(new Option("--limit <n>", "Maximum results").argParser(positiveInteger).default(20))
     .option("--json", "Output as JSON")
-    .action(async (opts: { search?: string; tag?: string; limit?: string; json?: boolean }) => {
+    .action(async (opts: { search?: string; topic?: string; limit: number; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
@@ -160,8 +167,8 @@ export function docsCommand(): Command {
       const result = await client.page.listWithTags.query({
         knowledge_store_id: ksId,
         searchTerm: opts.search,
-        topic_id: opts.tag,
-        limit: Number.parseInt(opts.limit ?? "20", 10),
+        topic_id: opts.topic,
+        limit: opts.limit,
       });
       const pages = result.data;
 
@@ -190,15 +197,15 @@ export function docsCommand(): Command {
     .command("get")
     .description("Get a document")
     .argument("<id>", "Page ID")
-    .option("--version <v>", "Specific version number")
+    .addOption(new Option("--revision <n>", "Specific revision number").argParser(positiveInteger))
     .option("--json", "Output as JSON")
-    .action(async (id: string, opts: { version?: string; json?: boolean }) => {
+    .action(async (id: string, opts: { revision?: number; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
       const page = await client.page.get.query({
         page_id: id,
-        version: opts.version ? Number.parseInt(opts.version, 10) : undefined,
+        version: opts.revision,
       });
 
       if (opts.json) {
@@ -228,7 +235,7 @@ export function docsCommand(): Command {
     .description("Create a new document")
     .requiredOption("--title <title>", "Document title")
     .option("--body <markdown>", "Document body (markdown)")
-    .option("--body-file <path>", "Read body from file")
+    .addOption(new Option("--body-file <path>", "Read body from file").conflicts("body"))
     .option("--json", "Output as JSON")
     .action(async (opts: { title: string; body?: string; bodyFile?: string; json?: boolean }) => {
       const cfg = requireConfig();
@@ -257,20 +264,23 @@ export function docsCommand(): Command {
     .argument("<id>", "Page ID")
     .option("--title <title>", "New title")
     .option("--body <markdown>", "New body (markdown)")
-    .option("--body-file <path>", "Read body from file")
+    .addOption(new Option("--body-file <path>", "Read body from file").conflicts("body"))
     .option("--json", "Output as JSON")
     .action(
       async (
         id: string,
         opts: { title?: string; body?: string; bodyFile?: string; json?: boolean },
       ) => {
+        if (opts.title === undefined && opts.body === undefined && opts.bodyFile === undefined) {
+          throw new Error("Specify at least one of --title, --body, or --body-file.");
+        }
         const cfg = requireConfig();
         const client = createTypedClient(cfg);
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
         const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
         const body = readBody(opts);
-        const result = await client.page.update.mutate({
+        await client.page.update.mutate({
           id,
           knowledge_store_id: ksId,
           title: opts.title,
@@ -278,7 +288,7 @@ export function docsCommand(): Command {
         });
 
         if (opts.json) {
-          printResult(result, opts);
+          printResult({ success: true, id }, opts);
           return;
         }
         console.log(pc.green("Document updated."));
@@ -359,21 +369,25 @@ export function docsCommand(): Command {
     .command("restore")
     .description("Restore a document version")
     .argument("<id>", "Page ID")
-    .requiredOption("--version <n>", "Version number to restore")
+    .addOption(
+      new Option("--revision <n>", "Revision number to restore")
+        .argParser(positiveInteger)
+        .makeOptionMandatory(),
+    )
     .option("--json", "Output as JSON")
-    .action(async (id: string, opts: { version: string; json?: boolean }) => {
+    .action(async (id: string, opts: { revision: number; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       await client.page.restoreVersion.mutate({
         page_id: id,
-        version_to_restore: Number.parseInt(opts.version, 10),
+        version_to_restore: opts.revision,
       });
 
       if (opts.json) {
-        printResult({ success: true, id, version: opts.version }, opts);
+        printResult({ success: true, id, revision: opts.revision }, opts);
         return;
       }
-      console.log(pc.green(`Document restored to version ${opts.version}.`));
+      console.log(pc.green(`Document restored to version ${opts.revision}.`));
     });
 
   // ── generate ──
@@ -423,47 +437,33 @@ export function docsCommand(): Command {
   cmd
     .command("import")
     .description("Import documents from an external platform")
-    .argument("<platform>", "Platform: github, gitlab, azure_devops, confluence, notion, coda")
+    .addArgument(new Argument("<platform>", "Import platform").choices([...IMPORT_PLATFORMS]))
     .requiredOption("--files <ids>", "Comma-separated file/page IDs to import")
     .option("--json", "Output as JSON")
-    .action(async (platform: string, opts: { files: string; json?: boolean }) => {
+    .action(async (platform: ImportPlatform, opts: { files: string; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
       const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
-      const fileIds = opts.files.split(",").map((id) => id.trim());
-
-      // biome-ignore lint/suspicious/noExplicitAny: dynamic platform dispatch
-      const importFn: Record<string, (input: any) => Promise<any>> = {
-        github: (input) => client.docImports.importGithubFiles.mutate(input),
-        gitlab: (input) => client.docImports.importGitlabFiles.mutate(input),
-        azure_devops: (input) => client.docImports.importAzureDevopsFiles.mutate(input),
-        confluence: (input) => client.docImports.importConfluencePages.mutate(input),
-        notion: (input) => client.docImports.importNotionPages.mutate(input),
-        coda: (input) => client.docImports.importCodaPages.mutate(input),
-      };
-
-      const fn = importFn[platform.toLowerCase()];
-      if (!fn) {
-        console.error(
-          pc.red(
-            `Unknown platform: ${platform}. Use: github, gitlab, azure_devops, confluence, notion, coda`,
-          ),
-        );
-        process.exit(1);
+      const fileIds = opts.files
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean);
+      if (fileIds.length === 0) {
+        throw new Error("--files must contain at least one file or page ID.");
       }
 
-      const idField = ["confluence", "notion", "coda"].includes(platform.toLowerCase())
-        ? "page_ids"
-        : "file_ids";
-
       try {
-        const result = await fn({
-          knowledge_store_id: ksId,
-          // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-          space_id: cfg.active_account!.target!.space_id!,
-          [idField]: fileIds,
-        });
+        const result = await importDocuments(
+          client,
+          platform,
+          {
+            knowledgeStoreId: ksId,
+            // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
+            spaceId: cfg.active_account!.target!.space_id!,
+          },
+          fileIds,
+        );
 
         if (opts.json) {
           printResult(result, opts);
@@ -498,13 +498,16 @@ export function docsCommand(): Command {
   cmd
     .command("import-status")
     .description("Check import task status")
-    .argument("<task-id>", "Import task ID")
+    .addArgument(new Argument("<task-id>", "Import task ID").argParser(uuid))
     .option("--json", "Output as JSON")
     .action(async (taskId: string, opts: { json?: boolean }) => {
       const cfg = requireConfig();
-      const client = createTypedClient(cfg);
-
-      const status = await client.docImports.getImportStatus.query(taskId);
+      // Import creates backend UUIDv7 task IDs. Query the task owner directly;
+      // the App wrapper accepts UUIDv4 only and cannot consume its own output.
+      const response = await new Client(cfg).get(
+        `/doc-imports/status/${encodeURIComponent(taskId)}`,
+      );
+      const status = response.status === 404 ? null : await parseBackendResponse(response);
 
       if (opts.json) {
         printResult(status, opts);

--- a/src/commands/integrations.test.ts
+++ b/src/commands/integrations.test.ts
@@ -138,13 +138,17 @@ describe("integrations status", () => {
     expect(allOutput()).toContain("connected");
   });
 
-  it("shows not connected on error", async () => {
+  it("surfaces tRPC errors instead of reporting a false disconnected state", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockRejectedValueOnce(new Error("not found"));
 
-    await run("status", "gitlab");
+    await expect(run("status", "gitlab")).rejects.toThrow("not found");
+  });
 
-    expect(allOutput()).toContain("not connected");
+  it("rejects unknown platforms before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("status", "unknown")).rejects.toThrow();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   it("shows not connected when connection is null", async () => {
@@ -203,18 +207,13 @@ describe("integrations status azure_devops", () => {
     expect(allOutput()).toContain("not connected");
   });
 
-  it("continues past a probe that throws", async () => {
+  it("propagates a probe error instead of reporting stale connection state", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery
-      .mockRejectedValueOnce(new Error("boom")) // OAuth throws
-      .mockResolvedValueOnce({ id: "ado-pat" }); // PAT - connected
+    mockQuery.mockRejectedValueOnce(new Error("boom"));
 
-    await run("status", "azure_devops");
+    await expect(run("status", "azure_devops")).rejects.toThrow("boom");
 
-    expect(mockQuery).toHaveBeenCalledTimes(2);
-    const output = allOutput();
-    expect(output).toContain("connected");
-    expect(output).not.toContain("not connected");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 
   it("outputs JSON with the connection payload when connected", async () => {
@@ -249,29 +248,23 @@ describe("integrations status gitlab (multi-auth)", () => {
     expect(output).not.toContain("not connected");
   });
 
-  it("still supports `status gitlab-pat` as a standalone platform", async () => {
+  it("rejects the obsolete standalone gitlab-pat platform", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({ id: "gl-pat" });
 
-    await run("status", "gitlab-pat");
+    await expect(run("status", "gitlab-pat")).rejects.toThrow();
 
-    expect(mockQuery).toHaveBeenCalledTimes(1);
-    expect(mockQuery.mock.calls[0][1]).toMatchObject({
-      provider: "gitlab",
-      providerConfigKey: "gitlab-pat",
-    });
-    expect(allOutput()).toContain("connected");
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 });
 
 describe("integrations status (not queryable via nango)", () => {
-  it("reports github as not connected without issuing a nango query", async () => {
+  it("reports github status as unavailable without issuing a nango query", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
 
     await run("status", "github");
 
     expect(mockQuery).not.toHaveBeenCalled();
-    expect(allOutput()).toContain("not connected");
+    expect(allOutput()).toContain("status unavailable");
   });
 
   it("outputs a JSON note for a not-queryable platform", async () => {
@@ -281,8 +274,8 @@ describe("integrations status (not queryable via nango)", () => {
 
     const output = JSON.parse(allOutput());
     expect(output.platform).toBe("github");
-    expect(output.connected).toBe(false);
-    expect(output.note).toContain("not queryable");
+    expect(output.connected).toBeNull();
+    expect(output.note).toContain("status unavailable");
     expect(mockQuery).not.toHaveBeenCalled();
   });
 });
@@ -324,7 +317,9 @@ describe("integrations github-collaborators", () => {
       { user_name: "octocat", full_name: "Mona", email: "mona@gh.com" },
     ]);
 
-    await run("github-collaborators");
+    await run("github-collaborators", "123");
+
+    expect(mockQuery).toHaveBeenCalledWith("githubRepository.getCollaborators", 123);
 
     const output = allOutput();
     expect(output).toContain("octocat");
@@ -334,14 +329,14 @@ describe("integrations github-collaborators", () => {
   it("prints message for empty results", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce([]);
-    await run("github-collaborators");
+    await run("github-collaborators", "123");
     expect(allOutput()).toContain("No collaborators found");
   });
 
   it("handles missing username, name, and email fields", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce([{}]);
-    await run("github-collaborators");
+    await run("github-collaborators", "123");
     // All undefined fields should be replaced with "—"
     const output = allOutput();
     expect(output).toContain("—");
@@ -361,15 +356,11 @@ describe("integrations status (JSON branches)", () => {
     expect(output.connection).toBeTruthy();
   });
 
-  it("outputs JSON for error/not connected", async () => {
+  it("propagates an error in JSON mode", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockRejectedValueOnce(new Error("fail"));
 
-    await run("status", "--json", "gitlab");
-
-    const output = JSON.parse(allOutput());
-    expect(output.platform).toBe("gitlab");
-    expect(output.connected).toBe(false);
+    await expect(run("status", "--json", "gitlab")).rejects.toThrow("fail");
   });
 });
 
@@ -415,7 +406,7 @@ describe("integrations github-collaborators (JSON branch)", () => {
       { user_name: "octocat", full_name: "Mona", email: "mona@gh.com" },
     ]);
 
-    await run("github-collaborators", "--json");
+    await run("github-collaborators", "123", "--json");
 
     const output = JSON.parse(allOutput());
     expect(Array.isArray(output)).toBe(true);

--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -2,10 +2,11 @@
  * `dosu integrations` — integration status and management.
  */
 
-import { Command } from "commander";
+import { Argument, Command } from "commander";
 import pc from "picocolors";
 import { createTypedClient, type TypedClient } from "../client/trpc";
 import type { NangoGetConnectionInput } from "../generated/dosu-api-types";
+import { positiveInteger } from "./arguments";
 import { requireLoginConfig } from "./auth";
 import { printResult, printTable } from "./output";
 
@@ -20,49 +21,6 @@ function requireConfig() {
 
 type NangoProvider = NangoGetConnectionInput["provider"];
 
-/**
- * Nango probes per platform. A platform can be connectable under more than one
- * Nango provider, and a connection may exist under any of them; we report
- * connected if ANY probe returns a row.
- *
- * `nango.getConnection` exact-matches BOTH `provider` (the Nango DB provider
- * value) and `providerConfigKey` (the Nango integration id). These differ for
- * the alternate-auth integrations — the integration id is a distinct base, and
- * the DB provider stays the platform's canonical value. The primary auth method
- * (OAuth) is listed first so the common case short-circuits on the first probe;
- * the alternate (PAT / Basic) is the fallback:
- *   - GitLab: OAuth `{gitlab, gitlab}`, PAT `{gitlab, gitlab-pat}`
- *   - Confluence: OAuth `{confluence, confluence}`, Basic `{confluence, confluence-basic}`
- *   - Azure DevOps: OAuth `{microsoft-entra-id, microsoft-entra-id}`, PAT `{azure_devops, azure-devops}`
- * (Note `azure_devops` the DB provider vs `azure-devops` the integration id.)
- *
- * `gitlab-pat`/`confluence-basic` are also kept as standalone keys so
- * `status gitlab-pat` / `status confluence-basic` still work. Prod uses bare
- * integration ids (no env suffix), which is what the shipped CLI targets.
- */
-const NANGO_PROBES: Record<
-  string,
-  readonly { provider: NangoProvider; providerConfigKey: string }[]
-> = {
-  gitlab: [
-    { provider: "gitlab", providerConfigKey: "gitlab" },
-    { provider: "gitlab", providerConfigKey: "gitlab-pat" },
-  ],
-  "gitlab-pat": [{ provider: "gitlab", providerConfigKey: "gitlab-pat" }],
-  confluence: [
-    { provider: "confluence", providerConfigKey: "confluence" },
-    { provider: "confluence", providerConfigKey: "confluence-basic" },
-  ],
-  "confluence-basic": [{ provider: "confluence", providerConfigKey: "confluence-basic" }],
-  notion: [{ provider: "notion", providerConfigKey: "notion" }],
-  coda: [{ provider: "coda", providerConfigKey: "coda" }],
-  azure_devops: [
-    { provider: "microsoft-entra-id", providerConfigKey: "microsoft-entra-id" },
-    { provider: "azure_devops", providerConfigKey: "azure-devops" },
-  ],
-};
-
-/** All display platforms including those checked via other means */
 const DISPLAY_PLATFORMS = [
   "github",
   "gitlab",
@@ -73,34 +31,74 @@ const DISPLAY_PLATFORMS = [
   "coda",
   "teams",
 ] as const;
+type DisplayPlatform = (typeof DISPLAY_PLATFORMS)[number];
+
+type ConnectionProbeResult =
+  | { queryable: false; connected: null; connection: null }
+  | { queryable: true; connected: boolean; connection: unknown };
+
+/**
+ * Nango probes per platform. A platform can be connectable under more than one
+ * Nango provider, and a connection may exist under any of them; we report
+ * connected if ANY probe returns a row.
+ *
+ * `nango.getConnection` exact-matches BOTH `provider` (the Nango DB provider
+ * value) and `providerConfigKey` (the Nango integration id). These differ for
+ * the alternate-auth integrations — the integration id is a distinct base, and
+ * the DB provider stays the platform's canonical value. The primary auth method
+ * (OAuth) is listed first so the common case short-circuits on the first probe;
+ * the alternate (PAT / Basic) is the second supported auth method:
+ *   - GitLab: OAuth `{gitlab, gitlab}`, PAT `{gitlab, gitlab-pat}`
+ *   - Confluence: OAuth `{confluence, confluence}`, Basic `{confluence, confluence-basic}`
+ *   - Azure DevOps: OAuth `{microsoft-entra-id, microsoft-entra-id}`, PAT `{azure_devops, azure-devops}`
+ * (Note `azure_devops` the DB provider vs `azure-devops` the integration id.)
+ *
+ * Prod uses bare integration ids (no env suffix), which is what the shipped
+ * CLI targets.
+ */
+const NANGO_PROBES: Partial<
+  Record<DisplayPlatform, readonly { provider: NangoProvider; providerConfigKey: string }[]>
+> = {
+  gitlab: [
+    { provider: "gitlab", providerConfigKey: "gitlab" },
+    { provider: "gitlab", providerConfigKey: "gitlab-pat" },
+  ],
+  confluence: [
+    { provider: "confluence", providerConfigKey: "confluence" },
+    { provider: "confluence", providerConfigKey: "confluence-basic" },
+  ],
+  notion: [{ provider: "notion", providerConfigKey: "notion" }],
+  coda: [{ provider: "coda", providerConfigKey: "coda" }],
+  azure_devops: [
+    { provider: "microsoft-entra-id", providerConfigKey: "microsoft-entra-id" },
+    { provider: "azure_devops", providerConfigKey: "azure-devops" },
+  ],
+};
 
 /**
  * Probe a platform's Nango connection state. Platforms absent from
  * `NANGO_PROBES` (github, slack, teams) are reported as `queryable: false`.
  * Otherwise every probe is tried in order, short-circuiting on the first
- * connection found; a throwing probe is swallowed so the next one still runs.
+ * connection found. tRPC failures propagate so API drift and outages are not
+ * misreported as a disconnected integration.
  */
 async function probeConnection(
   client: TypedClient,
   orgId: string,
-  platform: string,
-): Promise<{ queryable: boolean; connected: boolean; connection: unknown }> {
+  platform: DisplayPlatform,
+): Promise<ConnectionProbeResult> {
   const probes = NANGO_PROBES[platform];
   if (!probes) {
-    return { queryable: false, connected: false, connection: null };
+    return { queryable: false, connected: null, connection: null };
   }
   for (const probe of probes) {
-    try {
-      const conn = await client.nango.getConnection.query({
-        provider: probe.provider,
-        providerConfigKey: probe.providerConfigKey,
-        orgId,
-      });
-      if (conn != null) {
-        return { queryable: true, connected: true, connection: conn };
-      }
-    } catch {
-      // Swallow and try the next probe.
+    const conn = await client.nango.getConnection.query({
+      provider: probe.provider,
+      providerConfigKey: probe.providerConfigKey,
+      orgId,
+    });
+    if (conn != null) {
+      return { queryable: true, connected: true, connection: conn };
     }
   }
   return { queryable: true, connected: false, connection: null };
@@ -141,7 +139,11 @@ export function integrationsCommand(): Command {
         ["Platform", "Status"],
         results.map((r) => [
           r.platform,
-          r.connected ? pc.green("connected") : pc.dim("not connected"),
+          r.connected === null
+            ? pc.dim("status unavailable")
+            : r.connected
+              ? pc.green("connected")
+              : pc.dim("not connected"),
         ]),
         { rawData: results },
       );
@@ -150,9 +152,9 @@ export function integrationsCommand(): Command {
   cmd
     .command("status")
     .description("Check connection status of a specific platform")
-    .argument("<platform>", `Platform: ${DISPLAY_PLATFORMS.join(", ")}`)
+    .addArgument(new Argument("<platform>", "Integration platform").choices([...DISPLAY_PLATFORMS]))
     .option("--json", "Output as JSON")
-    .action(async (platform: string, opts: { json?: boolean }) => {
+    .action(async (platform: DisplayPlatform, opts: { json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       const { queryable, connected, connection } = await probeConnection(
@@ -165,10 +167,13 @@ export function integrationsCommand(): Command {
       if (!queryable) {
         // github, slack, teams — not queryable via nango
         if (opts.json) {
-          printResult({ platform, connected: false, note: "not queryable via nango" }, opts);
+          printResult(
+            { platform, connected: null, note: "connection status unavailable via CLI" },
+            opts,
+          );
           return;
         }
-        console.log(`${platform}: ${pc.dim("not connected (not queryable)")}`);
+        console.log(`${platform}: ${pc.dim("connection status unavailable via CLI")}`);
         return;
       }
 
@@ -231,15 +236,15 @@ export function integrationsCommand(): Command {
   cmd
     .command("github-collaborators")
     .description("List GitHub repository collaborators")
+    .addArgument(
+      new Argument("<repository-id>", "Numeric GitHub repository ID").argParser(positiveInteger),
+    )
     .option("--json", "Output as JSON")
-    .action(async (opts: { json?: boolean }) => {
+    .action(async (repositoryId: number, opts: { json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      // getCollaborators takes a number (repo ID), not an org_id object
-      // This requires a repo ID — for now we pass 0 as placeholder
-      // TODO: accept --repo-id argument
-      const collaborators = await client.githubRepository.getCollaborators.query(0);
+      const collaborators = await client.githubRepository.getCollaborators.query(repositoryId);
 
       if (opts.json) {
         printResult(collaborators, opts);

--- a/src/commands/knowledge.test.ts
+++ b/src/commands/knowledge.test.ts
@@ -135,6 +135,12 @@ describe("knowledge search", () => {
     const output = allOutput();
     expect(output).toContain("2 more results not shown");
   });
+
+  it("rejects an invalid limit before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("search", "--limit", "0", "query")).rejects.toThrow();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
 });
 
 describe("knowledge list", () => {

--- a/src/commands/knowledge.ts
+++ b/src/commands/knowledge.ts
@@ -2,9 +2,10 @@
  * `dosu knowledge` — knowledge base search and listing.
  */
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 import { createTypedClient } from "../client/trpc";
+import { positiveInteger } from "./arguments";
 import { requireLoginConfig } from "./auth";
 import { printResult, printTable, truncate } from "./output";
 
@@ -25,8 +26,8 @@ export function knowledgeCommand(): Command {
     .description("Search the knowledge base")
     .argument("<query>", "Search query")
     .option("--json", "Output as JSON")
-    .option("--limit <n>", "Maximum results", "10")
-    .action(async (query: string, opts: { json?: boolean; limit?: string }) => {
+    .addOption(new Option("--limit <n>", "Maximum results").argParser(positiveInteger).default(10))
+    .action(async (query: string, opts: { json?: boolean; limit: number }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
@@ -63,8 +64,7 @@ export function knowledgeCommand(): Command {
         return;
       }
 
-      const limit = Number.parseInt(opts.limit ?? "10", 10);
-      const limited = results.slice(0, limit);
+      const limited = results.slice(0, opts.limit);
 
       printTable(
         ["Title", "Type"],
@@ -75,8 +75,8 @@ export function knowledgeCommand(): Command {
         { json: false, rawData: limited },
       );
 
-      if (results.length > limit) {
-        console.log(pc.dim(`\n${results.length - limit} more results not shown.`));
+      if (results.length > opts.limit) {
+        console.log(pc.dim(`\n${results.length - opts.limit} more results not shown.`));
       }
     });
 

--- a/src/commands/members.test.ts
+++ b/src/commands/members.test.ts
@@ -68,51 +68,9 @@ afterEach(() => {
   exitSpy.mockRestore();
 });
 
-describe("members list", () => {
-  it("calls invitations.getInvitations with no args", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({
-      items: [{ email: "a@b.com", org: { name: "Acme" } }],
-      tokenAvailable: true,
-      authProvider: "email",
-    });
-
-    await run("list");
-
-    expect(mockQuery).toHaveBeenCalledWith("invitations.getInvitations", undefined);
-  });
-
-  it("outputs valid JSON with --json", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({
-      items: [{ email: "a@b.com" }],
-      tokenAvailable: true,
-      authProvider: "email",
-    });
-    await run("list", "--json");
-    const output = JSON.parse(allOutput());
-    expect(output.items).toHaveLength(1);
-    expect(output.items[0]).toMatchObject({ email: "a@b.com" });
-  });
-
-  it("prints message for empty results", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({ items: [], tokenAvailable: true, authProvider: "email" });
-    await run("list");
-    expect(allOutput()).toContain("No members");
-  });
-
-  it("handles missing role and status fields", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({
-      items: [{ email: "a@b.com" }],
-      tokenAvailable: true,
-      authProvider: "email",
-    });
-    await run("list");
-    const output = allOutput();
-    expect(output).toContain("a@b.com");
-    expect(output).toContain("—");
+describe("members command surface", () => {
+  it("only exposes the organization invite operation supported by CLI tRPC", () => {
+    expect(membersCommand().commands.map((command) => command.name())).toEqual(["invite"]);
   });
 });
 
@@ -139,6 +97,12 @@ describe("members invite", () => {
     expect(mockMutate.mock.calls[0][1].role).toBe("ADMIN");
   });
 
+  it("rejects unsupported roles before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("invite", "new@user.com", "--role", "owner")).rejects.toThrow();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockMutate.mockResolvedValueOnce({ id: "inv1" });
@@ -158,120 +122,14 @@ describe("members invite", () => {
   });
 });
 
-describe("members approve", () => {
-  it("calls invitations.acceptInvitation", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockResolvedValueOnce({});
-
-    await run("approve", "req@user.com");
-
-    expect(mockMutate).toHaveBeenCalledWith("invitations.acceptInvitation", {
-      orgId: "org1",
-      email: "req@user.com",
-    });
-  });
-
-  it("outputs JSON with --json", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockResolvedValueOnce({});
-    await run("approve", "--json", "req@user.com");
-    const output = JSON.parse(allOutput());
-    expect(output.success).toBe(true);
-    expect(output.action).toBe("approved");
-  });
-
-  it("prints human-readable confirmation", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockResolvedValueOnce({});
-    await run("approve", "req@user.com");
-    expect(allOutput()).toContain("Access request from req@user.com approved");
-  });
-});
-
-describe("members deny", () => {
-  it("calls invitations.rejectInvitation", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockResolvedValueOnce({});
-
-    await run("deny", "req@user.com");
-
-    expect(mockMutate).toHaveBeenCalledWith("invitations.rejectInvitation", {
-      orgId: "org1",
-      email: "req@user.com",
-    });
-  });
-
-  it("outputs JSON with --json", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockResolvedValueOnce({});
-    await run("deny", "--json", "req@user.com");
-    const output = JSON.parse(allOutput());
-    expect(output.success).toBe(true);
-    expect(output.action).toBe("denied");
-  });
-
-  it("prints human-readable confirmation", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockMutate.mockResolvedValueOnce({});
-    await run("deny", "req@user.com");
-    expect(allOutput()).toContain("Access request from req@user.com denied");
-  });
-});
-
-describe("members requests", () => {
-  it("lists pending access requests", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({
-      items: [{ email: "req@user.com", org: { name: "Acme" } }],
-      tokenAvailable: true,
-      authProvider: "email",
-    });
-    await run("requests");
-    expect(allOutput()).toContain("req@user.com");
-  });
-
-  it("prints message for empty requests", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({ items: [], tokenAvailable: true, authProvider: "email" });
-    await run("requests");
-    expect(allOutput()).toContain("No pending access requests");
-  });
-
-  it("handles missing org field", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({
-      items: [{ email: "req@user.com" }],
-      tokenAvailable: true,
-      authProvider: "email",
-    });
-    await run("requests");
-    const output = allOutput();
-    expect(output).toContain("req@user.com");
-    expect(output).toContain("—");
-  });
-
-  it("outputs valid JSON with --json", async () => {
-    mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({
-      items: [{ email: "req@user.com", org: { name: "Acme" } }],
-      tokenAvailable: true,
-      authProvider: "email",
-    });
-    await run("requests", "--json");
-    const output = JSON.parse(allOutput());
-    expect(output.items).toHaveLength(1);
-    expect(output.items[0]).toMatchObject({ email: "req@user.com" });
-  });
-});
-
 describe("requireConfig", () => {
   it("exits when org_id is missing", async () => {
     mockLoadConfig.mockReturnValue(makeValidConfig({ org_id: undefined }));
-    await expect(run("list")).rejects.toThrow("exit");
+    await expect(run("invite", "new@user.com")).rejects.toThrow("exit");
   });
 
   it("exits when access_token is missing", async () => {
     mockLoadConfig.mockReturnValue(makeValidConfig({ access_token: "" }));
-    await expect(run("list")).rejects.toThrow("exit");
+    await expect(run("invite", "new@user.com")).rejects.toThrow("exit");
   });
 });

--- a/src/commands/members.ts
+++ b/src/commands/members.ts
@@ -2,11 +2,11 @@
  * `dosu members` — team member management.
  */
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 import { createTypedClient } from "../client/trpc";
 import { requireLoginConfig } from "./auth";
-import { printResult, printTable } from "./output";
+import { printResult } from "./output";
 
 function requireConfig() {
   const cfg = requireLoginConfig();
@@ -18,56 +18,28 @@ function requireConfig() {
 }
 
 export function membersCommand(): Command {
-  const cmd = new Command("members").description("Manage team members");
-
-  cmd
-    .command("list")
-    .description("List team members and invitations")
-    .option("--json", "Output as JSON")
-    .action(async (opts: { json?: boolean }) => {
-      const cfg = requireConfig();
-      const client = createTypedClient(cfg);
-
-      const data = await client.invitations.getInvitations.query();
-
-      if (opts.json) {
-        printResult(data, opts);
-        return;
-      }
-
-      if (!data.items || data.items.length === 0) {
-        console.log(pc.dim("No members or invitations found."));
-        return;
-      }
-
-      printTable(
-        ["Email", "Org"],
-        data.items.map((m: { email?: string | null; org?: { name?: string | null } | null }) => [
-          m.email ?? "—",
-          m.org?.name ?? "—",
-        ]),
-        { rawData: data },
-      );
-    });
+  const cmd = new Command("members").description("Invite organization members");
 
   cmd
     .command("invite")
     .description("Invite a member to the organization")
     .argument("<email>", "Email address to invite")
-    .option("--role <role>", "Role: admin or member", "member")
+    .addOption(
+      new Option("--role <role>", "Organization role")
+        .choices(["admin", "member"])
+        .default("member"),
+    )
     .option("--json", "Output as JSON")
-    .action(async (email: string, opts: { role: string; json?: boolean }) => {
+    .action(async (email: string, opts: { role: "admin" | "member"; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
-      // Role is a declared enum: ADMIN="ADMIN", MEMBER="MEMBER"
-      const role = opts.role.toUpperCase() === "ADMIN" ? "ADMIN" : "MEMBER";
+      const role = opts.role === "admin" ? "ADMIN" : "MEMBER";
       await client.invitations.invite.mutate({
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
         orgId: cfg.active_account!.target!.org_id!,
         email,
-        // biome-ignore lint/suspicious/noExplicitAny: Role enum requires cast from string
-        role: role as any,
+        role,
       });
 
       if (opts.json) {
@@ -75,80 +47,6 @@ export function membersCommand(): Command {
         return;
       }
       console.log(pc.green(`Invitation sent to ${email} as ${role}.`));
-    });
-
-  cmd
-    .command("requests")
-    .description("List pending access requests")
-    .option("--json", "Output as JSON")
-    .action(async (opts: { json?: boolean }) => {
-      const cfg = requireConfig();
-      const client = createTypedClient(cfg);
-
-      const data = await client.invitations.getInvitations.query();
-
-      if (opts.json) {
-        printResult(data, opts);
-        return;
-      }
-
-      if (!data.items || data.items.length === 0) {
-        console.log(pc.dim("No pending access requests."));
-        return;
-      }
-
-      printTable(
-        ["Email", "Org"],
-        data.items.map((r: { email?: string | null; org?: { name?: string | null } | null }) => [
-          r.email ?? "—",
-          r.org?.name ?? "—",
-        ]),
-        { rawData: data },
-      );
-    });
-
-  cmd
-    .command("approve")
-    .description("Approve an access request")
-    .argument("<email>", "Email of requester")
-    .option("--json", "Output as JSON")
-    .action(async (email: string, opts: { json?: boolean }) => {
-      const cfg = requireConfig();
-      const client = createTypedClient(cfg);
-
-      await client.invitations.acceptInvitation.mutate({
-        // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        orgId: cfg.active_account!.target!.org_id!,
-        email,
-      });
-
-      if (opts.json) {
-        printResult({ success: true, email, action: "approved" }, opts);
-        return;
-      }
-      console.log(pc.green(`Access request from ${email} approved.`));
-    });
-
-  cmd
-    .command("deny")
-    .description("Deny an access request")
-    .argument("<email>", "Email of requester")
-    .option("--json", "Output as JSON")
-    .action(async (email: string, opts: { json?: boolean }) => {
-      const cfg = requireConfig();
-      const client = createTypedClient(cfg);
-
-      await client.invitations.rejectInvitation.mutate({
-        // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
-        orgId: cfg.active_account!.target!.org_id!,
-        email,
-      });
-
-      if (opts.json) {
-        printResult({ success: true, email, action: "denied" }, opts);
-        return;
-      }
-      console.log(pc.green(`Access request from ${email} denied.`));
     });
 
   return cmd;

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -393,7 +393,7 @@ describe("review edit", () => {
 
   it("strips the prefix and saves a new draft revision for a draft id (body only)", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "old" }); // getMessage
+    mockQuery.mockResolvedValueOnce({ id: "msg-1", title: "Re: q", body: "old" });
     mockMutate.mockResolvedValueOnce(undefined);
 
     await run("edit", "draft_message:msg-1", "--body", "new body");

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -284,7 +284,7 @@ export function reviewCommand(): Command {
   // message.saveDraft (body only). After editing, `dosu review approve` publishes.
   cmd
     .command("edit")
-    .description("Edit a pending review item in place (doc body/title, or draft reply body)")
+    .description("Edit a pending doc or Dosu App draft in place")
     .argument("<id>", "Review item ID (from `dosu review list`)")
     .option("--title <title>", "New title")
     .option("--body <markdown>", "New body (markdown)")
@@ -326,10 +326,14 @@ export function reviewCommand(): Command {
             console.error(pc.red("Draft replies support --body only (no --title)."));
             process.exit(1);
           }
+          if (body === undefined) {
+            console.error(pc.red("Draft replies require --body or --body-file."));
+            process.exit(1);
+          }
           await requireDraft(client, id);
           await client.messages.saveDraft.mutate({
             messageId: bareMessageId(id),
-            body: body as string,
+            body,
           });
         } else {
           try {
@@ -474,8 +478,8 @@ export function reviewCommand(): Command {
   // agent run — so a draft-prefixed id is refused here (ENG-524).
   cmd
     .command("revert")
-    .description("Revert a doc change to pending review (not supported for draft replies)")
-    .argument("<id>", "Review item ID (from `dosu review list`)")
+    .description("Reopen a previously accepted or declined doc change for review")
+    .argument("<id>", "Page version ID (not a pending item from `dosu review list`)")
     .option("--json", "Output as JSON")
     .action(async (id: string, opts: { json?: boolean }) => {
       const cfg = requireConfig();

--- a/src/commands/sources.test.ts
+++ b/src/commands/sources.test.ts
@@ -204,6 +204,12 @@ describe("sources update", () => {
     await run("update", "ds1", "--name", "New Name");
     expect(allOutput()).toContain("Data source updated");
   });
+
+  it("rejects an update with no changes before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("update", "ds1")).rejects.toThrow();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
 });
 
 describe("sources delete", () => {

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -120,6 +120,9 @@ export function sourcesCommand(): Command {
     .option("--description <desc>", "New description")
     .option("--json", "Output as JSON")
     .action(async (id: string, opts: { name?: string; description?: string; json?: boolean }) => {
+      if (opts.name === undefined && opts.description === undefined) {
+        throw new Error("Specify at least one of --name or --description.");
+      }
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 

--- a/src/commands/suggest.test.ts
+++ b/src/commands/suggest.test.ts
@@ -17,6 +17,11 @@ vi.mock("../client/trpc", () => ({
   createTypedClient: vi.fn().mockImplementation(() => createMockProxy()),
 }));
 
+const mockListSpaceDataSourceIds = vi.fn();
+vi.mock("../client/supabase", () => ({
+  listSpaceDataSourceIds: (...args: unknown[]) => mockListSpaceDataSourceIds(...args),
+}));
+
 const mockLoadConfig = vi.fn();
 vi.mock("../config/config", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
@@ -55,6 +60,8 @@ async function run(...args: string[]) {
 beforeEach(() => {
   mockQuery.mockReset();
   mockMutate.mockReset();
+  mockListSpaceDataSourceIds.mockReset();
+  mockListSpaceDataSourceIds.mockResolvedValue(["ds1"]);
   mockLoadConfig.mockReset();
   mockQuery.mockResolvedValueOnce({ id: "ks1" }); // knowledgeStore.getBySpaceId
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -100,22 +107,22 @@ describe("suggest list", () => {
 });
 
 describe("suggest generate", () => {
-  it("fetches data sources then calls suggestedDoc.generate", async () => {
+  it("sends only data sources attached to the active space", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce([{ id: "ds1" }, { id: "ds2" }]); // dataSource.list
+    mockListSpaceDataSourceIds.mockResolvedValueOnce(["ds1", "ds3"]);
     mockMutate.mockResolvedValueOnce({});
 
     await run("generate");
 
     expect(mockMutate).toHaveBeenCalledWith("suggestedDoc.generate", {
       knowledgeStoreId: "ks1",
-      dataSourceIds: ["ds1", "ds2"],
+      dataSourceIds: ["ds1", "ds3"],
     });
+    expect(mockListSpaceDataSourceIds).toHaveBeenCalledWith(validConfig, "sp1");
   });
 
   it("outputs JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce([{ id: "ds1" }]);
     mockMutate.mockResolvedValueOnce({ status: "generating" });
 
     await run("generate", "--json");
@@ -125,12 +132,19 @@ describe("suggest generate", () => {
 
   it("prints human-readable confirmation", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce([{ id: "ds1" }]);
     mockMutate.mockResolvedValueOnce({});
 
     await run("generate");
 
     expect(allOutput()).toContain("Document suggestions are being generated");
+  });
+
+  it("rejects when the active deployment has no attached source", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockListSpaceDataSourceIds.mockResolvedValueOnce([]);
+
+    await expect(run("generate")).rejects.toThrow("No data sources are connected");
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 });
 

--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -4,6 +4,7 @@
 
 import { Command } from "commander";
 import pc from "picocolors";
+import { listSpaceDataSourceIds } from "../client/supabase";
 import { createTypedClient, type TypedClient } from "../client/trpc";
 import { requireLoginConfig } from "./auth";
 import { printResult, printTable } from "./output";
@@ -75,19 +76,14 @@ export function suggestCommand(): Command {
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
       const ksId = await getKnowledgeStoreId(client, cfg.active_account!.target!.space_id!);
 
-      if (!cfg.active_account?.target?.org_id) {
-        console.error(pc.red("Missing org config. Run 'dosu setup' to reconfigure."));
-        process.exit(1);
+      const dataSourceIds = await listSpaceDataSourceIds(
+        cfg,
+        // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
+        cfg.active_account!.target!.space_id!,
+      );
+      if (dataSourceIds.length === 0) {
+        throw new Error("No data sources are connected to the active deployment.");
       }
-
-      // Get data source IDs
-      const dataSources = await client.dataSource.list.query({
-        org_id: cfg.active_account?.target?.org_id,
-        excluded_provider_slugs: [],
-      });
-      const dataSourceIds = dataSources
-        .map((ds) => ds.id)
-        .filter((id): id is string => id !== null);
 
       const result = await client.suggestedDoc.generate.mutate({
         knowledgeStoreId: ksId,

--- a/src/commands/threads.test.ts
+++ b/src/commands/threads.test.ts
@@ -119,11 +119,22 @@ describe("threads list", () => {
     expect(mockQuery.mock.calls[0][1].search).toBe("bug fix");
   });
 
-  it("caps --limit at 100", async () => {
+  it("rejects --limit values above the tRPC maximum", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
-    mockQuery.mockResolvedValueOnce({ list: [], pageInfo: {} });
-    await run("list", "--limit", "200");
-    expect(mockQuery.mock.calls[0][1].limit).toBe(100);
+    await expect(run("list", "--limit", "200")).rejects.toThrow();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown status before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("list", "--status", "closed")).rejects.toThrow();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it.each(["0", "-1", "1.5", "nope"])("rejects invalid list --limit %s", async (limit) => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("list", "--limit", limit)).rejects.toThrow();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   it("outputs valid JSON with --json", async () => {

--- a/src/commands/threads.ts
+++ b/src/commands/threads.ts
@@ -2,10 +2,11 @@
  * `dosu threads` — list, view, and manage conversation threads.
  */
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 import { createTypedClient } from "../client/trpc";
 import type { ThreadListInput } from "../generated/dosu-api-types";
+import { messageLimit, positiveIntegerAtMost } from "./arguments";
 import { requireLoginConfig } from "./auth";
 import { formatDate, printInfo, printResult, printTable, truncate } from "./output";
 
@@ -24,11 +25,21 @@ export function threadsCommand(): Command {
   cmd
     .command("list")
     .description("List threads")
-    .option("--status <status>", "Filter by status: pending, resolved, archived")
+    .addOption(
+      new Option("--status <status>", "Filter by status").choices([
+        "pending",
+        "resolved",
+        "archived",
+      ]),
+    )
     .option("--search <query>", "Search threads")
-    .option("--limit <n>", "Maximum results (default: 20)", "20")
+    .addOption(
+      new Option("--limit <n>", "Maximum results (default: 20; max: 100)")
+        .argParser(positiveIntegerAtMost(100))
+        .default(20),
+    )
     .option("--json", "Output as JSON")
-    .action(async (opts: { status?: string; search?: string; limit?: string; json?: boolean }) => {
+    .action(async (opts: { status?: string; search?: string; limit: number; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
@@ -48,7 +59,7 @@ export function threadsCommand(): Command {
         // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
         space_id: cfg.active_account!.target!.space_id!,
         workspaces: undefined,
-        limit: Math.min(Number.parseInt(opts.limit ?? "20", 10), 100),
+        limit: opts.limit,
       };
 
       if (opts.search) input.search = opts.search;
@@ -95,9 +106,13 @@ export function threadsCommand(): Command {
     .command("get")
     .description("View a thread and its messages")
     .argument("<id>", "Thread ID")
-    .option("--limit <n>", "Number of messages to show (default: 20)", "20")
+    .addOption(
+      new Option("--limit <n>", "Number of messages to show (default: 20; -1 for all)")
+        .argParser(messageLimit)
+        .default(20),
+    )
     .option("--json", "Output as JSON")
-    .action(async (id: string, opts: { limit?: string; json?: boolean }) => {
+    .action(async (id: string, opts: { limit: number; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
 
@@ -105,7 +120,7 @@ export function threadsCommand(): Command {
         client.thread.get.query(id),
         client.messages.list.query({
           thread_id: id,
-          limit: Number.parseInt(opts.limit ?? "20", 10),
+          limit: opts.limit,
         }),
       ]);
 

--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -116,6 +116,12 @@ describe("topics pages", () => {
     expect(call[1].limit).toBe(5);
   });
 
+  it("rejects an invalid page limit before calling tRPC", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    await expect(run("pages", "tag1", "--limit", "nope")).rejects.toThrow();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
   it("outputs valid JSON with --json", async () => {
     mockLoadConfig.mockReturnValue(validConfig);
     mockQuery.mockResolvedValueOnce({ data: [{ id: "p1", title: "Doc A" }] });

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -5,9 +5,10 @@
  * list them and the pages under each, but cannot create, edit, or remove them.
  */
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 import { createTypedClient, type TypedClient } from "../client/trpc";
+import { positiveInteger } from "./arguments";
 import { requireLoginConfig } from "./auth";
 import { printResult, printTable } from "./output";
 
@@ -32,10 +33,7 @@ async function getKnowledgeStoreId(client: TypedClient, spaceId: string): Promis
 }
 
 export function topicsCommand(): Command {
-  // `tags` kept as a hidden alias for back-compat with the pre-rename CLI.
-  const cmd = new Command("topics")
-    .alias("tags")
-    .description("Browse Topics in your knowledge base");
+  const cmd = new Command("topics").description("Browse Topics in your knowledge base");
 
   cmd
     .command("list")
@@ -77,9 +75,9 @@ export function topicsCommand(): Command {
     .description("List pages with a specific topic")
     .argument("<topic-id>", "Topic ID")
     .option("--search <query>", "Search within the topic's pages")
-    .option("--limit <n>", "Maximum results", "10")
+    .addOption(new Option("--limit <n>", "Maximum results").argParser(positiveInteger).default(10))
     .option("--json", "Output as JSON")
-    .action(async (topicId: string, opts: { search?: string; limit?: string; json?: boolean }) => {
+    .action(async (topicId: string, opts: { search?: string; limit: number; json?: boolean }) => {
       const cfg = requireConfig();
       const client = createTypedClient(cfg);
       // biome-ignore lint/style/noNonNullAssertion: checked in requireConfig
@@ -89,7 +87,7 @@ export function topicsCommand(): Command {
         knowledge_store_id: ksId,
         topic_id: topicId,
         searchTerm: opts.search,
-        limit: Number.parseInt(opts.limit ?? "10", 10),
+        limit: opts.limit,
       });
       const pages = result.data;
 

--- a/src/setup/github-step.test.ts
+++ b/src/setup/github-step.test.ts
@@ -95,7 +95,33 @@ vi.mock("../client/trpc", () => ({
 import * as p from "@clack/prompts";
 import type { Config } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
-import { detectGitRepo, stepConnectGitHubRepo, verifyDataSourcesPersist } from "./github-step";
+import {
+  detectGitRepo,
+  parseAvailableRepos,
+  parseDeploymentIds,
+  stepConnectGitHubRepo,
+  verifyDataSourcesPersist,
+} from "./github-step";
+
+describe("parseAvailableRepos", () => {
+  it("validates the unguarded App output before setup uses it", () => {
+    expect(
+      parseAvailableRepos([
+        { repository_id: 1, name: "api", slug: "acme/api", is_deployed: false },
+      ]),
+    ).toEqual([{ repository_id: 1, name: "api", slug: "acme/api", is_deployed: false }]);
+    expect(() => parseAvailableRepos([{ repository_id: "1" }])).toThrow("invalid repository");
+    expect(() => parseAvailableRepos(null)).toThrow("non-array");
+  });
+});
+
+describe("parseDeploymentIds", () => {
+  it("validates the unguarded App output before setup uses it", () => {
+    expect(parseDeploymentIds([{ deployment_id: "dep-1" }])).toEqual(["dep-1"]);
+    expect(() => parseDeploymentIds([{ id: "wrong-shape" }])).toThrow("invalid deployment");
+    expect(() => parseDeploymentIds(null)).toThrow("non-array");
+  });
+});
 
 // Skip the post-connect verify-poll budget so each test resolves in real
 // time without needing fake timers to coexist with the install-flow promise

--- a/src/setup/github-step.ts
+++ b/src/setup/github-step.ts
@@ -111,6 +111,47 @@ interface AvailableRepo {
   created_at?: string;
 }
 
+export function parseAvailableRepos(value: unknown): AvailableRepo[] {
+  if (!Array.isArray(value)) throw new Error("githubRepository.listForOrg returned a non-array");
+  return value.map((repository, index) => {
+    if (
+      repository === null ||
+      typeof repository !== "object" ||
+      !("repository_id" in repository) ||
+      typeof repository.repository_id !== "number" ||
+      !("name" in repository) ||
+      typeof repository.name !== "string" ||
+      !("slug" in repository) ||
+      typeof repository.slug !== "string" ||
+      !("is_deployed" in repository) ||
+      typeof repository.is_deployed !== "boolean" ||
+      ("created_at" in repository &&
+        repository.created_at !== undefined &&
+        typeof repository.created_at !== "string")
+    ) {
+      throw new Error(
+        `githubRepository.listForOrg returned an invalid repository at index ${index}`,
+      );
+    }
+    return repository as AvailableRepo;
+  });
+}
+
+export function parseDeploymentIds(value: unknown): string[] {
+  if (!Array.isArray(value)) throw new Error("workspaces.listForSpace returned a non-array");
+  return value.map((deployment, index) => {
+    if (
+      deployment === null ||
+      typeof deployment !== "object" ||
+      !("deployment_id" in deployment) ||
+      typeof deployment.deployment_id !== "string"
+    ) {
+      throw new Error(`workspaces.listForSpace returned an invalid deployment at index ${index}`);
+    }
+    return deployment.deployment_id;
+  });
+}
+
 export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null {
   let url: string;
   try {
@@ -137,9 +178,11 @@ export function detectGitRepo(cwd: string = process.cwd()): DetectedRepo | null 
 
 async function fetchListForOrg(trpc: TypedClient, orgID: string): Promise<AvailableRepo[]> {
   try {
-    const repos = (await trpc.githubRepository.listForOrg.query({
-      org_id: orgID,
-    })) as AvailableRepo[];
+    const repos = parseAvailableRepos(
+      await trpc.githubRepository.listForOrg.query({
+        org_id: orgID,
+      }),
+    );
     return sortReposByRecency(repos);
   } catch (err: unknown) {
     /* v8 ignore next -- non-fatal; caller decides what to do with an empty list */
@@ -354,12 +397,13 @@ async function createDeploymentForRepo(
       space_id: spaceID,
       data_source_ids: [dataSourceID],
     });
-    const spaceDeployments: { deployment_id: string }[] =
-      await trpc.workspaces.listForSpace.query(spaceID);
+    const spaceDeploymentIds = parseDeploymentIds(
+      await trpc.workspaces.listForSpace.query(spaceID),
+    );
     await Promise.all(
-      spaceDeployments.map((d) =>
+      spaceDeploymentIds.map((deploymentID) =>
         trpc.deploymentDataSource.create.mutate({
-          deployment_id: d.deployment_id,
+          deployment_id: deploymentID,
           data_source_id: dataSourceID,
         }),
       ),


### PR DESCRIPTION
## Summary

- align every platform command's tRPC inputs and supported command surface with the current Dosu App CLI router
- validate numeric choices and unguarded App outputs at the CLI boundary, and remove commands that mapped to different invitation semantics
- scope deployment switching and suggestion generation to the active Dosu MCP deployment, including a fresh deployment API key and exact space data sources
- route import-status to the backend task owner because imports return UUIDv7 IDs while the App wrapper accepts UUIDv4 only
- update CLI documentation to match the supported topics, members, and deployments commands

## Testing

- `bun run test` (71 files, 1644 tests)
- `bunx biome check .`
- `bun run typecheck`
- `bun run deadcode`
- `bun run build:dev`
- compared the vendored CLI contract byte-for-byte with the current App-generated contract
- ran the local App, Supabase, and backend against the locally built CLI; exercised all read command paths plus representative create/update/archive/restore/delete/import/sync/invite/switch/suggest mutations

## Sentry references

- invitation header-auth failures: removed unsupported list/request-management commands
- suggestion generation source mismatch: derive exact source attachments from the active space
- stale setup config: verified the current default remains aligned
