### PR TITLE
fix(telemetry): associate CLI events with organizations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,9 @@ All tRPC calls MUST be typed through the generated contract (`CliApiClient` / `T
 
 Telemetry is enabled by default and has one global enable/disable switch. Signed-out command events
 use a random installation ID. Signed-in command and setup-funnel events use the stable Dosu user ID;
-Sentry errors may additionally include that user's email. Never alias prior installation history to
-an account.
+when a selected organization UUID is available, analytics events associate it through
+`$groups.organization`. Sentry errors may additionally include that user's email. Never alias prior
+installation history to an account.
 Setup analytics may include only the documented coarse fields. Never collect prompts, raw command
 lines, free-form argument or option values, user source code, file contents, local paths, environment
 variable names or values, credentials, raw error messages, or `debug.log`. Keep payloads allowlisted, transports

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -8,7 +8,8 @@ does, what it must never do, and the operational work required before a producti
 Dosu sends two kinds of telemetry:
 
 1. **Usage analytics** measure whether coarse, named CLI workflows succeed. Signed-in commands use
-   the same stable Dosu user ID as the web app; signed-out commands use a random installation ID.
+   the same stable Dosu user ID as the web app and, when available, associate the event with the
+   selected organization UUID; signed-out commands use a random installation ID.
 2. **Error diagnostics** send a minimal error fingerprint, Dosu-owned stack frames, and, when the
    local session has a verified identity, only the user's ID and email.
 
@@ -95,15 +96,19 @@ The `properties` allowlist is:
 | `is_ci` | Boolean. |
 | `is_tty` | Boolean for stdout. |
 | `mode` | `cloud` or `oss`. |
+| `org_id` | Optional validated organization UUID from the authenticated account's selected target. |
+| `$groups` | Optional `{ "organization": "<org UUID>" }` PostHog group association, present only with a validated signed-in user and organization UUID. |
 | `is_authenticated` | Boolean only; it does not duplicate the top-level identity. |
 | `exit_code` | Integer clamped to `0..255`. |
 | `error_code` | Optional validated, stable, low-cardinality code; never a message. |
 
 Signed-in command events join the existing PostHog person identified by the web app with the same
-Dosu user UUID. The CLI does not send email to PostHog on this path and does not alias prior
-installation history, avoiding cross-account linkage on shared machines. Signed-out `distinct_id`
-is pseudonymous rather than anonymous: it links command events from one installation until the
-user rotates it.
+Dosu user UUID. When the current authenticated config has a selected organization UUID, the event
+also carries `org_id` for property-based queries and `$groups.organization` so PostHog organization
+funnels can aggregate it. The CLI does not send email to PostHog on this path and does not alias
+prior installation history, avoiding cross-account linkage on shared machines. Signed-out
+`distinct_id` is pseudonymous rather than anonymous: it links command events from one installation
+until the user rotates it.
 
 ### Error diagnostics: Sentry
 
@@ -162,6 +167,9 @@ development origins.
 When authentication completes, the server aliases that run ID to the signed-in user ID, identifies
 the PostHog person with user ID and email, and captures subsequent events under the user ID.
 Authenticated events may also include `org_id`, `deployment_id`, and `space_id`.
+When `org_id` is a UUID, they also include `$groups.organization` with the same value so PostHog
+organization funnels can aggregate those events. Pre-auth events and authenticated events without
+a selected organization do not include a group association.
 
 Current common setup properties are `cli_version`, `install_channel`, `platform`, `arch`, and `mode`.
 Current callers also use only these workflow properties: `onboarding_run_id`,
@@ -192,7 +200,8 @@ The payloads constructed by the CLI never include:
 - arbitrary environment-variable names or values (the explicitly configured public PostHog token
   and Sentry DSN are transport metadata, not event properties);
 - configuration contents other than the validated session user ID/email and setup identifiers
-  listed above, cookies, vendor management keys, or command/API request and response bodies.
+  listed above, including the selected organization UUID used for group association, cookies,
+  vendor management keys, or command/API request and response bodies.
   Telemetry event fields never contain Dosu credentials; authenticated setup requests necessarily
   carry the existing Dosu session token as a transport header to the Dosu API, where it is used for
   authorization and is not forwarded to PostHog or Sentry;

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -177,6 +177,7 @@ describe("CLI", () => {
     const originalConfigRoot = process.env.XDG_CONFIG_HOME;
     process.env.XDG_CONFIG_HOME = configRoot;
     const userID = "22222222-2222-4222-8222-222222222222";
+    const orgID = "33333333-3333-4333-8333-333333333333";
     const payload = Buffer.from(
       JSON.stringify({ sub: userID, email: "user@example.com", private: "must-not-leak" }),
     ).toString("base64url");
@@ -193,6 +194,7 @@ describe("CLI", () => {
         active_account: {
           user_id: userID,
           session: { access_token: accessToken, refresh_token: "refresh-secret", expires_at: 0 },
+          target: { org_id: orgID },
         },
       });
 
@@ -202,6 +204,7 @@ describe("CLI", () => {
         mode: "cloud",
         isAuthenticated: true,
         user: { id: userID, email: "user@example.com" },
+        orgId: orgID,
       });
       const calls = JSON.stringify(vi.mocked(telemetry.start).mock.calls);
       expect(calls).not.toContain(accessToken);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -105,10 +105,12 @@ function commandTelemetryContext(): CommandTelemetryContext {
     const tokenUserID = getAccessTokenUserID(accessToken);
     const userID = configUserID && configUserID === tokenUserID ? configUserID : undefined;
     const email = userID ? getAccessTokenEmail(accessToken) : undefined;
+    const orgId = userID ? cfg.active_account?.target?.org_id : undefined;
     return {
       mode: cfg.mode === MODE_OSS ? "oss" : "cloud",
       isAuthenticated: authenticated,
       ...(userID ? { user: { id: userID, ...(email ? { email } : {}) } } : {}),
+      ...(orgId ? { orgId } : {}),
     };
   } catch {
     return { mode: "cloud", isAuthenticated: false };

--- a/src/setup/analytics.test.ts
+++ b/src/setup/analytics.test.ts
@@ -35,6 +35,7 @@ import { trackCliOnboardingEvent, trackCliOnboardingPreAuthEvent } from "./analy
 const mutate = vi.fn();
 const RUN_ID = "11111111-1111-4111-8111-111111111111";
 const OTHER_RUN_ID = "22222222-2222-4222-8222-222222222222";
+const ORG_ID = "33333333-3333-4333-8333-333333333333";
 let originalPostHogOverride: string | undefined;
 
 function makeConfig(overrides: Partial<FlatTestConfig> = {}): Config {
@@ -42,7 +43,7 @@ function makeConfig(overrides: Partial<FlatTestConfig> = {}): Config {
     access_token: "token",
     refresh_token: "refresh",
     expires_at: 0,
-    org_id: "org-1",
+    org_id: ORG_ID,
     deployment_id: "dep-1",
     space_id: "space-1",
     ...overrides,
@@ -170,12 +171,25 @@ describe("setup analytics", () => {
         onboarding_run_id: RUN_ID,
         install_channel: "npm",
         mode: "oss",
-        org_id: "org-1",
+        org_id: ORG_ID,
+        $groups: { organization: ORG_ID },
         deployment_id: "dep-1",
         space_id: "space-1",
         completed_mcp: true,
       }),
     });
+  });
+
+  it("does not associate onboarding events with a non-UUID organization identifier", async () => {
+    await trackCliOnboardingEvent(
+      makeConfig({ org_id: "organization-name" }),
+      RUN_ID,
+      "cli_onboarding_started",
+    );
+
+    const properties = mutate.mock.calls[0]?.[0].properties;
+    expect(properties).not.toHaveProperty("org_id");
+    expect(properties).not.toHaveProperty("$groups");
   });
 
   it("logs and swallows authenticated tracking failures", async () => {

--- a/src/setup/analytics.ts
+++ b/src/setup/analytics.ts
@@ -42,7 +42,11 @@ interface CliOnboardingProperties {
   logs_handoff?: "accepted" | "declined" | "cancelled";
 }
 
-type SafePropertyValue = string | number | boolean | string[] | undefined;
+interface OrganizationGroups {
+  organization: string;
+}
+
+type SafePropertyValue = string | number | boolean | string[] | OrganizationGroups | undefined;
 type SafeProperties = Record<string, SafePropertyValue>;
 
 const SETUP_FAILURE_REASONS = new Set([
@@ -157,13 +161,14 @@ function analyticsReleaseEnabled(): boolean {
 }
 
 function baseProperties(cfg: Config): SafeProperties {
+  const orgId = cfg.active_account?.target?.org_id;
   return {
     cli_version: safeIdentifier(VERSION, 32),
     install_channel: safeIdentifier(INSTALL_CHANNEL, 32),
     platform: safeIdentifier(process.platform, 24),
     arch: safeIdentifier(process.arch, 24),
     mode: cfg.mode ?? "cloud",
-    org_id: safeIdentifier(cfg.active_account?.target?.org_id, 128),
+    ...(orgId && isUUID(orgId) ? { org_id: orgId, $groups: { organization: orgId } } : {}),
     deployment_id: safeIdentifier(cfg.active_account?.target?.deployment_id, 128),
     space_id: safeIdentifier(cfg.active_account?.target?.space_id, 128),
   };

--- a/src/telemetry/telemetry.test.ts
+++ b/src/telemetry/telemetry.test.ts
@@ -41,6 +41,7 @@ const AUTHENTICATED_CONTEXT = {
     id: "22222222-2222-4222-8222-222222222222",
     email: "user@example.com",
   },
+  orgId: "33333333-3333-4333-8333-333333333333",
 } as const;
 
 const DOSU_SOURCE_FILE = fileURLToPath(new URL("../commands/ask.ts", import.meta.url));
@@ -137,7 +138,50 @@ describe("safe payload builders", () => {
 
     expect(payload.distinct_id).toBe("22222222-2222-4222-8222-222222222222");
     expect(payload.properties).not.toHaveProperty("$process_person_profile");
+    expect(payload.properties).toMatchObject({
+      org_id: "33333333-3333-4333-8333-333333333333",
+      $groups: { organization: "33333333-3333-4333-8333-333333333333" },
+    });
     expect(JSON.stringify(payload)).not.toContain("user@example.com");
+  });
+
+  it("omits organization association unless both user and organization IDs are valid", () => {
+    const invalidUserPayload = buildPostHogPayload({
+      apiKey: "phc_public_project_token",
+      installId: "11111111-1111-4111-8111-111111111111",
+      command: "status",
+      result: "success",
+      durationMs: 1,
+      exitCode: 0,
+      context: {
+        mode: "cloud",
+        isAuthenticated: true,
+        user: { id: "not-a-user-id" },
+        orgId: "33333333-3333-4333-8333-333333333333",
+      },
+      runtime: SAFE_RUNTIME,
+    });
+
+    const invalidOrgPayload = buildPostHogPayload({
+      apiKey: "phc_public_project_token",
+      installId: "11111111-1111-4111-8111-111111111111",
+      command: "status",
+      result: "success",
+      durationMs: 1,
+      exitCode: 0,
+      context: {
+        mode: "cloud",
+        isAuthenticated: true,
+        user: { id: "22222222-2222-4222-8222-222222222222" },
+        orgId: "organization-name",
+      },
+      runtime: SAFE_RUNTIME,
+    });
+
+    for (const payload of [invalidUserPayload, invalidOrgPayload]) {
+      expect(payload.properties).not.toHaveProperty("org_id");
+      expect(payload.properties).not.toHaveProperty("$groups");
+    }
   });
 
   it("keeps command events personless when authenticated identity is invalid", () => {

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -106,6 +106,7 @@ export interface TelemetrySettings {
 export interface CommandTelemetryContext {
   mode?: "cloud" | "oss";
   isAuthenticated?: boolean;
+  orgId?: string;
   user?: {
     id?: string;
     email?: string;
@@ -115,6 +116,7 @@ export interface CommandTelemetryContext {
 interface NormalizedContext {
   mode: "cloud" | "oss";
   isAuthenticated: boolean;
+  orgId?: string;
   user?: {
     id: string;
     email?: string;
@@ -150,6 +152,7 @@ export interface SafeError {
 
 interface PostHogProperties {
   $geoip_disable: true;
+  $groups?: { organization: string };
   $process_person_profile?: false;
   schema_version: 1;
   command: string;
@@ -164,6 +167,7 @@ interface PostHogProperties {
   is_ci: boolean;
   is_tty: boolean;
   mode: "cloud" | "oss";
+  org_id?: string;
   is_authenticated: boolean;
   exit_code: number;
   error_code?: string;
@@ -256,14 +260,14 @@ function normalizeContext(context: CommandTelemetryContext | undefined): Normali
   const isAuthenticated = context?.isAuthenticated === true;
   const id = safeRead(context?.user, "id");
   const email = safeRead(context?.user, "email");
+  const orgId = safeRead(context, "orgId");
   const user =
-    isAuthenticated && validUserId(id)
-      ? { id, ...(validEmail(email) ? { email } : {}) }
-      : undefined;
+    isAuthenticated && isUUID(id) ? { id, ...(validEmail(email) ? { email } : {}) } : undefined;
   return {
     mode: context?.mode === "oss" ? "oss" : "cloud",
     isAuthenticated,
     ...(user ? { user } : {}),
+    ...(user && isUUID(orgId) ? { orgId } : {}),
   };
 }
 
@@ -285,15 +289,11 @@ function normalizeRuntime(runtime: RuntimeMetadata): RuntimeMetadata {
   };
 }
 
-function validInstallId(value: unknown): value is string {
+function isUUID(value: unknown): value is string {
   return (
     typeof value === "string" &&
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
   );
-}
-
-function validUserId(value: unknown): value is string {
-  return validInstallId(value);
 }
 
 function validEmail(value: unknown): value is string {
@@ -493,7 +493,7 @@ export function buildPostHogPayload(input: PostHogPayloadInput): PostHogPayload 
   return {
     api_key: input.apiKey,
     distinct_id:
-      context.user?.id ?? (validInstallId(input.installId) ? input.installId : FALLBACK_INSTALL_ID),
+      context.user?.id ?? (isUUID(input.installId) ? input.installId : FALLBACK_INSTALL_ID),
     event: "cli_command_completed",
     properties: {
       $geoip_disable: true,
@@ -511,6 +511,12 @@ export function buildPostHogPayload(input: PostHogPayloadInput): PostHogPayload 
       is_ci: runtime.isCi,
       is_tty: runtime.isTty,
       mode: context.mode,
+      ...(context.orgId
+        ? {
+            org_id: context.orgId,
+            $groups: { organization: context.orgId },
+          }
+        : {}),
       is_authenticated: context.isAuthenticated,
       exit_code: normalizeExitCode(input.exitCode),
       ...(errorCode ? { error_code: errorCode } : {}),
@@ -655,7 +661,14 @@ export function buildSentryEnvelope(input: SentryEnvelopeInput): SentryEnvelope 
     level: "error",
     release: `dosu-cli@${runtime.version}`,
     tags: sentryTags(command, context, runtime, error),
-    ...(context.user ? { user: context.user } : {}),
+    ...(context.user
+      ? {
+          user: {
+            id: context.user.id,
+            ...(context.user.email ? { email: context.user.email } : {}),
+          },
+        }
+      : {}),
     ...(mappedBundle
       ? {
           debug_meta: {
@@ -875,7 +888,7 @@ function safeNow(now: () => number): number {
 function safeUuid(generate: () => string): string | undefined {
   try {
     const value = generate();
-    return validInstallId(value) ? value : undefined;
+    return isUUID(value) ? value : undefined;
   } catch {
     return undefined;
   }
@@ -927,7 +940,7 @@ export function createCommandTelemetry(
   let resolvedInstallId = settings.install_id;
 
   function installId(): string | undefined {
-    if (validInstallId(resolvedInstallId)) return resolvedInstallId;
+    if (isUUID(resolvedInstallId)) return resolvedInstallId;
     if (installIdResolved) return undefined;
     installIdResolved = true;
     try {
@@ -935,7 +948,7 @@ export function createCommandTelemetry(
     } catch {
       resolvedInstallId = undefined;
     }
-    return validInstallId(resolvedInstallId) ? resolvedInstallId : undefined;
+    return isUUID(resolvedInstallId) ? resolvedInstallId : undefined;
   }
 
   function debugPayload(payload: string): void {


### PR DESCRIPTION
## Summary

- attach the authenticated selected org UUID to command events as org_id and properties.$groups.organization
- attach the same PostHog group association to authenticated setup/onboarding events
- omit group association for pre-auth events, invalid users, and non-UUID org values
- document the updated telemetry and privacy contract

## Verification

- bun run test
- bun run typecheck
- bun run check
- bun run build:npm

Historical PostHog events are intentionally not backfilled by this PR.