### PR TITLE
fix: remove retired library auto-publish setting

### DIFF
--- a/src/commands/libraries.test.ts
+++ b/src/commands/libraries.test.ts
@@ -160,6 +160,14 @@ describe("libraries config", () => {
     expect(mockQuery).not.toHaveBeenCalled();
     expect(mockMutate).not.toHaveBeenCalled();
   });
+
+  it("rejects the removed default save-publish setting before any request", async () => {
+    await expect(
+      run("config", "set", LIBRARY, "default_save_publish", "--value", "true", "--confirm"),
+    ).rejects.toThrow();
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
 });
 
 describe("libraries sources", () => {

--- a/src/commands/libraries.ts
+++ b/src/commands/libraries.ts
@@ -14,13 +14,13 @@ import { confirmAction } from "./confirmation";
 import { formatDate, printInfo, printResult, printTable } from "./output";
 
 const LIBRARY_VISIBILITIES = ["public", "internal", "private"] as const;
-const CONFIG_SETTINGS: Record<LibrariesConfigSetInput["setting"], true> = {
+type ConfigSetting = Exclude<LibrariesConfigSetInput["setting"], "default_save_publish">;
+const CONFIG_SETTINGS: Record<ConfigSetting, true> = {
   commit_to_trigger_pr: true,
   default_accept_review: true,
-  default_save_publish: true,
   review_timeout_days: true,
 };
-const CONFIG_SETTING_NAMES = Object.keys(CONFIG_SETTINGS) as LibrariesConfigSetInput["setting"][];
+const CONFIG_SETTING_NAMES = Object.keys(CONFIG_SETTINGS) as ConfigSetting[];
 
 function validatedDocumentationValue(
   setting: LibrariesConfigSetInput["setting"],
@@ -214,7 +214,7 @@ export function librariesCommand(): Command {
     .action(
       async (
         libraryId: string,
-        setting: LibrariesConfigSetInput["setting"],
+        setting: ConfigSetting,
         opts: { value: CliJson; confirm?: boolean; json?: boolean },
       ) => {
         const value = validatedDocumentationValue(setting, opts.value);


### PR DESCRIPTION
## Summary

- remove `default_save_publish` from the supported `libraries config set` choices
- preserve exhaustive type checking against both the current vendored contract and the incoming API contract
- cover rejection of the retired setting before any API request

This unblocks the CLI Consumer Typecheck for dosu-ai/dosu#12266. Merge this PR before rerunning that PR CI.

## Testing

- `bun run typecheck`
- incoming dosu-ai/dosu#12266 contract + `bun run typecheck`
- `bunx vitest run src/commands/libraries.test.ts`
- `bun run test` (71 files, 1,678 tests)
- `bun run check`