### PR TITLE
feat(knowledge): transcript-attributed notes with the backend as source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ Dosu CLI (`@dosu/cli`) — a CLI tool that manages MCP (Model Context Protocol) 
 
 ```bash
 bun install                     # Install dependencies
-bun run dev                     # Run CLI from source (loads .env.development; Bun's NODE_ENV default)
-bun run dev:local               # Run CLI from source (local dev endpoints, DOSU_DEV=true)
+bun run dev                     # Production endpoints + isolated ~/.config/dosu-cli-dev (DOSU_DEV=true)
+bun run dev:local               # Run CLI from source (local endpoints + DOSU_DEV=true)
 bun run build                   # Compile to single binary via bun build --compile
 bun run build:npm               # Bundle for npm distribution (bin/dosu.js)
 bun run build:all               # Cross-platform build matrix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosu/cli",
-  "version": "0.53.0-beta.6",
+  "version": "0.53.0-beta.5",
   "type": "module",
   "description": "Dosu CLI - Manage MCP servers for AI tools",
   "license": "MIT",
@@ -17,8 +17,8 @@
     "bin/dosu.js"
   ],
   "scripts": {
-    "dev": "bun run src/index.ts",
-    "dev:local": "DOSU_DEV=true bun run src/index.ts",
+    "dev": "DOSU_DEV=true bun --env-file=.env.production run src/index.ts",
+    "dev:local": "DOSU_DEV=true bun --env-file=.env.development run src/index.ts",
     "reset:dev": "bun run scripts/reset-dev.ts",
     "build": "bun --env-file=.env.production run scripts/build-compile.ts",
     "build:dev": "bun --env-file=.env.development run scripts/build-compile.ts",

--- a/src/client/contract.ts
+++ b/src/client/contract.ts
@@ -1,2 +1,2 @@
 export const CLI_CONTRACT_HASH: typeof import("../generated/dosu-api-types").CLI_CONTRACT_HASH =
-  "1d4be4b6214f";
+  "79ec0bbacf70";

--- a/src/commands/knowledge.test.ts
+++ b/src/commands/knowledge.test.ts
@@ -53,6 +53,11 @@ vi.mock("../sync/watermark", async (importOriginal) => ({
   loadSyncState: (...args: unknown[]) => mockLoadSyncState(...args),
 }));
 
+const mockEmitReport = vi.fn();
+vi.mock("../report/generate", () => ({
+  emitKnowledgeReport: (...args: unknown[]) => mockEmitReport(...args),
+}));
+
 interface FakeAgent {
   id: string;
   name: string;
@@ -137,6 +142,8 @@ beforeEach(() => {
   mockGetSyncStatus.mockReset();
   mockListBacklog.mockReset();
   mockLoadSyncState.mockReset();
+  mockEmitReport.mockReset();
+  mockEmitReport.mockResolvedValue("/tmp/dosu-knowledge-report.html");
   fakeAgents = [];
   enableCalls.length = 0;
   disableCalls.length = 0;
@@ -522,6 +529,57 @@ describe("knowledge sync", () => {
     await run("sync", "--json");
 
     expect(JSON.parse(allOutput())).toMatchObject({ status: "backlog", readySessions: 2 });
+  });
+
+  it("--report writes and opens the harvest HTML after a foreground sync", async () => {
+    mockLoadConfig.mockReturnValue(makeValidConfig({ deployment_id: "dep1" }));
+    mockRunSync.mockResolvedValue({
+      status: "mined",
+      readySessions: 2,
+      inFlightSessions: 0,
+      sessions: [],
+      minedSessions: 2,
+      miner: { outcome: "completed", notesWritten: 1, turns: 4 },
+    });
+
+    await run("sync", "--report", "--out", "/tmp/custom-report.html");
+
+    expect(mockEmitReport).toHaveBeenCalledWith({
+      out: "/tmp/custom-report.html",
+      open: true,
+    });
+    expect(allOutput()).toContain("Wrote /tmp/dosu-knowledge-report.html");
+  });
+
+  it("knowledge report writes the HTML without running sync", async () => {
+    mockLoadConfig.mockReturnValue(makeValidConfig({ deployment_id: "dep1" }));
+    await run("report", "--no-open");
+    expect(mockRunSync).not.toHaveBeenCalled();
+    expect(mockEmitReport).toHaveBeenCalledWith({
+      out: undefined,
+      open: false,
+    });
+    expect(allOutput()).toContain("Wrote /tmp/dosu-knowledge-report.html");
+  });
+
+  it("--quiet --report stays silent and does not write HTML", async () => {
+    mockRunSync.mockResolvedValue({ status: "mined", readySessions: 0, inFlightSessions: 0 });
+    await run("sync", "--quiet", "--report");
+    expect(mockEmitReport).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("--json --report includes the HTML path and does not open a browser", async () => {
+    mockRunSync.mockResolvedValue({ status: "nothing-new", readySessions: 0, inFlightSessions: 0 });
+    await run("sync", "--json", "--report", "--out", "/tmp/custom-report.html");
+    expect(mockEmitReport).toHaveBeenCalledWith({
+      out: "/tmp/custom-report.html",
+      open: false,
+    });
+    expect(JSON.parse(allOutput())).toMatchObject({
+      status: "nothing-new",
+      report: "/tmp/dosu-knowledge-report.html",
+    });
   });
 
   it("--detach re-spawns and never runs the pipeline inline", async () => {

--- a/src/commands/knowledge.ts
+++ b/src/commands/knowledge.ts
@@ -10,6 +10,7 @@ import { createTypedClient } from "../client/trpc";
 import { loadConfig } from "../config/config";
 import { allHookAgents, getHookAgent, type HookAgent } from "../hooks/agents";
 import { HookConfigError, hookCommand } from "../hooks/formats";
+import { emitKnowledgeReport } from "../report/generate";
 import type { AgentSession } from "../sessions/scan";
 import { listSessionBacklog } from "../sync/backlog";
 import { spawnDetachedSelf } from "../sync/detach";
@@ -202,6 +203,11 @@ export function knowledgeCommand(): Command {
       "Backfill mode: mine the full local session history regardless of age and drain the backlog (used by setup)",
     )
     .option("--status", "Show whether a sync is running now, plus watermark and recent activity")
+    .option(
+      "--report",
+      "Write the same HTML harvest report as the log-to-dosu-knowledge skill and open it",
+    )
+    .option("--out <path>", "HTML report path (default: tmp/dosu-knowledge-report.html)")
     .option("--json", "Output as JSON")
     .action(
       async (opts: {
@@ -209,6 +215,8 @@ export function knowledgeCommand(): Command {
         detach?: boolean;
         bootstrap?: boolean;
         status?: boolean;
+        report?: boolean;
+        out?: string;
         json?: boolean;
       }) => {
         // --status never scans or mines: it reads the lock, the persisted
@@ -231,6 +239,8 @@ export function knowledgeCommand(): Command {
             "sync",
             ...(opts.quiet ? ["--quiet"] : []),
             ...(opts.bootstrap ? ["--bootstrap"] : []),
+            ...(opts.report ? ["--report"] : []),
+            ...(opts.out ? ["--out", opts.out] : []),
           ]);
           return;
         }
@@ -255,14 +265,53 @@ export function knowledgeCommand(): Command {
         if (opts.quiet) return; // Invisible by contract; details are in the debug log.
 
         if (opts.json) {
-          printResult(outcome, opts);
           if (outcome.status === "error") process.exitCode = 1;
+          if (opts.report) {
+            // The sync outcome must reach stdout even when the report fails:
+            // mining already happened and callers parse this JSON.
+            try {
+              const report = await emitKnowledgeReport({ out: opts.out, open: false });
+              printResult({ ...outcome, report }, opts);
+            } catch (err) {
+              const report_error = err instanceof Error ? err.message : String(err);
+              printResult({ ...outcome, report_error }, opts);
+            }
+          } else {
+            printResult(outcome, opts);
+          }
           return;
         }
 
         printSyncOutcome(outcome);
+        if (opts.report) {
+          try {
+            const report = await emitKnowledgeReport({ out: opts.out, open: true });
+            console.log(`Wrote ${report}`);
+          } catch (err) {
+            console.error(err instanceof Error ? err.message : String(err));
+            process.exitCode = 1;
+          }
+        }
       },
     );
+
+  cmd
+    .command("report")
+    .description("Render the knowledge report from your Dosu notes and the local session logs")
+    .option("--out <path>", "HTML report path (default: tmp/dosu-knowledge-report.html)")
+    .option("--json", "Output the report path as JSON")
+    .option("--no-open", "Write the file without opening a browser")
+    .action(async (opts: { out?: string; json?: boolean; open?: boolean }) => {
+      const path = await emitKnowledgeReport({
+        out: opts.out,
+        open: opts.json ? false : opts.open,
+      });
+      if (opts.json) {
+        printResult({ report: path }, opts);
+        return;
+      }
+      console.log(`Wrote ${path}`);
+    });
 
   cmd.addCommand(hooksCommand());
 

--- a/src/config/constants.test.ts
+++ b/src/config/constants.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getBackendURL, getSupabaseAnonKey, getSupabaseURL, getWebAppURL } from "./constants";
+import {
+  getBackendURL,
+  getLlmGatewayURL,
+  getSupabaseAnonKey,
+  getSupabaseURL,
+  getWebAppURL,
+  isAbsoluteHttpUrl,
+} from "./constants";
 
 describe("constants", () => {
   const savedEnv: Record<string, string | undefined> = {};
@@ -10,6 +17,7 @@ describe("constants", () => {
     "SUPABASE_ANON_KEY",
     "DOSU_WEB_APP_URL_OVERRIDE",
     "DOSU_BACKEND_URL_OVERRIDE",
+    "DOSU_LLM_GATEWAY_URL_OVERRIDE",
     "SUPABASE_URL_OVERRIDE",
     "SUPABASE_ANON_KEY_OVERRIDE",
   ];
@@ -79,6 +87,32 @@ describe("constants", () => {
       process.env.SUPABASE_URL = "https://prod.supabase.co";
       process.env.SUPABASE_URL_OVERRIDE = "https://staging.supabase.co";
       expect(getSupabaseURL()).toBe("https://staging.supabase.co");
+    });
+  });
+
+  describe("getLlmGatewayURL", () => {
+    it("returns empty when the backend URL is unset", () => {
+      expect(getLlmGatewayURL()).toBe("");
+    });
+
+    it("appends /v1/llm-gateway to the backend URL", () => {
+      process.env.DOSU_BACKEND_URL = "https://api.dosu.dev";
+      expect(getLlmGatewayURL()).toBe("https://api.dosu.dev/v1/llm-gateway");
+    });
+
+    it("DOSU_LLM_GATEWAY_URL_OVERRIDE wins over the backend URL", () => {
+      process.env.DOSU_BACKEND_URL = "https://api.dosu.dev";
+      process.env.DOSU_LLM_GATEWAY_URL_OVERRIDE = "https://gw.example/v1";
+      expect(getLlmGatewayURL()).toBe("https://gw.example/v1");
+    });
+  });
+
+  describe("isAbsoluteHttpUrl", () => {
+    it("accepts http(s) URLs and rejects relative paths", () => {
+      expect(isAbsoluteHttpUrl("https://api.dosu.dev/v1/llm-gateway")).toBe(true);
+      expect(isAbsoluteHttpUrl("http://localhost:7001/v1/llm-gateway")).toBe(true);
+      expect(isAbsoluteHttpUrl("/v1/llm-gateway")).toBe(false);
+      expect(isAbsoluteHttpUrl("")).toBe(false);
     });
   });
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -17,8 +17,22 @@ export function getSupabaseAnonKey(): string {
   return process.env.SUPABASE_ANON_KEY_OVERRIDE ?? process.env.SUPABASE_ANON_KEY ?? "";
 }
 
+/** True for `http(s)://…` so the miner never gets a relative path like `/v1/llm-gateway`. */
+export function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /** Base URL of the Dosu LLM gateway (the miner's ANTHROPIC_BASE_URL); the SDK binary appends
- * `/v1/messages`. */
+ * `/v1/messages`. Empty when the backend URL is unset (uncompiled source without an env file),
+ * which would otherwise become the relative `/v1/llm-gateway`. */
 export function getLlmGatewayURL(): string {
-  return process.env.DOSU_LLM_GATEWAY_URL_OVERRIDE ?? `${getBackendURL()}/v1/llm-gateway`;
+  const override = process.env.DOSU_LLM_GATEWAY_URL_OVERRIDE;
+  if (override) return override;
+  const backend = getBackendURL().replace(/\/$/, "");
+  return backend ? `${backend}/v1/llm-gateway` : "";
 }

--- a/src/generated/dosu-api-types.d.ts
+++ b/src/generated/dosu-api-types.d.ts
@@ -84,7 +84,6 @@ export type CliDataSource = {
 	generated_description: string | null
 	gitlab_project: CliDataSourceGitlabProject | null
 	gitlab_project_id: string | null
-	grandfather: boolean
 	id: string
 	is_indexed: boolean
 	knowledge_store_id: string | null
@@ -329,7 +328,6 @@ export type CliLibraryDataSource = {
 	} | null
 	gitlab_project: CliDataSourceGitlabProject | null
 	gitlab_project_id: string | null
-	grandfather: boolean
 	id: string
 	is_indexed: boolean
 	knowledge_store_id: string | null
@@ -563,7 +561,7 @@ export type CliSlackChannelRow = {
 	topic?: string | null
 }
 
-export declare const CLI_CONTRACT_HASH: '1d4be4b6214f'
+export declare const CLI_CONTRACT_HASH: '79ec0bbacf70'
 
 export type AgentsAddAdminsInput = {
 	deployment_id: string
@@ -620,6 +618,7 @@ export type AgentsListOutput = Array<CliDeployment>
 export type AgentsListAddableAdminsInput = string
 
 export type AgentsListAddableAdminsOutput = Array<{
+	is_agent_admin: boolean
 	profile: {
 		display_name: string | null
 		email: string | null
@@ -1229,6 +1228,23 @@ export type NangoGetConnectionInput = {
 
 export type NangoGetConnectionOutput = any
 
+export type NotesListMineInput = {
+	limit?: number
+	org_id: string
+}
+
+export type NotesListMineOutput = {
+	notes: Array<{
+		body: string
+		branch: string | null
+		created_at: string
+		id: string
+		repo: string | null
+		title: string
+		transcript_id: string | null
+	}>
+}
+
 export type OrganizationGetOrganizationByIdInput = string
 
 export type OrganizationGetOrganizationByIdOutput = {
@@ -1297,7 +1313,7 @@ export type PageDeleteOutput = {
 	parent_id: string | null
 	sync_provider: 'github' | 'coda' | 'confluence' | 'notion' | 'gitlab' | 'azure_devops' | null
 	synced_from_document_source_id: string | null
-	title: string | null
+	title: string
 	type: 'document' | 'answer' | 'changelog' | 'template' | 'topic'
 	updated_at: string | null
 }
@@ -2048,6 +2064,9 @@ export interface CliApiClient {
 	}
 	nango: {
 		getConnection: QueryProcedure<NangoGetConnectionInput, NangoGetConnectionOutput>
+	}
+	notes: {
+		listMine: QueryProcedure<NotesListMineInput, NotesListMineOutput>
 	}
 	organization: {
 		getOrganizationById: QueryProcedure<

--- a/src/miner/runner.test.ts
+++ b/src/miner/runner.test.ts
@@ -81,6 +81,14 @@ describe("classifyGatewayError", () => {
 });
 
 describe("runMiner", () => {
+  it("fails closed when the gateway URL is not absolute", async () => {
+    const result = await runMiner({ ...baseOptions, gatewayURL: "/v1/llm-gateway" });
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toMatch(/gateway URL/i);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
   it("fails closed on settings conflicts without spawning", async () => {
     conflictsMock.mockReturnValue([
       { file: "/etc/claude-code/managed-settings.json", keys: ["apiKeyHelper"] },
@@ -182,6 +190,49 @@ describe("runMiner", () => {
     const result = await runMiner(baseOptions);
 
     expect(result.notesWritten).toBe(2);
+  });
+
+  it("injects the last-read session as transcript_id into write_knowledge payloads", async () => {
+    type GateResult = { behavior: string; updatedInput?: Record<string, unknown> };
+    type GateParams = {
+      options: { canUseTool: (name: string, input: object, extra: object) => Promise<GateResult> };
+    };
+    const gateResults: GateResult[] = [];
+    queryMock.mockImplementation((params: GateParams) => {
+      return (async function* () {
+        // Before any read there is nothing to inject: the payload passes as-is.
+        gateResults.push(
+          await params.options.canUseTool(
+            "mcp__dosu__write_knowledge",
+            { title: "Early", content: "No session read yet.", transcript_id: "model-invented" },
+            {},
+          ),
+        );
+        await params.options.canUseTool("mcp__sessions__read_session", { id: "s1" }, {});
+        // An id-less read (e.g. a paging call) keeps the last session attribution.
+        await params.options.canUseTool("mcp__sessions__read_session", { offset: 2 }, {});
+        gateResults.push(
+          await params.options.canUseTool(
+            "mcp__dosu__write_knowledge",
+            { title: "OAuth refresh", content: "Retry after 401.", transcript_id: "model-junk" },
+            {},
+          ),
+        );
+        yield successResult();
+      })();
+    });
+
+    const result = await runMiner(baseOptions);
+
+    expect(result.notesWritten).toBe(2);
+    // Pre-read write: untouched (nothing deterministic to inject).
+    expect(gateResults[0].updatedInput).toMatchObject({ transcript_id: "model-invented" });
+    // Post-read write: whatever the model authored is overwritten.
+    expect(gateResults[1].updatedInput).toEqual({
+      title: "OAuth refresh",
+      content: "Retry after 401.",
+      transcript_id: "s1",
+    });
   });
 
   it("maps a consent-off gateway refusal from the result text", async () => {

--- a/src/miner/runner.ts
+++ b/src/miner/runner.ts
@@ -1,9 +1,10 @@
 /** Mining-agent runner: spawns an Agent SDK session routed to the Dosu LLM gateway, fenced to
  * four tools. This is the only module in the CLI that imports the Agent SDK. */
 
-import { getLlmGatewayURL } from "../config/constants";
+import { getLlmGatewayURL, isAbsoluteHttpUrl } from "../config/constants";
 import { logger } from "../debug/logger";
 import { mcpHeaders, mcpURL } from "../mcp/config-helpers";
+import { sessionIdFromReadInput } from "../report/notes";
 import type { AgentSession } from "../sessions/scan";
 import { getVersionString } from "../version/version";
 import { createRunConfigDir } from "./config-dir";
@@ -138,6 +139,17 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
     };
   }
 
+  const gatewayURL = options.gatewayURL ?? getLlmGatewayURL();
+  if (!isAbsoluteHttpUrl(gatewayURL)) {
+    return {
+      outcome: "error",
+      notesWritten: 0,
+      turns: 0,
+      message:
+        "LLM gateway URL is not set. From source, use `bun run dev` (production endpoints) or `bun run dev:local` (local stack).",
+    };
+  }
+
   // The SDK is dynamically imported so no other CLI path pays its cost.
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
 
@@ -159,11 +171,12 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
   const timer = setTimeout(() => abort.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
   let notesWritten = 0;
+  let lastSessionId: string | undefined;
   let turns = 0;
 
   const env = buildMinerEnv({
     apiKey: options.apiKey,
-    gatewayURL: options.gatewayURL ?? getLlmGatewayURL(),
+    gatewayURL,
     configDir: configDir.path,
     runID,
     trigger: options.trigger,
@@ -210,6 +223,9 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
               message: `Tool ${toolName} is not permitted in mining runs.`,
             };
           }
+          if (toolName === `mcp__${SESSIONS_SERVER_NAME}__read_session`) {
+            lastSessionId = sessionIdFromReadInput(input) ?? lastSessionId;
+          }
           if (toolName === `mcp__${KNOWLEDGE_SERVER_NAME}__write_knowledge`) {
             if (notesWritten >= maxNotes) {
               return {
@@ -218,6 +234,16 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
               };
             }
             notesWritten += 1;
+            // Per-note transcript identity: overwrite the argument with the
+            // last-read session id. The model never authors this field (its
+            // own value, if any, is discarded here), and the backend only
+            // trusts it from attested clients. Deterministic injection is
+            // what lets the DB be the single source of truth for the
+            // knowledge report.
+            return {
+              behavior: "allow",
+              updatedInput: lastSessionId ? { ...input, transcript_id: lastSessionId } : input,
+            };
           }
           return { behavior: "allow", updatedInput: input };
         },

--- a/src/report/css.ts
+++ b/src/report/css.ts
@@ -1,0 +1,153 @@
+export const REPORT_CSS = `
+  :root {
+    --ink: #14201c;
+    --muted: #5c6b64;
+    --line: #d5ddd8;
+    --bg: #f4f7f5;
+    --card: #ffffff;
+    --accent: #0b6e4f;
+    --accent-soft: #e3f2eb;
+    --warn: #8a5a00;
+    --warn-bg: #fff6e5;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    color: var(--ink);
+    background: var(--bg);
+    line-height: 1.45;
+  }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+  header.hero {
+    border-bottom: 2px solid var(--ink);
+    padding-bottom: 1.25rem;
+    margin-bottom: 1.75rem;
+  }
+  .eyebrow {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.72rem;
+    color: var(--muted);
+    margin: 0 0 0.4rem;
+  }
+  h1 { font-size: 2rem; font-weight: 600; margin: 0 0 0.5rem; letter-spacing: -0.02em; }
+  h2 { font-size: 1.25rem; margin: 2rem 0 0.75rem; border-top: 1px solid var(--line); padding-top: 1.25rem; }
+  h3 { margin: 0; font-size: 1.05rem; }
+  .lede { color: var(--muted); margin: 0 0 1rem; }
+  .meta-line { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 0.85rem; color: var(--muted); }
+  .toolbar { display: flex; flex-wrap: wrap; gap: 0.6rem; margin: 1rem 0 0; }
+  button, .btn {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    border: 1px solid var(--ink);
+    background: var(--ink);
+    color: #fff;
+    padding: 0.55rem 0.9rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    text-decoration: none;
+    display: inline-block;
+  }
+  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem; margin: 1rem 0; }
+  .stat { background: var(--card); border: 1px solid var(--line); padding: 0.85rem 1rem; border-radius: 6px; }
+  .stat.highlight { background: var(--accent-soft); border-color: #b7d8c7; }
+  .stat .label {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+  }
+  .stat .value { font-size: 1.35rem; font-weight: 600; margin-top: 0.25rem; }
+  .pct { font-size: 0.9rem; font-weight: 500; color: var(--accent); }
+  table { width: 100%; border-collapse: collapse; font-family: ui-sans-serif, system-ui, sans-serif; font-size: 0.82rem; background: var(--card); }
+  th, td { border-bottom: 1px solid var(--line); padding: 0.45rem 0.5rem; text-align: left; vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 1rem 1.1rem; margin: 0.75rem 0; }
+  .card header { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: baseline; }
+  .badge {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border: 1px solid var(--line);
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    color: var(--muted);
+  }
+  .status-written { background: var(--accent-soft); color: var(--accent); border-color: #b7d8c7; }
+  .status-pending { background: var(--warn-bg); color: var(--warn); border-color: #efd59a; }
+  .status-proposed { background: #eef1f0; }
+  .status-already_in_library { background: #eef1f0; }
+  .note-body {
+    white-space: pre-wrap;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 0.86rem;
+    background: var(--bg);
+    border-radius: 4px;
+    padding: 0.75rem;
+    overflow-x: auto;
+  }
+  .idea { font-size: 1.05rem; color: var(--ink); margin: 0.5rem 0 0.4rem; }
+  .work { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 0.85rem; color: var(--muted); margin: 0.25rem 0 0.5rem; }
+  .work-label {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+    margin-right: 0.4rem;
+  }
+  .note-tech { margin-top: 0.6rem; }
+  .note-tech summary { cursor: pointer; font-family: ui-sans-serif, system-ui, sans-serif; font-size: 0.82rem; color: var(--muted); margin-top: 0.5rem; }
+  .trace { margin-top: 0.65rem; }
+  .trace > summary { cursor: pointer; font-family: ui-sans-serif, system-ui, sans-serif; font-size: 0.82rem; color: var(--muted); }
+  .trace-bar { display: flex; height: 8px; border-radius: 999px; overflow: hidden; background: #e8eee9; margin: 0.5rem 0 0.35rem; }
+  .tb { display: block; height: 100%; }
+  .tb.context { background: var(--accent); }
+  .tb.planning { background: #8a97a3; }
+  .tb.other { background: #b5a89a; }
+  .trace-legend { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 0.75rem; color: var(--muted); margin: 0 0 0.45rem; }
+  .trace-steps { list-style: none; padding: 0; margin: 0.35rem 0 0; }
+  .trace-steps li {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    column-gap: 0.4rem;
+    align-items: baseline;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 0.78rem;
+    padding: 0.16rem 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .trace-steps .chip { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.04em; padding: 0.08rem 0.38rem; margin: 0; }
+  .trace-steps .pv { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .trace-steps .tok { font-variant-numeric: tabular-nums; color: var(--muted); text-align: right; }
+  .ts-head { color: var(--muted); font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--line); }
+  .ts-head .chip { background: none; border: 0; padding-left: 0; color: inherit; }
+  .ts-head .pv, .ts-head .tok { color: inherit; overflow: visible; text-overflow: unset; }
+  .ts-user .chip { background: #eef1f0; }
+  .ts-context .chip { background: var(--accent-soft); color: var(--accent); border-color: #b7d8c7; }
+  .ts-planning .chip { background: #eef1f4; }
+  .ts-other .chip { background: #f3efe9; }
+  .ts-code { opacity: 0.55; color: var(--muted); }
+  .ts-omit .pv { font-style: italic; }
+  .meta, .query, .muted, .footnote {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  code { font-size: 0.84em; }
+  footer.cta { margin-top: 2.5rem; padding: 1.25rem; background: var(--accent-soft); border: 1px solid #b7d8c7; border-radius: 8px; }
+  footer.cta h2 { border: 0; padding: 0; margin: 0 0 0.5rem; }
+  @media print {
+    body { background: #fff; }
+    .toolbar, .no-print { display: none !important; }
+    .wrap { max-width: none; padding: 0; }
+    .card, .stat { break-inside: avoid; }
+    a { color: inherit; text-decoration: none; }
+    details.trace > *:not(summary) { display: none !important; }
+  }
+`;

--- a/src/report/digest.test.ts
+++ b/src/report/digest.test.ts
@@ -1,0 +1,261 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../sessions/scan";
+import { digestTurnText, sessionToDigest } from "./digest";
+import { buildReportHtml } from "./html";
+import { attributeRediscovery } from "./notes";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "dosu-digest-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function session(id: string, harness: AgentSession["harness"], lines: unknown[]): AgentSession {
+  const path = join(dir, `${id}.jsonl`);
+  writeFileSync(path, lines.map((l) => (typeof l === "string" ? l : JSON.stringify(l))).join("\n"));
+  return { id, harness, path, updated: "2026-09-09T00:00:00.000Z" };
+}
+
+function claudeSession(id: string, lines: unknown[]): AgentSession {
+  return session(id, "claude", lines);
+}
+
+describe("sessionToDigest", () => {
+  it("keeps Read/Grep tool_use with path and pattern, using file line numbers", () => {
+    const session = claudeSession("s1", [
+      { type: "file-history-snapshot", messageId: "x" },
+      { type: "user", message: { content: "why does auth retry?" } },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "looking" },
+            { type: "tool_use", name: "Read", input: { path: "src/auth.py" } },
+            { type: "tool_use", name: "Grep", input: { pattern: "retry after 401" } },
+          ],
+        },
+      },
+    ]);
+    const turns = sessionToDigest(session).turns;
+    expect(turns.map((t) => t.line)).toEqual([2, 3]);
+    expect(turns[1].tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Read", path: "src/auth.py" }),
+        expect.objectContaining({ name: "Grep", pattern: "retry after 401" }),
+      ]),
+    );
+  });
+
+  it("skips tool_result-only user rows so the cycle stays one stretch", () => {
+    const session = claudeSession("s1", [
+      { type: "user", message: { content: "find the oauth retry" } },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", name: "Read", input: { path: "tokens.py" } }] },
+      },
+      {
+        type: "user",
+        message: { content: [{ type: "tool_result", content: "ok" }] },
+      },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "retry after 401" }] },
+      },
+    ]);
+    const turns = sessionToDigest(session).turns;
+    expect(turns.map((t) => t.role)).toEqual(["user", "assistant", "assistant"]);
+    const [note] = attributeRediscovery(
+      [{ title: "OAuth retry", content: "Retry after 401 in tokens.py", transcript_id: "s1" }],
+      [session],
+    );
+    expect(note.investigation_lines).toBe("1-4");
+    const html = buildReportHtml({
+      inventory: { transcripts: [] },
+      candidates: [note],
+      digests: { s1: sessionToDigest(session) },
+    });
+    expect(html).toContain("Work to learn this");
+    expect(html).toContain("tokens.py");
+    expect(html).toMatch(/Read/);
+    expect(html).not.toMatch(/Work to learn this · 1 reasoning ·/);
+  });
+
+  it("digests Cursor role/message logs with tool previews, skipping other roles and bad lines", () => {
+    const s = session("c1", "cursor", [
+      "{not json",
+      { role: "system", message: { content: "ignored" } },
+      { role: "user", message: { content: "where is retry?" } },
+      {
+        role: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "checking" },
+            { type: "tool_use", name: "Read", input: { file_path: "src/a.ts" } },
+            { type: "tool_use", name: "Shell", input: { command: "grep -r retry" } },
+            { type: "tool_use", name: "Task", input: { prompt: "find the retry loop" } },
+            { type: "tool_use", name: "SemanticSearch", input: { query: "retry backoff" } },
+            { type: "tool_use", name: "Glob", input: { description: "list source files" } },
+          ],
+        },
+      },
+    ]);
+    const turns = sessionToDigest(s).turns;
+    expect(turns.map((t) => t.role)).toEqual(["user", "assistant"]);
+    expect(turns[1].tools).toEqual([
+      expect.objectContaining({ name: "Read", file_path: "src/a.ts", path: "src/a.ts" }),
+      expect.objectContaining({ name: "Shell", command_preview: "grep -r retry" }),
+      expect.objectContaining({ name: "Task", prompt: "find the retry loop" }),
+      expect.objectContaining({ name: "SemanticSearch", query: "retry backoff" }),
+      expect.objectContaining({ name: "Glob", command_preview: "list source files" }),
+    ]);
+  });
+
+  it("captures MCP tool metadata: mcp__ input as arguments, CallMcpTool names, GetMcpTools pattern", () => {
+    const s = claudeSession("m1", [
+      { type: "user", message: { content: "use dosu" } },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name: "mcp__dosu__read_knowledge", input: { query: "auth" } },
+            {
+              type: "tool_use",
+              name: "CallMcpTool",
+              input: { toolName: "write_knowledge", server: "dosu", arguments: { title: "t" } },
+            },
+            { type: "tool_use", name: "GetMcpTools", input: { pattern: "knowledge" } },
+          ],
+        },
+      },
+    ]);
+    const tools = sessionToDigest(s).turns[1].tools ?? [];
+    expect(tools[0]).toMatchObject({
+      name: "mcp__dosu__read_knowledge",
+      arguments: { query: "auth" },
+    });
+    expect(tools[1]).toMatchObject({
+      toolName: "write_knowledge",
+      server: "dosu",
+      arguments: { title: "t" },
+    });
+    expect(tools[2]).toMatchObject({ name: "GetMcpTools", pattern: "knowledge" });
+  });
+
+  it("truncates long assistant text and counts tool_result chars into est_tokens", () => {
+    const long = "x".repeat(5000);
+    const s = claudeSession("t1", [
+      { type: "assistant", message: { content: [{ type: "text", text: long }] } },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "text", text: "next question" },
+            { type: "tool_result", content: [{ type: "text", text: "result payload" }] },
+          ],
+        },
+      },
+    ]);
+    const turns = sessionToDigest(s).turns;
+    expect(turns[0].text?.[0]).toContain("…[truncated]");
+    expect(turns[0].text?.[0].length).toBeLessThan(4100);
+    expect(turns[1].est_tokens).toBeGreaterThan(Math.round("next question".length / 4));
+  });
+
+  it("digests Codex event_msg and function_call records, skipping everything else", () => {
+    const long = "y".repeat(5000);
+    const s = session("x1", "codex", [
+      "{not json",
+      { type: "turn_context", payload: {} },
+      { type: "event_msg", payload: { type: "user_message", message: "why 401s?" } },
+      { type: "event_msg", payload: { type: "agent_message", message: long } },
+      { type: "event_msg", payload: { type: "agent_message", message: "" } },
+      {
+        type: "response_item",
+        payload: { type: "function_call", name: "read_file", arguments: '{"path":"a.ts"}' },
+      },
+      { type: "response_item", payload: { type: "function_call", arguments: { path: "b.ts" } } },
+    ]);
+    const turns = sessionToDigest(s).turns;
+    expect(turns.map((t) => t.role)).toEqual(["user", "assistant", "assistant", "assistant"]);
+    expect(turns[0].text).toEqual(["why 401s?"]);
+    expect((turns[1].text as string[])[0]).toContain("…[truncated]");
+    expect(turns[2].tools).toEqual([{ name: "read_file", command_preview: '{"path":"a.ts"}' }]);
+    expect(turns[3].tools).toEqual([{ name: "function_call", command_preview: '{"path":"b.ts"}' }]);
+  });
+
+  it("skips malformed and non-object lines in Claude logs", () => {
+    const s = session("bad1", "claude", [
+      "{not json",
+      "123",
+      { type: "user", message: { content: "still works" } },
+    ]);
+    const turns = sessionToDigest(s).turns;
+    expect(turns).toHaveLength(1);
+    expect(turns[0].line).toBe(3);
+  });
+
+  it("handles Codex records with missing payloads, empty user messages, and bare function_calls", () => {
+    const s = session("x2", "codex", [
+      "123",
+      { type: "event_msg" },
+      { type: "event_msg", payload: { type: "user_message", message: "" } },
+      { type: "event_msg", payload: { type: "user_message" } },
+      { type: "response_item", payload: { type: "function_call", name: "read_file" } },
+    ]);
+    const turns = sessionToDigest(s).turns;
+    expect(turns).toHaveLength(1);
+    expect(turns[0].tools).toEqual([{ name: "read_file", command_preview: '""' }]);
+  });
+
+  it("drops nameless tool_use blocks, tool_result-only user rows, and empty assistant turns", () => {
+    const s = claudeSession("edge1", [
+      { type: "user", message: { content: "# AGENTS.md\nrepo rules only" } },
+      { type: "user", message: { content: [{ type: "tool_result", content: null }] } },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", input: {} },
+            { type: "tool_use", name: 42, input: {} },
+            { type: "text", text: "" },
+            "not-a-record",
+          ],
+        },
+      },
+      { type: "assistant", message: {} },
+    ]);
+    // Only the plain-text user turn survives; nameless tools, empty text
+    // blocks, and content-less messages all drop.
+    expect(sessionToDigest(s).turns.map((t) => t.role)).toEqual(["user"]);
+  });
+
+  it("digestTurnText joins arrays, passes strings through, and tolerates missing text", () => {
+    expect(digestTurnText({ text: ["a", "", "b"] })).toBe("a\nb");
+    expect(digestTurnText({ text: "plain" })).toBe("plain");
+    expect(digestTurnText({})).toBe("");
+  });
+
+  it("degrades to zero turns for opencode sessions and unreadable files", () => {
+    const missing: AgentSession = {
+      id: "gone",
+      harness: "claude",
+      path: join(dir, "missing.jsonl"),
+      updated: "2026-09-09T00:00:00.000Z",
+    };
+    expect(sessionToDigest(missing).turns).toEqual([]);
+    const opencode: AgentSession = {
+      id: "oc1",
+      harness: "opencode",
+      path: join(dir, "missing.db"),
+      updated: "2026-09-09T00:00:00.000Z",
+    };
+    expect(sessionToDigest(opencode).turns).toEqual([]);
+  });
+});

--- a/src/report/digest.ts
+++ b/src/report/digest.ts
@@ -1,0 +1,288 @@
+/**
+ * Session digest matching parse_agent_logs.build_digest: each JSONL line
+ * that has text or tool_use becomes a turn with file line numbers and tool
+ * previews (path/pattern/command). The HTML "Work to learn this" expander
+ * reads this — empty tools collapse every assistant turn to "Reasoning".
+ */
+
+import { readFileSync } from "node:fs";
+import { readSessionTurns } from "../sessions/read";
+import type { AgentSession } from "../sessions/scan";
+import { extractUserQueries } from "./queries";
+import type { DigestTool, DigestTurn, ReportDigest } from "./types";
+
+const CHARS_PER_TOKEN = 4;
+const MAX_ASSISTANT_CHARS = 4000;
+const MCP_DIGEST_TOOLS = new Set(["CallMcpTool", "GetMcpTools"]);
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function estimateTokens(text: string): number {
+  return Math.round(text.length / CHARS_PER_TOKEN);
+}
+
+function digestEstTokens(texts: string[], tools: DigestTool[], resultChars: number): number {
+  const countable = tools.filter((t) => t.name !== "tool_result");
+  let payload = texts.join("\n");
+  if (countable.length > 0) payload += JSON.stringify(countable);
+  let tokens = estimateTokens(payload);
+  if (resultChars > 0) tokens += Math.max(1, Math.round(resultChars / CHARS_PER_TOKEN));
+  return tokens;
+}
+
+function copyToolInputFields(entry: DigestTool, inp: unknown): void {
+  const row = asRecord(inp);
+  if (!row) return;
+  if (typeof row.path === "string") entry.path = row.path;
+  if (typeof row.file_path === "string") {
+    entry.file_path = row.file_path;
+    entry.path ??= row.file_path;
+  }
+  if (typeof row.pattern === "string") entry.pattern = row.pattern;
+  if (row.command != null) entry.command_preview = String(row.command).slice(0, 160);
+  if (row.prompt != null) {
+    entry.prompt = String(row.prompt).slice(0, 160);
+    entry.command_preview ??= entry.prompt;
+  }
+  if (typeof row.query === "string") entry.query = row.query;
+  if (typeof row.description === "string" && !entry.command_preview) {
+    entry.command_preview = row.description.slice(0, 160);
+  }
+}
+
+function copyMcpFields(entry: DigestTool, name: string, inp: unknown): void {
+  const row = asRecord(inp);
+  if (!row) return;
+  const isMcp =
+    MCP_DIGEST_TOOLS.has(name) || name.startsWith("mcp__") || Boolean(row.toolName || row.server);
+  if (!isMcp) return;
+  const toolName = row.toolName ?? row.tool_name;
+  if (typeof toolName === "string") entry.toolName = toolName;
+  if (typeof row.server === "string") entry.server = row.server;
+  if (name === "GetMcpTools" && typeof row.pattern === "string") entry.pattern = row.pattern;
+  const args = asRecord(row.arguments);
+  if (args) entry.arguments = args;
+  else if (name.startsWith("mcp__")) entry.arguments = row;
+}
+
+function blocksToDigest(
+  content: unknown,
+  maxTextChars: number,
+): { texts: string[]; tools: DigestTool[]; resultChars: number } {
+  const texts: string[] = [];
+  const tools: DigestTool[] = [];
+  let resultChars = 0;
+  const blocks = Array.isArray(content)
+    ? content
+    : typeof content === "string" && content
+      ? [{ type: "text", text: content }]
+      : [];
+  for (const block of blocks) {
+    const item = asRecord(block);
+    if (!item) continue;
+    const btype = item.type;
+    if (
+      (btype === "text" || btype === "input_text" || btype === "output_text") &&
+      typeof item.text === "string" &&
+      item.text
+    ) {
+      let t = item.text;
+      if (t.length > maxTextChars) t = `${t.slice(0, maxTextChars)}\n…[truncated]`;
+      texts.push(t);
+    } else if (btype === "tool_use" && typeof item.name === "string") {
+      const entry: DigestTool = { name: item.name };
+      const inp = item.input ?? {};
+      copyToolInputFields(entry, inp);
+      copyMcpFields(entry, item.name, inp);
+      tools.push(entry);
+    } else if (btype === "tool_result") {
+      const c = item.content;
+      if (typeof c === "string") resultChars += c.length;
+      else if (c != null) resultChars += JSON.stringify(c).length;
+      tools.push({ name: "tool_result" });
+    }
+  }
+  return { texts, tools, resultChars };
+}
+
+function pushTurn(
+  turns: DigestTurn[],
+  line: number,
+  role: string,
+  texts: string[],
+  tools: DigestTool[],
+  resultChars: number,
+): void {
+  if (role === "user" && texts.length > 0) {
+    const qs = extractUserQueries(texts.join("\n"));
+    if (qs.length > 0) texts.splice(0, texts.length, ...qs);
+  }
+  // Skip tool_result-only user rows so user-query cycles stay one stretch.
+  if (role === "user" && texts.length === 0) return;
+  if (texts.length === 0 && tools.length === 0) return;
+  turns.push({
+    line,
+    role,
+    text: texts,
+    tools,
+    est_tokens: digestEstTokens(texts, tools, resultChars),
+  });
+}
+
+function digestCursor(raw: string): DigestTurn[] {
+  const turns: DigestTurn[] = [];
+  const lines = raw.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    let obj: JsonRecord;
+    try {
+      const parsed = asRecord(JSON.parse(line));
+      if (!parsed) continue;
+      obj = parsed;
+    } catch {
+      continue;
+    }
+    const role = obj.role;
+    if (role !== "user" && role !== "assistant") continue;
+    const message = asRecord(obj.message);
+    const { texts, tools, resultChars } = blocksToDigest(
+      message?.content,
+      role === "assistant" ? MAX_ASSISTANT_CHARS : 2000,
+    );
+    pushTurn(turns, i + 1, role, texts, tools, resultChars);
+  }
+  return turns;
+}
+
+function digestClaude(raw: string): DigestTurn[] {
+  const turns: DigestTurn[] = [];
+  const lines = raw.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    let obj: JsonRecord;
+    try {
+      const parsed = asRecord(JSON.parse(line));
+      if (!parsed) continue;
+      obj = parsed;
+    } catch {
+      continue;
+    }
+    const etype = obj.type;
+    if (etype !== "user" && etype !== "assistant") continue;
+    if (obj.isSidechain === true) continue;
+    const message = asRecord(obj.message);
+    const { texts, tools, resultChars } = blocksToDigest(
+      message?.content,
+      etype === "assistant" ? MAX_ASSISTANT_CHARS : 2000,
+    );
+    pushTurn(turns, i + 1, etype, texts, tools, resultChars);
+  }
+  return turns;
+}
+
+function digestCodex(raw: string): DigestTurn[] {
+  const turns: DigestTurn[] = [];
+  const lines = raw.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    let obj: JsonRecord;
+    try {
+      const parsed = asRecord(JSON.parse(line));
+      if (!parsed) continue;
+      obj = parsed;
+    } catch {
+      continue;
+    }
+    const payload = asRecord(obj.payload) ?? {};
+    const etype = obj.type;
+    if (etype === "event_msg" && payload.type === "user_message") {
+      const msg = String(payload.message ?? "").slice(0, 2000);
+      if (msg) {
+        turns.push({
+          line: i + 1,
+          role: "user",
+          text: [msg],
+          tools: [],
+          est_tokens: estimateTokens(msg),
+        });
+      }
+    } else if (etype === "event_msg" && payload.type === "agent_message") {
+      let msg = String(payload.message ?? "");
+      if (msg.length > MAX_ASSISTANT_CHARS)
+        msg = `${msg.slice(0, MAX_ASSISTANT_CHARS)}\n…[truncated]`;
+      if (msg) {
+        turns.push({
+          line: i + 1,
+          role: "assistant",
+          text: [msg],
+          tools: [],
+          est_tokens: estimateTokens(msg),
+        });
+      }
+    } else if (etype === "response_item" && payload.type === "function_call") {
+      const name = typeof payload.name === "string" ? payload.name : "function_call";
+      const args = payload.arguments;
+      const preview =
+        typeof args === "string" ? args.slice(0, 160) : JSON.stringify(args ?? "").slice(0, 160);
+      turns.push({
+        line: i + 1,
+        role: "assistant",
+        text: [],
+        tools: [{ name, command_preview: preview }],
+        est_tokens: estimateTokens(preview),
+      });
+    }
+  }
+  return turns;
+}
+
+/** Build the skill-shaped digest; any failure degrades to no turns. */
+export function sessionToDigest(session: AgentSession): ReportDigest {
+  try {
+    switch (session.harness) {
+      case "claude":
+        return { turns: digestClaude(readFileSync(session.path, "utf8")) };
+      case "cursor":
+        return { turns: digestCursor(readFileSync(session.path, "utf8")) };
+      case "codex":
+        return { turns: digestCodex(readFileSync(session.path, "utf8")) };
+      case "opencode": {
+        const turns = readSessionTurns(session).map((turn, index) => ({
+          role: turn.role,
+          line: index + 1,
+          est_tokens: Math.round(turn.text.length / CHARS_PER_TOKEN),
+          text: [turn.text],
+          tools: [] as DigestTool[],
+        }));
+        return { turns };
+      }
+    }
+  } catch {
+    return { turns: [] };
+  }
+}
+
+export function digestsForSessions(
+  sessions: readonly AgentSession[],
+): Record<string, ReportDigest> {
+  const out: Record<string, ReportDigest> = {};
+  for (const session of sessions) {
+    out[session.id] = sessionToDigest(session);
+  }
+  return out;
+}
+
+export function digestTurnText(turn: DigestTurn): string {
+  const texts = turn.text ?? [];
+  if (typeof texts === "string") return texts;
+  return texts.filter(Boolean).join("\n");
+}

--- a/src/report/fetch.test.ts
+++ b/src/report/fetch.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../config/config";
+
+const mockQuery = vi.fn();
+const mockCreateTypedClient = vi.fn(() => ({ notes: { listMine: { query: mockQuery } } }));
+vi.mock("../client/trpc", () => ({
+  createTypedClient: () => mockCreateTypedClient(),
+}));
+
+import { fetchReportNotes, REPORT_NOTES_LIMIT } from "./fetch";
+
+function authedConfig(): Config {
+  return {
+    schema_version: 2,
+    active_account: {
+      user_id: "u1",
+      session: { access_token: "tok", refresh_token: "r", expires_at: 0 },
+      target: { org_id: "11111111-1111-4111-8111-111111111111" },
+    },
+  } as unknown as Config;
+}
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockCreateTypedClient.mockClear();
+});
+
+describe("fetchReportNotes", () => {
+  it("maps backend notes, keeping optional fields only when present", async () => {
+    mockQuery.mockResolvedValue({
+      notes: [
+        {
+          id: "n1",
+          title: "OAuth refresh",
+          body: "Retry after 401.",
+          repo: "git@x/y",
+          branch: "main",
+          transcript_id: "conv-1",
+          created_at: "2026-09-01T00:00:00+00:00",
+        },
+        {
+          id: "n2",
+          title: "Bare",
+          body: "No provenance.",
+          repo: null,
+          branch: null,
+          transcript_id: null,
+          created_at: "2026-09-02T00:00:00+00:00",
+        },
+      ],
+    });
+
+    const notes = await fetchReportNotes(authedConfig());
+    expect(mockQuery).toHaveBeenCalledWith({
+      org_id: "11111111-1111-4111-8111-111111111111",
+      limit: REPORT_NOTES_LIMIT,
+    });
+    expect(notes).toEqual([
+      {
+        title: "OAuth refresh",
+        content: "Retry after 401.",
+        at: "2026-09-01T00:00:00+00:00",
+        transcript_id: "conv-1",
+        repo: "git@x/y",
+        branch: "main",
+      },
+      { title: "Bare", content: "No provenance.", at: "2026-09-02T00:00:00+00:00" },
+    ]);
+  });
+
+  it("rejects with an actionable message when signed out or missing an org", async () => {
+    await expect(fetchReportNotes({ schema_version: 2 } as Config)).rejects.toThrow(
+      /Not signed in/,
+    );
+    const noToken = authedConfig();
+    // biome-ignore lint/style/noNonNullAssertion: shaped above
+    noToken.active_account!.session.access_token = "";
+    await expect(fetchReportNotes(noToken)).rejects.toThrow(/Not signed in/);
+    expect(mockCreateTypedClient).not.toHaveBeenCalled();
+  });
+
+  it("propagates backend failures unchanged (online-only by design)", async () => {
+    mockQuery.mockRejectedValue(new Error("404 NOT_FOUND"));
+    await expect(fetchReportNotes(authedConfig())).rejects.toThrow("404 NOT_FOUND");
+  });
+});

--- a/src/report/fetch.ts
+++ b/src/report/fetch.ts
@@ -1,0 +1,33 @@
+/**
+ * Fetch the caller's knowledge notes from the backend — the single source of
+ * truth for the report. Online-only by design: a report without the backend
+ * would have nothing honest to show, so failures surface as actionable errors
+ * instead of a silently empty page.
+ */
+
+import type { Config } from "../config/config";
+import type { ReportNote } from "./types";
+
+export const REPORT_NOTES_LIMIT = 500;
+
+export async function fetchReportNotes(cfg: Config): Promise<ReportNote[]> {
+  const orgId = cfg.active_account?.target?.org_id;
+  if (!orgId || !cfg.active_account?.session.access_token) {
+    throw new Error("Not signed in. Run `dosu setup` to connect an account first.");
+  }
+  // Dynamic so report-free CLI paths never pay for the tRPC client.
+  const { createTypedClient } = await import("../client/trpc");
+  const client = createTypedClient(cfg);
+  const { notes } = await client.notes.listMine.query({
+    org_id: orgId,
+    limit: REPORT_NOTES_LIMIT,
+  });
+  return notes.map((note) => ({
+    title: note.title,
+    content: note.body,
+    at: note.created_at,
+    ...(note.transcript_id ? { transcript_id: note.transcript_id } : {}),
+    ...(note.repo ? { repo: note.repo } : {}),
+    ...(note.branch ? { branch: note.branch } : {}),
+  }));
+}

--- a/src/report/generate.test.ts
+++ b/src/report/generate.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoadConfig = vi.fn();
+vi.mock("../config/config", () => ({
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+}));
+
+const mockLoadSyncState = vi.fn();
+vi.mock("../sync/watermark", () => ({
+  loadSyncState: (...args: unknown[]) => mockLoadSyncState(...args),
+}));
+
+const mockScan = vi.fn();
+vi.mock("../sessions/scan", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../sessions/scan")>()),
+  scanAgentSessions: (...args: unknown[]) => mockScan(...args),
+}));
+
+const mockWrite = vi.fn();
+vi.mock("./write", () => ({
+  defaultReportPath: () => "/tmp/dosu-knowledge-report.html",
+  writeAndOpenReport: (...args: unknown[]) => mockWrite(...args),
+}));
+
+import { emitKnowledgeReport } from "./generate";
+
+let dir: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dir = mkdtempSync(join(tmpdir(), "dosu-report-gen-"));
+  mockLoadConfig.mockReturnValue({
+    schema_version: 2,
+    active_account: { target: { org_name: "Acme" } },
+  });
+  mockLoadSyncState.mockReturnValue({
+    schema_version: 1,
+    watermark: null,
+    consecutive_failures: 0,
+  });
+  mockScan.mockReturnValue([]);
+  mockWrite.mockResolvedValue("/tmp/dosu-knowledge-report.html");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function claudeSession(id: string, lines: unknown[]) {
+  const path = join(dir, `${id}.jsonl`);
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join("\n"));
+  return { id, harness: "claude" as const, path, updated: "2026-09-09T00:00:00.000Z" };
+}
+
+describe("emitKnowledgeReport", () => {
+  it("renders fetched notes with traces from their referenced sessions only", async () => {
+    const source = claudeSession("s1", [
+      { type: "user", message: { content: "why does auth retry?" } },
+      { type: "assistant", message: { content: [{ type: "text", text: "because 401" }] } },
+    ]);
+    const unrelated = claudeSession("noise", [
+      { type: "user", message: { content: "completely different topic" } },
+    ]);
+    mockScan.mockReturnValue([source, unrelated]);
+    mockWrite.mockImplementation(async (opts: { html: string; out?: string }) => {
+      expect(opts.html).toContain("OAuth retry");
+      expect(opts.html).toContain("Work to learn this");
+      // Unreferenced local history must not leak into the report.
+      expect(opts.html).not.toContain("completely different topic");
+      return opts.out ?? "/tmp/x.html";
+    });
+
+    const out = await emitKnowledgeReport({
+      fetchNotes: async () => [
+        {
+          title: "OAuth retry",
+          content: "Retry after 401.",
+          transcript_id: "s1",
+          at: "2026-09-09T10:00:00Z",
+        },
+      ],
+      out: join(dir, "report.html"),
+      open: false,
+    });
+    expect(out).toBe(join(dir, "report.html"));
+  });
+
+  it("orders notes chronologically regardless of fetch order", async () => {
+    mockWrite.mockImplementation(async (opts: { html: string }) => {
+      expect(opts.html.indexOf("Older note")).toBeLessThan(opts.html.indexOf("Newer note"));
+      return "/tmp/x.html";
+    });
+    await emitKnowledgeReport({
+      fetchNotes: async () => [
+        { title: "Newer note", content: "b", at: "2026-09-02T00:00:00Z" },
+        { title: "Older note", content: "a", at: "2026-09-01T00:00:00Z" },
+      ],
+      open: false,
+    });
+    expect(mockWrite).toHaveBeenCalled();
+  });
+
+  it("propagates fetch failures instead of rendering an empty page", async () => {
+    await expect(
+      emitKnowledgeReport({
+        fetchNotes: async () => {
+          throw new Error("Not signed in. Run `dosu setup` to connect an account first.");
+        },
+        open: false,
+      }),
+    ).rejects.toThrow(/Not signed in/);
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("uses the all-time distilled baseline and note anchors for the header", async () => {
+    mockLoadSyncState.mockReturnValue({
+      schema_version: 1,
+      watermark: null,
+      consecutive_failures: 0,
+      total_learning_tokens: 50_000,
+    });
+    mockWrite.mockImplementation(async (opts: { html: string }) => {
+      expect(opts.html).toContain("Dosu knowledge report — Acme");
+      expect(opts.html).toContain("git@x/y");
+      expect(opts.html).toContain("feat/report");
+      return "/tmp/x.html";
+    });
+    await emitKnowledgeReport({
+      fetchNotes: async () => [
+        { title: "Anchored", content: "Body.", repo: "git@x/y", branch: "feat/report" },
+      ],
+      open: false,
+    });
+    expect(mockWrite).toHaveBeenCalled();
+  });
+
+  it("renders notes without transcripts as bare cards", async () => {
+    mockWrite.mockImplementation(async (opts: { html: string }) => {
+      expect(opts.html).toContain("Unattributed");
+      expect(opts.html).not.toContain("Work to learn this");
+      return "/tmp/x.html";
+    });
+    await emitKnowledgeReport({
+      fetchNotes: async () => [
+        { title: "Unattributed", content: "No transcript.", at: "garbage-date" },
+      ],
+      open: false,
+    });
+    expect(mockWrite).toHaveBeenCalled();
+  });
+
+  it("accepts injected notes without fetching", async () => {
+    const fetchNotes = vi.fn();
+    await emitKnowledgeReport({ notes: [{ title: "A", content: "B" }], fetchNotes, open: false });
+    expect(fetchNotes).not.toHaveBeenCalled();
+    expect(mockWrite).toHaveBeenCalled();
+  });
+});

--- a/src/report/generate.ts
+++ b/src/report/generate.ts
@@ -1,0 +1,75 @@
+/**
+ * Assemble the knowledge report: fetch the caller's notes from the backend
+ * (the single source of truth), attribute each note's investigation stretch
+ * against the local session logs, and emit the HTML.
+ */
+
+import { type Config, loadConfig } from "../config/config";
+import type { AgentSession } from "../sessions/scan";
+import { scanAgentSessions } from "../sessions/scan";
+import { loadSyncState } from "../sync/watermark";
+import { fetchReportNotes } from "./fetch";
+import { buildReportHtml } from "./html";
+import { attributeRediscovery, digestsForSessions, sessionsToInventory } from "./notes";
+import type { ReportNote } from "./types";
+import { defaultReportPath, writeAndOpenReport } from "./write";
+
+export interface EmitReportOptions {
+  /** Injectable for tests; the default fetches from the backend. */
+  notes?: ReportNote[];
+  sessions?: AgentSession[];
+  orgName?: string;
+  repo?: string;
+  branch?: string;
+  out?: string;
+  open?: boolean;
+  openUrl?: (url: string) => Promise<unknown>;
+  generatedAt?: Date;
+  fetchNotes?: (cfg: Config) => Promise<ReportNote[]>;
+}
+
+/** Only the sessions the notes actually reference: traces and inventory must
+ * never widen to unrelated local history when attribution is missing. */
+function sessionsForNotes(
+  notes: readonly ReportNote[],
+  sessions: readonly AgentSession[],
+): AgentSession[] {
+  const ids = new Set(notes.map((n) => n.transcript_id).filter((id): id is string => Boolean(id)));
+  return sessions.filter((s) => ids.has(s.id));
+}
+
+function noteTime(note: ReportNote): number {
+  const parsed = Date.parse(note.at ?? "");
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export async function emitKnowledgeReport(options: EmitReportOptions = {}): Promise<string> {
+  const cfg = loadConfig();
+  const notes = [...(options.notes ?? (await (options.fetchNotes ?? fetchReportNotes)(cfg)))].sort(
+    (a, b) => noteTime(a) - noteTime(b),
+  );
+  const scanned = options.sessions ?? scanAgentSessions();
+  const sessions = sessionsForNotes(notes, scanned);
+  const candidates = attributeRediscovery(notes, sessions);
+  const inventory = sessionsToInventory(sessions);
+  const state = loadSyncState();
+  if (inventory.totals && state.total_learning_tokens && !options.sessions) {
+    // All-time distilled baseline, when this machine has mined.
+    inventory.totals.learning_tokens = state.total_learning_tokens;
+  }
+  const html = buildReportHtml({
+    inventory,
+    candidates,
+    orgName: options.orgName ?? cfg.active_account?.target?.org_name ?? "Your team",
+    repo: options.repo ?? notes.find((n) => n.repo)?.repo,
+    branch: options.branch ?? notes.find((n) => n.branch)?.branch,
+    generatedAt: options.generatedAt,
+    digests: digestsForSessions(sessions),
+  });
+  return writeAndOpenReport({
+    html,
+    out: options.out ?? defaultReportPath(),
+    open: options.open,
+    openUrl: options.openUrl,
+  });
+}

--- a/src/report/html.test.ts
+++ b/src/report/html.test.ts
@@ -1,0 +1,616 @@
+import { describe, expect, it } from "vitest";
+import { buildReportHtml, parseLineSpec, renderTraceHtml, tokenTotalsFromCandidates } from "./html";
+import type { ReportCandidate, ReportInventory } from "./types";
+
+const inventory: ReportInventory = {
+  transcripts: [
+    {
+      source: "claude",
+      transcript_id: "sess-1",
+      title: "why does auth retry?",
+      learning_tokens: 20_000,
+      rediscovery_tool_calls: 4,
+      user_queries: ["why does auth retry?"],
+    },
+  ],
+  totals: { learning_tokens: 20_000 },
+};
+
+const written: ReportCandidate = {
+  title: "OAuth refresh token expiry",
+  content: "Retry after 401; do not reuse the expired access token.",
+  transcript_id: "sess-1",
+  status: "written",
+  approx_rediscovery_tokens: 12_000,
+  investigation_lines: "1-2",
+  user_query: "why does auth retry?",
+};
+
+describe("tokenTotalsFromCandidates", () => {
+  it("uses rediscovery minus note read cost against inventory learning_tokens", () => {
+    const totals = tokenTotalsFromCandidates([written], inventory);
+    expect(totals?.baseline_tokens).toBe(20_000);
+    expect(totals?.replaced_baseline_tokens).toBe(12_000);
+    expect(totals?.read_knowledge_tokens).toBeGreaterThan(0);
+    expect(totals?.tokens_saved).toBe(12_000 - (totals?.read_knowledge_tokens ?? 0));
+  });
+
+  it("returns null when no note has a rediscovery estimate", () => {
+    expect(
+      tokenTotalsFromCandidates([{ title: "x", content: "y", status: "written" }], inventory),
+    ).toBeNull();
+  });
+});
+
+describe("buildReportHtml", () => {
+  it("renders the skill report sections for written notes", () => {
+    const html = buildReportHtml({
+      inventory,
+      candidates: [written],
+      orgName: "Acme",
+      repo: "git@github.com:acme/api.git",
+      branch: "dosu/log-backfill/20260909-120000",
+      generatedAt: new Date("2026-09-09T19:00:00Z"),
+    });
+    expect(html).toContain("Dosu knowledge report — Acme");
+    expect(html).toContain("Dosu · Knowledge report");
+    expect(html).toContain("Iowan Old Style");
+    expect(html).toContain("Estimated context savings");
+    expect(html).toContain("Notes written to Dosu");
+    expect(html).toContain("OAuth refresh token expiry");
+    expect(html).toContain("Heaviest sessions");
+    expect(html).toContain("Print / Save as PDF");
+    expect(html).toContain("git@github.com:acme/api.git");
+    expect(html).toContain("why does auth retry?");
+    expect(html).toContain("window.print()");
+    expect(html).not.toContain("<code>sess-1</code>");
+  });
+
+  it("escapes HTML in titles", () => {
+    const html = buildReportHtml({
+      inventory,
+      candidates: [{ ...written, title: "<script>alert(1)</script>" }],
+    });
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("labels dry-run candidates as proposed", () => {
+    const html = buildReportHtml({
+      inventory,
+      candidates: [{ title: "A", content: "B" }],
+      dryRun: true,
+    });
+    expect(html).toContain("Proposed write_knowledge calls");
+    expect(html).toContain("status-proposed");
+  });
+
+  it("includes a Work to learn this expander from a digest", () => {
+    const html = buildReportHtml({
+      inventory,
+      candidates: [written],
+      digests: {
+        "sess-1": {
+          turns: [
+            { role: "user", line: 1, est_tokens: 12, text: ["why does auth retry?"], tools: [] },
+            {
+              role: "assistant",
+              line: 2,
+              est_tokens: 40,
+              text: [],
+              tools: [{ name: "Read", path: "src/auth.py" }],
+            },
+          ],
+        },
+      },
+    });
+    expect(html).toContain("Work to learn this");
+    expect(html).toContain("auth.py");
+  });
+});
+
+describe("renderTraceHtml", () => {
+  it("returns empty without a matching digest", () => {
+    expect(renderTraceHtml({ transcript_id: "missing" }, {})).toBe("");
+  });
+});
+
+describe("parseLineSpec", () => {
+  it("parses ranges and singles", () => {
+    expect([...parseLineSpec("1-3,5")].sort((a, b) => a - b)).toEqual([1, 2, 3, 5]);
+  });
+
+  it("accepts arrays, reversed ranges, and empty values", () => {
+    expect([...parseLineSpec(["4-2", "9"])].sort((a, b) => a - b)).toEqual([2, 3, 4, 9]);
+    expect(parseLineSpec(null).size).toBe(0);
+    expect(parseLineSpec("").size).toBe(0);
+  });
+});
+
+describe("buildReportHtml empty and mixed", () => {
+  it("renders the empty-notes copy", () => {
+    const html = buildReportHtml({ inventory, candidates: [] });
+    expect(html).toContain("write_knowledge notes");
+    expect(html).toContain("No write_knowledge payloads yet");
+    expect(html).toContain("No rediscovery estimates");
+  });
+
+  it("falls back to transcript learning_tokens when inventory totals are missing", () => {
+    const totals = tokenTotalsFromCandidates([written], { transcripts: inventory.transcripts });
+    expect(totals?.baseline_tokens).toBe(20_000);
+  });
+
+  it("labels mixed statuses in the notes heading", () => {
+    const html = buildReportHtml({
+      inventory,
+      candidates: [
+        { ...written, status: "written" },
+        { title: "Draft", content: "soon", status: "pending" },
+        { title: "Idea", content: "maybe", status: "proposed" },
+        { title: "Known", content: "already", status: "already_in_library" },
+      ],
+    });
+    expect(html).toContain("1 written");
+    expect(html).toContain("1 pending");
+    expect(html).toContain("1 proposed");
+    expect(html).toContain("1 already in library");
+  });
+
+  it("renders with no candidates argument at all", () => {
+    const html = buildReportHtml({ inventory });
+    expect(html).toContain("write_knowledge notes");
+  });
+});
+
+describe("renderTraceHtml tools", () => {
+  it("classifies SQL, planning, and code tools in the expander", () => {
+    const html = renderTraceHtml(
+      { transcript_id: "sess-1", investigation_lines: "1-4", approx_rediscovery_tokens: 100 },
+      {
+        "sess-1": {
+          turns: [
+            { role: "user", line: 1, est_tokens: 10, text: ["why?"], tools: [] },
+            {
+              role: "assistant",
+              line: 2,
+              est_tokens: 30,
+              text: [],
+              tools: [{ name: "execute_sql", query: "select 1 from orders" }],
+            },
+            {
+              role: "assistant",
+              line: 3,
+              est_tokens: 20,
+              text: [],
+              tools: [{ name: "TodoWrite" }],
+            },
+            {
+              role: "assistant",
+              line: 4,
+              est_tokens: 8,
+              text: [],
+              tools: [{ name: "Edit", path: "src/auth.py" }],
+            },
+          ],
+        },
+      },
+    );
+    expect(html).toContain("Work to learn this");
+    expect(html).toContain("SQL");
+    expect(html).toContain("implementation (not counted)");
+    expect(html).toContain("auth.py");
+  });
+});
+
+describe("trace preview fallback ladder", () => {
+  const digestFor = (tools: object[], text: string[] = []) => ({
+    "sess-1": {
+      turns: [
+        { role: "user", line: 1, est_tokens: 5, text: ["q"], tools: [] },
+        { role: "assistant", line: 2, est_tokens: 40, text, tools },
+      ],
+    },
+  });
+  const cand = { transcript_id: "sess-1", investigation_lines: "1-2" };
+
+  it("walks pattern, command, query, file_path, and prompt previews", () => {
+    const html = renderTraceHtml(
+      cand,
+      digestFor([
+        { name: "Grep", pattern: "retry after 401" },
+        { name: "Shell", command_preview: "rg refresh" },
+        { name: "Search", query: "token rotation" },
+        { name: "Read", file_path: "src/deep/leaf-file.ts" },
+        { name: "Read", file_path: "noslash.ts" },
+        { name: "Task", prompt: "trace the retry loop" },
+        { name: "Read", path: "bare-path.ts" },
+      ]),
+    );
+    for (const s of [
+      "retry after 401",
+      "rg refresh",
+      "token rotation",
+      "leaf-file.ts",
+      "noslash.ts",
+      "trace the retry loop",
+      "bare-path.ts",
+    ]) {
+      expect(html).toContain(s);
+    }
+  });
+
+  it("falls back to MCP knowledge args, arguments, tool_name/server, and canned labels", () => {
+    const html = renderTraceHtml(
+      cand,
+      digestFor([
+        { name: "CallMcpTool", knowledge: { tool: "query_logs", arguments: { sql: "select 2" } } },
+        { name: "mcp__srv__deep_tool", arguments: { description: "described call" } },
+        { name: "CallMcpTool", tool_name: "snake_tool", server: "dosu" },
+        { name: "GetMcpTools" },
+        { name: "CallMcpTool" },
+        { name: "CallMcpTool", knowledge: { tool: "some_tool" } },
+        { name: "mcp:inner_tool" },
+        {},
+      ]),
+    );
+    expect(html).toContain("select 2");
+    expect(html).toContain("described call");
+    expect(html).toContain("snake_tool · dosu");
+    expect(html).toContain("Look up available MCP tools");
+    expect(html).toContain("MCP call");
+    expect(html).toContain("MCP call · some_tool");
+    expect(html).toContain("inner_tool");
+    expect(html).toContain("No input recorded");
+    expect(html).toContain("Logs");
+    expect(html).toContain("MCP schema");
+  });
+
+  it("caps long traces with an omitted-steps row and counts reasoning turns", () => {
+    const turns = [
+      { role: "user", line: 1, est_tokens: 5, text: ["q"], tools: [] },
+      { role: "assistant", line: 2, est_tokens: 3, text: ["thinking it through"], tools: [] },
+      { role: "user", line: 3, est_tokens: 0, text: [""], tools: [] },
+      ...Array.from({ length: 60 }, (_, i) => ({
+        role: "assistant",
+        line: i + 4,
+        est_tokens: 0,
+        text: [],
+        tools: [{ name: "Read", path: `f${i}.ts` }],
+      })),
+    ];
+    const html = renderTraceHtml(
+      { transcript_id: "sess-1", investigation_lines: "1-70" },
+      { "sess-1": { turns } },
+    );
+    expect(html).toContain("earlier steps omitted");
+    expect(html).toContain("1 reasoning");
+  });
+
+  it("buckets write_knowledge as other and keeps two-status headings partial", () => {
+    const html = renderTraceHtml(
+      cand,
+      digestFor([{ name: "write_knowledge" }, { name: "finalize_session_knowledge" }]),
+    );
+    expect(html).toContain("Work to learn this");
+    const heading = buildReportHtml({
+      inventory,
+      candidates: [
+        { ...written, status: "written" },
+        { title: "Draft", content: "soon", status: "pending" },
+      ],
+    });
+    expect(heading).toContain("1 written, 1 pending —");
+  });
+});
+
+describe("presentation and inventory edges", () => {
+  it("uses how_found and plain_english when present", () => {
+    const html = buildReportHtml({
+      inventory: {
+        cwd: "git@fallback/repo.git",
+        transcripts: [
+          { source: "claude", transcript_id: "a", learning_tokens: 9 },
+          { source: "cursor", transcript_id: "b", learning_tokens: 40 },
+        ],
+      },
+      candidates: [
+        {
+          title: "Idea",
+          content: "Idea",
+          plain_english: "Say it simply.",
+          how_found: "Read tokens.py then retried.",
+          status: "already_in_library",
+        },
+      ],
+    });
+    expect(html).toContain("Notes already in the Library");
+    expect(html).toContain("Say it simply.");
+    expect(html).toContain("To find this");
+    expect(html).toContain("Read tokens.py then retried.");
+    expect(html).toContain("git@fallback/repo.git");
+    expect(html).toContain("cursor");
+  });
+
+  it("shows an em dash when rediscovery tokens are missing", () => {
+    const html = buildReportHtml({
+      inventory,
+      candidates: [{ title: "X", content: "Y", status: "written" }],
+    });
+    expect(html).toContain("rediscovery ~— tok");
+    expect(html).toContain("Investigation stretch was not measured.");
+  });
+});
+
+describe("renderTraceHtml coverage", () => {
+  it("renders no trace when investigation_lines is absent — never a session-sized one", () => {
+    const html = renderTraceHtml(
+      { transcript_id: "sess-1" },
+      {
+        "sess-1": {
+          turns: [
+            { role: "user", line: 2, est_tokens: 4, text: "plain string question" },
+            { role: "assistant", line: 3, est_tokens: 6, text: ["because 401"] },
+          ],
+        },
+      },
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders a trace from an attributed line range (string text turns included)", () => {
+    const html = renderTraceHtml(
+      { transcript_id: "sess-1", investigation_lines: "2-3" },
+      {
+        "sess-1": {
+          turns: [
+            { role: "user", line: 2, est_tokens: 4, text: "plain string question" },
+            { role: "assistant", line: 3, est_tokens: 6, text: ["because 401"] },
+          ],
+        },
+      },
+    );
+    expect(html).toContain("Question");
+    expect(html).toContain("Reasoning");
+  });
+
+  it("skips empty user turns, tool_result, and caps long traces", () => {
+    const turns = [
+      { role: "user", line: 1, est_tokens: 1, text: [] },
+      ...Array.from({ length: 55 }, (_, i) => ({
+        role: "assistant" as const,
+        line: i + 2,
+        est_tokens: 2,
+        text: [`step ${i}`],
+      })),
+    ];
+    const html = renderTraceHtml(
+      { transcript_id: "sess-1", investigation_lines: `1-${turns.length}` },
+      { "sess-1": { turns } },
+    );
+    expect(html).toContain("earlier steps omitted");
+  });
+
+  it("previews MCP wrappers, arguments, and knowledge payloads", () => {
+    const html = renderTraceHtml(
+      { transcript_id: "sess-1", investigation_lines: "1-8" },
+      {
+        "sess-1": {
+          turns: [
+            { role: "user", line: 1, est_tokens: 3, text: ["go"] },
+            {
+              role: "assistant",
+              line: 2,
+              est_tokens: 4,
+              text: [],
+              tools: [{ name: "Grep", pattern: "OAuthRefresh" }],
+            },
+            {
+              role: "assistant",
+              line: 3,
+              est_tokens: 4,
+              text: [],
+              tools: [{ name: "Bash", command_preview: "git status" }],
+            },
+            {
+              role: "assistant",
+              line: 4,
+              est_tokens: 4,
+              text: [],
+              tools: [{ name: "Read", file_path: "pkg/tokens.py" }],
+            },
+            {
+              role: "assistant",
+              line: 5,
+              est_tokens: 4,
+              text: [],
+              tools: [{ name: "Agent", prompt: "summarize the retry path" }],
+            },
+            {
+              role: "assistant",
+              line: 6,
+              est_tokens: 4,
+              text: [],
+              tools: [
+                {
+                  name: "CallMcpTool",
+                  knowledge: { tool: "execute_sql", arguments: { sql: "select 1" } },
+                },
+              ],
+            },
+            {
+              role: "assistant",
+              line: 7,
+              est_tokens: 4,
+              text: [],
+              tools: [{ name: "GetMcpTools" }],
+            },
+            {
+              role: "assistant",
+              line: 8,
+              est_tokens: 4,
+              text: [],
+              tools: [
+                { name: "tool_result" },
+                {
+                  name: "mcp__dosu__write_knowledge",
+                  arguments: { query: "oauth refresh" },
+                },
+                { name: "mcp:query_logs" },
+                { name: "CallMcpTool", toolName: "ask", server: "dosu" },
+              ],
+            },
+          ],
+        },
+      },
+    );
+    expect(html).toContain("OAuthRefresh");
+    expect(html).toContain("git status");
+    expect(html).toContain("tokens.py");
+    expect(html).toContain("summarize the retry path");
+    expect(html).toContain("SQL");
+    expect(html).toContain("MCP schema");
+    expect(html).toContain("Logs");
+    expect(html).toContain("select 1");
+  });
+});
+
+describe("remaining html branches", () => {
+  it("parses invalid fragments without throwing", () => {
+    expect([...parseLineSpec(" , ,1-x, foo, 8")]).toEqual([8]);
+  });
+
+  it("computes 0% savings when the inventory has no baseline", () => {
+    const totals = tokenTotalsFromCandidates(
+      [{ title: "n", content: "c", approx_rediscovery_tokens: 0 }],
+      { transcripts: [] },
+    );
+    expect(totals).toEqual({
+      baseline_tokens: 0,
+      replaced_baseline_tokens: 0,
+      read_knowledge_tokens: Math.round("n\nc".length / 4),
+      tokens_saved: 0,
+      pct_saved: 0,
+    });
+  });
+
+  it("renders untitled notes, mixed statuses, and missing inventory rows", () => {
+    const html = buildReportHtml({
+      inventory: { transcripts: undefined as unknown as [] },
+      candidates: [
+        { status: "proposed" },
+        { title: "P", content: "pending", status: "pending" },
+        { title: "A", content: "already", status: "already_in_library" },
+        { title: "W", content: "written", status: "written" },
+      ],
+    });
+    expect(html).toContain("Untitled");
+    expect(html).toContain("1 written");
+    expect(html).toContain("1 proposed");
+    expect(html).toContain("1 pending");
+    expect(html).toContain("1 already in library");
+    expect(html).toContain("No sessions");
+    expect(html).toContain("Extract a lean note");
+  });
+
+  it("returns empty traces for empty or unmatched digests", () => {
+    expect(renderTraceHtml({ transcript_id: "sess-1" }, { "sess-1": { turns: [] } })).toBe("");
+    expect(
+      renderTraceHtml(
+        { transcript_id: "sess-1", investigation_lines: "90-91" },
+        {
+          "sess-1": {
+            turns: [{ role: "assistant", line: 1, est_tokens: 0, text: [] }],
+          },
+        },
+      ),
+    ).toBe("");
+    expect(
+      renderTraceHtml(
+        { transcript_id: "sess-1" },
+        { "sess-1": { turns: [{ role: "assistant", line: 0, est_tokens: 2, text: ["x"] }] } },
+      ),
+    ).toBe("");
+  });
+
+  it("covers leftover tool preview branches", () => {
+    const long = "x".repeat(90);
+    const html = renderTraceHtml(
+      { transcript_id: "sess-1", investigation_lines: "1-6" },
+      {
+        "sess-1": {
+          turns: [
+            { role: "user", line: 1, est_tokens: 0, text: ["   "] },
+            {
+              role: "assistant",
+              line: 2,
+              est_tokens: 0,
+              text: [],
+              tools: [{ name: "Read", path: "auth.py" }, { name: "" }],
+            },
+            {
+              role: "assistant",
+              line: 3,
+              est_tokens: 3,
+              text: [],
+              tools: [{ name: "CallMcpTool" }],
+            },
+            {
+              role: "assistant",
+              line: 4,
+              est_tokens: 3,
+              text: [],
+              tools: [{ name: "Grep", arguments: { query: "" } }],
+            },
+            {
+              role: "assistant",
+              line: 5,
+              est_tokens: 3,
+              text: [],
+              tools: [{ name: "Write", path: long }],
+            },
+            { role: "assistant", line: 6, est_tokens: 0, text: [] },
+          ],
+        },
+      },
+    );
+    expect(html).toContain("MCP call");
+    expect(html).toContain("auth.py");
+    expect(html).toContain("No input recorded");
+    expect(html).toContain("implementation (not counted)");
+  });
+});
+
+it("uses turn text as the tool preview and empty-step traces", () => {
+  expect(
+    renderTraceHtml(
+      { transcript_id: "sess-1", investigation_lines: "1" },
+      { "sess-1": { turns: [{ role: "assistant", line: 1, est_tokens: 0, text: [] }] } },
+    ),
+  ).toBe("");
+  const html = renderTraceHtml(
+    { transcript_id: "sess-1", investigation_lines: "1-3" },
+    {
+      "sess-1": {
+        turns: [
+          { role: "user", line: 1, est_tokens: 1, text: ["ask"] },
+          {
+            role: "assistant",
+            line: 2,
+            est_tokens: 4,
+            text: ["looked at the retry loop"],
+            tools: [{ name: "UnknownTool" }],
+          },
+          {
+            role: "assistant",
+            line: 3,
+            est_tokens: 2,
+            text: [],
+            tools: [{ name: "CallMcpTool", tool_name: "  " }],
+          },
+        ],
+      },
+    },
+  );
+  expect(html).toContain("looked at the retry loop");
+  expect(html).toContain("MCP call");
+});

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -1,0 +1,629 @@
+/**
+ * Self-contained HTML harvest report — same document as dosu-skill
+ * log-to-dosu-knowledge/scripts/generate_report.py.
+ */
+
+import { REPORT_CSS } from "./css";
+import type {
+  DigestTool,
+  DigestTurn,
+  ReportCandidate,
+  ReportDigest,
+  ReportInventory,
+} from "./types";
+
+const CHARS_PER_TOKEN = 4;
+const MAX_TRACE_STEPS = 50;
+const PREVIEW_CHARS = 80;
+const SQL_DISPLAY = new Set(["execute_sql", "query_run", "list_tables"]);
+const LOGS_DISPLAY = new Set(["query_logs"]);
+const SKIP_TOOL_NAMES = new Set(["tool_result"]);
+const TAG_RE = /<[^>]+>/g;
+const WS_RE = /\s+/g;
+
+export interface BuildReportOptions {
+  inventory: ReportInventory;
+  candidates?: ReportCandidate[];
+  orgName?: string;
+  repo?: string;
+  branch?: string;
+  summary?: string;
+  dryRun?: boolean;
+  generatedAt?: Date;
+  digests?: Record<string, ReportDigest>;
+}
+
+function esc(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function fmtInt(n: unknown): string {
+  const v = Number(n);
+  if (!Number.isFinite(v)) return "—";
+  return Math.trunc(v).toLocaleString("en-US");
+}
+
+function applyStatusDefaults(candidates: ReportCandidate[], dryRun: boolean): ReportCandidate[] {
+  const fallback = dryRun ? "proposed" : "written";
+  const known = new Set(["written", "pending", "proposed", "already_in_library"]);
+  return candidates.map((c) => {
+    const current = (c.status ?? "").trim().toLowerCase();
+    return { ...c, status: known.has(current) ? current : fallback };
+  });
+}
+
+export function tokenTotalsFromCandidates(
+  candidates: ReportCandidate[],
+  inventory: ReportInventory,
+): {
+  baseline_tokens: number;
+  replaced_baseline_tokens: number;
+  read_knowledge_tokens: number;
+  tokens_saved: number;
+  pct_saved: number;
+} | null {
+  if (candidates.length === 0) return null;
+  let replaced = 0;
+  let hasRediscovery = false;
+  let readCost = 0;
+  for (const c of candidates) {
+    const raw = c.approx_rediscovery_tokens;
+    if (raw != null) {
+      hasRediscovery = true;
+      replaced += Math.max(0, Number(raw) || 0);
+    }
+    const blob = `${c.title ?? ""}\n${c.content ?? ""}`;
+    readCost += Math.round(blob.length / CHARS_PER_TOKEN);
+  }
+  if (!hasRediscovery) return null;
+  let baseline = inventory.totals?.learning_tokens ?? 0;
+  if (!baseline) {
+    baseline = inventory.transcripts.reduce((sum, t) => sum + (t.learning_tokens || 0), 0);
+  }
+  const saved = Math.max(0, replaced - readCost);
+  const pct = baseline ? Math.round((1000 * saved) / baseline) / 10 : 0;
+  return {
+    baseline_tokens: baseline,
+    replaced_baseline_tokens: replaced,
+    read_knowledge_tokens: readCost,
+    tokens_saved: saved,
+    pct_saved: pct,
+  };
+}
+
+function presentationCopy(c: ReportCandidate): [string, string] {
+  const idea = (c.plain_english || "").trim() || (c.content || "").trim();
+  const how = (c.how_found || "").trim();
+  if (how) return [idea, how];
+  const raw = c.approx_rediscovery_tokens ?? c.baseline_tokens;
+  const n = raw == null ? 0 : Number(raw) || 0;
+  const work = n
+    ? `About ${n.toLocaleString("en-US")} tokens of reading, searching, and tracing in this session before the conclusion.`
+    : "Investigation stretch was not measured.";
+  return [idea, work];
+}
+
+export function parseLineSpec(spec: unknown): Set<number> {
+  const out = new Set<number>();
+  if (spec == null) return out;
+  const raw = Array.isArray(spec) ? spec.map(String).join(",") : String(spec);
+  if (!raw.trim()) return out;
+  for (const part of raw.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    if (trimmed.includes("-")) {
+      const [a, b] = trimmed.split("-", 2);
+      let start = Number.parseInt(a.trim(), 10);
+      let end = Number.parseInt(b.trim(), 10);
+      if (!Number.isFinite(start) || !Number.isFinite(end)) continue;
+      if (end < start) [start, end] = [end, start];
+      for (let i = start; i <= end; i++) out.add(i);
+    } else {
+      const n = Number.parseInt(trimmed, 10);
+      if (Number.isFinite(n)) out.add(n);
+    }
+  }
+  return out;
+}
+
+function expandDigestTurns(turns: DigestTurn[], spec: Set<number>): DigestTurn[] {
+  if (turns.length === 0 || spec.size === 0) return [];
+  const minLine = Math.min(...spec);
+  const maxLine = Math.max(...spec);
+  let start = minLine;
+  for (const turn of turns) {
+    const line = Number(turn.line) || 0;
+    if (turn.role === "user" && line <= minLine) start = line;
+  }
+  return turns.filter((turn) => {
+    const line = Number(turn.line) || 0;
+    return start <= line && line <= maxLine;
+  });
+}
+
+function collapsePreview(text: string, limit = PREVIEW_CHARS): string {
+  const cleaned = (text || "").replace(TAG_RE, " ").replace(WS_RE, " ").trim();
+  if (cleaned.length > limit) return `${cleaned.slice(0, limit - 1).trimEnd()}…`;
+  return cleaned;
+}
+
+function turnText(turn: DigestTurn): string {
+  const texts = turn.text ?? [];
+  if (typeof texts === "string") return texts;
+  return texts.filter(Boolean).join(" ");
+}
+
+function innerToolName(tool: DigestTool): string {
+  const name = String(tool.name ?? "");
+  for (const key of ["toolName", "tool_name"] as const) {
+    const val = tool[key];
+    if (val) return String(val);
+  }
+  if (tool.knowledge?.tool) return String(tool.knowledge.tool);
+  if (name.startsWith("mcp:")) return name.split(":", 2)[1] ?? name;
+  if (name.startsWith("mcp__")) return name.split("__").at(-1) ?? name;
+  return name;
+}
+
+function displayToolName(tool: DigestTool): string {
+  const inner = innerToolName(tool);
+  const wrapper = String(tool.name ?? "");
+  if (inner === "GetMcpTools" || wrapper === "GetMcpTools") return "MCP schema";
+  if (SQL_DISPLAY.has(inner)) return "SQL";
+  if (LOGS_DISPLAY.has(inner)) return "Logs";
+  return inner || wrapper || "tool";
+}
+
+function firstArgPreview(args: unknown, keys: string[]): string {
+  if (typeof args !== "object" || args === null) return "";
+  const row = args as Record<string, unknown>;
+  for (const key of keys) {
+    if (row[key]) {
+      const pv = collapsePreview(String(row[key]));
+      if (pv) return pv;
+    }
+  }
+  return "";
+}
+
+function toolPreview(tool: DigestTool, text: string): string {
+  const name = String(tool.name ?? "");
+  const inner = innerToolName(tool);
+  if (tool.path) {
+    const raw = String(tool.path);
+    const leaf = raw.includes("/") ? raw.split("/").at(-1) : raw;
+    const pv = collapsePreview(leaf ?? "");
+    if (pv) return pv;
+  }
+  if (tool.pattern) {
+    const pv = collapsePreview(String(tool.pattern));
+    if (pv) return pv;
+  }
+  if (tool.command_preview) {
+    const pv = collapsePreview(String(tool.command_preview));
+    if (pv) return pv;
+  }
+  if (tool.query) {
+    const pv = collapsePreview(String(tool.query));
+    if (pv) return pv;
+  }
+  if (tool.file_path) {
+    const raw = String(tool.file_path);
+    const leaf = raw.includes("/") ? raw.split("/").at(-1) : raw;
+    const pv = collapsePreview(leaf ?? "");
+    if (pv) return pv;
+  }
+  if (tool.prompt) {
+    const pv = collapsePreview(String(tool.prompt));
+    if (pv) return pv;
+  }
+  if (tool.knowledge) {
+    const pv = firstArgPreview(tool.knowledge.arguments, ["query", "sql", "command"]);
+    if (pv) return pv;
+  }
+  const fromArgs = firstArgPreview(tool.arguments, ["query", "sql", "command", "description"]);
+  if (fromArgs) return fromArgs;
+  const toolName = tool.toolName || tool.tool_name;
+  if (toolName) {
+    const combo = tool.server ? `${toolName} · ${tool.server}` : String(toolName);
+    const pv = collapsePreview(combo);
+    if (pv) return pv;
+  }
+  const fromText = collapsePreview(text);
+  if (fromText) return fromText;
+  if (name === "GetMcpTools" || inner === "GetMcpTools") return "Look up available MCP tools";
+  if (name === "CallMcpTool") {
+    const extra = toolName || (inner !== "CallMcpTool" ? inner : "");
+    return extra ? `MCP call · ${extra}` : "MCP call";
+  }
+  return "No input recorded";
+}
+
+function classifyDigestTool(tool: DigestTool): string {
+  const name = String(tool.name ?? "");
+  const inner = innerToolName(tool);
+  const canonical = inner || name;
+  if (["Write", "Edit", "MultiEdit", "StrReplace", "Delete"].includes(canonical)) return "code";
+  if (["TodoWrite", "update_plan", "SwitchMode"].includes(canonical)) return "planning";
+  if (["write_knowledge", "finalize_session_knowledge"].includes(canonical)) return "other";
+  return "context";
+}
+
+function usableTools(turn: DigestTurn): DigestTool[] {
+  return (turn.tools ?? []).filter((tool) => !SKIP_TOOL_NAMES.has(String(tool.name ?? "")));
+}
+
+interface TraceStep {
+  kind?: string;
+  bucket?: string;
+  label?: string;
+  preview?: string;
+  tokens?: number;
+  omitted?: number;
+}
+
+function buildTraceSteps(turns: DigestTurn[]): TraceStep[] {
+  const steps: TraceStep[] = [];
+  for (const turn of turns) {
+    const role = turn.role ?? "";
+    const est = Number(turn.est_tokens) || 0;
+    const text = turnText(turn);
+    const tools = usableTools(turn);
+    if (role === "user") {
+      if (!text) continue;
+      steps.push({
+        kind: "user",
+        bucket: "other",
+        label: "Question",
+        preview: collapsePreview(text) || "No input recorded",
+        tokens: est,
+      });
+      continue;
+    }
+    if (tools.length > 0) {
+      const share = Math.trunc(est / tools.length);
+      const remainder = est - share * tools.length;
+      tools.forEach((tool, i) => {
+        const bucket = classifyDigestTool(tool);
+        const preview = toolPreview(tool, text);
+        steps.push({
+          kind: "tool",
+          bucket,
+          label: displayToolName(tool),
+          preview: bucket === "code" ? `${preview} · implementation (not counted)` : preview,
+          tokens: share + (i === 0 ? remainder : 0),
+        });
+      });
+      continue;
+    }
+    if (text) {
+      steps.push({
+        kind: "reasoning",
+        bucket: "other",
+        label: "Reasoning",
+        preview: collapsePreview(text),
+        tokens: est,
+      });
+    }
+  }
+  return steps;
+}
+
+function capTraceSteps(steps: TraceStep[]): TraceStep[] {
+  if (steps.length <= MAX_TRACE_STEPS) return steps;
+  const omitted = steps.length - MAX_TRACE_STEPS;
+  return [steps[0], { omitted }, ...steps.slice(-(MAX_TRACE_STEPS - 1))];
+}
+
+export function renderTraceHtml(
+  candidate: ReportCandidate,
+  digests: Record<string, ReportDigest> | undefined,
+): string {
+  const tid = String(candidate.transcript_id ?? "").trim();
+  const digest = tid ? digests?.[tid] : undefined;
+  if (!digest) return "";
+  // No attributed investigation stretch means no trace: rendering the whole
+  // session here would present a session-sized token count as if it were the
+  // cost of learning this one note, which the report must never do.
+  const spec = parseLineSpec(candidate.investigation_lines);
+  if (spec.size === 0) return "";
+  const turns = expandDigestTurns(digest.turns, spec);
+  if (turns.length === 0) return "";
+  const steps = buildTraceSteps(turns);
+  if (steps.length === 0) return "";
+
+  const learning = { context: 0, planning: 0, other: 0 };
+  const toolCounts = new Map<string, number>();
+  let reasoningN = 0;
+  for (const step of steps) {
+    const bucket = step.bucket;
+    const tokens = Number(step.tokens) || 0;
+    if (bucket === "context" || bucket === "planning" || bucket === "other") {
+      learning[bucket] += tokens;
+    }
+    if (step.kind === "reasoning") reasoningN += 1;
+    else if (step.kind === "tool" && bucket !== "code") {
+      const label = String(step.label || "tool");
+      toolCounts.set(label, (toolCounts.get(label) ?? 0) + 1);
+    }
+  }
+  const learningTotal = learning.context + learning.planning + learning.other;
+  const official = candidate.approx_rediscovery_tokens;
+  const summaryTokens =
+    official != null && Number.isFinite(Number(official)) ? Number(official) : learningTotal;
+  const bits = [...toolCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([name, n]) => `${n} ${name}`);
+  if (reasoningN) bits.push(`${reasoningN} reasoning`);
+  bits.push(`~${fmtInt(summaryTokens)} tok`);
+  const summary = `Work to learn this · ${bits.join(" · ")}`;
+  const learnSum = learningTotal || 1;
+  const bar = (["context", "planning", "other"] as const)
+    .map((bucket) => {
+      const pct = learningTotal ? (100 * learning[bucket]) / learnSum : 0;
+      return `<span class="tb ${bucket}" style="width:${pct.toFixed(1)}%"></span>`;
+    })
+    .join("");
+  const legendParts: string[] = [];
+  if (learning.context) legendParts.push(`Reads &amp; search ${fmtInt(learning.context)}`);
+  if (learning.planning) legendParts.push(`Planning ${fmtInt(learning.planning)}`);
+  if (learning.other) legendParts.push(`Reasoning ${fmtInt(learning.other)}`);
+
+  const rows = [
+    '<li class="ts-head" aria-hidden="true"><span class="chip">Action</span><span class="pv">What it did</span><span class="tok">Tokens</span></li>',
+  ];
+  for (const step of capTraceSteps(steps)) {
+    if (step.omitted) {
+      rows.push(
+        `<li class="ts-omit"><span class="chip"></span><span class="pv">${esc(step.omitted)} earlier steps omitted</span><span class="tok"></span></li>`,
+      );
+      continue;
+    }
+    const bucket = String(step.bucket || "other");
+    const css =
+      step.kind === "user"
+        ? "ts-user"
+        : ({ context: "ts-context", planning: "ts-planning", other: "ts-other", code: "ts-code" }[
+            bucket
+          ] ?? "ts-other");
+    const tok = step.tokens
+      ? `<span class="tok">${esc(fmtInt(step.tokens))}</span>`
+      : '<span class="tok"></span>';
+    rows.push(
+      `<li class="${css}"><span class="chip">${esc(step.label)}</span><span class="pv">${esc(step.preview)}</span>${tok}</li>`,
+    );
+  }
+
+  return `
+<details class="trace">
+  <summary>${esc(summary)}</summary>
+  <div class="trace-bar" title="context / planning / other">${bar}</div>
+  <p class="trace-legend">${legendParts.join(" · ")}</p>
+  <ol class="trace-steps">${rows.join("")}</ol>
+</details>
+`;
+}
+
+function notesSectionCopy(candidates: ReportCandidate[]): [string, string, string, string] {
+  const n = candidates.length;
+  const written = candidates.filter(
+    (c) => (c.status || "written").toLowerCase() === "written",
+  ).length;
+  const pending = candidates.filter((c) => (c.status || "").toLowerCase() === "pending").length;
+  const already = candidates.filter(
+    (c) => (c.status || "").toLowerCase() === "already_in_library",
+  ).length;
+  const proposed = n - written - pending - already;
+  if (n > 0 && already === n) {
+    return [
+      "Notes already in the Library",
+      "These pages were already present — no new write_knowledge calls.",
+      "Share",
+      "Nothing new to write; the Library already had these pages.",
+    ];
+  }
+  if (n > 0 && written === n) {
+    return [
+      "Notes written to Dosu",
+      "",
+      "Share",
+      "Notes are on the backfill branch and in the candidate-topic pipeline. Print / Save as PDF if you want a copy.",
+    ];
+  }
+  if (n > 0 && proposed === n) {
+    return [
+      "Proposed write_knowledge calls",
+      "Plain-English takeaway plus what it took to find — not the original user prompts.",
+      "Next step",
+      "Run the skill (without dry-run) so these payloads are written via write_knowledge.",
+    ];
+  }
+  if (n === 0) {
+    return [
+      "write_knowledge notes",
+      "Plain-English takeaway plus what it took to find — not the original user prompts.",
+      "Next step",
+      "Run knowledge sync so learnings are extracted and written via write_knowledge.",
+    ];
+  }
+  const bits: string[] = [];
+  if (written) bits.push(`${written} written`);
+  if (proposed) bits.push(`${proposed} proposed`);
+  if (pending) bits.push(`${pending} pending`);
+  if (already) bits.push(`${already} already in library`);
+  return [
+    "write_knowledge notes",
+    `${bits.join(", ")} — Plain-English takeaway plus what it took to find — not the original user prompts.`,
+    "Share",
+    "Written notes are in the candidate-topic pipeline. Proposed/pending items still need a write.",
+  ];
+}
+
+export function buildReportHtml(options: BuildReportOptions): string {
+  const inventory = options.inventory;
+  const transcripts = inventory.transcripts ?? [];
+  let candidates = applyStatusDefaults(options.candidates ?? [], Boolean(options.dryRun));
+  candidates = [...candidates].sort((a, b) => {
+    const av = Number(a.approx_rediscovery_tokens) || 0;
+    const bv = Number(b.approx_rediscovery_tokens) || 0;
+    return bv - av;
+  });
+
+  const org = options.orgName || "Your team";
+  const repo = options.repo || inventory.cwd || "—";
+  const branch = options.branch || "—";
+  const summary =
+    options.summary ||
+    "Local agent session logs were mined into Dosu notes so the next task can reuse them — reducing rediscovery cost.";
+  const generated = `${(options.generatedAt ?? new Date()).toISOString().replace("T", " ").slice(0, 16)} UTC`;
+
+  const derived = tokenTotalsFromCandidates(candidates, inventory);
+  const [notesHeading, notesLede, footerTitle, footerBody] = notesSectionCopy(candidates);
+
+  const candidateRows = candidates.map((c, i) => {
+    const [idea, work] = presentationCopy(c);
+    const traceHtml = renderTraceHtml(c, options.digests);
+    const content = (c.content || "").trim();
+    const ideaHtml = idea
+      ? `<p class="idea">${esc(idea)}</p>`
+      : "<p class='muted'>Extract a lean note before writing to Dosu.</p>";
+    const workHtml = `<p class="work"><span class="work-label">To find this</span> ${esc(work)}</p>`;
+    const techHtml =
+      content && content !== idea
+        ? `<details class="note-tech"><summary>Technical note</summary><pre class="note-body">${esc(content)}</pre></details>`
+        : "";
+    const status = c.status || "written";
+    const queryHtml = c.user_query
+      ? `<p class="query"><strong>Trigger:</strong> ${esc(c.user_query)}</p>`
+      : "";
+    return `
+<article class="card" id="c-${i + 1}">
+  <header>
+    <span class="badge status-${esc(status)}">${esc(status)}</span>
+    <h3>${esc(c.title || "Untitled")}</h3>
+  </header>
+  <p class="meta">
+    session ${esc(c.session_title || c.transcript_id || "—")}
+    · rediscovery ~${fmtInt(c.approx_rediscovery_tokens ?? c.baseline_tokens)} tok
+  </p>
+  ${ideaHtml}
+  ${workHtml}
+  ${traceHtml}
+  ${techHtml}
+  ${queryHtml}
+</article>`;
+  });
+
+  const heavy = [...transcripts]
+    .sort((a, b) => (b.learning_tokens || 0) - (a.learning_tokens || 0))
+    .slice(0, 8);
+  const heavyRows = heavy
+    .map((t) => {
+      const title = (t.title || "").trim() || t.transcript_id;
+      const query = (t.user_queries?.[0] || "").slice(0, 100);
+      return `<tr>
+      <td>${esc(t.source)}</td>
+      <td>${esc(title)}</td>
+      <td class="num">${fmtInt(t.learning_tokens)}</td>
+      <td class="num">${fmtInt(t.rediscovery_tool_calls)}</td>
+      <td>${esc(query)}</td>
+    </tr>`;
+    })
+    .join("");
+
+  let tokenSection: string;
+  if (derived) {
+    tokenSection = `
+<section>
+  <h2>Estimated context savings</h2>
+  <p class="lede">Counterfactual: replace rediscovery stretches with a Dosu <code>read_knowledge</code> hit.</p>
+  <div class="stats">
+    <div class="stat"><div class="label">Baseline (cost to learn)</div><div class="value">${fmtInt(derived.baseline_tokens)}</div></div>
+    <div class="stat"><div class="label">Learning replaced</div><div class="value">${fmtInt(derived.replaced_baseline_tokens)}</div></div>
+    <div class="stat"><div class="label">Read cost</div><div class="value">${fmtInt(derived.read_knowledge_tokens)}</div></div>
+    <div class="stat highlight"><div class="label">Est. tokens saved</div><div class="value">${fmtInt(derived.tokens_saved)} <span class="pct">(${esc(`${derived.pct_saved}%`)})</span></div></div>
+  </div>
+</section>`;
+  } else {
+    tokenSection = `
+<section>
+  <h2>Estimated context savings</h2>
+  <p class="muted">No rediscovery estimates on the notes yet — each candidate needs <code>approx_rediscovery_tokens</code>.</p>
+</section>`;
+  }
+
+  const notesBody =
+    candidateRows.join("") ||
+    '<p class="muted">No write_knowledge payloads yet. Run knowledge sync so the miner extracts learnings.</p>';
+  const lede = notesLede ? `<p class="lede">${esc(notesLede)}</p>` : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Dosu knowledge report — ${esc(org)}</title>
+<style>
+${REPORT_CSS}
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="hero">
+      <p class="eyebrow">Dosu · Knowledge report</p>
+      <h1>${esc(org)}</h1>
+      <p class="lede">${esc(summary)}</p>
+      <p class="meta-line">
+        Repo <code>${esc(repo)}</code>
+        · branch <code>${esc(branch)}</code>
+        · generated ${esc(generated)}
+      </p>
+      <div class="toolbar no-print">
+        <button type="button" onclick="window.print()">Print / Save as PDF</button>
+      </div>
+    </header>
+
+    ${tokenSection}
+
+    <section>
+      <h2>${esc(notesHeading)} <span class="muted">(${candidates.length})</span></h2>
+      ${lede}
+      ${notesBody}
+    </section>
+
+    <section>
+      <h2>Heaviest sessions</h2>
+      <p class="lede">Where learning cost was highest — prime targets for Dosu cache hits.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Host</th><th>Session</th><th>Learning tokens</th><th>Rediscovery tools</th><th>Query</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${heavyRows || '<tr><td colspan="5" class="muted">No sessions</td></tr>'}
+        </tbody>
+      </table>
+    </section>
+
+    <footer class="cta">
+      <h2>${esc(footerTitle)}</h2>
+      <p>${esc(footerBody)}</p>
+      <p class="meta">
+        Print tip: use <strong>Print / Save as PDF</strong> above (or ⌘P / Ctrl+P).
+        Session logs stay between you and your agent — only note text is written to Dosu.
+      </p>
+      <div class="toolbar no-print">
+        <button type="button" onclick="window.print()">Print / Save as PDF</button>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>
+`;
+}

--- a/src/report/notes.test.ts
+++ b/src/report/notes.test.ts
@@ -1,0 +1,217 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../sessions/scan";
+import { attributeRediscovery, sessionIdFromReadInput, sessionsToInventory } from "./notes";
+import { extractUserQueries, sessionTitleFromUserText } from "./queries";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "dosu-report-notes-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function claudeSession(id: string, lines: unknown[]): AgentSession {
+  const path = join(dir, `${id}.jsonl`);
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join("\n"));
+  return { id, harness: "claude", path, updated: "2026-09-09T00:00:00.000Z" };
+}
+
+describe("sessionIdFromReadInput", () => {
+  it("reads the session id from read_session input", () => {
+    expect(sessionIdFromReadInput({ id: "abc", offset: 2 })).toBe("abc");
+    expect(sessionIdFromReadInput({ offset: 0 })).toBeUndefined();
+    expect(sessionIdFromReadInput(["id"])).toBeUndefined();
+    expect(sessionIdFromReadInput({ id: "  " })).toBeUndefined();
+  });
+});
+
+describe("attributeRediscovery", () => {
+  it("gives each note its matching user-query cycle, not the whole session", () => {
+    const session = claudeSession("s1", [
+      { type: "user", message: { content: "why does auth retry?" } },
+      { type: "assistant", message: { content: [{ type: "text", text: "because 401" }] } },
+      { type: "user", message: { content: "and the refresh path?" } },
+      { type: "assistant", message: { content: [{ type: "text", text: "see tokens.py" }] } },
+    ]);
+    const notes = [
+      { title: "OAuth retry", content: "Retry after 401.", transcript_id: "s1" },
+      { title: "Refresh path", content: "tokens.py owns it.", transcript_id: "s1" },
+    ];
+    const [first, second] = attributeRediscovery(notes, [session]);
+    expect(first.approx_rediscovery_tokens).toBeGreaterThan(0);
+    expect(second.approx_rediscovery_tokens).toBeGreaterThan(0);
+    expect(first.approx_rediscovery_tokens).toBeLessThan(
+      (first.approx_rediscovery_tokens ?? 0) + (second.approx_rediscovery_tokens ?? 0),
+    );
+    expect(
+      (first.approx_rediscovery_tokens ?? 0) + (second.approx_rediscovery_tokens ?? 0),
+    ).toBeLessThanOrEqual(
+      "why does auth retry?".length / 4 +
+        "because 401".length / 4 +
+        "and the refresh path?".length / 4 +
+        "see tokens.py".length / 4 +
+        2,
+    );
+    expect(first.user_query).toContain("why does auth retry?");
+    expect(second.user_query).toContain("refresh path");
+    expect(first.investigation_lines).toBe("1-2");
+    expect(second.investigation_lines).toBe("3-4");
+    expect(first.status).toBe("written");
+  });
+
+  it("does not invent a session-sized number for a later note", () => {
+    const long = "x".repeat(4000);
+    const session = claudeSession("s1", [
+      { type: "user", message: { content: "unrelated scaffolding question" } },
+      { type: "assistant", message: { content: [{ type: "text", text: long }] } },
+      { type: "user", message: { content: "why does oauth retry after 401" } },
+      { type: "assistant", message: { content: [{ type: "text", text: "retry after 401" }] } },
+    ]);
+    const [note] = attributeRediscovery(
+      [{ title: "OAuth retry after 401", content: "Retry after 401.", transcript_id: "s1" }],
+      [session],
+    );
+    expect(note.approx_rediscovery_tokens).toBeGreaterThan(0);
+    expect(note.approx_rediscovery_tokens).toBeLessThan(long.length / 4);
+    expect(note.investigation_lines).toBe("3-4");
+  });
+
+  it("never assigns the same cycle twice; the loser and no-overlap notes get no tokens", () => {
+    const session = claudeSession("s1", [
+      { type: "user", message: { content: "why does oauth retry after 401" } },
+      { type: "assistant", message: { content: [{ type: "text", text: "retry after 401" }] } },
+    ]);
+    const notes = [
+      { title: "OAuth retry after 401", content: "Retry after 401.", transcript_id: "s1" },
+      { title: "OAuth retry", content: "Also about the 401 retry.", transcript_id: "s1" },
+      { title: "Unrelated zebra fact", content: "Zebras have stripes.", transcript_id: "s1" },
+    ];
+    const results = attributeRediscovery(notes, [session]);
+    const withTokens = results.filter((r) => (r.approx_rediscovery_tokens ?? 0) > 0);
+    expect(withTokens).toHaveLength(1);
+    expect(withTokens[0].title).toBe("OAuth retry after 401");
+    expect(results[2].approx_rediscovery_tokens).toBeUndefined();
+  });
+
+  it("matches a cycle through tool paths and patterns when the text never names the file", () => {
+    const session = claudeSession("s1", [
+      { type: "user", message: { content: "where is the refresh handled?" } },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name: "Read", input: { path: "src/auth/tokens.py" } },
+            { type: "tool_use", name: "Grep", input: { pattern: "refresh_grant" } },
+            { type: "tool_use", name: "Shell", input: { command: "rg refresh_grant" } },
+          ],
+        },
+      },
+    ]);
+    const [note] = attributeRediscovery(
+      [{ title: "tokens.py refresh_grant", content: "tokens.py owns it.", transcript_id: "s1" }],
+      [session],
+    );
+    expect(note.approx_rediscovery_tokens).toBeGreaterThan(0);
+    expect(note.investigation_lines).toBe("1-2");
+  });
+
+  it("skips rediscovery tokens when the session has no turns", () => {
+    const session = claudeSession("empty", []);
+    const [note] = attributeRediscovery(
+      [{ title: "A", content: "B", transcript_id: "empty" }],
+      [session],
+    );
+    expect(note.user_query).toBeUndefined();
+    expect(note.investigation_lines).toBeUndefined();
+    expect(note.approx_rediscovery_tokens).toBeUndefined();
+  });
+
+  it("ignores notes whose transcript id matches no scanned session", () => {
+    const session = claudeSession("s1", [
+      { type: "user", message: { content: "why does oauth retry?" } },
+    ]);
+    const [unknown, bare] = attributeRediscovery(
+      [
+        { title: "OAuth retry", content: "Retry.", transcript_id: "not-scanned" },
+        { title: "No transcript", content: "Bare." },
+      ],
+      [session],
+    );
+    expect(unknown.approx_rediscovery_tokens).toBeUndefined();
+    expect(bare.approx_rediscovery_tokens).toBeUndefined();
+  });
+
+  it("keeps the session title but assigns no cycle when only scaffolding matches", () => {
+    const session = claudeSession("s1", [
+      { type: "user", message: { content: "# AGENTS.md\nrules" } },
+      { type: "user", message: { content: "find the oauth retry in tokens.py" } },
+      { type: "assistant", message: { content: [{ type: "text", text: "retry after 401" }] } },
+    ]);
+    const [note] = attributeRediscovery(
+      [{ title: "OAuth retry tokens.py", content: "Retry after 401.", transcript_id: "s1" }],
+      [session],
+    );
+    expect(note.session_title).toBe("find the oauth retry in tokens.py");
+    expect(note.approx_rediscovery_tokens).toBeGreaterThan(0);
+  });
+});
+
+describe("extractUserQueries", () => {
+  it("pulls the inner user_query and drops timestamp wrappers", () => {
+    expect(
+      extractUserQueries(
+        "<user_query>\ncheck slack\n</user_query>\n<timestamp>2026-09-09</timestamp>",
+      ),
+    ).toEqual(["check slack"]);
+    expect(sessionTitleFromUserText("<user_query>fix oauth retry after 401</user_query>")).toBe(
+      "fix oauth retry after 401",
+    );
+  });
+});
+
+describe("sessionsToInventory", () => {
+  it("uses learning_tokens not tool-call counts", () => {
+    const session = claudeSession("s1", [
+      { type: "user", message: { content: "hello there friend" } },
+      { type: "assistant", message: { content: [{ type: "text", text: "working on it now" }] } },
+    ]);
+    const inventory = sessionsToInventory([session]);
+    expect(inventory.transcripts[0]).toMatchObject({
+      source: "claude",
+      transcript_id: "s1",
+      title: "hello there friend",
+      rediscovery_tool_calls: 0,
+    });
+    expect(inventory.totals?.learning_tokens).toBe(inventory.transcripts[0].learning_tokens);
+    expect(inventory.totals?.learning_tokens).toBeGreaterThan(0);
+  });
+
+  it("counts rediscovery tools and strips Cursor wrappers from the title", () => {
+    const session = claudeSession("s2", [
+      {
+        type: "user",
+        message: { content: "<user_query>check out how slack is implemented</user_query>" },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "looking" },
+            { type: "tool_use", name: "Read", input: {} },
+            { type: "tool_use", name: "Grep", input: {} },
+          ],
+        },
+      },
+    ]);
+    const row = sessionsToInventory([session]).transcripts[0];
+    expect(row.title).toBe("check out how slack is implemented");
+    expect(row.user_queries).toEqual(["check out how slack is implemented"]);
+    expect(row.rediscovery_tool_calls).toBe(2);
+  });
+});

--- a/src/report/notes.ts
+++ b/src/report/notes.ts
@@ -1,0 +1,226 @@
+/**
+ * Capture write_knowledge payloads during a mining run, persist them, and
+ * attribute rediscovery tokens the same way the skill report does: the cost
+ * to learn THIS fact (the matching user-query cycle), never a session-sized
+ * number and never an equal split of one session across notes.
+ */
+
+import {
+  countRediscoveryToolCalls,
+  estimateSessionTokens,
+  readSessionTurns,
+} from "../sessions/read";
+import type { AgentSession } from "../sessions/scan";
+import { digestTurnText, sessionToDigest } from "./digest";
+import { extractUserQueries, sessionTitleFromUserText } from "./queries";
+import type { DigestTurn, ReportCandidate, ReportInventory, ReportNote } from "./types";
+
+export { digestsForSessions } from "./digest";
+
+export function sessionIdFromReadInput(input: unknown): string | undefined {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return undefined;
+  const id = (input as Record<string, unknown>).id;
+  return typeof id === "string" && id.trim() ? id : undefined;
+}
+
+const STOP_WORDS = new Set([
+  "about",
+  "after",
+  "also",
+  "and",
+  "are",
+  "but",
+  "can",
+  "does",
+  "for",
+  "from",
+  "have",
+  "into",
+  "just",
+  "must",
+  "not",
+  "that",
+  "the",
+  "this",
+  "they",
+  "with",
+  "what",
+  "when",
+  "which",
+  "will",
+  "your",
+]);
+
+function significantWords(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const raw of text.toLowerCase().match(/[a-z][a-z0-9._-]{2,}/g) ?? []) {
+    const word = raw.replace(/^\.+|\.+$/g, "");
+    if (word.length >= 3 && !STOP_WORDS.has(word)) out.add(word);
+  }
+  return out;
+}
+
+function overlapCount(a: Set<string>, b: Set<string>): number {
+  let n = 0;
+  for (const word of a) if (b.has(word)) n += 1;
+  return n;
+}
+
+/** A note's title/content vocabulary, precomputed once per note for scoring. */
+interface NoteWords {
+  title: Set<string>;
+  content: Set<string>;
+}
+
+function noteWords(note: Pick<ReportNote, "title" | "content">): NoteWords {
+  return { title: significantWords(note.title), content: significantWords(note.content) };
+}
+
+/** One user-query cycle: a user turn and everything until the next user turn,
+ * flattened to matchable text (turn text plus tool paths/patterns/commands). */
+interface SessionCycle {
+  start: number;
+  end: number;
+  text: string;
+}
+
+function sessionCycles(turns: readonly DigestTurn[]): SessionCycle[] {
+  const starts: number[] = [];
+  for (let i = 0; i < turns.length; i++) {
+    if (turns[i].role === "user" && digestTurnText(turns[i]).trim()) starts.push(i);
+  }
+  return starts.map((start, i) => {
+    const end = i + 1 < starts.length ? starts[i + 1] : turns.length;
+    const text = turns
+      .slice(start, end)
+      .map((t) => {
+        const paths = (t.tools ?? [])
+          .map((tool) => tool.path || tool.pattern || tool.command_preview || "")
+          .filter(Boolean)
+          .join(" ");
+        return `${digestTurnText(t)} ${paths}`;
+      })
+      .join("\n");
+    return { start, end, text };
+  });
+}
+
+/** Title words count double: the title is the note's identity, the body is corroboration. */
+function cycleMatchScore(words: NoteWords, cycleText: string): number {
+  const cycleWords = significantWords(cycleText);
+  return overlapCount(words.title, cycleWords) * 2 + overlapCount(words.content, cycleWords);
+}
+
+function cleanedUserQuery(text: string): string {
+  const queries = extractUserQueries(text);
+  return (queries[0] ?? text).replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Cost to learn THIS note: the user-query cycle that best matches the title
+ * (and content), not the whole session. The skill forbids inventing a
+ * session-sized number or splitting one session budget equally across notes.
+ * Cycles are assigned greedily so two notes never share the same stretch.
+ */
+export function attributeRediscovery(
+  notes: readonly ReportNote[],
+  sessions: readonly AgentSession[],
+): ReportCandidate[] {
+  const byId = new Map(sessions.map((s) => [s.id, s]));
+  const candidates: ReportCandidate[] = notes.map((note) => ({
+    title: note.title,
+    content: note.content,
+    transcript_id: note.transcript_id,
+    repo: note.repo,
+    branch: note.branch,
+    status: "written",
+  }));
+
+  const indexesBySession = new Map<string, number[]>();
+  for (let i = 0; i < notes.length; i++) {
+    const id = notes[i].transcript_id;
+    if (!id || !byId.has(id)) continue;
+    const list = indexesBySession.get(id) ?? [];
+    list.push(i);
+    indexesBySession.set(id, list);
+  }
+
+  for (const [sessionId, indexes] of indexesBySession) {
+    const session = byId.get(sessionId);
+    if (!session) continue;
+    const turns = sessionToDigest(session).turns;
+    const firstUser = turns.find((t) => t.role === "user");
+    const firstText = firstUser ? digestTurnText(firstUser) : "";
+    const sessionTitle = firstText ? sessionTitleFromUserText(firstText) : undefined;
+    for (const i of indexes) {
+      if (sessionTitle) candidates[i].session_title = sessionTitle;
+      if (firstText) candidates[i].user_query = cleanedUserQuery(firstText).slice(0, 200);
+    }
+    if (turns.length === 0) continue;
+
+    const cycles = sessionCycles(turns);
+    const taken = new Set<number>();
+    const ranked = indexes
+      .map((i) => {
+        const words = noteWords(notes[i]);
+        let bestScore = 0;
+        for (const cycle of cycles) {
+          const score = cycleMatchScore(words, cycle.text);
+          if (score > bestScore) bestScore = score;
+        }
+        return { i, words, bestScore };
+      })
+      .sort((a, b) => b.bestScore - a.bestScore);
+
+    for (const item of ranked) {
+      if (item.bestScore <= 0) continue;
+      let pick = -1;
+      let pickScore = 0;
+      for (let ci = 0; ci < cycles.length; ci++) {
+        if (taken.has(ci)) continue;
+        const score = cycleMatchScore(item.words, cycles[ci].text);
+        if (score > pickScore) {
+          pickScore = score;
+          pick = ci;
+        }
+      }
+      if (pick < 0 || pickScore <= 0) continue;
+      taken.add(pick);
+      const cycle = cycles[pick];
+      const slice = turns.slice(cycle.start, cycle.end);
+      const tokens = slice.reduce((sum, t) => sum + (Number(t.est_tokens) || 0), 0);
+      candidates[item.i].approx_rediscovery_tokens = tokens;
+      const startLine = slice[0]?.line ?? cycle.start + 1;
+      const endLine = slice.at(-1)?.line ?? cycle.end;
+      candidates[item.i].investigation_lines = `${startLine}-${endLine}`;
+      const cycleUser = slice.find((t) => t.role === "user");
+      if (cycleUser) {
+        const q = digestTurnText(cycleUser);
+        candidates[item.i].user_query = cleanedUserQuery(q).slice(0, 200);
+        candidates[item.i].session_title = sessionTitleFromUserText(q);
+      }
+    }
+  }
+
+  return candidates;
+}
+
+export function sessionsToInventory(sessions: readonly AgentSession[]): ReportInventory {
+  const transcripts = sessions.map((session) => {
+    const turns = readSessionTurns(session);
+    const queries = turns
+      .filter((t) => t.role === "user")
+      .flatMap((t) => extractUserQueries(t.text));
+    const title = queries[0] ? sessionTitleFromUserText(queries[0]) : undefined;
+    return {
+      source: session.harness,
+      transcript_id: session.id,
+      ...(title ? { title } : {}),
+      learning_tokens: estimateSessionTokens(session),
+      rediscovery_tool_calls: countRediscoveryToolCalls(session),
+      user_queries: queries.slice(0, 3),
+    };
+  });
+  const learning_tokens = transcripts.reduce((sum, t) => sum + t.learning_tokens, 0);
+  return { transcripts, totals: { learning_tokens } };
+}

--- a/src/report/queries.test.ts
+++ b/src/report/queries.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { extractUserQueries, sessionTitleFromUserText } from "./queries";
+
+describe("extractUserQueries", () => {
+  it("returns every user_query block when tags are present", () => {
+    expect(
+      extractUserQueries("<user_query>first ask</user_query><user_query>second ask</user_query>"),
+    ).toEqual(["first ask", "second ask"]);
+  });
+
+  it("falls back to the cleaned text when no tags are present", () => {
+    expect(extractUserQueries("plain question <timestamp>2026-09-09</timestamp>")).toEqual([
+      "plain question",
+    ]);
+  });
+
+  it("drops injected scaffolding blocks", () => {
+    expect(extractUserQueries("# AGENTS.md\nrepo rules")).toEqual([]);
+    expect(extractUserQueries("<INSTRUCTIONS>do things</INSTRUCTIONS>")).toEqual([]);
+    expect(
+      extractUserQueries("<permissions instructions>ask first</permissions instructions>"),
+    ).toEqual([]);
+    expect(extractUserQueries("   ")).toEqual([]);
+  });
+});
+
+describe("sessionTitleFromUserText", () => {
+  it("collapses whitespace and truncates long titles with an ellipsis", () => {
+    const long = `explain   ${"word ".repeat(30)}`;
+    const title = sessionTitleFromUserText(long);
+    expect(title.length).toBeLessThanOrEqual(80);
+    expect(title.endsWith("…")).toBe(true);
+    expect(title).not.toContain("  ");
+  });
+
+  it("returns empty for scaffolding-only text", () => {
+    expect(sessionTitleFromUserText("# AGENTS.md\nrules")).toBe("");
+  });
+});

--- a/src/report/queries.ts
+++ b/src/report/queries.ts
@@ -1,0 +1,26 @@
+/** Cursor / Claude user-query text, same rules as parse_agent_logs.extract_user_queries. */
+
+const TITLE_CHARS = 80;
+const USER_QUERY_RE = /<user_query>\s*([\s\S]*?)\s*<\/user_query>/gi;
+const TIMESTAMP_RE = /<timestamp>[\s\S]*?<\/timestamp>/gi;
+
+export function extractUserQueries(text: string): string[] {
+  const matches = [...text.matchAll(USER_QUERY_RE)].map((m) => m[1].trim()).filter(Boolean);
+  if (matches.length > 0) return matches;
+  const cleaned = text.replace(TIMESTAMP_RE, "").trim();
+  if (
+    cleaned.startsWith("# AGENTS.md") ||
+    cleaned.startsWith("<INSTRUCTIONS>") ||
+    cleaned.startsWith("<permissions instructions>")
+  ) {
+    return [];
+  }
+  return cleaned ? [cleaned] : [];
+}
+
+export function sessionTitleFromUserText(text: string, max = TITLE_CHARS): string {
+  const first = extractUserQueries(text)[0] ?? "";
+  const collapsed = first.replace(/\s+/g, " ").trim();
+  if (collapsed.length > max) return `${collapsed.slice(0, max - 1).trimEnd()}…`;
+  return collapsed;
+}

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -1,0 +1,74 @@
+/** Shapes matching the log-to-dosu-knowledge generate_report.py inputs. */
+
+interface ReportTranscript {
+  source: string;
+  transcript_id: string;
+  /** First user query, tags stripped — shown instead of the UUID. */
+  title?: string;
+  learning_tokens: number;
+  rediscovery_tool_calls?: number;
+  user_queries?: string[];
+}
+
+export interface ReportInventory {
+  cwd?: string;
+  transcripts: ReportTranscript[];
+  totals?: { learning_tokens: number };
+}
+
+/** One write_knowledge payload, plus report-only helper fields. */
+export interface ReportCandidate {
+  title?: string;
+  content?: string;
+  transcript_id?: string;
+  session_title?: string;
+  repo?: string;
+  branch?: string;
+  status?: string;
+  approx_rediscovery_tokens?: number | null;
+  investigation_lines?: string;
+  plain_english?: string;
+  how_found?: string;
+  user_query?: string;
+  baseline_tokens?: number;
+}
+
+export interface DigestTool {
+  name?: string;
+  path?: string;
+  pattern?: string;
+  command_preview?: string;
+  query?: string;
+  file_path?: string;
+  prompt?: string;
+  arguments?: Record<string, unknown>;
+  toolName?: string;
+  tool_name?: string;
+  server?: string;
+  knowledge?: { tool?: string; arguments?: Record<string, unknown> };
+}
+
+export interface DigestTurn {
+  role?: string;
+  line?: number;
+  est_tokens?: number;
+  text?: string | string[];
+  tools?: DigestTool[];
+}
+
+export interface ReportDigest {
+  turns: DigestTurn[];
+}
+
+/** One knowledge note as the report consumes it. The backend is the single
+ * source of truth: `transcript_id` is the agent conversation the note was
+ * learned from, injected at the miner's tool gate at write time. */
+export interface ReportNote {
+  title: string;
+  content: string;
+  transcript_id?: string;
+  repo?: string;
+  branch?: string;
+  /** ISO write time, for chronological ordering. */
+  at?: string;
+}

--- a/src/report/write.test.ts
+++ b/src/report/write.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockOpen = vi.hoisted(() => vi.fn());
+vi.mock("open", () => ({ default: (...args: unknown[]) => mockOpen(...args) }));
+
+import { defaultReportPath, writeAndOpenReport } from "./write";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "dosu-report-write-"));
+  mockOpen.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("writeAndOpenReport", () => {
+  it("writes the HTML and opens the file URL by default", async () => {
+    const openUrl = vi.fn().mockResolvedValue(undefined);
+    const out = join(dir, "report.html");
+    const path = await writeAndOpenReport({ html: "<html>hi</html>", out, openUrl });
+    expect(path).toBe(out);
+    expect(readFileSync(out, "utf8")).toBe("<html>hi</html>");
+    expect(openUrl).toHaveBeenCalledWith(expect.stringMatching(/^file:\/\//));
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it("skips opening when open is false", async () => {
+    const openUrl = vi.fn();
+    await writeAndOpenReport({
+      html: "<html/>",
+      out: join(dir, "quiet.html"),
+      open: false,
+      openUrl,
+    });
+    expect(openUrl).not.toHaveBeenCalled();
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it("uses the default tmp path and the open package when no injector is given", async () => {
+    expect(defaultReportPath()).toContain("dosu-knowledge-report.html");
+    const out = join(dir, "opened.html");
+    await writeAndOpenReport({ html: "<html>open</html>", out });
+    expect(mockOpen).toHaveBeenCalledWith(expect.stringMatching(/^file:\/\//));
+  });
+
+  it("writes to the default tmp file when out is omitted", async () => {
+    const path = await writeAndOpenReport({ html: "<html>tmp</html>", open: false });
+    expect(path).toBe(defaultReportPath());
+    expect(readFileSync(path, "utf8")).toBe("<html>tmp</html>");
+  });
+});

--- a/src/report/write.ts
+++ b/src/report/write.ts
@@ -1,0 +1,31 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function defaultReportPath(): string {
+  return join(tmpdir(), "dosu-knowledge-report.html");
+}
+
+export interface WriteReportOptions {
+  html: string;
+  out?: string;
+  open?: boolean;
+  openUrl?: (url: string) => Promise<unknown>;
+}
+
+export async function writeAndOpenReport(options: WriteReportOptions): Promise<string> {
+  const out = resolve(options.out ?? defaultReportPath());
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, options.html, "utf8");
+  if (options.open !== false) {
+    const url = pathToFileURL(out).href;
+    if (options.openUrl) {
+      await options.openUrl(url);
+    } else {
+      const open = await import("open");
+      await open.default(url);
+    }
+  }
+  return out;
+}

--- a/src/sessions/read.test.ts
+++ b/src/sessions/read.test.ts
@@ -3,7 +3,12 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { estimateSessionTokens, isWorthMining, readSessionTurns } from "./read";
+import {
+  countRediscoveryToolCalls,
+  estimateSessionTokens,
+  isWorthMining,
+  readSessionTurns,
+} from "./read";
 import type { AgentSession } from "./scan";
 
 let dir: string;
@@ -289,6 +294,61 @@ describe("isWorthMining", () => {
 
   it("rejects an unreadable session", () => {
     expect(isWorthMining(session("claude", join(dir, "missing.jsonl")))).toBe(false);
+  });
+});
+
+describe("countRediscoveryToolCalls", () => {
+  it("counts Cursor/Claude tool_use names in REDISCOVERY_TOOLS", () => {
+    const path = writeLog("tools.jsonl", [
+      { type: "user", message: { role: "user", content: "why?" } },
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "looking" },
+            { type: "tool_use", name: "Read", input: {} },
+            { type: "tool_use", name: "Grep", input: {} },
+            { type: "tool_use", name: "TodoWrite", input: {} },
+          ],
+        },
+      },
+    ]);
+    expect(countRediscoveryToolCalls(session("claude", path))).toBe(2);
+  });
+
+  it("counts Cursor role/message tool_use the same way", () => {
+    const path = writeLog("cursor-tools.jsonl", [
+      {
+        role: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "looking" },
+            { type: "tool_use", name: "Read" },
+            { type: "tool_use", name: "Grep" },
+            { type: "tool_use", name: "TodoWrite" },
+          ],
+        },
+      },
+    ]);
+    expect(countRediscoveryToolCalls(session("cursor", path))).toBe(2);
+  });
+
+  it("counts Codex function_call names", () => {
+    const path = writeLog("codex.jsonl", [
+      { type: "response_item", payload: { type: "function_call", name: "read_file" } },
+      { type: "response_item", payload: { type: "function_call", name: "exec_command" } },
+      { type: "response_item", payload: { type: "function_call", name: "unknown_tool" } },
+    ]);
+    expect(countRediscoveryToolCalls(session("codex", path))).toBe(2);
+  });
+
+  it("returns 0 for an unreadable session", () => {
+    expect(countRediscoveryToolCalls(session("claude", join(dir, "missing.jsonl")))).toBe(0);
+  });
+
+  it("returns 0 for opencode sessions", () => {
+    expect(countRediscoveryToolCalls(session("opencode", join(dir, "missing.db")))).toBe(0);
   });
 });
 

--- a/src/sessions/read.ts
+++ b/src/sessions/read.ts
@@ -155,6 +155,80 @@ export function readSessionTurns(session: AgentSession): SessionTurn[] {
   }
 }
 
+/** Cursor + Claude Code + Codex names the skill report counts as rediscovery. */
+const REDISCOVERY_TOOLS = new Set([
+  "Read",
+  "Grep",
+  "Glob",
+  "Shell",
+  "WebSearch",
+  "WebFetch",
+  "Task",
+  "SemanticSearch",
+  "Bash",
+  "Edit",
+  "MultiEdit",
+  "NotebookEdit",
+  "Agent",
+  "exec_command",
+  "write_stdin",
+  "web_search",
+  "web_search_call",
+  "open_page",
+  "apply_patch",
+  "update_plan",
+  "list_dir",
+  "grep_files",
+  "read_file",
+]);
+
+function isRediscoveryTool(name: string): boolean {
+  return REDISCOVERY_TOOLS.has(name) || name.startsWith("web_search");
+}
+
+function toolNamesFromContent(content: unknown): string[] {
+  if (!Array.isArray(content)) return [];
+  const names: string[] = [];
+  for (const entry of content) {
+    const item = asRecord(entry);
+    if (item?.type === "tool_use" && typeof item.name === "string") names.push(item.name);
+  }
+  return names;
+}
+
+/** Count investigation tool calls the way parse_agent_logs.py does (Read/Grep/Bash/…). */
+export function countRediscoveryToolCalls(session: AgentSession): number {
+  try {
+    switch (session.harness) {
+      case "claude":
+      case "cursor": {
+        let n = 0;
+        for (const record of jsonlRecords(readFileSync(session.path, "utf8"))) {
+          const message = asRecord(record.message);
+          for (const name of toolNamesFromContent(message?.content)) {
+            if (isRediscoveryTool(name)) n += 1;
+          }
+        }
+        return n;
+      }
+      case "codex": {
+        let n = 0;
+        for (const record of jsonlRecords(readFileSync(session.path, "utf8"))) {
+          const payload = asRecord(record.payload);
+          if (payload?.type === "function_call" && typeof payload.name === "string") {
+            if (isRediscoveryTool(payload.name)) n += 1;
+          }
+        }
+        return n;
+      }
+      case "opencode":
+        return 0;
+    }
+  } catch {
+    return 0;
+  }
+}
+
 /** chars → tokens, the same coarse model the log-backfill report uses. */
 const CHARS_PER_TOKEN = 4;
 

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -49,6 +49,10 @@ vi.mock("./pages-view", () => ({
   runPagesView: vi.fn(),
 }));
 
+vi.mock("../report/generate", () => ({
+  emitKnowledgeReport: vi.fn(),
+}));
+
 // The banner reads the update cache from disk; tests must not see the
 // developer machine's real cache file.
 vi.mock("../version/update-check", () => ({
@@ -110,6 +114,7 @@ import type { HookAgent } from "../hooks/agents";
 import { getHookAgent } from "../hooks/agents";
 import type { SetupProvider } from "../mcp/providers";
 import { allSetupProviders } from "../mcp/providers";
+import { emitKnowledgeReport } from "../report/generate";
 import { createProjectDirResolver } from "../sessions/project-dir";
 import type { AgentSession } from "../sessions/scan";
 import { scanAgentSessions } from "../sessions/scan";
@@ -136,6 +141,7 @@ const mockRunSwitchTarget = vi.mocked(runSwitchTarget);
 const mockRunActivityView = vi.mocked(runActivityView);
 const mockRunAnalyticsView = vi.mocked(runAnalyticsView);
 const mockRunPagesView = vi.mocked(runPagesView);
+const mockEmitReport = vi.mocked(emitKnowledgeReport);
 const mockAllSetupProviders = vi.mocked(allSetupProviders);
 const mockScanSessions = vi.mocked(scanAgentSessions);
 const mockMultiselect = vi.mocked(p.multiselect);
@@ -467,13 +473,16 @@ describe("runTUI", () => {
     const signedIn = mockMenuSelect.mock.calls[0]?.[1] ?? [];
     expect(signedIn.map((o) => o.value)).toEqual([
       "sync",
+      "report",
       "analytics",
       "pages",
       "settings",
       "exit",
     ]);
-    // Everyday rows are bare labels; only Setup carries a (warning) hint.
-    expect(signedIn.every((o) => o.hint === undefined)).toBe(true);
+    expect(signedIn.find((o) => o.value === "report")?.hint).toBe("(opens in browser)");
+    expect(signedIn.filter((o) => o.value !== "report").every((o) => o.hint === undefined)).toBe(
+      true,
+    );
 
     // Signed out: nothing works without an account, so the menu is just the
     // door — log in / sign up, or leave.
@@ -561,7 +570,14 @@ describe("runTUI", () => {
 
     expect(mockRunSetup).not.toHaveBeenCalled();
     const options = mockMenuSelect.mock.calls[0]?.[1] ?? [];
-    expect(options.map((o) => o.value)).toEqual(["sync", "analytics", "pages", "settings", "exit"]);
+    expect(options.map((o) => o.value)).toEqual([
+      "sync",
+      "report",
+      "analytics",
+      "pages",
+      "settings",
+      "exit",
+    ]);
   });
 
   it("flags the repo's AGENTS.md on the banner only inside a git work tree", async () => {
@@ -722,6 +738,27 @@ describe("runTUI", () => {
 
     expect(mockRunPagesView).toHaveBeenCalledOnce();
     expect(mockRunActivityView).not.toHaveBeenCalled();
+  });
+
+  it("report action writes and opens the harvest HTML", async () => {
+    writeRealConfig(makeCfg({}));
+    mockEmitReport.mockResolvedValue("/tmp/dosu-knowledge-report.html");
+    mockMenuSelect.mockResolvedValueOnce("report").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(mockEmitReport).toHaveBeenCalledWith({ open: true });
+    expect(mockRunActivityView).not.toHaveBeenCalled();
+  });
+
+  it("report action surfaces a write failure without leaving the TUI", async () => {
+    writeRealConfig(makeCfg({}));
+    mockEmitReport.mockRejectedValue(new Error("disk full"));
+    mockMenuSelect.mockResolvedValueOnce("report").mockResolvedValueOnce("exit");
+
+    await runTUI();
+
+    expect(p.log.error).toHaveBeenCalledWith("disk full");
   });
 
   it("settings submenu shows the active target and goes back", async () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -14,6 +14,7 @@ import {
 import { getWebAppURL } from "../config/constants";
 import { getHookAgent } from "../hooks/agents";
 import { allSetupProviders } from "../mcp/providers";
+import { emitKnowledgeReport } from "../report/generate";
 import { createProjectDirResolver } from "../sessions/project-dir";
 import { scanAgentSessions } from "../sessions/scan";
 import { dosuAgentsSectionState, inGitWorkTree } from "../setup/agents-md-step";
@@ -183,7 +184,7 @@ async function runMainMenu(): Promise<void> {
   const buildOptions = (): MenuOption[] => {
     if (!isAuthenticated(cfg)) {
       return [
-        { label: "Log in / Sign up", hint: "opens your browser", value: "auth" },
+        { label: "Log in / Sign up", hint: "(opens your browser)", value: "auth" },
         { label: "Exit", value: "exit" },
       ];
     }
@@ -201,6 +202,7 @@ async function runMainMenu(): Promise<void> {
         label: mining ? `Activity \u26CF\uFE0F ${brand("mining sessions...")}` : "Activity",
         value: "sync",
       },
+      { label: "Knowledge report", hint: "(opens in browser)", value: "report" },
       { label: "Analytics", value: "analytics" },
       { label: "Pages", value: "pages" },
       { label: "Settings", value: "settings" },
@@ -235,6 +237,10 @@ async function runMainMenu(): Promise<void> {
         await runActivityView();
         home();
         break;
+      case "report":
+        await runKnowledgeReport();
+        home();
+        break;
       case "analytics":
         await runAnalyticsView();
         home();
@@ -261,6 +267,19 @@ async function runMainMenu(): Promise<void> {
         home();
         break;
     }
+  }
+}
+
+/** Write the harvest HTML from persisted notes and open it, same as `dosu knowledge report`. */
+async function runKnowledgeReport(): Promise<void> {
+  const s = p.spinner();
+  s.start("Writing knowledge report...");
+  try {
+    const path = await emitKnowledgeReport({ open: true });
+    s.stop(`Opened ${path}`);
+  } catch (err) {
+    s.stop("Could not write the report");
+    p.log.error(err instanceof Error ? err.message : String(err));
   }
 }
 


### PR DESCRIPTION
**TLDR: the knowledge report is rebuilt on one exact identity — at write time, the miner's tool gate stamps every note with the conversation it came from (`transcript_id`), the backend stores it, and the report is just "fetch my notes, show the receipts." All local state and all guessing heuristics are deleted.** Backend counterpart (merge + deploy first): dosu-ai/dosu#12437. Supersedes #211.

## Before → after

| | Before (#211's design) | After |
|---|---|---|
| Note → conversation link | captured into a local `written_notes` file; recovered for history by a probabilistic correlator (~80% coverage, heuristic) | injected into the `write_knowledge` payload at the tool gate — exact, for every note, forever |
| Report data source | local window merged with a backend backfill (dedup keys, run-id grouping, 30-min tolerance windows) | the backend is the single source of truth: one `notes.listMine` fetch + local session logs |
| Offline behavior | silently rendered from the local window | online-only by design (product decision): clear, actionable errors ("Not signed in. Run `dosu setup`…") |
| Code carrying risk | correlate.ts, merge/dedup, watermark schema changes (~400 lines of the trickiest code) | deleted |
| Miner batch behavior | unchanged | unchanged (Option B: batching kept; the gate injects per note) |

## What renders

`dosu knowledge report`, `dosu knowledge sync --report`, and the TUI's **Knowledge report** row all produce the same HTML: one card per note; notes whose conversation log is on this machine get the full "Work to learn this" trace and a rediscovery-token estimate; notes without a transcript (pre-migration history, other machines) render as bare cards — honestly, never with a guessed trace.

## Review findings from #211, fixed here

- `sync --json --report`: a report failure can no longer destroy the sync's JSON output or exit code (`report_error` field instead).
- `--detach` now forwards `--report`/`--out` instead of silently dropping them.
- A note without an attributed stretch renders **no trace** — the whole-session token fallback (the number the design forbids) is gone.
- The report reads only sessions its notes reference; no more unbounded scan-and-digest of unrelated local history.

## Validation

- 2,234 tests, 90.26% branch coverage; typecheck/biome/knip clean; CI green.
- Full-stack e2e with the backend PR running locally (real `public-api`, real MCP write path, real sign-in): a note written through the actual gate-injection path rendered a complete trace against the exact local session that produced it; transcript-less and foreign-authored notes behaved correctly; error contracts verified (signed out, backend down, dead-backend `sync --json --report`).
- Vendored contract `79ec0bbacf70` (`transcript_id` on `notes.listMine`).

## Rollout

Backend deploys first; until then this report fails with a clear error rather than misbehaving. Merge/release this promptly after the backend deploy — old beta CLIs (one external org is actively mining) write permanently-bare notes until they upgrade. Historical attribution for existing notes is a separate one-shot, per-machine job (run-id snapshot preserved; the author's SQL is generated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)