### PR TITLE
fix(tui): let manual sync from the Activity screen ignore failure backoff

### DIFF
--- a/src/tui/activity-view.test.ts
+++ b/src/tui/activity-view.test.ts
@@ -25,6 +25,11 @@ import {
 import { ALT_SCREEN_ENTER, ALT_SCREEN_EXIT } from "./alt-screen";
 import { frameTopMargin } from "./layout";
 
+const mockSpawnDetachedSelf = vi.fn((_args: string[]) => true);
+vi.mock("../sync/detach", () => ({
+  spawnDetachedSelf: (args: string[]) => mockSpawnDetachedSelf(args),
+}));
+
 const ESC = String.fromCharCode(27);
 const CTRL_C = String.fromCharCode(3);
 
@@ -539,7 +544,9 @@ describe("renderActivityFrame", () => {
       ),
     );
     expect(frame).toContain("Mined sessions up to");
+    // The backoff line must advertise the manual escape hatch: s ignores the backoff.
     expect(frame).toContain("retrying after");
+    expect(frame).toContain("s syncs now");
     expect(frame).toContain("[sync] run started");
   });
 
@@ -1142,6 +1149,29 @@ describe("runActivityView", () => {
     expect(stripAnsi(written.join(""))).toContain(
       "[sync] sync requested \u00B7 starting a background run",
     );
+
+    input.emit("data", "q");
+    await view;
+  });
+
+  it("the default sync spawn omits --quiet so a manual run ignores the failure backoff", async () => {
+    mockSpawnDetachedSelf.mockClear();
+    const { input, output } = fakeIO();
+
+    const view = runActivityView({
+      input,
+      output,
+      getStatus: () => makeStatus(),
+      readLog: () => "",
+      createFollower: () => ({ poll() {} }),
+      // No startSync injected: the view falls through to spawnDetachedSelf.
+      listBacklog: () => ({ queued: [queuedSession()], open: [] }),
+      pollMs: 100,
+    });
+
+    input.emit("data", "s");
+    input.emit("data", "\r");
+    expect(mockSpawnDetachedSelf).toHaveBeenCalledWith(["knowledge", "sync", "--bootstrap"]);
 
     input.emit("data", "q");
     await view;

--- a/src/tui/activity-view.ts
+++ b/src/tui/activity-view.ts
@@ -356,7 +356,8 @@ export function renderActivityFrame(
   // Queue and open-session counts live in the tab bar, not a header line.
   const queueDetail: string[] = [];
   if (status.backoffUntil) {
-    queueDetail.push(`retrying after ${localTime(status.backoffUntil)}`);
+    // Manual runs skip the backoff, so point at the key instead of leaving a dead wait.
+    queueDetail.push(`retrying after ${localTime(status.backoffUntil)} \u00B7 s syncs now`);
   }
 
   // Run-scoped drain progress: batch commits advance it, and within a batch
@@ -503,9 +504,10 @@ export function runActivityView(io: ActivityViewIO = {}): Promise<void> {
   const readLog = io.readLog ?? defaultReadLog;
   const createFollower =
     io.createFollower ?? ((emit) => createLogFollower(logger.getLogPath(), emit));
-  // Bootstrap mode drains the whole displayed queue, not just one batch.
-  const startSync =
-    io.startSync ?? (() => spawnDetachedSelf(["knowledge", "sync", "--quiet", "--bootstrap"]));
+  // Bootstrap mode drains the whole displayed queue, not just one batch. Deliberately not
+  // --quiet: quiet runs honor the failure backoff and would silently skip, but pressing s is
+  // an explicit request — manual runs retry immediately (stdio is detached, so no output leaks).
+  const startSync = io.startSync ?? (() => spawnDetachedSelf(["knowledge", "sync", "--bootstrap"]));
   const stopSync = io.stopSync ?? stopSyncRun;
   const setPaused = io.setPaused ?? setSyncPaused;
   const listBacklog = io.listBacklog ?? listSessionBacklog;


### PR DESCRIPTION
## Problem

The Activity screen's `s` ("Start mining now?") spawned its manual run as `dosu knowledge sync --quiet --bootstrap`. Quiet mode honors the failure backoff by design (it's the mode session-end hooks use), so once mining had failed enough times to enter backoff, every press of `s` was silently skipped — the activity feed just filled with `skipping quiet sync: backoff until ...` lines and there was no way to rerun mining from the TUI until the backoff expired (up to 24h).

## Fix

- Drop `--quiet` from the Activity view's spawn so pressing `s` runs `dosu knowledge sync --bootstrap`. Manual runs ignore backoff and clear any pause, matching the documented contract in `watermark.ts` ("Manual runs ignore this"). The run is detached with stdio ignored, so the non-quiet stdout goes nowhere, and the miner trigger is now correctly recorded as `manual` instead of `hook`.
- The backoff status line now advertises the escape hatch: `retrying after 11:50:43 AM · s syncs now`.

## Tests

- New test pins the default spawn args to `["knowledge", "sync", "--bootstrap"]` (mocking `spawnDetachedSelf`).
- Updated the backoff-rendering assertion for the new copy.
- Full suite passes (95 files, 2164 tests); typecheck and Biome clean.