### PR TITLE
fix(miner): drop the stale metadata rule from the write-knowledge contract

### DIFF
--- a/src/miner/prompt-core.ts
+++ b/src/miner/prompt-core.ts
@@ -29,7 +29,6 @@ useful.
 6. Only pass repo/branch to write_knowledge when the session itself verifies them (an explicit
 cwd, git remote, or branch mentioned in the transcript). Never infer or guess a repo. When not
 verified, omit both.
-7. Populate write_knowledge metadata with source_agent and session_id for every note.
-8. Never quote credentials, tokens, or secrets — even redacted placeholders — and never include
+7. Never quote credentials, tokens, or secrets — even redacted placeholders — and never include
 long verbatim transcript spans. Summarize in your own words.
-9. A trivial session with no real user query is normal: skip it silently.`;
+8. A trivial session with no real user query is normal: skip it silently.`;

--- a/src/miner/prompt.test.ts
+++ b/src/miner/prompt.test.ts
@@ -16,7 +16,7 @@ describe("buildMinerSystemPrompt", () => {
     expect(prompt).toContain("durable");
     expect(prompt).toContain("EXCLUDE in-flight state");
     expect(prompt).toContain("Never infer or guess a repo");
-    expect(prompt).toContain("source_agent and session_id");
+    expect(prompt).not.toContain("metadata");
     expect(prompt).toContain("Never quote credentials");
   });
 


### PR DESCRIPTION
### What

Removes rule 7 from the miner's write-knowledge rules (`src/miner/prompt-core.ts`): "Populate write_knowledge metadata with source_agent and session_id for every note."

### Why

- `write_knowledge` no longer has a `metadata` parameter — it was removed at source in dosu-ai/dosu#12193; session identity (session id, client, model, session start) is injected via the `X-Dosu-*` headers the miner already sends, and the backend's arg-normalization middleware just strips the unknown arg. The rule teaches the model a phantom parameter.
- Rule 6 (pass `repo`/`branch` when the transcript verifies them) stays — after dosu-ai/dosu#12417 the server schema now agrees with it instead of fighting it ("DEPRECATED — omit this" made learners write unanchored notes; see the Pi topic-page Slack thread).

Rules 8–9 renumbered to 7–8; `prompt.test.ts` updated (asserts `metadata` no longer appears in the prompt). `bunx vitest run src/miner` green (55 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
