### PR TITLE
fix(miner): per-write transcript attribution (deterministic, no concentration)

### DIFF
--- a/src/miner/prompt.ts
+++ b/src/miner/prompt.ts
@@ -25,7 +25,10 @@ export function buildMinerPrompt(sessions: AgentSession[]): string {
 
 ${list}
 
-Read each session with read_session, decide what (if anything) is durable per your rules, dedupe \
-against read_knowledge, then write the distilled notes with write_knowledge. When you are done, \
-reply with a one-line summary: how many sessions you read and how many notes you wrote.`;
+Work through them ONE AT A TIME: read a single session with read_session, decide what (if \
+anything) is durable per your rules, dedupe against read_knowledge, and write that session's \
+notes with write_knowledge BEFORE moving on to the next session. Each note is attributed to the \
+session you read just before writing it, so do not read the next session until you have written \
+this one's notes. When you are done, reply with a one-line summary: how many sessions you read \
+and how many notes you wrote.`;
 }

--- a/src/miner/runner.test.ts
+++ b/src/miner/runner.test.ts
@@ -278,6 +278,28 @@ describe("runMiner", () => {
     });
   });
 
+  it("ignores an id-less read (a paging call) so it doesn't count as a session", async () => {
+    const g: GateResult[] = [];
+    queryMock.mockImplementation((params: GateParams) => {
+      return (async function* () {
+        // A read with no id (offset-only paging) adds nothing, so the following
+        // write has no session to attribute to.
+        await params.options.canUseTool("mcp__sessions__read_session", { offset: 2 }, {});
+        g.push(await params.options.canUseTool(...write("no-real-read")));
+        yield successResult();
+      })();
+    });
+
+    const result = await runMiner(baseOptions);
+
+    expect(result.notesWritten).toBe(1);
+    expect(g[0].updatedInput).toEqual({
+      title: "no-real-read",
+      content: "c",
+      transcript_id: "model-junk",
+    });
+  });
+
   it("maps a consent-off gateway refusal from the result text", async () => {
     queryReturning(successResult({ is_error: true, result: "API error: dosu_consent_off: nope" }));
 

--- a/src/miner/runner.test.ts
+++ b/src/miner/runner.test.ts
@@ -192,32 +192,27 @@ describe("runMiner", () => {
     expect(result.notesWritten).toBe(2);
   });
 
-  it("injects the last-read session as transcript_id into write_knowledge payloads", async () => {
-    type GateResult = { behavior: string; updatedInput?: Record<string, unknown> };
-    type GateParams = {
-      options: { canUseTool: (name: string, input: object, extra: object) => Promise<GateResult> };
-    };
-    const gateResults: GateResult[] = [];
+  type GateResult = { behavior: string; updatedInput?: Record<string, unknown>; message?: string };
+  type GateParams = {
+    options: { canUseTool: (name: string, input: object, extra: object) => Promise<GateResult> };
+  };
+  const read = (id: string) => ["mcp__sessions__read_session", { id }, {}] as const;
+  const write = (title: string) =>
+    [
+      "mcp__dosu__write_knowledge",
+      { title, content: "c", transcript_id: "model-junk" },
+      {},
+    ] as const;
+
+  it("attributes each note to the single session read just before it", async () => {
+    const g: GateResult[] = [];
     queryMock.mockImplementation((params: GateParams) => {
       return (async function* () {
-        // Before any read there is nothing to inject: the payload passes as-is.
-        gateResults.push(
-          await params.options.canUseTool(
-            "mcp__dosu__write_knowledge",
-            { title: "Early", content: "No session read yet.", transcript_id: "model-invented" },
-            {},
-          ),
-        );
-        await params.options.canUseTool("mcp__sessions__read_session", { id: "s1" }, {});
-        // An id-less read (e.g. a paging call) keeps the last session attribution.
-        await params.options.canUseTool("mcp__sessions__read_session", { offset: 2 }, {});
-        gateResults.push(
-          await params.options.canUseTool(
-            "mcp__dosu__write_knowledge",
-            { title: "OAuth refresh", content: "Retry after 401.", transcript_id: "model-junk" },
-            {},
-          ),
-        );
+        // Interleaved read→write→read→write: each note gets its own session.
+        await params.options.canUseTool(...read("s1"));
+        g.push(await params.options.canUseTool(...write("note-a")));
+        await params.options.canUseTool(...read("s2"));
+        g.push(await params.options.canUseTool(...write("note-b")));
         yield successResult();
       })();
     });
@@ -225,13 +220,52 @@ describe("runMiner", () => {
     const result = await runMiner(baseOptions);
 
     expect(result.notesWritten).toBe(2);
-    // Pre-read write: untouched (nothing deterministic to inject).
-    expect(gateResults[0].updatedInput).toMatchObject({ transcript_id: "model-invented" });
-    // Post-read write: whatever the model authored is overwritten.
-    expect(gateResults[1].updatedInput).toEqual({
-      title: "OAuth refresh",
-      content: "Retry after 401.",
-      transcript_id: "s1",
+    expect(g[0].updatedInput).toEqual({ title: "note-a", content: "c", transcript_id: "s1" });
+    expect(g[1].updatedInput).toEqual({ title: "note-b", content: "c", transcript_id: "s2" });
+  });
+
+  it("denies a write after reading several sessions, then attributes the re-read one", async () => {
+    const g: GateResult[] = [];
+    queryMock.mockImplementation((params: GateParams) => {
+      return (async function* () {
+        // Read-all-then-write: the source is ambiguous, so the write is denied.
+        await params.options.canUseTool(...read("s1"));
+        await params.options.canUseTool(...read("s2"));
+        g.push(await params.options.canUseTool(...write("ambiguous")));
+        // Model complies: re-reads only the right session, then writes.
+        await params.options.canUseTool(...read("s2"));
+        g.push(await params.options.canUseTool(...write("resolved")));
+        yield successResult();
+      })();
+    });
+
+    const result = await runMiner(baseOptions);
+
+    expect(g[0].behavior).toBe("deny");
+    expect(g[0].message).toMatch(/one session|before reading the next/i);
+    expect(g[1].updatedInput).toEqual({ title: "resolved", content: "c", transcript_id: "s2" });
+    // The denied write is not counted; only the resolved one is.
+    expect(result.notesWritten).toBe(1);
+  });
+
+  it("leaves a note unattributed when no session was read before it", async () => {
+    const g: GateResult[] = [];
+    queryMock.mockImplementation((params: GateParams) => {
+      return (async function* () {
+        g.push(await params.options.canUseTool(...write("orphan")));
+        yield successResult();
+      })();
+    });
+
+    const result = await runMiner(baseOptions);
+
+    expect(result.notesWritten).toBe(1);
+    // No transcript_id key injected — the model's own value is left as-is,
+    // and the backend discards it (unattested for that field).
+    expect(g[0].updatedInput).toEqual({
+      title: "orphan",
+      content: "c",
+      transcript_id: "model-junk",
     });
   });
 

--- a/src/miner/runner.test.ts
+++ b/src/miner/runner.test.ts
@@ -269,13 +269,10 @@ describe("runMiner", () => {
     const result = await runMiner(baseOptions);
 
     expect(result.notesWritten).toBe(1);
-    // No transcript_id key injected — the model's own value is left as-is,
-    // and the backend discards it (unattested for that field).
-    expect(g[0].updatedInput).toEqual({
-      title: "orphan",
-      content: "c",
-      transcript_id: "model-junk",
-    });
+    // No session to attribute → genuinely unattributed. Any transcript_id the
+    // model supplied is stripped so the attested backend stores null.
+    expect(g[0].updatedInput).toEqual({ title: "orphan", content: "c" });
+    expect(g[0].updatedInput).not.toHaveProperty("transcript_id");
   });
 
   it("ignores an id-less read (a paging call) so it doesn't count as a session", async () => {
@@ -293,11 +290,8 @@ describe("runMiner", () => {
     const result = await runMiner(baseOptions);
 
     expect(result.notesWritten).toBe(1);
-    expect(g[0].updatedInput).toEqual({
-      title: "no-real-read",
-      content: "c",
-      transcript_id: "model-junk",
-    });
+    // Stripped: an id-less read is no session, so the model's value must not survive.
+    expect(g[0].updatedInput).toEqual({ title: "no-real-read", content: "c" });
   });
 
   it("maps a consent-off gateway refusal from the result text", async () => {

--- a/src/miner/runner.test.ts
+++ b/src/miner/runner.test.ts
@@ -213,7 +213,7 @@ describe("runMiner", () => {
       {},
     ] as const;
 
-  it("attributes each note to the single session read just before it", async () => {
+  it("attributes each note to the session currently being mined", async () => {
     const g: GateResult[] = [];
     queryMock.mockImplementation((params: GateParams) => {
       return (async function* () {
@@ -231,6 +231,30 @@ describe("runMiner", () => {
     expect(result.notesWritten).toBe(2);
     expect(g[0].updatedInput).toEqual({ title: "note-a", content: "c", transcript_id: "s1" });
     expect(g[1].updatedInput).toEqual({ title: "note-b", content: "c", transcript_id: "s2" });
+  });
+
+  it("attributes EVERY note of a session read once and mined for several notes", async () => {
+    const g: GateResult[] = [];
+    queryMock.mockImplementation((params: GateParams) => {
+      return (async function* () {
+        // One read, three writes (the common shape); then the next session.
+        await params.options.canUseTool(...read("s1"));
+        g.push(await params.options.canUseTool(...write("s1-a")));
+        g.push(await params.options.canUseTool(...write("s1-b")));
+        g.push(await params.options.canUseTool(...write("s1-c")));
+        await params.options.canUseTool(...read("s2"));
+        g.push(await params.options.canUseTool(...write("s2-a")));
+        g.push(await params.options.canUseTool(...write("s2-b")));
+        yield successResult();
+      })();
+    });
+
+    const result = await runMiner(baseOptions);
+
+    expect(result.notesWritten).toBe(5);
+    // All three s1 notes → s1; both s2 notes → s2. No note goes null just for
+    // being the 2nd+ from its session (the bug real mining surfaced).
+    expect(g.map((r) => r.updatedInput?.transcript_id)).toEqual(["s1", "s1", "s1", "s2", "s2"]);
   });
 
   it("denies a write after reading several sessions, then attributes the re-read one", async () => {

--- a/src/miner/runner.test.ts
+++ b/src/miner/runner.test.ts
@@ -152,6 +152,15 @@ describe("runMiner", () => {
     expect(params.options.pathToClaudeCodeExecutable).toBe("/home/u/.local/bin/claude");
   });
 
+  it("routes SDK stderr into the debug log", async () => {
+    queryReturning(successResult());
+
+    await runMiner(baseOptions);
+
+    queryMock.mock.calls[0][0].options.stderr("boom on the sdk");
+    expect(debugMock).toHaveBeenCalledWith("miner", "[sdk] boom on the sdk");
+  });
+
   it("canUseTool denies non-allowlisted tools and enforces the note cap", async () => {
     queryReturning(successResult());
 

--- a/src/miner/runner.ts
+++ b/src/miner/runner.ts
@@ -257,16 +257,19 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
               };
             }
             notesWritten += 1;
-            // Exactly one session read since the last write: that is the note's
-            // source, stamped deterministically. Zero reads (a stray write with
-            // no preceding read) leaves it unattributed rather than guessing.
-            // The model never authors this field; the backend trusts it only
-            // from attested clients. Cleared so the next note is judged fresh.
+            // Exactly one session read since the last write is the note's source,
+            // stamped deterministically. The model never authors this field, so
+            // strip any transcript_id it supplied FIRST — the backend trusts the
+            // argument from this attested client, so a stray model value would
+            // otherwise be stored. Zero reads (a stray write with no preceding
+            // read) then leaves the note genuinely unattributed (null) rather
+            // than guessing. Cleared so the next note is judged fresh.
             const [transcriptId] = readSinceWrite;
             readSinceWrite.clear();
+            const { transcript_id: _authoredByModel, ...clean } = input as Record<string, unknown>;
             return {
               behavior: "allow",
-              updatedInput: transcriptId ? { ...input, transcript_id: transcriptId } : input,
+              updatedInput: transcriptId ? { ...clean, transcript_id: transcriptId } : clean,
             };
           }
           return { behavior: "allow", updatedInput: input };

--- a/src/miner/runner.ts
+++ b/src/miner/runner.ts
@@ -171,7 +171,14 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
   const timer = setTimeout(() => abort.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
   let notesWritten = 0;
-  let lastSessionId: string | undefined;
+  // Sessions read since the previous write_knowledge. A note is attributed
+  // only when this holds exactly one session — the one the note was just
+  // learned from. If the model read several before writing (or none), the
+  // source is ambiguous, so the note is left unattributed rather than stamped
+  // with a guess. Cleared after each write so the next note is judged on its
+  // own reads. See the deny path below, which trains the model to write each
+  // session's notes before reading the next.
+  const readSinceWrite = new Set<string>();
   let turns = 0;
 
   const env = buildMinerEnv({
@@ -224,7 +231,8 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
             };
           }
           if (toolName === `mcp__${SESSIONS_SERVER_NAME}__read_session`) {
-            lastSessionId = sessionIdFromReadInput(input) ?? lastSessionId;
+            const id = sessionIdFromReadInput(input);
+            if (id) readSinceWrite.add(id);
           }
           if (toolName === `mcp__${KNOWLEDGE_SERVER_NAME}__write_knowledge`) {
             if (notesWritten >= maxNotes) {
@@ -233,16 +241,32 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
                 message: `Note cap reached (${maxNotes} per run); stop writing and summarize.`,
               };
             }
+            // Reading several sessions before writing makes the note's source
+            // ambiguous. Deny to steer the model back to one-session-at-a-time,
+            // and clear the read set so its re-read of the right session starts
+            // fresh (otherwise the stale accumulation would deny forever). The
+            // note is not lost, just re-issued after it narrows the session.
+            if (readSinceWrite.size > 1) {
+              readSinceWrite.clear();
+              return {
+                behavior: "deny",
+                message:
+                  "Write each session's notes right after reading THAT session, before reading the next. " +
+                  "You have read multiple sessions without writing, so a note cannot be attributed to one. " +
+                  "Re-read only the session this note is about, then write it.",
+              };
+            }
             notesWritten += 1;
-            // Per-note transcript identity: overwrite the argument with the
-            // last-read session id. The model never authors this field (its
-            // own value, if any, is discarded here), and the backend only
-            // trusts it from attested clients. Deterministic injection is
-            // what lets the DB be the single source of truth for the
-            // knowledge report.
+            // Exactly one session read since the last write: that is the note's
+            // source, stamped deterministically. Zero reads (a stray write with
+            // no preceding read) leaves it unattributed rather than guessing.
+            // The model never authors this field; the backend trusts it only
+            // from attested clients. Cleared so the next note is judged fresh.
+            const [transcriptId] = readSinceWrite;
+            readSinceWrite.clear();
             return {
               behavior: "allow",
-              updatedInput: lastSessionId ? { ...input, transcript_id: lastSessionId } : input,
+              updatedInput: transcriptId ? { ...input, transcript_id: transcriptId } : input,
             };
           }
           return { behavior: "allow", updatedInput: input };

--- a/src/miner/runner.ts
+++ b/src/miner/runner.ts
@@ -171,14 +171,17 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
   const timer = setTimeout(() => abort.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
   let notesWritten = 0;
-  // Sessions read since the previous write_knowledge. A note is attributed
-  // only when this holds exactly one session — the one the note was just
-  // learned from. If the model read several before writing (or none), the
-  // source is ambiguous, so the note is left unattributed rather than stamped
-  // with a guess. Cleared after each write so the next note is judged on its
-  // own reads. See the deny path below, which trains the model to write each
-  // session's notes before reading the next.
-  const readSinceWrite = new Set<string>();
+  // The session the miner is currently mining: the most recently read one. It
+  // persists across writes, so every note written after reading a session — a
+  // session commonly yields several — is attributed to it, until a different
+  // session is read.
+  let currentSession: string | undefined;
+  // Distinct sessions read since the previous write, for ambiguity detection.
+  // Reading several DIFFERENT sessions before writing means the note's source
+  // is unclear, so that write is denied (the model is steered to write each
+  // session's notes before reading the next). Reset after each write; reading
+  // one session and writing many notes is NOT ambiguous. See the deny path.
+  const readsSinceWrite = new Set<string>();
   let turns = 0;
 
   const env = buildMinerEnv({
@@ -232,7 +235,10 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
           }
           if (toolName === `mcp__${SESSIONS_SERVER_NAME}__read_session`) {
             const id = sessionIdFromReadInput(input);
-            if (id) readSinceWrite.add(id);
+            if (id) {
+              currentSession = id;
+              readsSinceWrite.add(id);
+            }
           }
           if (toolName === `mcp__${KNOWLEDGE_SERVER_NAME}__write_knowledge`) {
             if (notesWritten >= maxNotes) {
@@ -241,13 +247,15 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
                 message: `Note cap reached (${maxNotes} per run); stop writing and summarize.`,
               };
             }
-            // Reading several sessions before writing makes the note's source
-            // ambiguous. Deny to steer the model back to one-session-at-a-time,
-            // and clear the read set so its re-read of the right session starts
-            // fresh (otherwise the stale accumulation would deny forever). The
-            // note is not lost, just re-issued after it narrows the session.
-            if (readSinceWrite.size > 1) {
-              readSinceWrite.clear();
+            // Reading several DIFFERENT sessions before writing makes the note's
+            // source ambiguous. Deny to steer the model back to
+            // one-session-at-a-time, and reset the read set (and current
+            // session) so its re-read of the right session starts fresh —
+            // otherwise the stale accumulation would deny forever. The note is
+            // not lost, just re-issued after it narrows the session.
+            if (readsSinceWrite.size > 1) {
+              readsSinceWrite.clear();
+              currentSession = undefined;
               return {
                 behavior: "deny",
                 message:
@@ -257,19 +265,19 @@ export async function runMiner(options: RunMinerOptions): Promise<MinerRunResult
               };
             }
             notesWritten += 1;
-            // Exactly one session read since the last write is the note's source,
-            // stamped deterministically. The model never authors this field, so
-            // strip any transcript_id it supplied FIRST — the backend trusts the
-            // argument from this attested client, so a stray model value would
-            // otherwise be stored. Zero reads (a stray write with no preceding
-            // read) then leaves the note genuinely unattributed (null) rather
-            // than guessing. Cleared so the next note is judged fresh.
-            const [transcriptId] = readSinceWrite;
-            readSinceWrite.clear();
+            // Attribute to the current session — the one being mined — which
+            // persists across the several notes a session usually yields. The
+            // model never authors this field, so strip any transcript_id it
+            // supplied FIRST: the backend trusts the argument from this attested
+            // client, so a stray model value would otherwise be stored. With no
+            // session read yet (a stray early write) the note is left genuinely
+            // unattributed (null) rather than guessed. Reset only the
+            // ambiguity set, not the current session.
+            readsSinceWrite.clear();
             const { transcript_id: _authoredByModel, ...clean } = input as Record<string, unknown>;
             return {
               behavior: "allow",
-              updatedInput: transcriptId ? { ...clean, transcript_id: transcriptId } : clean,
+              updatedInput: currentSession ? { ...clean, transcript_id: currentSession } : clean,
             };
           }
           return { behavior: "allow", updatedInput: input };


### PR DESCRIPTION
**TLDR: attribute each mined note to the session read *immediately before* that write, instead of the run's last-read session — so a batch that reads many sessions before writing no longer dumps all its notes onto one session.** CLI-only; no backend or schema change (still just sets `transcript_id`).

## The bug

The gate injects `transcript_id` at `write_knowledge` time, but the payload carries no session id, so the gate infers it. It inferred "last `read_session` seen in the run" — which is only correct if the miner interleaves read→write. The prompt said "read each session … *then* write," pushing read-all-then-write, so notes concentrated on whichever session was read last.

**Measured on prod history** (audit re-scoring each note against all local sessions): on large sessions, ~7–14% of notes were clearly mis-attributed (another session scored ≥1.5× higher), ~30% ambiguous ties. Impact is cosmetic — `transcript_id` only points the report's trace expander at a local log — but a card could show a plausible-but-wrong adjacent conversation's trace.

## The fix

- The gate tracks sessions read **since the previous write**. A note is attributed only when exactly **one** is pending — the session it was just learned from. The set clears after each write.
- Reading several sessions before a write is ambiguous → that write is **denied** with a message to write each session's notes before reading the next (the set clears so the model's re-read of the right session resolves it). The note isn't lost, just re-issued.
- A write with **no** preceding read → left **unattributed** rather than guessed (honest blank).
- Prompt now instructs one-session-at-a-time.

Net: deterministic **and** correct, or honestly unattributed — never a confident wrong stamp.

## Batching is preserved

A run still mines many sessions over one connection (the Option-B cost win). Only the intra-run ordering is constrained — reads and writes interleave instead of clustering. Same sessions per run, ~same token cost.

## Scope

Forward-only. Historical notes were already attributed by the one-shot content-match migration (bounded by run-id batch) and are left as-is. Only 8 forward notes existed pre-fix, so almost no data carries the old behavior.

## Tests

- New gate tests: interleaved read→write→read→write gives each note its own session; multi-read-before-write is denied then the re-read resolves; a read-less write is left unattributed. Existing note-cap and header tests unchanged.
- Full gate green: 2,250 tests, 90.23% branches, typecheck/biome/knip clean.
- **Live local e2e** (real gate → real backend → real DB): drove the actual `runMiner` gate through read-ingress→write, read-autovac→write, then read *both* before a third write — each allowed write performed as a genuine authenticated MCP `write_knowledge` against a running local backend. Verified in the DB: the ingress note linked to the ingress session, the autovac note to the autovac session (correctly discriminated, not concentrated), and the ambiguous third write was **denied at the gate and never reached the backend**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
