### PR TITLE
feat(setup): configure projects in bulk (3/3)

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   bindAccountIdentity,
   type Config,
+  clearConfigInPlace,
   emptyConfig,
   getConfigPath,
   isAuthenticated,
@@ -183,6 +184,43 @@ describe("config", () => {
     const loaded = loadConfig();
     expect(targetForDeployment(loaded, "dep-a")?.api_key).toBe("key-a");
     expect(targetForDeployment(loaded, "dep-b")?.api_key).toBe("key-b");
+  });
+
+  it("round-trips only normalized scan directories outside account credentials", () => {
+    const cfg = makeTestConfig({
+      access_token: "tok",
+      refresh_token: "ref",
+      expires_at: 1,
+      user_id: "account-a",
+    });
+    cfg.scan_directories = ["/work/repos", "/work/repos", "", "/work/other"];
+
+    saveConfig(cfg);
+
+    expect(loadConfig().scan_directories).toEqual(["/work/repos", "/work/other"]);
+  });
+
+  it("keeps scan directories when login credentials are cleared or replaced", () => {
+    const cfg = makeTestConfig({
+      access_token: "old",
+      refresh_token: "old-ref",
+      expires_at: 1,
+      user_id: "account-a",
+    });
+    cfg.scan_directories = ["/work/repos"];
+
+    replaceLoginSession(cfg, {
+      access_token: "new",
+      refresh_token: "new-refresh",
+      expires_at: 2,
+      user_id: "account-b",
+    });
+
+    expect(cfg.scan_directories).toEqual(["/work/repos"]);
+
+    clearConfigInPlace(cfg);
+    expect(cfg.active_account).toBeUndefined();
+    expect(cfg.scan_directories).toEqual(["/work/repos"]);
   });
 
   it("switches deployments without carrying the previous deployment key across", () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -213,11 +213,14 @@ function isConfigV2(value: unknown): value is Record<string, unknown> {
 function normalizeV3(value: Config): Config {
   const active = isRecord(value.active_account) ? value.active_account : undefined;
   const session = active && isRecord(active.session) ? active.session : undefined;
+  const scanDirectories = normalizeScanDirectories(value.scan_directories);
+  const base: Config = {
+    schema_version: CONFIG_SCHEMA_VERSION,
+    mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
+    ...(scanDirectories.length > 0 ? { scan_directories: scanDirectories } : {}),
+  };
   if (!active || !session) {
-    return {
-      schema_version: CONFIG_SCHEMA_VERSION,
-      mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
-    };
+    return base;
   }
 
   const accessToken = stringValue(session.access_token) ?? "";
@@ -226,8 +229,7 @@ function normalizeV3(value: Config): Config {
   const targets = userID ? normalizeTargets(active.targets) : {};
   if (target?.deployment_id) targets[target.deployment_id] = { ...target };
   return {
-    schema_version: CONFIG_SCHEMA_VERSION,
-    mode: value.mode === MODE_OSS ? MODE_OSS : undefined,
+    ...base,
     active_account: {
       user_id: userID,
       session: {
@@ -239,6 +241,18 @@ function normalizeV3(value: Config): Config {
       targets,
     },
   };
+}
+
+function normalizeScanDirectories(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ];
 }
 
 function migrateV2(value: Record<string, unknown>): Config {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -34,6 +34,8 @@ interface ActiveAccount {
 export interface Config {
   schema_version: typeof CONFIG_SCHEMA_VERSION;
   mode?: SetupMode;
+  /** User-approved parents searched by the bulk project setup flow. */
+  scan_directories?: string[];
   active_account?: ActiveAccount;
 }
 

--- a/src/mcp/project-proxy.test.ts
+++ b/src/mcp/project-proxy.test.ts
@@ -7,6 +7,7 @@ import {
   buildProjectProxyCommand,
   isDosuOwnedMcpServer,
   type ProjectProxyDependencies,
+  projectMcpTarget,
   resolveProjectProxyRuntime,
   runProjectProxy,
 } from "./project-proxy";
@@ -122,6 +123,21 @@ describe("project MCP proxy", () => {
       null,
     ])("rejects a foreign or ambiguous shape", (server) => {
       expect(isDosuOwnedMcpServer(server)).toBe(false);
+    });
+
+    it("extracts the project Library target from every released proxy shape", () => {
+      expect(
+        projectMcpTarget({
+          command: "dosu",
+          args: ["mcp", "proxy", "--deployment", "dep_123"],
+        }),
+      ).toEqual({ kind: "deployment", deploymentID: "dep_123" });
+      expect(
+        projectMcpTarget({
+          command: ["npx", "-y", "@dosu/cli@0.43.0", "mcp", "proxy", "--oss"],
+        }),
+      ).toEqual({ kind: "oss" });
+      expect(projectMcpTarget({ command: "other", args: [] })).toBeNull();
     });
   });
 

--- a/src/mcp/project-proxy.ts
+++ b/src/mcp/project-proxy.ts
@@ -19,6 +19,8 @@ export interface ProjectProxyRuntime {
   apiKey: string;
 }
 
+export type ProjectMcpTarget = { kind: "deployment"; deploymentID: string } | { kind: "oss" };
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -37,40 +39,56 @@ function projectCommand(value: unknown): { command: string; args: string[] } | n
   return null;
 }
 
-/** True only for an MCP entry shape written by a released Dosu CLI flow. */
-export function isDosuOwnedMcpServer(value: unknown): boolean {
-  if (!isRecord(value)) return false;
+/** Extract the target only from an MCP entry shape written by a released Dosu CLI flow. */
+export function projectMcpTarget(value: unknown): ProjectMcpTarget | null {
+  if (!isRecord(value)) return null;
 
   const command = projectCommand(value);
   if (command?.command === "dosu") {
     const [mcp, proxy, targetFlag, targetValue] = command.args;
-    const currentProxy =
-      mcp === "mcp" &&
-      proxy === "proxy" &&
-      ((targetFlag === "--oss" && targetValue === undefined && command.args.length === 3) ||
-        (targetFlag === "--deployment" &&
-          targetValue !== undefined &&
-          command.args.length === 4 &&
-          SAFE_DEPLOYMENT_ID.test(targetValue)));
-    if (currentProxy) return true;
+    if (mcp === "mcp" && proxy === "proxy") {
+      if (targetFlag === "--oss" && targetValue === undefined && command.args.length === 3) {
+        return { kind: "oss" };
+      }
+      if (
+        targetFlag === "--deployment" &&
+        targetValue !== undefined &&
+        command.args.length === 4 &&
+        SAFE_DEPLOYMENT_ID.test(targetValue)
+      ) {
+        return { kind: "deployment", deploymentID: targetValue };
+      }
+    }
   }
   if (command?.command === "npx") {
     const [yes, cliPackage, mcp, proxy, targetFlag, targetValue] = command.args;
-    const projectProxy =
+    const releasedPrefix =
       yes === "-y" &&
       typeof cliPackage === "string" &&
       /^@dosu\/cli@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(cliPackage) &&
       mcp === "mcp" &&
-      proxy === "proxy" &&
-      ((targetFlag === "--oss" && targetValue === undefined && command.args.length === 5) ||
-        (targetFlag === "--deployment" &&
-          targetValue !== undefined &&
-          command.args.length === 6 &&
-          SAFE_DEPLOYMENT_ID.test(targetValue)));
-    if (projectProxy) return true;
+      proxy === "proxy";
+    if (releasedPrefix) {
+      if (targetFlag === "--oss" && targetValue === undefined && command.args.length === 5) {
+        return { kind: "oss" };
+      }
+      if (
+        targetFlag === "--deployment" &&
+        targetValue !== undefined &&
+        command.args.length === 6 &&
+        SAFE_DEPLOYMENT_ID.test(targetValue)
+      ) {
+        return { kind: "deployment", deploymentID: targetValue };
+      }
+    }
   }
 
-  return false;
+  return null;
+}
+
+/** True only for an MCP entry shape written by a released Dosu CLI flow. */
+export function isDosuOwnedMcpServer(value: unknown): boolean {
+  return projectMcpTarget(value) !== null;
 }
 
 interface SpawnedProxy {

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -124,6 +124,26 @@ function isOwnedProjectSection(program: AST.TOMLProgram): boolean {
   return Boolean(command && args && isDosuOwnedMcpServer({ command, args }));
 }
 
+/** Read the standard project section for bulk preflight without changing its bytes. */
+export function readCodexProjectMcpEntry(projectRoot: string): unknown | undefined {
+  const content = readTOML(getConfigPath(false, projectRoot));
+  if (!content) return undefined;
+  const parsed = parseConfigTOML(content);
+  if (hasAlternateDosuDefinition(parsed)) {
+    throw new Error('Codex declares "mcp_servers.dosu" in an alternate TOML form');
+  }
+  const baseTables = dosuTables(parsed).filter((table) => table.resolvedKey.length === 2);
+  if (baseTables.length === 0) return undefined;
+  if (baseTables.length !== 1) throw new Error("Codex has duplicate mcp_servers.dosu tables");
+  const base = baseTables[0];
+  const commandNode = base.body.find((node) => keyName(node) === "command");
+  const argsNode = base.body.find((node) => keyName(node) === "args");
+  return {
+    command: commandNode ? stringValue(commandNode.value) : undefined,
+    args: argsNode ? stringArray(argsNode.value) : undefined,
+  };
+}
+
 function removeDosuTables(content: string, tables: readonly AST.TOMLTable[]): string {
   let result = content;
   for (const table of [...tables].sort((left, right) => right.range[0] - left.range[0])) {

--- a/src/rules/installer.test.ts
+++ b/src/rules/installer.test.ts
@@ -263,6 +263,15 @@ describe("marker-delimited instruction sections", () => {
     );
   });
 
+  it("refuses duplicate rule sections without changing the file", () => {
+    const path = join(tempDir, "GEMINI.md");
+    const section = `${DOSU_RULE_SECTION_START}\nold\n${DOSU_RULE_SECTION_END}\n`;
+    writeFileSync(path, `${section}${section}`);
+
+    expect(() => installRuleForAgent("gemini", "new content", tempDir)).toThrow(/markers/i);
+    expect(readFileSync(path, "utf8")).toBe(`${section}${section}`);
+  });
+
   it("ignores unsupported agents", () => {
     expect(installRuleForAgent("windsurf", "rule")).toBeNull();
     expect(removeRuleForAgent("windsurf")).toBeNull();

--- a/src/rules/installer.ts
+++ b/src/rules/installer.ts
@@ -182,15 +182,31 @@ function isOwnedProjectRuleFile(content: string, cursorFrontmatter: boolean): bo
 }
 
 function findSection(content: string): { start: number; end: number } | null {
-  const startMatch = content.match(DOSU_RULE_SECTION_START_RE);
-  const start = startMatch?.index ?? -1;
-  const end = content.indexOf(DOSU_RULE_SECTION_END, Math.max(start, 0));
-
-  if (start === -1 && end === -1) return null;
-  if (start === -1 || end < start) {
+  const starts = [...content.matchAll(new RegExp(DOSU_RULE_SECTION_START_RE.source, "g"))];
+  const ends = [...content.matchAll(new RegExp(DOSU_RULE_SECTION_END, "g"))];
+  if (starts.length === 0 && ends.length === 0) return null;
+  if (starts.length !== 1 || ends.length !== 1 || (ends[0]?.index ?? -1) < starts[0].index) {
     throw new Error("Dosu rule markers are incomplete; refusing to overwrite the instruction file");
   }
-  return { start, end };
+  return { start: starts[0].index, end: ends[0].index };
+}
+
+/** Read-only preflight used before a bulk flow performs any project write. */
+export function validateRuleForAgentMutation(agent: string, projectRoot: string): void {
+  if (!isRuleAgent(agent)) return;
+  const target = RULE_TARGETS[agent];
+  const path = target.path(projectRoot);
+  if (!path) return;
+  assertSafeProjectPath(projectRoot, path);
+  if (!existsSync(path)) return;
+  const content = readFileSync(path, "utf-8");
+  if (target.kind === "file") {
+    if (!isOwnedProjectRuleFile(content, Boolean(target.cursorFrontmatter))) {
+      throw new Error(`${path} contains a non-Dosu project rule; refusing to overwrite it`);
+    }
+    return;
+  }
+  findSection(content);
 }
 
 function lineEndingFor(content: string): "\r\n" | "\n" {

--- a/src/setup/agents-md-step.ts
+++ b/src/setup/agents-md-step.ts
@@ -69,6 +69,13 @@ function findSection(content: string): SectionLocation | null {
   return { start: starts[0].index, end: ends[0].index };
 }
 
+/** Read-only preflight used before a bulk flow performs any project write. */
+export function validateAgentsMdMutation(cwd: string): void {
+  const path = join(cwd, "AGENTS.md");
+  assertSafeProjectPath(cwd, path);
+  if (existsSync(path)) findSection(readFileSync(path, "utf-8"));
+}
+
 /**
  * Create AGENTS.md with the Dosu section, or upsert the section into an
  * existing file (replace between markers when present, append otherwise).

--- a/src/setup/bulk-flow.test.ts
+++ b/src/setup/bulk-flow.test.ts
@@ -26,6 +26,7 @@ import { CursorProvider } from "../mcp/providers/cursor";
 import { OpenCodeProvider } from "../mcp/providers/opencode";
 import {
   type BulkProjectSetupDependencies,
+  bulkSkillProviders,
   configureBulkRepository,
   runBulkProjectSetup,
 } from "./bulk-flow";
@@ -112,6 +113,12 @@ describe("bulk project setup flow", () => {
       .mockResolvedValueOnce(repositories.map((repo) => repo.path) as never)
       .mockResolvedValueOnce(["cursor"] as never);
     vi.mocked(p.confirm).mockResolvedValue(true as never);
+  });
+
+  it("skips the global skill installer for agents without a supported skill target", () => {
+    expect(
+      bulkSkillProviders([provider("mcporter"), provider("cursor")]).map((item) => item.id()),
+    ).toEqual(["cursor"]);
   });
 
   it("uses the fixed Library → repositories → agents → preview → execute order", async () => {

--- a/src/setup/bulk-flow.test.ts
+++ b/src/setup/bulk-flow.test.ts
@@ -240,6 +240,262 @@ describe("bulk project setup flow", () => {
     expect(dependencies.configureRepository).not.toHaveBeenCalled();
     expect(dependencies.reconcileGlobal).not.toHaveBeenCalled();
   });
+
+  it("blocks before prompting when no complete Library credential exists", async () => {
+    const cfg = config();
+    if (!cfg.active_account) throw new Error("expected authenticated config");
+    cfg.active_account.targets = {
+      "dep-only": { deployment_id: "dep-only" },
+      "key-only": { api_key: "key-only" },
+    };
+    cfg.active_account.target = undefined;
+
+    const result = await runBulkProjectSetup(cfg, dependencies);
+
+    expect(result).toEqual({ status: "blocked", repositories: [] });
+    expect(p.select).not.toHaveBeenCalled();
+  });
+
+  it("uses deployment IDs when Library names are unavailable", async () => {
+    const cfg = config();
+    if (!cfg.active_account?.target || !cfg.active_account.targets) {
+      throw new Error("expected deployment targets");
+    }
+    cfg.active_account.target.deployment_name = undefined;
+    for (const target of Object.values(cfg.active_account.targets)) {
+      target.deployment_name = undefined;
+    }
+    vi.mocked(p.text).mockResolvedValue(" /scan,\n " as never);
+
+    const result = await runBulkProjectSetup(cfg, dependencies);
+
+    expect(result.status).toBe("completed");
+    expect(dependencies.validateDirectories).toHaveBeenCalledWith(["/scan"]);
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Library: dep-b"));
+  });
+
+  it("supports cancellation at every selection boundary", async () => {
+    const cancel = Symbol("cancel");
+    vi.mocked(p.isCancel).mockImplementation((value) => value === cancel);
+    const resetPromptResponses = () => {
+      vi.mocked(p.select)
+        .mockReset()
+        .mockResolvedValue("dep-b" as never);
+      vi.mocked(p.text)
+        .mockReset()
+        .mockResolvedValue("/scan" as never);
+      vi.mocked(p.multiselect)
+        .mockReset()
+        .mockResolvedValueOnce(repositories.map((repo) => repo.path) as never)
+        .mockResolvedValueOnce(["cursor"] as never);
+      vi.mocked(p.confirm)
+        .mockReset()
+        .mockResolvedValue(true as never);
+    };
+
+    resetPromptResponses();
+    vi.mocked(p.select).mockResolvedValueOnce(cancel as never);
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "cancelled",
+      repositories: [],
+    });
+
+    resetPromptResponses();
+    vi.mocked(p.text).mockResolvedValueOnce(cancel as never);
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "cancelled",
+      repositories: [],
+    });
+
+    resetPromptResponses();
+    vi.mocked(p.multiselect).mockReset();
+    vi.mocked(p.multiselect).mockResolvedValueOnce(cancel as never);
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "cancelled",
+      repositories: [],
+    });
+
+    resetPromptResponses();
+    vi.mocked(p.multiselect)
+      .mockReset()
+      .mockResolvedValueOnce(repositories.map((repo) => repo.path) as never)
+      .mockResolvedValueOnce(cancel as never);
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "cancelled",
+      repositories: [],
+    });
+
+    resetPromptResponses();
+    vi.mocked(p.confirm).mockResolvedValueOnce(cancel as never);
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "cancelled",
+      repositories: [],
+    });
+
+    expect(dependencies.configureRepository).not.toHaveBeenCalled();
+  });
+
+  it("blocks when the selected Library disappears or scanning finds nothing", async () => {
+    vi.mocked(p.select).mockResolvedValueOnce("missing" as never);
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "blocked",
+      repositories: [],
+    });
+
+    vi.mocked(p.select).mockResolvedValueOnce("dep-b" as never);
+    vi.mocked(p.text).mockResolvedValueOnce("/scan" as never);
+    vi.mocked(dependencies.scanRepositories).mockReturnValueOnce([]);
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "blocked",
+      repositories: [],
+    });
+  });
+
+  it.each([
+    new Error("unsafe root"),
+    "unsafe root",
+  ])("blocks invalid scan directories without writing (%s)", async (failure) => {
+    vi.mocked(dependencies.validateDirectories).mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result).toEqual({ status: "blocked", repositories: [] });
+    expect(dependencies.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it("skips missing inspection state and unselected repositories", async () => {
+    vi.mocked(dependencies.inspectRepository).mockReturnValue(undefined as never);
+
+    const missingState = await runBulkProjectSetup(config(), dependencies);
+
+    expect(missingState).toEqual({ status: "cancelled", repositories: [] });
+    expect(dependencies.configureRepository).not.toHaveBeenCalled();
+
+    vi.mocked(dependencies.inspectRepository).mockImplementation((path: string) => state(path));
+    vi.mocked(p.multiselect)
+      .mockReset()
+      .mockResolvedValueOnce([repositories[0].path] as never)
+      .mockResolvedValueOnce(["cursor"] as never);
+
+    const selectedOne = await runBulkProjectSetup(config(), dependencies);
+
+    expect(selectedOne.status).toBe("completed");
+    expect(dependencies.configureRepository).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a replacement prompt and cancels when every replacement is declined", async () => {
+    vi.mocked(dependencies.inspectRepository).mockImplementation((path: string) =>
+      state(path, { targets: [{ kind: "deployment", deploymentID: "dep-old" }] }),
+    );
+    const cancel = Symbol("cancel");
+    vi.mocked(p.isCancel).mockImplementation((value) => value === cancel);
+    vi.mocked(p.confirm).mockResolvedValueOnce(cancel as never);
+
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "cancelled",
+      repositories: [],
+    });
+
+    vi.mocked(p.multiselect)
+      .mockReset()
+      .mockResolvedValueOnce(repositories.map((repo) => repo.path) as never)
+      .mockResolvedValueOnce(["cursor"] as never);
+    vi.mocked(p.confirm).mockResolvedValue(false as never);
+    await expect(runBulkProjectSetup(config(), dependencies)).resolves.toEqual({
+      status: "cancelled",
+      repositories: [],
+    });
+    expect(dependencies.configureRepository).not.toHaveBeenCalled();
+  });
+
+  it("blocks when no installed project agent is available", async () => {
+    dependencies.providers = vi.fn(() => []);
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result).toEqual({ status: "blocked", repositories: [] });
+    expect(dependencies.installSkills).not.toHaveBeenCalled();
+  });
+
+  it("cancels when the selected agent set resolves to nothing", async () => {
+    vi.mocked(p.multiselect)
+      .mockReset()
+      .mockResolvedValueOnce(repositories.map((repo) => repo.path) as never)
+      .mockResolvedValueOnce(["missing-agent"] as never);
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result).toEqual({ status: "cancelled", repositories: [] });
+    expect(dependencies.installSkills).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when global skill installation fails", async () => {
+    vi.mocked(dependencies.installSkills).mockResolvedValueOnce(false);
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result).toEqual({ status: "failed", repositories: [] });
+    expect(dependencies.fetchInstruction).not.toHaveBeenCalled();
+    expect(dependencies.configureRepository).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new Error("rule unavailable"),
+    "rule unavailable",
+  ])("fails closed when project preparation fails (%s)", async (failure) => {
+    vi.mocked(dependencies.fetchInstruction).mockRejectedValueOnce(failure);
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result).toEqual({ status: "failed", repositories: [] });
+    expect(dependencies.configureRepository).not.toHaveBeenCalled();
+  });
+
+  it("reports returned failures with and without provider details", async () => {
+    vi.mocked(dependencies.configureRepository)
+      .mockResolvedValueOnce({ projectRoot: "/scan/one", success: false, error: "explicit" })
+      .mockResolvedValueOnce({ projectRoot: "/scan/two", success: false });
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result.repositories).toHaveLength(2);
+    expect(p.log.error).toHaveBeenCalledWith("/scan/one: explicit");
+    expect(p.log.error).toHaveBeenCalledWith("/scan/two: project setup failed");
+    expect(dependencies.reconcileGlobal).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a non-Error repository failure and preserves successful projects", async () => {
+    vi.mocked(dependencies.configureRepository)
+      .mockImplementationOnce(async () => {
+        throw "unexpected failure";
+      })
+      .mockResolvedValueOnce({ projectRoot: "/scan/two", success: true });
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result.repositories[0]).toEqual({
+      projectRoot: "/scan/one",
+      success: false,
+      error: "unexpected failure",
+    });
+    expect(dependencies.reconcileGlobal).not.toHaveBeenCalled();
+  });
+
+  it("leaves legacy global config unchanged when reconciliation itself fails", async () => {
+    vi.mocked(dependencies.reconcileGlobal).mockImplementationOnce(() => {
+      throw new Error("read-only filesystem");
+    });
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result.status).toBe("completed");
+    expect(result.repositories.every((repository) => repository.success)).toBe(true);
+    expect(p.log.warn).toHaveBeenCalledWith(
+      "Project setup succeeded, but old global configuration was left unchanged.",
+    );
+  });
 });
 
 describe("bulk repository execution", () => {
@@ -325,5 +581,145 @@ describe("bulk repository execution", () => {
     expect(readFileSync(rulePath, "utf8")).toBe("user-owned rule\n");
     expect(existsSync(join(projectRoot, ".cursor", "mcp.json"))).toBe(false);
     expect(existsSync(join(projectRoot, "AGENTS.md"))).toBe(false);
+  });
+
+  it("rejects a repository whose inspected state was already blocked", async () => {
+    const mcporter = provider("mcporter");
+
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [mcporter],
+      knownProviders: [mcporter],
+      initialState: state(projectRoot, {
+        blockers: [
+          {
+            providerID: "mcporter",
+            path: join(projectRoot, "config", "mcporter.json"),
+            status: "foreign",
+          },
+        ],
+      }),
+      replaceExisting: false,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result).toEqual({
+      projectRoot,
+      success: false,
+      error: "project configuration changed or cannot be safely replaced",
+    });
+    expect(mcporter.install).not.toHaveBeenCalled();
+  });
+
+  it("returns the MCP installation error without attempting later project writes", async () => {
+    const mcporter = provider("mcporter");
+    vi.mocked(mcporter.install).mockImplementation(() => {
+      throw new Error("MCP write failed");
+    });
+
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [mcporter],
+      knownProviders: [mcporter],
+      initialState: state(projectRoot),
+      replaceExisting: false,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result).toEqual({ projectRoot, success: false, error: "MCP write failed" });
+    expect(existsSync(join(projectRoot, "AGENTS.md"))).toBe(false);
+  });
+
+  it("fails when a required rule cannot be verified after MCP setup", async () => {
+    const cursor = provider("cursor");
+    vi.mocked(cursor.install).mockImplementation(() => {
+      mkdirSync(join(projectRoot, ".cursor", "rules"), { recursive: true });
+      writeFileSync(join(projectRoot, ".cursor", "rules", "dosu.mdc"), "foreign rule\n");
+    });
+
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [cursor],
+      knownProviders: [cursor],
+      initialState: state(projectRoot),
+      replaceExisting: false,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result).toEqual({
+      projectRoot,
+      success: false,
+      error: "a required project rule could not be verified",
+    });
+    expect(existsSync(join(projectRoot, "AGENTS.md"))).toBe(false);
+  });
+
+  it("fails when AGENTS.md becomes malformed after the write preflight", async () => {
+    const mcporter = provider("mcporter");
+    vi.mocked(mcporter.install).mockImplementation(() => {
+      writeFileSync(join(projectRoot, "AGENTS.md"), "<!-- dosu:mcp:start v3 -->\n");
+    });
+
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [mcporter],
+      knownProviders: [mcporter],
+      initialState: state(projectRoot),
+      replaceExisting: false,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result).toEqual({
+      projectRoot,
+      success: false,
+      error: "AGENTS.md could not be verified",
+    });
+  });
+
+  it("fails final verification when the provider did not create a project binding", async () => {
+    const mcporter = provider("mcporter");
+
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [mcporter],
+      knownProviders: [mcporter],
+      initialState: state(projectRoot),
+      replaceExisting: false,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result).toEqual({
+      projectRoot,
+      success: false,
+      error: "project MCP binding could not be verified",
+    });
+  });
+
+  it("normalizes a non-Error thrown during final provider verification", async () => {
+    const cursor = CursorProvider();
+    cursor.isProjectConfigured = () => {
+      throw "provider verification failed";
+    };
+
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [cursor],
+      knownProviders: [cursor],
+      initialState: inspectRepositoryBindings(projectRoot, [cursor]),
+      replaceExisting: false,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result).toEqual({
+      projectRoot,
+      success: false,
+      error: "provider verification failed",
+    });
   });
 });

--- a/src/setup/bulk-flow.test.ts
+++ b/src/setup/bulk-flow.test.ts
@@ -1,0 +1,322 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  select: vi.fn(),
+  text: vi.fn(),
+  multiselect: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: vi.fn(() => false),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import * as p from "@clack/prompts";
+import type { Config } from "../config/config";
+import { updateTarget } from "../config/config";
+import { makeTestConfig } from "../config/config.test-utils";
+import type { SetupProvider } from "../mcp/providers";
+import { CursorProvider } from "../mcp/providers/cursor";
+import { OpenCodeProvider } from "../mcp/providers/opencode";
+import {
+  type BulkProjectSetupDependencies,
+  configureBulkRepository,
+  runBulkProjectSetup,
+} from "./bulk-flow";
+import type { RepositoryBindingState } from "./project-inspection";
+import { inspectRepositoryBindings } from "./project-inspection";
+
+function provider(id = "cursor"): SetupProvider {
+  return {
+    id: () => id,
+    name: () => id,
+    configurationKind: () => "project",
+    install: vi.fn(),
+    remove: vi.fn(),
+    detectPaths: () => [],
+    isInstalled: () => true,
+    isConfigured: () => false,
+    globalConfigPath: () => `/global/${id}`,
+    projectConfigPath: (root) => `${root}/.${id}/mcp.json`,
+    isProjectConfigured: () => true,
+    priority: () => 0,
+  };
+}
+
+function config(): Config {
+  const cfg = makeTestConfig({
+    access_token: "token",
+    refresh_token: "refresh",
+    expires_at: 4_102_444_800,
+    user_id: "user",
+    deployment_id: "dep-a",
+    deployment_name: "Library A",
+    api_key: "key-a",
+  });
+  updateTarget(cfg, {
+    deployment_id: "dep-b",
+    deployment_name: "Library B",
+    api_key: "key-b",
+  });
+  return cfg;
+}
+
+function state(
+  path: string,
+  options: Partial<RepositoryBindingState> = {},
+): RepositoryBindingState {
+  return {
+    projectRoot: path,
+    inspections: [],
+    blockers: [],
+    targets: [],
+    ownedProviderIDs: [],
+    ...options,
+  };
+}
+
+describe("bulk project setup flow", () => {
+  const cursor = provider();
+  const repositories = [
+    { kind: "repository" as const, path: "/scan/one" },
+    { kind: "worktree" as const, path: "/scan/two" },
+  ];
+  let dependencies: Required<BulkProjectSetupDependencies>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(p.isCancel).mockReturnValue(false);
+    dependencies = {
+      providers: vi.fn(() => [cursor]),
+      validateDirectories: vi.fn(() => ["/scan"]),
+      scanRepositories: vi.fn(() => repositories),
+      inspectRepository: vi.fn((path: string) => state(path)),
+      installSkills: vi.fn().mockResolvedValue(true),
+      fetchInstruction: vi.fn().mockResolvedValue("canonical rule\n"),
+      configureRepository: vi.fn(async ({ repository }) => ({
+        projectRoot: repository.path,
+        success: true,
+      })),
+      reconcileGlobal: vi.fn(() => ({ outcomes: [], removed: [], preserved: [] })),
+      saveConfig: vi.fn(),
+    };
+    vi.mocked(p.select).mockResolvedValue("dep-b" as never);
+    vi.mocked(p.text).mockResolvedValue("/scan" as never);
+    vi.mocked(p.multiselect)
+      .mockResolvedValueOnce(repositories.map((repo) => repo.path) as never)
+      .mockResolvedValueOnce(["cursor"] as never);
+    vi.mocked(p.confirm).mockResolvedValue(true as never);
+  });
+
+  it("uses the fixed Library → repositories → agents → preview → execute order", async () => {
+    const cfg = config();
+
+    const result = await runBulkProjectSetup(cfg, dependencies);
+
+    expect(result.status).toBe("completed");
+    expect(p.select).toHaveBeenCalledWith(expect.objectContaining({ message: "Select Library" }));
+    expect(vi.mocked(p.multiselect).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ message: "Select projects" }),
+    );
+    expect(vi.mocked(p.multiselect).mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({ message: "Select agents" }),
+    );
+    expect(p.log.info).toHaveBeenCalledWith(expect.stringContaining("Library B"));
+    expect(p.confirm).toHaveBeenLastCalledWith({ message: "Apply this plan?" });
+    expect(dependencies.installSkills).toHaveBeenCalledWith([cursor]);
+    expect(dependencies.fetchInstruction).toHaveBeenCalledOnce();
+    expect(dependencies.configureRepository).toHaveBeenCalledTimes(2);
+    expect(dependencies.configureRepository).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          active_account: expect.objectContaining({
+            target: expect.objectContaining({ deployment_id: "dep-b", api_key: "key-b" }),
+          }),
+        }),
+      }),
+    );
+    expect(cfg.scan_directories).toEqual(["/scan"]);
+    expect(dependencies.saveConfig).toHaveBeenCalledWith(cfg);
+    expect(dependencies.reconcileGlobal).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks for replacement separately per conflicting project and skips declines", async () => {
+    vi.mocked(dependencies.inspectRepository).mockImplementation((path: string) =>
+      state(path, {
+        targets: [{ kind: "deployment", deploymentID: "dep-old" }],
+        ownedProviderIDs: ["cursor"],
+      }),
+    );
+    vi.mocked(p.confirm)
+      .mockResolvedValueOnce(false as never)
+      .mockResolvedValueOnce(true as never)
+      .mockResolvedValueOnce(true as never);
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result.status).toBe("completed");
+    expect(p.confirm).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: expect.stringContaining("/scan/one") }),
+    );
+    expect(p.confirm).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ message: expect.stringContaining("/scan/two") }),
+    );
+    expect(dependencies.configureRepository).toHaveBeenCalledTimes(1);
+    expect(dependencies.configureRepository).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: repositories[1], replaceExisting: true }),
+    );
+  });
+
+  it("blocks foreign or malformed projects before any write to that project", async () => {
+    vi.mocked(dependencies.inspectRepository).mockImplementation((path: string) =>
+      path.endsWith("one")
+        ? state(path, {
+            blockers: [
+              {
+                providerID: "cursor",
+                path: `${path}/.cursor/mcp.json`,
+                status: "foreign",
+              },
+            ],
+          })
+        : state(path),
+    );
+
+    await runBulkProjectSetup(config(), dependencies);
+
+    const repoOptions = vi.mocked(p.multiselect).mock.calls[0]?.[0]?.options as Array<{
+      value: string;
+      disabled?: boolean;
+    }>;
+    expect(repoOptions.find((option) => option.value === "/scan/one")?.disabled).toBe(true);
+    expect(dependencies.configureRepository).toHaveBeenCalledTimes(1);
+    expect(dependencies.configureRepository).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: repositories[1] }),
+    );
+  });
+
+  it("continues after one repository fails but withholds global cleanup", async () => {
+    vi.mocked(dependencies.configureRepository)
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockResolvedValueOnce({ projectRoot: "/scan/two", success: true });
+
+    const result = await runBulkProjectSetup(config(), dependencies);
+
+    expect(result.status).toBe("completed");
+    expect(result.repositories).toEqual([
+      { projectRoot: "/scan/one", success: false, error: "disk full" },
+      { projectRoot: "/scan/two", success: true },
+    ]);
+    expect(dependencies.configureRepository).toHaveBeenCalledTimes(2);
+    expect(dependencies.reconcileGlobal).not.toHaveBeenCalled();
+  });
+
+  it("makes cancellation before execution a zero-write operation", async () => {
+    vi.mocked(p.confirm).mockResolvedValueOnce(false as never);
+    const cfg = config();
+    const before = structuredClone(cfg);
+
+    const result = await runBulkProjectSetup(cfg, dependencies);
+
+    expect(result.status).toBe("cancelled");
+    expect(cfg).toEqual(before);
+    expect(dependencies.saveConfig).not.toHaveBeenCalled();
+    expect(dependencies.installSkills).not.toHaveBeenCalled();
+    expect(dependencies.configureRepository).not.toHaveBeenCalled();
+    expect(dependencies.reconcileGlobal).not.toHaveBeenCalled();
+  });
+});
+
+describe("bulk repository execution", () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), "dosu-bulk-project-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it("writes only the project MCP, rule, and AGENTS.md bundle with no project skill copy", async () => {
+    const cursor = CursorProvider();
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [cursor],
+      knownProviders: [cursor],
+      initialState: inspectRepositoryBindings(projectRoot, [cursor]),
+      replaceExisting: false,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result).toEqual({ projectRoot, success: true });
+    const projectMcp = readFileSync(join(projectRoot, ".cursor", "mcp.json"), "utf8");
+    expect(projectMcp).toContain('"dosu"');
+    expect(projectMcp).toContain('"dep-b"');
+    expect(projectMcp).not.toContain("key-b");
+    expect(existsSync(join(projectRoot, ".cursor", "rules", "dosu.mdc"))).toBe(true);
+    expect(existsSync(join(projectRoot, "AGENTS.md"))).toBe(true);
+    expect(existsSync(join(projectRoot, ".agents", "skills"))).toBe(false);
+  });
+
+  it("retargets every existing owned MCP entry after replacement is approved", async () => {
+    const cursor = CursorProvider();
+    const opencode = OpenCodeProvider();
+    const oldConfig = makeTestConfig({
+      access_token: "token",
+      refresh_token: "refresh",
+      expires_at: 4_102_444_800,
+      user_id: "user",
+      deployment_id: "dep-old",
+      api_key: "key-old",
+    });
+    opencode.install(oldConfig, { scope: "project", projectRoot });
+    const initialState = inspectRepositoryBindings(projectRoot, [cursor, opencode]);
+
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [cursor],
+      knownProviders: [cursor, opencode],
+      initialState,
+      replaceExisting: true,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result.success).toBe(true);
+    expect(inspectRepositoryBindings(projectRoot, [cursor, opencode]).targets).toEqual([
+      { kind: "deployment", deploymentID: "dep-b" },
+    ]);
+  });
+
+  it("preflights foreign rules before writing the project MCP or AGENTS.md", async () => {
+    const cursor = CursorProvider();
+    const rulePath = join(projectRoot, ".cursor", "rules", "dosu.mdc");
+    mkdirSync(join(projectRoot, ".cursor", "rules"), { recursive: true });
+    writeFileSync(rulePath, "user-owned rule\n");
+
+    const result = await configureBulkRepository({
+      config: config(),
+      repository: { path: projectRoot, kind: "repository" },
+      selectedProviders: [cursor],
+      knownProviders: [cursor],
+      initialState: inspectRepositoryBindings(projectRoot, [cursor]),
+      replaceExisting: false,
+      instruction: "canonical rule\n",
+    });
+
+    expect(result.success).toBe(false);
+    expect(readFileSync(rulePath, "utf8")).toBe("user-owned rule\n");
+    expect(existsSync(join(projectRoot, ".cursor", "mcp.json"))).toBe(false);
+    expect(existsSync(join(projectRoot, "AGENTS.md"))).toBe(false);
+  });
+});

--- a/src/setup/bulk-flow.ts
+++ b/src/setup/bulk-flow.ts
@@ -1,4 +1,5 @@
 import * as p from "@clack/prompts";
+import { skillInstallTargetForProvider } from "../commands/skill";
 import type { AccountTarget, Config } from "../config/config";
 import { saveConfig } from "../config/config";
 import { allSetupProviders, type SetupProvider } from "../mcp/providers";
@@ -210,13 +211,20 @@ function defaultDependencies(
     validateDirectories: validateScanDirectories,
     scanRepositories: scanGitRepositories,
     inspectRepository: inspectRepositoryBindings,
-    installSkills: runInstallSkill,
+    installSkills: async (providers) => {
+      const supported = bulkSkillProviders(providers);
+      return supported.length === 0 || runInstallSkill(supported);
+    },
     fetchInstruction: fetchDosuRule,
     configureRepository: configureBulkRepository,
     reconcileGlobal: reconcileLegacyGlobalSetup,
     saveConfig,
     ...overrides,
   };
+}
+
+export function bulkSkillProviders(providers: readonly SetupProvider[]): SetupProvider[] {
+  return providers.filter((provider) => skillInstallTargetForProvider(provider.id()) !== null);
 }
 
 function reloadableProjectProviders(providers: readonly SetupProvider[]): SetupProvider[] {
@@ -383,23 +391,27 @@ export async function runBulkProjectSetup(
   const results: BulkRepositoryResult[] = [];
   for (const selected of selectedRepositories) {
     try {
-      results.push(
-        await dependencies.configureRepository({
-          config: projectConfig,
-          repository: selected.repository,
-          selectedProviders,
-          knownProviders,
-          initialState: selected.state,
-          replaceExisting: selected.replaceExisting,
-          instruction,
-        }),
-      );
+      const result = await dependencies.configureRepository({
+        config: projectConfig,
+        repository: selected.repository,
+        selectedProviders,
+        knownProviders,
+        initialState: selected.state,
+        replaceExisting: selected.replaceExisting,
+        instruction,
+      });
+      results.push(result);
+      if (!result.success) {
+        p.log.error(`${result.projectRoot}: ${result.error ?? "project setup failed"}`);
+      }
     } catch (error: unknown) {
-      results.push({
+      const result = {
         projectRoot: selected.repository.path,
         success: false,
         error: error instanceof Error ? error.message : String(error),
-      });
+      };
+      results.push(result);
+      p.log.error(`${result.projectRoot}: ${result.error}`);
     }
   }
 

--- a/src/setup/bulk-flow.ts
+++ b/src/setup/bulk-flow.ts
@@ -1,0 +1,420 @@
+import * as p from "@clack/prompts";
+import type { AccountTarget, Config } from "../config/config";
+import { saveConfig } from "../config/config";
+import { allSetupProviders, type SetupProvider } from "../mcp/providers";
+import {
+  fetchDosuRule,
+  isRuleAgent,
+  rulePathForAgent,
+  validateRuleForAgentMutation,
+} from "../rules/installer";
+import { stepUpdateAgentsMd, validateAgentsMdMutation } from "./agents-md-step";
+import { logLegacyGlobalReconciliation, runInstallSkill, stepConfigureTools } from "./flow";
+import {
+  type LegacyGlobalReconciliation,
+  reconcileLegacyGlobalSetup,
+} from "./legacy-global-cleanup";
+import {
+  inspectRepositoryBindings,
+  type RepositoryBindingState,
+  repositoryNeedsTargetReplacement,
+} from "./project-inspection";
+import {
+  type ScannedRepository,
+  scanGitRepositories,
+  validateScanDirectories,
+} from "./repository-scan";
+import { stepConfigureAgentRules } from "./rules-step";
+
+export interface BulkRepositoryResult {
+  projectRoot: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface BulkProjectSetupResult {
+  status: "cancelled" | "blocked" | "failed" | "completed";
+  repositories: BulkRepositoryResult[];
+}
+
+export interface BulkConfigureRepositoryRequest {
+  config: Config;
+  repository: ScannedRepository;
+  selectedProviders: SetupProvider[];
+  knownProviders: SetupProvider[];
+  initialState: RepositoryBindingState;
+  replaceExisting: boolean;
+  instruction: string;
+}
+
+type ConfigureRepository = (
+  request: BulkConfigureRepositoryRequest,
+) => Promise<BulkRepositoryResult>;
+
+export interface BulkProjectSetupDependencies {
+  providers?: () => SetupProvider[];
+  validateDirectories?: (inputs: readonly string[]) => string[];
+  scanRepositories?: (directories: readonly string[]) => ScannedRepository[];
+  inspectRepository?: (
+    projectRoot: string,
+    providers: readonly SetupProvider[],
+  ) => RepositoryBindingState;
+  installSkills?: (providers: SetupProvider[]) => Promise<boolean>;
+  fetchInstruction?: () => Promise<string>;
+  configureRepository?: ConfigureRepository;
+  reconcileGlobal?: (
+    selectedProviders: readonly SetupProvider[],
+    projectRoot: string,
+    knownProviders: readonly SetupProvider[],
+  ) => LegacyGlobalReconciliation;
+  saveConfig?: (config: Config) => void;
+}
+
+function targetKey(target: AccountTarget): string | null {
+  return target.deployment_id && target.api_key ? target.deployment_id : null;
+}
+
+function availableTargets(config: Config): AccountTarget[] {
+  const byID = new Map<string, AccountTarget>();
+  for (const target of Object.values(config.active_account?.targets ?? {})) {
+    const key = targetKey(target);
+    if (key) byID.set(key, target);
+  }
+  const active = config.active_account?.target;
+  const activeKey = active ? targetKey(active) : null;
+  if (active && activeKey) byID.set(activeKey, active);
+  return [...byID.values()].sort((left, right) =>
+    (left.deployment_name ?? left.deployment_id ?? "").localeCompare(
+      right.deployment_name ?? right.deployment_id ?? "",
+    ),
+  );
+}
+
+function configForTarget(config: Config, target: AccountTarget): Config {
+  const copy = structuredClone(config);
+  if (!copy.active_account) throw new Error("Authenticate before configuring projects in bulk.");
+  copy.mode = undefined;
+  copy.active_account.target = structuredClone(target);
+  return copy;
+}
+
+function parseDirectoryInput(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function selectedTargetMatches(state: RepositoryBindingState, deploymentID: string): boolean {
+  return (
+    state.targets.length === 1 &&
+    state.targets[0]?.kind === "deployment" &&
+    state.targets[0].deploymentID === deploymentID
+  );
+}
+
+export async function configureBulkRepository(
+  request: BulkConfigureRepositoryRequest,
+): Promise<BulkRepositoryResult> {
+  const {
+    config,
+    repository,
+    selectedProviders,
+    knownProviders,
+    initialState,
+    replaceExisting,
+    instruction,
+  } = request;
+  const currentState = inspectRepositoryBindings(repository.path, knownProviders);
+  const deploymentID = config.active_account?.target?.deployment_id;
+  if (
+    initialState.blockers.length > 0 ||
+    currentState.blockers.length > 0 ||
+    !deploymentID ||
+    (repositoryNeedsTargetReplacement(currentState, deploymentID) && !replaceExisting)
+  ) {
+    return {
+      projectRoot: repository.path,
+      success: false,
+      error: "project configuration changed or cannot be safely replaced",
+    };
+  }
+
+  try {
+    validateAgentsMdMutation(repository.path);
+    for (const provider of selectedProviders) {
+      validateRuleForAgentMutation(provider.id(), repository.path);
+    }
+    const providerIDs = new Set(selectedProviders.map((provider) => provider.id()));
+    if (replaceExisting) {
+      for (const providerID of currentState.ownedProviderIDs) providerIDs.add(providerID);
+    }
+    const providersToInstall = knownProviders.filter((provider) => providerIDs.has(provider.id()));
+    const mcpResults = stepConfigureTools(
+      config,
+      { toInstall: providersToInstall, toRemove: [], skipped: [] },
+      repository.path,
+    );
+    const mcpFailure = mcpResults.find((result) => result.error);
+    if (mcpFailure) throw mcpFailure.error;
+
+    const ruleResults = await stepConfigureAgentRules(
+      { toInstall: selectedProviders, toRemove: [] },
+      mcpResults,
+      repository.path,
+      instruction,
+    );
+    const requiredRuleIDs = new Set(
+      selectedProviders
+        .filter(
+          (provider) =>
+            isRuleAgent(provider.id()) && rulePathForAgent(provider.id(), repository.path) !== null,
+        )
+        .map((provider) => provider.id()),
+    );
+    const successfulRuleIDs = new Set(
+      ruleResults
+        .filter((result) => !result.error && result.action !== "not_found")
+        .map((result) => result.provider.id()),
+    );
+    if ([...requiredRuleIDs].some((providerID) => !successfulRuleIDs.has(providerID))) {
+      throw new Error("a required project rule could not be verified");
+    }
+    if (!(await stepUpdateAgentsMd(repository.path, instruction))) {
+      throw new Error("AGENTS.md could not be verified");
+    }
+
+    const after = inspectRepositoryBindings(repository.path, knownProviders);
+    if (
+      after.blockers.length > 0 ||
+      !selectedTargetMatches(after, deploymentID) ||
+      selectedProviders.some((provider) => !provider.isProjectConfigured(repository.path))
+    ) {
+      throw new Error("project MCP binding could not be verified");
+    }
+    return { projectRoot: repository.path, success: true };
+  } catch (error: unknown) {
+    return {
+      projectRoot: repository.path,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function defaultDependencies(
+  overrides: BulkProjectSetupDependencies,
+): Required<BulkProjectSetupDependencies> {
+  return {
+    providers: allSetupProviders,
+    validateDirectories: validateScanDirectories,
+    scanRepositories: scanGitRepositories,
+    inspectRepository: inspectRepositoryBindings,
+    installSkills: runInstallSkill,
+    fetchInstruction: fetchDosuRule,
+    configureRepository: configureBulkRepository,
+    reconcileGlobal: reconcileLegacyGlobalSetup,
+    saveConfig,
+    ...overrides,
+  };
+}
+
+function reloadableProjectProviders(providers: readonly SetupProvider[]): SetupProvider[] {
+  return providers.filter(
+    (provider) => provider.configurationKind() === "project" && provider.isInstalled(),
+  );
+}
+
+function preview(
+  target: AccountTarget,
+  repositories: readonly { repository: ScannedRepository; replaceExisting: boolean }[],
+  providers: readonly SetupProvider[],
+): string {
+  const replacementCount = repositories.filter((item) => item.replaceExisting).length;
+  return [
+    `Library: ${target.deployment_name ?? target.deployment_id}`,
+    `Projects: ${repositories.length}`,
+    `Agents: ${providers.map((provider) => provider.name()).join(", ")}`,
+    `Library replacements: ${replacementCount}`,
+    ...repositories.map(
+      (item) => `  ${item.replaceExisting ? "replace" : "configure"} ${item.repository.path}`,
+    ),
+  ].join("\n");
+}
+
+export async function runBulkProjectSetup(
+  config: Config,
+  overrides: BulkProjectSetupDependencies = {},
+): Promise<BulkProjectSetupResult> {
+  const dependencies = defaultDependencies(overrides);
+  const targets = availableTargets(config);
+  if (targets.length === 0) {
+    p.log.warn("No Library credential is available. Configure the current project first.");
+    return { status: "blocked", repositories: [] };
+  }
+
+  const targetID = await p.select({
+    message: "Select Library",
+    options: targets.map((target) => ({
+      label: target.deployment_name ?? target.deployment_id ?? "Unnamed Library",
+      value: target.deployment_id ?? "",
+    })),
+  });
+  if (p.isCancel(targetID)) return { status: "cancelled", repositories: [] };
+  const target = targets.find((candidate) => candidate.deployment_id === targetID);
+  if (!target?.deployment_id) return { status: "blocked", repositories: [] };
+
+  const directoryInput = await p.text({
+    message: "Directories to scan (comma or newline separated)",
+    initialValue: config.scan_directories?.join(", ") ?? "",
+    placeholder: "~/code, ~/work",
+  });
+  if (p.isCancel(directoryInput)) return { status: "cancelled", repositories: [] };
+  let scanDirectories: string[];
+  try {
+    scanDirectories = dependencies.validateDirectories(parseDirectoryInput(String(directoryInput)));
+  } catch (error: unknown) {
+    p.log.error(error instanceof Error ? error.message : String(error));
+    return { status: "blocked", repositories: [] };
+  }
+
+  const knownProviders = dependencies.providers();
+  const repositories = dependencies.scanRepositories(scanDirectories);
+  if (repositories.length === 0) {
+    p.log.warn("No Git repositories or worktrees were found in those directories.");
+    return { status: "blocked", repositories: [] };
+  }
+  const states = new Map(
+    repositories.map((repository) => [
+      repository.path,
+      dependencies.inspectRepository(repository.path, knownProviders),
+    ]),
+  );
+  const repositoryIDs = await p.multiselect({
+    message: "Select projects",
+    options: repositories.map((repository) => {
+      const state = states.get(repository.path);
+      const blocked = Boolean(state?.blockers.length);
+      return {
+        label: repository.path,
+        value: repository.path,
+        hint: blocked
+          ? "blocked: foreign or malformed config"
+          : state?.targets.length
+            ? "already bound to a Library"
+            : repository.kind,
+        ...(blocked ? { disabled: true } : {}),
+      };
+    }),
+    initialValues: repositories
+      .filter((repository) => !states.get(repository.path)?.blockers.length)
+      .map((repository) => repository.path),
+    required: true,
+  });
+  if (p.isCancel(repositoryIDs)) return { status: "cancelled", repositories: [] };
+  const requestedIDs = new Set(repositoryIDs as string[]);
+  const selectedRepositories: Array<{
+    repository: ScannedRepository;
+    state: RepositoryBindingState;
+    replaceExisting: boolean;
+  }> = [];
+  for (const repository of repositories) {
+    if (!requestedIDs.has(repository.path)) continue;
+    const state = states.get(repository.path);
+    if (!state || state.blockers.length > 0) {
+      p.log.warn(`Skipped blocked project: ${repository.path}`);
+      continue;
+    }
+    const replaceExisting = repositoryNeedsTargetReplacement(state, target.deployment_id);
+    if (replaceExisting) {
+      const replace = await p.confirm({
+        message: `${repository.path} is bound to another Library. Replace its Dosu binding?`,
+      });
+      if (p.isCancel(replace)) return { status: "cancelled", repositories: [] };
+      if (!replace) continue;
+    }
+    selectedRepositories.push({ repository, state, replaceExisting });
+  }
+  if (selectedRepositories.length === 0) {
+    p.log.warn("No projects remain selected.");
+    return { status: "cancelled", repositories: [] };
+  }
+
+  const availableProviders = reloadableProjectProviders(knownProviders);
+  if (availableProviders.length === 0) {
+    p.log.warn("No supported project-scoped agents are installed.");
+    return { status: "blocked", repositories: [] };
+  }
+  const providerIDs = await p.multiselect({
+    message: "Select agents",
+    options: availableProviders.map((provider) => ({
+      label: provider.name(),
+      value: provider.id(),
+    })),
+    required: true,
+  });
+  if (p.isCancel(providerIDs)) return { status: "cancelled", repositories: [] };
+  const selectedProviderIDs = new Set(providerIDs as string[]);
+  const selectedProviders = availableProviders.filter((provider) =>
+    selectedProviderIDs.has(provider.id()),
+  );
+  if (selectedProviders.length === 0) return { status: "cancelled", repositories: [] };
+
+  p.log.info(preview(target, selectedRepositories, selectedProviders));
+  const confirmed = await p.confirm({ message: "Apply this plan?" });
+  if (p.isCancel(confirmed) || !confirmed) return { status: "cancelled", repositories: [] };
+
+  if (!(await dependencies.installSkills(selectedProviders))) {
+    p.log.error("Official Dosu skills could not be installed; no project was changed.");
+    return { status: "failed", repositories: [] };
+  }
+  let instruction: string;
+  try {
+    instruction = await dependencies.fetchInstruction();
+    config.scan_directories = scanDirectories;
+    dependencies.saveConfig(config);
+  } catch (error: unknown) {
+    p.log.error(
+      `Could not prepare bulk project setup: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { status: "failed", repositories: [] };
+  }
+  const projectConfig = configForTarget(config, target);
+  const results: BulkRepositoryResult[] = [];
+  for (const selected of selectedRepositories) {
+    try {
+      results.push(
+        await dependencies.configureRepository({
+          config: projectConfig,
+          repository: selected.repository,
+          selectedProviders,
+          knownProviders,
+          initialState: selected.state,
+          replaceExisting: selected.replaceExisting,
+          instruction,
+        }),
+      );
+    } catch (error: unknown) {
+      results.push({
+        projectRoot: selected.repository.path,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (results.length > 0 && results.every((result) => result.success)) {
+    try {
+      logLegacyGlobalReconciliation(
+        dependencies.reconcileGlobal(selectedProviders, results[0].projectRoot, knownProviders),
+      );
+    } catch {
+      p.log.warn("Project setup succeeded, but old global configuration was left unchanged.");
+    }
+  }
+  const succeeded = results.filter((result) => result.success).length;
+  const failed = results.length - succeeded;
+  if (failed > 0) p.log.warn(`Configured ${succeeded} project(s); ${failed} failed.`);
+  else p.log.success(`Configured ${succeeded} project(s).`);
+  return { status: "completed", repositories: results };
+}

--- a/src/setup/flow.ts
+++ b/src/setup/flow.ts
@@ -384,7 +384,7 @@ export async function runSetup(opts: SetupOptions = {}): Promise<void> {
   }
 }
 
-function logLegacyGlobalReconciliation(report: LegacyGlobalReconciliation): void {
+export function logLegacyGlobalReconciliation(report: LegacyGlobalReconciliation): void {
   if (report.removed.length > 0) {
     p.log.info(
       formatSetupSummary(

--- a/src/setup/project-inspection.test.ts
+++ b/src/setup/project-inspection.test.ts
@@ -1,0 +1,120 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CodexProvider } from "../mcp/providers/codex";
+import { CursorProvider } from "../mcp/providers/cursor";
+import { OpenCodeProvider } from "../mcp/providers/opencode";
+import {
+  inspectProjectProvider,
+  inspectRepositoryBindings,
+  repositoryNeedsTargetReplacement,
+} from "./project-inspection";
+
+describe("project MCP inspection", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), "dosu-project-inspect-")));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeJSON(path: string, value: unknown): void {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(value, null, 2));
+  }
+
+  it("extracts a secretless deployment binding and reports an absent config", () => {
+    const cursor = CursorProvider();
+    expect(inspectProjectProvider(cursor, tempDir)).toMatchObject({ status: "absent" });
+
+    const path = cursor.projectConfigPath(tempDir) ?? "";
+    writeJSON(path, {
+      mcpServers: {
+        dosu: { command: "dosu", args: ["mcp", "proxy", "--deployment", "dep-a"] },
+      },
+    });
+
+    expect(inspectProjectProvider(cursor, tempDir)).toMatchObject({
+      status: "owned",
+      target: { kind: "deployment", deploymentID: "dep-a" },
+      path,
+    });
+  });
+
+  it("blocks foreign, malformed, and symlinked project config", () => {
+    const cursor = CursorProvider();
+    const path = cursor.projectConfigPath(tempDir) ?? "";
+    writeJSON(path, { mcpServers: { dosu: { command: "foreign", args: [] } } });
+    const foreignBytes = readFileSync(path, "utf-8");
+    expect(inspectProjectProvider(cursor, tempDir)).toMatchObject({ status: "foreign" });
+    expect(readFileSync(path, "utf-8")).toBe(foreignBytes);
+
+    writeFileSync(path, '{"mcpServers":');
+    expect(inspectProjectProvider(cursor, tempDir)).toMatchObject({ status: "malformed" });
+
+    rmSync(dirname(path), { recursive: true, force: true });
+    const outside = join(tempDir, "outside");
+    mkdirSync(outside);
+    symlinkSync(outside, dirname(path));
+    expect(inspectProjectProvider(cursor, tempDir)).toMatchObject({ status: "malformed" });
+  });
+
+  it("reads multiline Codex TOML without changing its comments", () => {
+    const codex = CodexProvider();
+    const path = codex.projectConfigPath(tempDir) ?? "";
+    mkdirSync(dirname(path), { recursive: true });
+    const content = [
+      "# keep",
+      "[mcp_servers.dosu]",
+      'command = "dosu"',
+      'args = ["mcp", "proxy", "--deployment", "dep-codex"]',
+      "",
+      "[features]",
+      "apps = true",
+      "",
+    ].join("\n");
+    writeFileSync(path, content);
+
+    expect(inspectProjectProvider(codex, tempDir)).toMatchObject({
+      status: "owned",
+      target: { kind: "deployment", deploymentID: "dep-codex" },
+    });
+    expect(readFileSync(path, "utf-8")).toBe(content);
+  });
+
+  it("aggregates conflicting bindings and requires explicit replacement", () => {
+    const cursor = CursorProvider();
+    const opencode = OpenCodeProvider();
+    writeJSON(cursor.projectConfigPath(tempDir) ?? "", {
+      mcpServers: {
+        dosu: { command: "dosu", args: ["mcp", "proxy", "--deployment", "dep-a"] },
+      },
+    });
+    writeJSON(opencode.projectConfigPath(tempDir) ?? "", {
+      mcp: {
+        dosu: { command: "dosu", args: ["mcp", "proxy", "--deployment", "dep-b"] },
+      },
+    });
+
+    const state = inspectRepositoryBindings(tempDir, [cursor, opencode]);
+    expect(state.blockers).toEqual([]);
+    expect(state.targets).toEqual([
+      { kind: "deployment", deploymentID: "dep-a" },
+      { kind: "deployment", deploymentID: "dep-b" },
+    ]);
+    expect(repositoryNeedsTargetReplacement(state, "dep-a")).toBe(true);
+    expect(repositoryNeedsTargetReplacement(state, "dep-c")).toBe(true);
+  });
+});

--- a/src/setup/project-inspection.test.ts
+++ b/src/setup/project-inspection.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SetupProvider } from "../mcp/providers";
 import { CodexProvider } from "../mcp/providers/codex";
 import { CursorProvider } from "../mcp/providers/cursor";
 import { OpenCodeProvider } from "../mcp/providers/opencode";
@@ -116,5 +117,74 @@ describe("project MCP inspection", () => {
     ]);
     expect(repositoryNeedsTargetReplacement(state, "dep-a")).toBe(true);
     expect(repositoryNeedsTargetReplacement(state, "dep-c")).toBe(true);
+  });
+
+  it("treats missing paths and missing Dosu entries as absent", () => {
+    const noPath: SetupProvider = {
+      ...CursorProvider(),
+      id: () => "no-path",
+      projectConfigPath: () => null,
+    };
+    expect(inspectProjectProvider(noPath, tempDir)).toEqual({
+      providerID: "no-path",
+      path: null,
+      status: "absent",
+    });
+
+    const cursor = CursorProvider();
+    writeJSON(cursor.projectConfigPath(tempDir) ?? "", {
+      mcpServers: { other: { command: "other", args: [] } },
+    });
+    expect(inspectProjectProvider(cursor, tempDir)).toMatchObject({ status: "absent" });
+  });
+
+  it("blocks unsupported formats and normalizes non-Error inspection failures", () => {
+    const unsupportedPath = join(tempDir, ".unknown", "mcp.json");
+    const unsupported: SetupProvider = {
+      ...CursorProvider(),
+      id: () => "unknown-agent",
+      projectConfigPath: () => unsupportedPath,
+    };
+    writeJSON(unsupportedPath, { mcpServers: { dosu: {} } });
+
+    const throwing: SetupProvider = {
+      ...CursorProvider(),
+      id: () => "throwing-agent",
+      projectConfigPath: () => {
+        throw "path inspection failed";
+      },
+    };
+
+    const inspected = inspectRepositoryBindings(tempDir, [unsupported, throwing]);
+
+    expect(inspected.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          providerID: "unknown-agent",
+          status: "malformed",
+          error: "unsupported project config format",
+        }),
+        expect.objectContaining({
+          providerID: "throwing-agent",
+          path: null,
+          status: "malformed",
+          error: "path inspection failed",
+        }),
+      ]),
+    );
+  });
+
+  it("recognizes an OSS project binding as requiring replacement for a cloud Library", () => {
+    const cursor = CursorProvider();
+    writeJSON(cursor.projectConfigPath(tempDir) ?? "", {
+      mcpServers: {
+        dosu: { command: "dosu", args: ["mcp", "proxy", "--oss"] },
+      },
+    });
+
+    const inspected = inspectRepositoryBindings(tempDir, [cursor]);
+
+    expect(inspected.targets).toEqual([{ kind: "oss" }]);
+    expect(repositoryNeedsTargetReplacement(inspected, "dep-cloud")).toBe(true);
   });
 });

--- a/src/setup/project-inspection.ts
+++ b/src/setup/project-inspection.ts
@@ -1,0 +1,128 @@
+import { existsSync } from "node:fs";
+import { getJSONServer } from "../mcp/config-helpers";
+import { type ProjectMcpTarget, projectMcpTarget } from "../mcp/project-proxy";
+import type { SetupProvider } from "../mcp/providers";
+import { readCodexProjectMcpEntry } from "../mcp/providers/codex";
+import { assertSafeProjectPath } from "./project-root";
+
+export type ProjectProviderInspection =
+  | { providerID: string; path: string | null; status: "absent" }
+  | {
+      providerID: string;
+      path: string;
+      status: "owned";
+      target: ProjectMcpTarget;
+    }
+  | { providerID: string; path: string; status: "foreign" }
+  | { providerID: string; path: string | null; status: "malformed"; error?: string };
+
+type ProjectBindingBlocker = Extract<
+  ProjectProviderInspection,
+  { status: "foreign" | "malformed" }
+>;
+
+export interface RepositoryBindingState {
+  projectRoot: string;
+  inspections: ProjectProviderInspection[];
+  blockers: ProjectBindingBlocker[];
+  targets: ProjectMcpTarget[];
+  ownedProviderIDs: string[];
+}
+
+const JSON_TOP_KEY: Readonly<Record<string, string>> = {
+  claude: "mcpServers",
+  cursor: "mcpServers",
+  vscode: "servers",
+  gemini: "mcpServers",
+  zed: "context_servers",
+  copilot: "mcpServers",
+  opencode: "mcp",
+  mcporter: "mcpServers",
+  factory: "mcpServers",
+};
+
+export function inspectProjectProvider(
+  provider: SetupProvider,
+  projectRoot: string,
+): ProjectProviderInspection {
+  const providerID = provider.id();
+  let path: string | null = null;
+
+  try {
+    path = provider.projectConfigPath(projectRoot);
+    if (!path) return { providerID, path, status: "absent" };
+    assertSafeProjectPath(projectRoot, path);
+    if (!existsSync(path)) return { providerID, path, status: "absent" };
+    let entry: unknown;
+    if (providerID === "codex") {
+      entry = readCodexProjectMcpEntry(projectRoot);
+    } else {
+      const topKey = JSON_TOP_KEY[providerID];
+      if (!topKey) {
+        return {
+          providerID,
+          path,
+          status: "malformed",
+          error: "unsupported project config format",
+        };
+      }
+      entry = getJSONServer(path, topKey);
+    }
+    if (entry === undefined) return { providerID, path, status: "absent" };
+    const target = projectMcpTarget(entry);
+    if (!target) return { providerID, path, status: "foreign" };
+    return { providerID, path, status: "owned", target };
+  } catch (error: unknown) {
+    return {
+      providerID,
+      path,
+      status: "malformed",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function targetKey(target: ProjectMcpTarget): string {
+  return target.kind === "oss" ? "oss" : `deployment:${target.deploymentID}`;
+}
+
+export function inspectRepositoryBindings(
+  projectRoot: string,
+  providers: readonly SetupProvider[],
+): RepositoryBindingState {
+  const inspections = providers
+    .filter((provider) => provider.configurationKind() === "project")
+    .map((provider) => inspectProjectProvider(provider, projectRoot));
+  const blockerByPath = new Map<string, ProjectBindingBlocker>();
+  const targetByKey = new Map<string, ProjectMcpTarget>();
+  const ownedProviderIDs = new Set<string>();
+
+  for (const inspection of inspections) {
+    if (inspection.status === "foreign" || inspection.status === "malformed") {
+      blockerByPath.set(inspection.path ?? `${inspection.providerID}:unknown`, inspection);
+    }
+    if (inspection.status === "owned") {
+      targetByKey.set(targetKey(inspection.target), inspection.target);
+      ownedProviderIDs.add(inspection.providerID);
+    }
+  }
+
+  return {
+    projectRoot,
+    inspections,
+    blockers: [...blockerByPath.values()],
+    targets: [...targetByKey.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([, target]) => target),
+    ownedProviderIDs: [...ownedProviderIDs].sort(),
+  };
+}
+
+export function repositoryNeedsTargetReplacement(
+  state: RepositoryBindingState,
+  deploymentID: string,
+): boolean {
+  return state.targets.some(
+    (target) => target.kind === "oss" || target.deploymentID !== deploymentID,
+  );
+}

--- a/src/setup/repository-scan.test.ts
+++ b/src/setup/repository-scan.test.ts
@@ -1,0 +1,77 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { scanGitRepositories, validateScanDirectories } from "./repository-scan";
+
+describe("repository scanning", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), "dosu-repo-scan-")));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function initRepository(path: string): void {
+    mkdirSync(path, { recursive: true });
+    execFileSync("git", ["init", "-q", path]);
+    execFileSync("git", ["-C", path, "config", "user.name", "Dosu Test"]);
+    execFileSync("git", ["-C", path, "config", "user.email", "dosu@example.test"]);
+    writeFileSync(join(path, "README.md"), "test\n");
+    execFileSync("git", ["-C", path, "add", "README.md"]);
+    execFileSync("git", ["-C", path, "commit", "-qm", "initial"]);
+  }
+
+  it("finds a normal checkout and each linked worktree as separate projects", () => {
+    const repository = join(tempDir, "projects", "main");
+    const worktree = join(tempDir, "projects", "feature");
+    initRepository(repository);
+    execFileSync("git", ["-C", repository, "worktree", "add", "-qb", "feature", worktree]);
+
+    expect(scanGitRepositories([join(tempDir, "projects")])).toEqual([
+      { kind: "worktree", path: realpathSync(worktree) },
+      { kind: "repository", path: realpathSync(repository) },
+    ]);
+  });
+
+  it("does not follow directory symlinks while scanning", () => {
+    const outside = join(tempDir, "outside", "repo");
+    const scanRoot = join(tempDir, "scan");
+    initRepository(outside);
+    mkdirSync(scanRoot);
+    symlinkSync(dirname(outside), join(scanRoot, "linked"));
+
+    expect(scanGitRepositories([scanRoot])).toEqual([]);
+  });
+
+  it("deduplicates overlapping scan roots", () => {
+    const repository = join(tempDir, "projects", "repo");
+    initRepository(repository);
+
+    expect(scanGitRepositories([join(tempDir, "projects"), repository])).toEqual([
+      { kind: "repository", path: realpathSync(repository) },
+    ]);
+  });
+
+  it("rejects Home, its ancestors, missing paths, and symlinked roots", () => {
+    const fakeHome = join(tempDir, "home", "user");
+    const safeRoot = join(fakeHome, "code");
+    mkdirSync(safeRoot, { recursive: true });
+    const linkedRoot = join(tempDir, "linked-code");
+    symlinkSync(safeRoot, linkedRoot);
+
+    expect(() => validateScanDirectories([fakeHome], fakeHome)).toThrow(/Home/i);
+    expect(() => validateScanDirectories([dirname(fakeHome)], fakeHome)).toThrow(/Home/i);
+    expect(() => validateScanDirectories([join(tempDir, "missing")], fakeHome)).toThrow(
+      /directory/i,
+    );
+    expect(() => validateScanDirectories([linkedRoot], fakeHome)).toThrow(/symbolic link/i);
+    expect(validateScanDirectories([safeRoot, safeRoot], fakeHome)).toEqual([
+      realpathSync(safeRoot),
+    ]);
+  });
+});

--- a/src/setup/repository-scan.ts
+++ b/src/setup/repository-scan.ts
@@ -1,0 +1,114 @@
+import { execFileSync } from "node:child_process";
+import { type Dirent, existsSync, lstatSync, readdirSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { hasSymlinkInPath } from "./project-root";
+
+export interface ScannedRepository {
+  path: string;
+  kind: "repository" | "worktree";
+}
+
+function expandInputPath(value: string, home: string): string {
+  const trimmed = value.trim();
+  if (trimmed === "~") return home;
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return join(home, trimmed.slice(2));
+  }
+  return resolve(trimmed);
+}
+
+function containsPath(parent: string, child: string): boolean {
+  const childRelative = relative(parent, child);
+  return (
+    childRelative === "" ||
+    (!childRelative.startsWith(`..${sep}`) && childRelative !== ".." && !isAbsolute(childRelative))
+  );
+}
+
+/** Validate user-approved scan roots without ever accepting Home or a parent of Home. */
+export function validateScanDirectories(
+  inputs: readonly string[],
+  home: string = homedir(),
+): string[] {
+  const resolvedHome = realpathSync(home);
+  const directories: string[] = [];
+
+  for (const input of inputs) {
+    const candidate = expandInputPath(input, resolvedHome);
+    if (existsSync(candidate) && hasSymlinkInPath(candidate)) {
+      throw new Error(`Scan path contains a symbolic link: ${candidate}`);
+    }
+    if (!existsSync(candidate) || !lstatSync(candidate).isDirectory()) {
+      throw new Error(`Scan path is not a directory: ${candidate}`);
+    }
+    const canonical = realpathSync(candidate);
+    if (containsPath(canonical, resolvedHome)) {
+      throw new Error("Choose a directory inside Home, not Home itself or one of its parents.");
+    }
+    if (!directories.includes(canonical)) directories.push(canonical);
+  }
+
+  if (directories.length === 0) throw new Error("Choose at least one scan directory.");
+  return directories;
+}
+
+function gitCheckoutKind(path: string): ScannedRepository["kind"] | null {
+  const marker = join(path, ".git");
+  if (!existsSync(marker)) return null;
+  let kind: ScannedRepository["kind"];
+  try {
+    const stat = lstatSync(marker);
+    if (stat.isSymbolicLink()) return null;
+    if (stat.isDirectory()) kind = "repository";
+    else if (stat.isFile()) kind = "worktree";
+    else return null;
+    const reportedRoot = execFileSync("git", ["-C", path, "rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+    }).trim();
+    if (realpathSync(reportedRoot) !== realpathSync(path)) return null;
+    return kind;
+  } catch {
+    return null;
+  }
+}
+
+/** Recursively find checkout roots while skipping every symbolic-link directory. */
+export function scanGitRepositories(scanDirectories: readonly string[]): ScannedRepository[] {
+  const repositories = new Map<string, ScannedRepository>();
+  const visited = new Set<string>();
+
+  const visit = (path: string): void => {
+    let canonical: string;
+    try {
+      if (lstatSync(path).isSymbolicLink()) return;
+      canonical = realpathSync(path);
+    } catch {
+      return;
+    }
+    if (visited.has(canonical)) return;
+    visited.add(canonical);
+
+    const kind = gitCheckoutKind(canonical);
+    if (kind) {
+      repositories.set(canonical, { path: canonical, kind });
+      return;
+    }
+
+    let entries: Dirent<string>[];
+    try {
+      entries = readdirSync(canonical, { withFileTypes: true, encoding: "utf8" });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === ".git" || entry.isSymbolicLink() || !entry.isDirectory()) continue;
+      visit(join(canonical, entry.name));
+    }
+  };
+
+  for (const directory of scanDirectories) visit(directory);
+  return [...repositories.values()].sort((left, right) => left.path.localeCompare(right.path));
+}

--- a/src/setup/rules-step.ts
+++ b/src/setup/rules-step.ts
@@ -77,6 +77,7 @@ export async function stepConfigureAgentRules(
   selection: SetupSelection,
   mcpResults: McpResult[],
   projectRoot?: string,
+  canonicalRule?: string,
 ): Promise<AgentRuleSetupResult[]> {
   const successfulInstalls = successfulAgentIDs(mcpResults, "install");
   const successfulRemovals = successfulAgentIDs(mcpResults, "remove");
@@ -95,7 +96,7 @@ export async function stepConfigureAgentRules(
   const results: AgentRuleSetupResult[] = [];
 
   if (toInstall.length > 0) {
-    const content = await fetchDosuRule();
+    const content = canonicalRule ?? (await fetchDosuRule());
     for (const provider of toInstall) {
       try {
         const installed = installRuleForAgent(provider.id(), content, projectRoot);

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -35,6 +35,14 @@ vi.mock("../setup/flow", () => ({
   runSetup: vi.fn(),
 }));
 
+vi.mock("../setup/bulk-flow", () => ({
+  runBulkProjectSetup: vi.fn(),
+}));
+
+vi.mock("../commands/upgrade", () => ({
+  completeUpgrade: vi.fn(),
+}));
+
 vi.mock("../commands/insights", () => ({
   executeInsights: vi.fn(),
 }));
@@ -55,9 +63,11 @@ import { OAuthCallbackError } from "../auth/errors";
 import { startOAuthFlow } from "../auth/flow";
 import { Client } from "../client/client";
 import { executeInsights } from "../commands/insights";
+import { completeUpgrade } from "../commands/upgrade";
 import type { Config } from "../config/config";
 import { emptyConfig, loadConfig, saveConfig, updateTarget } from "../config/config";
 import { type FlatTestConfig, makeTestConfig } from "../config/config.test-utils";
+import { runBulkProjectSetup } from "../setup/bulk-flow";
 import { runSetup } from "../setup/flow";
 import { handleLogout, runTUI } from "./tui";
 
@@ -67,6 +77,8 @@ const mockIsCancel = vi.mocked(p.isCancel);
 const mockOutro = vi.mocked(p.outro);
 const mockStartOAuthFlow = vi.mocked(startOAuthFlow);
 const mockRunSetup = vi.mocked(runSetup);
+const mockRunBulkProjectSetup = vi.mocked(runBulkProjectSetup);
+const mockCompleteUpgrade = vi.mocked(completeUpgrade);
 const mockExecuteInsights = vi.mocked(executeInsights);
 
 // ---------------------------------------------------------------------------
@@ -185,6 +197,27 @@ describe("handleLogout (direct)", () => {
 // ---------------------------------------------------------------------------
 
 describe("runTUI", () => {
+  it("keeps the three core project and upgrade entries in the main menu", async () => {
+    mockSelect.mockResolvedValueOnce("exit");
+    mockIsCancel.mockReturnValue(false);
+
+    await runTUI();
+
+    const opts = mockSelect.mock.calls[0]?.[0]?.options as Array<{
+      label: string;
+      value: string;
+    }>;
+    expect(opts.slice(0, 3)).toEqual([
+      { label: "Configure current project", value: "setup", hint: "Configure this Git project" },
+      {
+        label: "Configure projects in bulk",
+        value: "bulk-setup",
+        hint: "Scan selected directories and configure several Git projects",
+      },
+      { label: "Upgrade Dosu", value: "upgrade", hint: "Update the CLI and installed skills" },
+    ]);
+  });
+
   it("shows the main menu before authentication", async () => {
     mockSelect.mockResolvedValueOnce("exit");
     mockIsCancel.mockReturnValue(false);
@@ -484,5 +517,32 @@ describe("runTUI", () => {
 
     const nextOptions = mockSelect.mock.calls[1]?.[0]?.options as Array<{ value: string }>;
     expect(nextOptions.map((option) => option.value)).not.toContain("insights");
+  });
+
+  it("runs bulk project setup and reloads saved scan directories", async () => {
+    const cfg = makeCfg({ access_token: "tok" });
+    writeRealConfig(cfg);
+    mockIsCancel.mockReturnValue(false);
+    mockRunBulkProjectSetup.mockImplementation(async (current) => {
+      current.scan_directories = ["/work/repos"];
+      writeRealConfig(current);
+      return { status: "completed", repositories: [] };
+    });
+    mockSelect.mockResolvedValueOnce("bulk-setup").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockRunBulkProjectSetup).toHaveBeenCalled();
+    expect(readRealConfig().scan_directories).toEqual(["/work/repos"]);
+  });
+
+  it("runs the existing CLI upgrade path from the TUI", async () => {
+    mockIsCancel.mockReturnValue(false);
+    mockCompleteUpgrade.mockResolvedValue(0);
+    mockSelect.mockResolvedValueOnce("upgrade").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockCompleteUpgrade).toHaveBeenCalledOnce();
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -8,6 +8,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { Client } from "../client/client";
 import { executeInsights } from "../commands/insights";
+import { completeUpgrade } from "../commands/upgrade";
 import {
   clearConfigInPlace,
   isAuthenticated,
@@ -15,6 +16,7 @@ import {
   replaceLoginSession,
   saveConfig,
 } from "../config/config";
+import { runBulkProjectSetup } from "../setup/bulk-flow";
 import { runSetup } from "../setup/flow";
 import { browserFallbackHint } from "../setup/styles";
 
@@ -43,9 +45,19 @@ export async function runTUI(): Promise<void> {
     );
     const options: Array<{ label: string; value: string; hint?: string }> = [
       {
-        label: "Setup",
+        label: "Configure current project",
         value: "setup",
-        hint: "Configure MCP for your AI tools",
+        hint: "Configure this Git project",
+      },
+      {
+        label: "Configure projects in bulk",
+        value: "bulk-setup",
+        hint: "Scan selected directories and configure several Git projects",
+      },
+      {
+        label: "Upgrade Dosu",
+        value: "upgrade",
+        hint: "Update the CLI and installed skills",
       },
     ];
     if (insightsReady) {
@@ -86,6 +98,18 @@ export async function runTUI(): Promise<void> {
           cfg.mode = fresh.mode;
           cfg.active_account = fresh.active_account;
         }
+        break;
+      case "bulk-setup":
+        await runBulkProjectSetup(cfg);
+        {
+          const fresh = loadConfig();
+          cfg.mode = fresh.mode;
+          cfg.scan_directories = fresh.scan_directories;
+          cfg.active_account = fresh.active_account;
+        }
+        break;
+      case "upgrade":
+        await completeUpgrade();
         break;
       case "insights":
         await executeInsights(cfg);


### PR DESCRIPTION
## Summary

- add a TUI bulk setup path with the fixed flow: select Library → select projects → select one agent set → preview → execute
- let users enter and persist explicit scan directories while rejecting Home, parents of Home, missing paths, and symlinked roots; recursive scanning never follows directory symlinks
- discover both normal Git repositories and linked worktree checkouts as independent project paths
- use project MCP files as the only binding source of truth; global config stores only scan directories and the existing per-deployment credentials
- require an individual confirmation before replacing a project's Library binding and block foreign, malformed, duplicate, symlinked, or unsafe MCP/rule/`AGENTS.md` state before that project is changed
- execute repositories independently, continue after failures, and run legacy global reconciliation only when every selected repository verifies successfully
- keep official skills global and install them once for the selected agent set; no project skill copies, hooks, plugins, or project registry are added
- expose the three core TUI actions first: configure current project, configure projects in bulk, and upgrade Dosu

This is stack **3/3**, based on #170.

## Safety and behavior

- cancellation before the final confirmation performs no config, skill, or project write
- scan traversal uses real paths, skips symlink entries, and validates checkout roots with `git rev-parse --show-toplevel`
- normal repositories (`.git` directory) and linked worktrees (`.git` file) remain separate selectable checkouts, matching Git's worktree model ([Git worktree docs](https://git-scm.com/docs/git-worktree), [git rev-parse docs](https://git-scm.com/docs/git-rev-parse))
- preflight reads all supported project MCP files and the selected agents' rules plus `AGENTS.md`; foreign/malformed content blocks that repository instead of being overwritten
- approved Library replacement retargets every existing Dosu-owned project MCP entry so a repository cannot be left split across Libraries
- project files contain only `dosu mcp proxy --deployment <id>`; API keys remain in the private global v3 credential registry
- one repository failure never rolls back successful repositories and never stops later repositories, but it withholds global cleanup for the whole batch

## Red / green evidence

- red commit `a2a1084`: 7 focused files failed against the previous layer (four missing bulk modules plus scan-directory persistence, project-target extraction, and duplicate-rule safety failures)
- green commit `c5eb5d0`: the same focused area passes — 7 files, 125 tests
- follow-up red/green commits `f64888e` / `42b74b7`: agents without a supported skill target no longer produce an empty global-skill install step, and per-project failures are printed with their path and reason
- coverage red/green: exact head `42b74b7` reproduced the CI failure at 89.07% branch coverage; test-only commit `25116cc` covers bulk cancellation/failure and MCP-inspection safety branches without changing production code
- full suite: 80 files, 1,883 tests passed with 90.07% branch coverage
- `bun run check`, `bun run deadcode`, and `bun run typecheck`
- Bun 1.4.0 native build, npm build, `npm pack --dry-run`, and all seven platform binaries
- GitHub CI on exact head `25116cc`: lint/dead-code, typecheck, coverage tests, builds, and Windows npm smoke all passed ([run](https://github.com/dosu-ai/dosu-cli/actions/runs/33021761234))
- isolated packed-CLI TUI smoke: selected **Library B**, selected one normal repository plus one linked worktree, selected MCPorter once, previewed, and executed; both checkouts received secretless `dep-b` project MCP plus `AGENTS.md`, no project skill directory appeared, the active global Library stayed `dep-a`, both Library credentials remained intact, the scan root was persisted, and exact old global Dosu MCP was removed while unrelated global content remained; a second packed-CLI run reported both projects already up to date, performed no empty skill step, and made no global cleanup mutation

## Stack

- #169 — project-scoped setup foundation (1/3)
- #170 — safe legacy global reconciliation (2/3)
- **this PR — bulk project TUI (3/3)**

## 2026-08-27 refresh

- absorbed refreshed #170 without conflicts or force-pushing; bulk production logic remained unchanged
- exact head: e1cc8aa
- full local gate: 82 files / 1,942 tests, 90.00% branch coverage, check, dead-code, typecheck, native build, seven-platform build, and npm pack
- exact-head GitHub CI passed through temporary validation PR #197: https://github.com/dosu-ai/dosu-cli/actions/runs/33116481801
- validation PR #197 was closed and its remote branch deleted after the run