### PR TITLE
feat(skill): link Dosu documents as live Claude Code skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Key modules:
 - **`src/commands/`** — The Dosu platform command layer (the list above). Thin Commander wrappers over `src/client/` calls; `output.ts` standardizes human vs JSON output.
 - **`src/setup/`** — Interactive setup wizard (authenticate → select org → select deployment → mint API key → detect installed tools → configure). Uses `@clack/prompts`.
 - **`src/agent/`** — Non-interactive setup for coding agents (`setup --agent --tool <id>`) and the ticket-based login commands (`login --request`/`--check`). Emits machine-readable JSON via `output.ts` for agent consumption.
+- **`src/skills/`** — Live knowledge skills (`dosu skill link|resolve|links|unlink`). `binding.ts` renders and parses the generated `SKILL.md` with its ownership marker, `resolve.ts` fetches the highest published (or pinned) revision of a document through the typed client and classifies failures, `store.ts` owns the filesystem layer (skill roots, containment, atomic write, list, remove). Pure modules; the Commander wiring lives in `src/commands/skill.ts`.
 - **`src/telemetry/`** — Default-on analytics and error diagnostics with one persisted global switch, safe payload builders, and fail-open transport. User controls live under `dosu telemetry status|enable|disable|reset`.
 - **`src/tui/`** — Main menu TUI when running `dosu` with no subcommand.
 - **`src/version/`** — Version string from the build-time `DOSU_VERSION` env var, plus background update checks (`update-check.ts`, `skill-update-check.ts`).

--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ Once authenticated against a deployment, you can drive the Dosu platform without
 | `dosu deployments` | List / show / switch Dosu MCP deployments |
 | `dosu analytics` | View usage statistics |
 | `dosu insights` | Open a visual report of your Dosu space activity |
-| `dosu skill` | Install / update / remove the Dosu agent skill |
+| `dosu skill` | Install / update / remove the Dosu agent skill; link Dosu documents as live Claude Code skills (`link`, `resolve`, `links`, `unlink`) |
 
 Run `dosu <command> --help` for subcommands and flags.
+
+### Live knowledge skills
+
+`dosu skill link <document-id> --name <skill-name> --agent claude` writes a Claude Code skill that fetches the document's current published revision every time it runs, so editing the document in Dosu changes what every agent using the skill does. Add `--revision <n>` to pin a binding to one revision. See [docs/live-skills.md](docs/live-skills.md).
 
 ### Supported AI tools
 

--- a/docs/live-skills.md
+++ b/docs/live-skills.md
@@ -1,0 +1,85 @@
+# Live knowledge skills
+
+`dosu skill link` turns one Dosu document into a Claude Code skill. Every time the skill runs, the agent fetches the document's current **published** revision through the CLI and follows it. Editing and publishing the document in Dosu changes what every agent using the skill does. Nothing is reinstalled.
+
+```bash
+dosu skill link <document-id> --name migration-review --agent claude
+```
+
+Then, in a new Claude Code session:
+
+```
+/migration-review review migrations/0042_widen_status_enum.sql
+```
+
+The agent prints the source it used before doing anything else:
+
+```
+Using Dosu procedure "DB Enum Widening Checklist" (document 879cbca9-…, revision 4, live)
+```
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `dosu skill link <document-id> --name <name> --agent claude [--revision <n>] [--description <text>] [--project] [--force] [--json]` | Resolve the document once, then write `<skills-root>/<name>/SKILL.md`. Fails without writing anything if the document is missing, unpublished, archived, in another Library, or larger than the size limit. |
+| `dosu skill resolve --document <id> --library <id> [--revision <n>] [--json]` | Fetch the highest published revision (or the pinned one) and print it. This is the command the generated skill runs. Exit code 1 on every failure. |
+| `dosu skill links [--project] [--json]` | List the bindings the CLI owns in the user root and, with `--project` or when `<cwd>/.claude/skills` exists, the project root. |
+| `dosu skill unlink <name> --agent claude [--project] [--json]` | Remove a binding the CLI owns. Foreign skills are never touched. |
+
+`skill install`, `skill update`, and `skill remove` manage the official `dosu` skill and are unaffected by linked skills.
+
+## Where files go
+
+| Scope | Root | When |
+|---|---|---|
+| user (default) | `$CLAUDE_CONFIG_DIR/skills/<name>/SKILL.md`, falling back to `~/.claude/skills/<name>/SKILL.md` | Skill is available in every project on this machine. |
+| project (`--project`) | `<cwd>/.claude/skills/<name>/SKILL.md` | Requires a git work tree. Commit the file so teammates in the same Library get the skill. |
+
+Only that one file is written. Sibling skill directories are never read, modified, or removed.
+
+If a newly linked skill does not appear in Claude Code, start a new session.
+
+## Live vs pinned
+
+- **Live** (default): each invocation lists the document's revisions, keeps only published ones, and fetches the highest. Drafts are never used. A publish during a run does not change the revision already returned; the next invocation resolves fresh.
+- **Pinned** (`--revision <n>`): each invocation fetches exactly revision `n`. If that revision is unavailable or unpublished the skill stops with an error instead of falling back to the current revision.
+
+The frontmatter `description` (the trigger Claude Code matches on) is fixed at link time. Only the body is live. Override it with `--description`.
+
+## Updating a procedure
+
+1. Edit the document in the Dosu web app and publish the new revision.
+2. Confirm with `dosu docs versions <document-id>`.
+3. Start a new agent session and invoke the skill. The source line shows the new revision.
+
+Re-running `dosu skill link` with the same name and document is safe. It reports `unchanged` when nothing differs, `updated` when you changed `--revision` or `--description`, and refuses with `binding_modified` if you edited the generated file by hand. `--force` overwrites your edits. `--force` also lets you point an existing binding at a different document. It never overwrites a skill the CLI did not create (`name_taken`).
+
+## What the generated file contains
+
+`SKILL.md` carries a versioned marker comment with the document id, Library id, pinned revision (or `null`), template version, CLI version, and a SHA-256 of the file's content. That marker is how `links` finds bindings and how `unlink` refuses to delete foreign skills. The file contains no credentials: the resolver reads your session from `~/.config/dosu-cli/config.json` when it runs.
+
+## Failure reasons
+
+Every failure exits 1. With `--json`, a single object with `status: "error"`, `reason`, `message`, and `agent_next_steps` is printed to stdout so the agent can report it.
+
+| `reason` | Meaning |
+|---|---|
+| `library_mismatch` | The active Library differs from the one the skill was linked in, or the document lives in another Library. |
+| `document_not_found` | Missing or inaccessible document. The CLI never searches by title. |
+| `no_published_revision` | Every revision is a draft. |
+| `revision_unavailable` | The pinned revision does not exist. |
+| `revision_not_published` | The pinned revision is a draft. |
+| `document_archived` | The document is archived. |
+| `empty_body` | The published revision has no body. |
+| `procedure_too_large` | The body exceeds 32,000 characters. Nothing is truncated. |
+| `access_denied` | The current account cannot read the document. |
+| `network_error` | The procedure could not be loaded. |
+| `name_taken` | A skill with that name exists and the CLI did not create it. |
+| `binding_modified` | The generated file was edited by hand. Use `--force` to overwrite. |
+| `binding_points_elsewhere` | The existing binding tracks a different document. Use `--force`. |
+| `not_a_dosu_link` | `unlink` was asked to remove a skill the CLI does not own. |
+
+## Scope of v1
+
+Claude Code only. Other `--agent` values are rejected. Out of scope for now: other clients, per-binding size limits, setup-wizard integration, and a TUI entry.

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -324,6 +324,23 @@ describe("docs update", () => {
     expect(call[0]).toBe("page.update");
     expect(call[1].id).toBe("p1");
     expect(call[1].title).toBe("Updated");
+    expect(call[1]).not.toHaveProperty("body");
+  });
+
+  it("omits title on a body-only update so the existing title is preserved", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockResolvedValueOnce(undefined);
+    await run("update", "p1", "--body", "New procedure");
+    const input = mockMutate.mock.calls[0][1];
+    expect(input.body).toBe("New procedure");
+    expect(input).not.toHaveProperty("title");
+  });
+
+  it("preserves explicitly empty fields in an update", async () => {
+    mockLoadConfig.mockReturnValue(validConfig);
+    mockMutate.mockResolvedValueOnce(undefined);
+    await run("update", "p1", "--title", "", "--body", "");
+    expect(mockMutate.mock.calls[0][1]).toMatchObject({ title: "", body: "" });
   });
 
   it("outputs JSON with --json", async () => {

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -283,8 +283,9 @@ export function docsCommand(): Command {
         await client.page.update.mutate({
           id,
           knowledge_store_id: ksId,
-          title: opts.title,
-          body: body,
+          // The API checks key presence; explicit undefined can clear existing content.
+          ...(opts.title !== undefined ? { title: opts.title } : {}),
+          ...(body !== undefined ? { body } : {}),
         });
 
         if (opts.json) {

--- a/src/commands/skill.test.ts
+++ b/src/commands/skill.test.ts
@@ -1,6 +1,17 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { TRPCClientError } from "@trpc/client";
+import pc from "picocolors";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecSync = vi.fn();
@@ -10,6 +21,48 @@ vi.mock("node:child_process", () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
 }));
 
+const mockQuery = vi.fn();
+const mockMutate = vi.fn();
+
+function createMockProxy(path: string[] = []): unknown {
+  return new Proxy(() => {}, {
+    get(_, prop: string) {
+      if (prop === "query") return (input: unknown) => mockQuery(path.join("."), input);
+      if (prop === "mutate") return (input: unknown) => mockMutate(path.join("."), input);
+      return createMockProxy([...path, prop]);
+    },
+  });
+}
+
+vi.mock("../client/trpc", () => ({
+  createTypedClient: vi.fn().mockImplementation(() => createMockProxy()),
+}));
+
+// Only `loadConfig` is faked: `skill-update-check` still needs the real
+// `getConfigDir` so the install/update cache tests keep writing under XDG.
+const mockLoadConfig = vi.fn();
+vi.mock("../config/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config")>()),
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+}));
+
+vi.mock("../debug/logger", () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+// Wrap (not replace) `skillPathsFor` so one test can make the containment
+// check fire; every other export stays real and hits a temp directory.
+vi.mock("../skills/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../skills/store")>();
+  return { ...actual, skillPathsFor: vi.fn(actual.skillPathsFor) };
+});
+
+import { makeTestConfig } from "../config/config.test-utils";
+import { CONFIG_SCHEMA_VERSION } from "../config/schema";
+import { defaultSkillDescription, parseMarker, renderSkillMarkdown } from "../skills/binding";
+import { skillPathsFor } from "../skills/store";
+import { type LinkMarker, SKILL_LINK_TEMPLATE_VERSION } from "../skills/types";
+import { VERSION } from "../version/version";
 import {
   installSkill,
   skillAgentIDsForProviders,
@@ -35,7 +88,12 @@ function allErrors(): string {
 
 async function run(...args: string[]) {
   const cmd = skillCommand();
-  cmd.exitOverride();
+  // Commander copies exitOverride into subcommands only at creation time, so
+  // usage errors raised inside `skill <sub>` need it applied per subcommand.
+  for (const command of [cmd, ...cmd.commands]) {
+    command.exitOverride();
+    command.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+  }
   await cmd.parseAsync(["node", "test", ...args]);
 }
 
@@ -382,5 +440,795 @@ describe("installSkill helper", () => {
     const result = await installSkill();
     expect(result.success).toBe(false);
     expect(result.sha).toBeUndefined();
+  });
+});
+
+// ─── Live knowledge skills (`skill link|resolve|links|unlink`) ───────────────
+
+const DOC = "879cbca9-2fbf-45be-9a3e-1b74303238be";
+const OTHER_DOC = "5b1f0c0e-6f1a-4c2b-9d3e-0a1b2c3d4e5f";
+const LIB = "11111111-1111-4111-8111-111111111111";
+const OTHER_LIB = "22222222-2222-4222-8222-222222222222";
+const ORG = "33333333-3333-4333-8333-333333333333";
+const STORE = "66e1c189-0000-4000-8000-000000000000";
+const TITLE = "DB Enum Widening Checklist";
+const BODY = "# DB Enum Widening Checklist\n\n1. Confirm the enum is widened, never narrowed.\n";
+/** Distinctive so a leak into the generated file cannot hide behind a short token. */
+const SECRETS = {
+  access_token: "tok-secret-123",
+  refresh_token: "ref-secret-456",
+  api_key: "sk_user_secret_789",
+};
+const linkedConfig = makeTestConfig({ ...SECRETS, expires_at: 0, space_id: LIB, org_id: ORG });
+
+const FOREIGN_SKILL = "---\nname: mine\ndescription: hand written\n---\n\n# mine\n";
+const CORRUPT_SKILL =
+  "---\nname: broken\n---\n<!-- dosu:skill-link v1 {not json} -->\n\n# broken\n";
+
+type Handler = (input: unknown) => unknown;
+
+/** Script return values (or thrown errors) per procedure path. Unscripted paths reject loudly. */
+function script(handlers: Record<string, Handler>): void {
+  mockQuery.mockImplementation(async (path: string, input: unknown) => {
+    const handler = handlers[path];
+    if (!handler) throw new Error(`unscripted procedure: ${path}`);
+    return handler(input);
+  });
+}
+
+function version(v: number, published: boolean) {
+  return { id: `pv-${v}`, version: v, published };
+}
+
+function page(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DOC,
+    title: TITLE,
+    body: BODY,
+    version: 2,
+    page_version_id: "pv-2",
+    published: true,
+    archived: false,
+    knowledge_store_id: STORE,
+    updated_at: "2026-09-10T01:08:02.487426+00:00",
+    ...overrides,
+  };
+}
+
+/** Store found, the given revision inventory, and `page.get` echoing the requested version. */
+function scriptDocument(versions: unknown[], extra: Record<string, Handler> = {}): void {
+  script({
+    "knowledgeStore.getBySpaceId": () => ({ id: STORE, space_id: LIB }),
+    "page.listVersions": () => versions,
+    "page.get": (input) => {
+      const { version: v } = input as { version: number };
+      return page({ version: v, page_version_id: `pv-${v}` });
+    },
+    ...extra,
+  });
+}
+
+function trpcError(code: string) {
+  return new TRPCClientError("upstream failure", {
+    result: { error: { code: -32000, message: "upstream failure", data: { code } } },
+  });
+}
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping for stable assertions
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+function plainOutput(): string {
+  return stripAnsi(allOutput());
+}
+
+/** JSON mode must print exactly one JSON document and nothing else on stdout. */
+function singleJSON(): Record<string, unknown> {
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy.mock.calls[0]).toHaveLength(1);
+  return JSON.parse(String(logSpy.mock.calls[0][0]));
+}
+
+async function expectExit(promise: Promise<unknown>): Promise<void> {
+  await expect(promise).rejects.toThrow("exit");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+}
+
+/** `inGitWorkTree` shells out to git; answer that one command and nothing else. */
+function stubGitWorkTree(inside: boolean): void {
+  mockExecSync.mockImplementation((command: unknown) =>
+    String(command).startsWith("git rev-parse")
+      ? Buffer.from(inside ? "true\n" : "false\n")
+      : undefined,
+  );
+}
+
+function marker(overrides: Partial<Omit<LinkMarker, "content_sha256">> = {}) {
+  return {
+    document_id: DOC,
+    library_id: LIB,
+    org_id: ORG,
+    revision: null,
+    template: SKILL_LINK_TEMPLATE_VERSION,
+    cli_version: VERSION,
+    ...overrides,
+  };
+}
+
+/** Byte-identical to what `skill link` renders for the same inputs. */
+function expectedRender(name: string, revision: number | null = null, description?: string) {
+  return renderSkillMarkdown({
+    name,
+    description: description ?? defaultSkillDescription(TITLE, name, revision),
+    marker: marker({ revision }),
+  });
+}
+
+function seed(file: string, content: string): void {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+describe("live knowledge skills", () => {
+  let claudeDir: string;
+  let projectDir: string;
+
+  function skillFile(name: string, root: string = join(claudeDir, "skills")): string {
+    return join(root, name, "SKILL.md");
+  }
+
+  function projectSkillFile(name: string): string {
+    return skillFile(name, join(projectDir, ".claude", "skills"));
+  }
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockMutate.mockReset();
+    mockLoadConfig.mockReset();
+    mockLoadConfig.mockReturnValue(linkedConfig);
+    claudeDir = join(tempDir, "claude");
+    projectDir = join(tempDir, "repo");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", claudeDir);
+  });
+
+  it("describes the parent command's two jobs", () => {
+    expect(skillCommand().description()).toBe(
+      "Manage the Dosu agent skill and link Dosu documents as live skills",
+    );
+  });
+
+  describe("skill link", () => {
+    it("creates SKILL.md and reports the binding as one JSON object", async () => {
+      scriptDocument([version(1, true), version(2, true)]);
+      await run("link", DOC, "--name", "migration-review", "--agent", "claude", "--json");
+
+      const file = skillFile("migration-review");
+      expect(singleJSON()).toEqual({
+        step: "skill_link",
+        status: "ok",
+        action: "created",
+        skill: { name: "migration-review", agent: "claude", scope: "user", path: file },
+        source: {
+          document_id: DOC,
+          title: TITLE,
+          library_id: LIB,
+          tracking: "live",
+          resolved_revision: 2,
+        },
+        agent_next_steps:
+          "Invoke /migration-review in Claude Code. If the skill does not appear, start a new session.",
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      const content = readFileSync(file, "utf-8");
+      expect(content).toBe(expectedRender("migration-review"));
+      expect(parseMarker(content)).toMatchObject({ kind: "ok", edited: false, marker: marker() });
+      expect(mockQuery).toHaveBeenCalledWith("page.get", { page_id: DOC, version: 2 });
+    });
+
+    it("prints a human summary with title, path and the new-session note", async () => {
+      scriptDocument([version(1, true)]);
+      await run("link", DOC, "--name", "migration-review", "--agent", "claude");
+
+      const output = plainOutput();
+      expect(output).toContain("✓ Linked skill 'migration-review' (created)");
+      expect(output).toContain(TITLE);
+      expect(output).toContain(DOC);
+      expect(output).toContain(skillFile("migration-review"));
+      expect(output).toMatch(/Tracking\s+live/);
+      expect(output).toMatch(/Resolved\s+revision 1/);
+      expect(output).toContain(
+        "Invoke /migration-review in Claude Code. If the skill does not appear, start a new session.",
+      );
+    });
+
+    it("pins to --revision and fetches only that revision", async () => {
+      scriptDocument([version(1, true), version(2, true), version(3, true)]);
+      await run("link", DOC, "--name", "pinned", "--agent", "claude", "--revision", "2", "--json");
+
+      const out = singleJSON();
+      expect(out.action).toBe("created");
+      expect(out.source).toMatchObject({ tracking: "pinned", resolved_revision: 2 });
+      expect(mockQuery).not.toHaveBeenCalledWith("page.listVersions", expect.anything());
+      expect(mockQuery).toHaveBeenCalledWith("page.get", { page_id: DOC, version: 2 });
+
+      const content = readFileSync(skillFile("pinned"), "utf-8");
+      expect(content).toBe(expectedRender("pinned", 2));
+      expect(content).toContain(`--library ${LIB} --revision 2 --json`);
+      expect(content).toContain("(pinned to revision 2)");
+    });
+
+    it("shows pinned tracking in human mode", async () => {
+      scriptDocument([]);
+      await run("link", DOC, "--name", "pinned", "--agent", "claude", "--revision", "2");
+      expect(plainOutput()).toMatch(/Tracking\s+pinned to revision 2/);
+    });
+
+    it("uses --description verbatim instead of the generated one", async () => {
+      scriptDocument([version(1, true)]);
+      await run(
+        "link",
+        DOC,
+        "--name",
+        "custom",
+        "--agent",
+        "claude",
+        "--description",
+        "Review enum migrations.",
+      );
+      const content = readFileSync(skillFile("custom"), "utf-8");
+      expect(content).toContain('description: "Review enum migrations."');
+      expect(content).toBe(expectedRender("custom", null, "Review enum migrations."));
+    });
+
+    it("treats re-linking an identical binding as unchanged without rewriting", async () => {
+      scriptDocument([version(1, true)]);
+      await run("link", DOC, "--name", "migration-review", "--agent", "claude");
+      const file = skillFile("migration-review");
+      const before = readFileSync(file, "utf-8");
+      const past = new Date(Date.now() - 60_000);
+      utimesSync(file, past, past);
+      const mtime = statSync(file).mtimeMs;
+
+      logSpy.mockClear();
+      await run("link", DOC, "--name", "migration-review", "--agent", "claude", "--json");
+      expect(singleJSON().action).toBe("unchanged");
+      expect(readFileSync(file, "utf-8")).toBe(before);
+      expect(statSync(file).mtimeMs).toBe(mtime);
+    });
+
+    it("rewrites an owned binding when --revision changes", async () => {
+      scriptDocument([version(1, true), version(2, true)]);
+      await run("link", DOC, "--name", "migration-review", "--agent", "claude");
+
+      logSpy.mockClear();
+      await run(
+        "link",
+        DOC,
+        "--name",
+        "migration-review",
+        "--agent",
+        "claude",
+        "--revision",
+        "2",
+        "--json",
+      );
+      expect(singleJSON().action).toBe("updated");
+      const content = readFileSync(skillFile("migration-review"), "utf-8");
+      expect(content).toBe(expectedRender("migration-review", 2));
+      expect(parseMarker(content)).toMatchObject({ kind: "ok", edited: false });
+    });
+
+    it("refuses to overwrite a hand-edited binding unless --force", async () => {
+      scriptDocument([version(1, true)]);
+      await run("link", DOC, "--name", "migration-review", "--agent", "claude");
+      const file = skillFile("migration-review");
+      const edited = `${readFileSync(file, "utf-8")}\nLocal note.\n`;
+      writeFileSync(file, edited);
+
+      logSpy.mockClear();
+      await expectExit(
+        run("link", DOC, "--name", "migration-review", "--agent", "claude", "--json"),
+      );
+      expect(singleJSON()).toMatchObject({
+        step: "skill_link",
+        status: "error",
+        reason: "binding_modified",
+        agent_next_steps: "Re-run with --force to overwrite your edits, or unlink and link again.",
+      });
+      expect(readFileSync(file, "utf-8")).toBe(edited);
+
+      logSpy.mockClear();
+      await run(
+        "link",
+        DOC,
+        "--name",
+        "migration-review",
+        "--agent",
+        "claude",
+        "--force",
+        "--json",
+      );
+      expect(singleJSON().action).toBe("updated");
+      expect(readFileSync(file, "utf-8")).toBe(expectedRender("migration-review"));
+    });
+
+    it("refuses to repoint an owned binding at another document unless --force", async () => {
+      scriptDocument([version(1, true)]);
+      await run("link", DOC, "--name", "migration-review", "--agent", "claude");
+      const file = skillFile("migration-review");
+      const before = readFileSync(file, "utf-8");
+
+      logSpy.mockClear();
+      await expectExit(
+        run("link", OTHER_DOC, "--name", "migration-review", "--agent", "claude", "--json"),
+      );
+      const out = singleJSON();
+      expect(out).toMatchObject({
+        status: "error",
+        reason: "binding_points_elsewhere",
+        details: { previous_document_id: DOC },
+      });
+      expect(String(out.message)).toContain(DOC);
+      expect(String(out.agent_next_steps)).toContain(OTHER_DOC);
+      expect(readFileSync(file, "utf-8")).toBe(before);
+
+      logSpy.mockClear();
+      await run(
+        "link",
+        OTHER_DOC,
+        "--name",
+        "migration-review",
+        "--agent",
+        "claude",
+        "--force",
+        "--json",
+      );
+      expect(singleJSON().action).toBe("updated");
+      expect(parseMarker(readFileSync(file, "utf-8"))).toMatchObject({
+        kind: "ok",
+        marker: { document_id: OTHER_DOC },
+      });
+    });
+
+    it("never overwrites a skill Dosu does not own, even with --force", async () => {
+      scriptDocument([version(1, true)]);
+      const file = skillFile("mine");
+      seed(file, FOREIGN_SKILL);
+
+      await expectExit(run("link", DOC, "--name", "mine", "--agent", "claude", "--json"));
+      expect(singleJSON()).toMatchObject({ status: "error", reason: "name_taken" });
+      expect(readFileSync(file, "utf-8")).toBe(FOREIGN_SKILL);
+
+      logSpy.mockClear();
+      await expectExit(run("link", DOC, "--name", "mine", "--agent", "claude", "--force"));
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(allErrors()).toContain("Error [name_taken]:");
+      expect(allErrors()).toContain("--force does not overwrite skills Dosu does not own.");
+      expect(readFileSync(file, "utf-8")).toBe(FOREIGN_SKILL);
+    });
+
+    it("reports a corrupt marker and overwrites it only with --force", async () => {
+      scriptDocument([version(1, true)]);
+      const file = skillFile("broken");
+      seed(file, CORRUPT_SKILL);
+
+      await expectExit(run("link", DOC, "--name", "broken", "--agent", "claude", "--json"));
+      const out = singleJSON();
+      expect(out).toMatchObject({ status: "error", reason: "binding_corrupt" });
+      expect(String(out.message)).toContain("Dosu skill-link marker");
+      expect(readFileSync(file, "utf-8")).toBe(CORRUPT_SKILL);
+
+      logSpy.mockClear();
+      await run("link", DOC, "--name", "broken", "--agent", "claude", "--force", "--json");
+      expect(singleJSON().action).toBe("updated");
+      expect(parseMarker(readFileSync(file, "utf-8")).kind).toBe("ok");
+    });
+
+    it("writes nothing when the document cannot be resolved", async () => {
+      scriptDocument([]);
+      await expectExit(
+        run("link", DOC, "--name", "migration-review", "--agent", "claude", "--json"),
+      );
+      const out = singleJSON();
+      expect(out).toMatchObject({
+        step: "skill_link",
+        status: "error",
+        reason: "document_not_found",
+      });
+      expect(out.message).toBeTypeOf("string");
+      expect(out.agent_next_steps).toBeTypeOf("string");
+      expect(existsSync(join(claudeDir, "skills"))).toBe(false);
+    });
+
+    it("surfaces an API access failure as access_denied in human mode", async () => {
+      scriptDocument([], {
+        "page.listVersions": () => {
+          throw trpcError("FORBIDDEN");
+        },
+      });
+      await expectExit(run("link", DOC, "--name", "migration-review", "--agent", "claude"));
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(allErrors()).toContain("Error [access_denied]:");
+      expect(existsSync(join(claudeDir, "skills"))).toBe(false);
+    });
+
+    it.each(["../x", "dosu", ".hidden"])("rejects the skill name %j", async (name) => {
+      scriptDocument([version(1, true)]);
+      await expectExit(run("link", DOC, "--name", name, "--agent", "claude", "--json"));
+      expect(singleJSON()).toMatchObject({ status: "error", reason: "invalid_name" });
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(existsSync(join(claudeDir, "skills"))).toBe(false);
+    });
+
+    it("fails closed when the containment check refuses the path", async () => {
+      scriptDocument([version(1, true)]);
+      vi.mocked(skillPathsFor).mockReturnValueOnce(null);
+      await expectExit(run("link", DOC, "--name", "escapee", "--agent", "claude", "--json"));
+      const out = singleJSON();
+      expect(out).toMatchObject({ status: "error", reason: "invalid_name" });
+      expect(String(out.message)).toContain("escapee");
+      expect(existsSync(join(claudeDir, "skills"))).toBe(false);
+    });
+
+    it("rejects an unsupported --agent as a usage error", async () => {
+      await expect(run("link", DOC, "--name", "x", "--agent", "cursor")).rejects.toMatchObject({
+        code: "commander.invalidArgument",
+      });
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it("requires --name and --agent", async () => {
+      await expect(run("link", DOC, "--agent", "claude")).rejects.toMatchObject({
+        code: "commander.missingMandatoryOptionValue",
+      });
+      await expect(run("link", DOC, "--name", "x")).rejects.toMatchObject({
+        code: "commander.missingMandatoryOptionValue",
+      });
+    });
+
+    it("validates the document id and --revision", async () => {
+      await expect(
+        run("link", "not-a-uuid", "--name", "x", "--agent", "claude"),
+      ).rejects.toMatchObject({
+        code: "commander.invalidArgument",
+      });
+      await expect(
+        run("link", DOC, "--name", "x", "--agent", "claude", "--revision", "0"),
+      ).rejects.toMatchObject({ code: "commander.invalidArgument" });
+    });
+
+    it("refuses --project outside a git work tree", async () => {
+      stubGitWorkTree(false);
+      scriptDocument([version(1, true)]);
+      await expectExit(run("link", DOC, "--name", "x", "--agent", "claude", "--project", "--json"));
+      expect(singleJSON()).toMatchObject({
+        status: "error",
+        reason: "not_a_git_work_tree",
+        message: "--project requires a git work tree.",
+      });
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(existsSync(join(projectDir, ".claude"))).toBe(false);
+    });
+
+    it("writes under <cwd>/.claude/skills with --project inside a work tree", async () => {
+      mkdirSync(projectDir, { recursive: true });
+      vi.spyOn(process, "cwd").mockReturnValue(projectDir);
+      stubGitWorkTree(true);
+      scriptDocument([version(1, true)]);
+
+      await run("link", DOC, "--name", "repo-skill", "--agent", "claude", "--project", "--json");
+      const file = projectSkillFile("repo-skill");
+      expect(singleJSON()).toMatchObject({
+        action: "created",
+        skill: { scope: "project", path: file },
+      });
+      expect(readFileSync(file, "utf-8")).toBe(expectedRender("repo-skill"));
+      expect(existsSync(join(claudeDir, "skills"))).toBe(false);
+      expect(mockExecSync).toHaveBeenCalledWith(
+        "git rev-parse --is-inside-work-tree",
+        expect.objectContaining({ cwd: projectDir }),
+      );
+    });
+
+    it("requires login before resolving anything", async () => {
+      mockLoadConfig.mockReturnValue({ schema_version: CONFIG_SCHEMA_VERSION });
+      await expectExit(run("link", DOC, "--name", "x", "--agent", "claude"));
+      expect(allErrors()).toContain("Not logged in. Run 'dosu login' first.");
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it("requires a selected Library", async () => {
+      mockLoadConfig.mockReturnValue(makeTestConfig({ ...SECRETS, expires_at: 0, org_id: ORG }));
+      await expectExit(run("link", DOC, "--name", "x", "--agent", "claude"));
+      expect(allErrors()).toContain("Missing space config. Run 'dosu setup' to reconfigure.");
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it("never writes credentials into the generated file", async () => {
+      scriptDocument([version(1, true)]);
+      await run("link", DOC, "--name", "migration-review", "--agent", "claude");
+      const content = readFileSync(skillFile("migration-review"), "utf-8");
+      for (const secret of Object.values(SECRETS)) expect(content).not.toContain(secret);
+      expect(content).toContain(LIB);
+      expect(content).toContain(ORG);
+    });
+  });
+
+  describe("skill resolve", () => {
+    it("returns source and body as one JSON object", async () => {
+      scriptDocument([version(1, true), version(2, true), version(3, false)]);
+      await run("resolve", "--document", DOC, "--library", LIB, "--json");
+      expect(singleJSON()).toMatchObject({
+        step: "skill_resolve",
+        status: "ok",
+        source: {
+          document_id: DOC,
+          title: TITLE,
+          revision: 2,
+          page_version_id: "pv-2",
+          published: true,
+          tracking: "live",
+          library_id: LIB,
+          knowledge_store_id: STORE,
+        },
+        body: BODY,
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("fetches only the pinned revision with --revision", async () => {
+      scriptDocument([]);
+      await run("resolve", "--document", DOC, "--library", LIB, "--revision", "1", "--json");
+      expect(singleJSON().source).toMatchObject({ revision: 1, tracking: "pinned" });
+      expect(mockQuery).not.toHaveBeenCalledWith("page.listVersions", expect.anything());
+      expect(mockQuery).toHaveBeenCalledWith("page.get", { page_id: DOC, version: 1 });
+    });
+
+    it("prints a source header and the body verbatim in human mode", async () => {
+      scriptDocument([version(2, true)]);
+      await run("resolve", "--document", DOC, "--library", LIB);
+      const output = plainOutput();
+      expect(output).toContain(`Source: "${TITLE}" · document ${DOC} · revision 2 · live`);
+      expect(output).toContain(BODY);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("emits a failure as one JSON object on stdout and exits 1", async () => {
+      scriptDocument([version(1, true)]);
+      await expectExit(run("resolve", "--document", DOC, "--library", OTHER_LIB, "--json"));
+      const out = singleJSON();
+      expect(out).toMatchObject({
+        step: "skill_resolve",
+        status: "error",
+        reason: "library_mismatch",
+        details: { linked_library_id: OTHER_LIB, active_library_id: LIB },
+      });
+      expect(out.message).toBeTypeOf("string");
+      expect(out.agent_next_steps).toBeTypeOf("string");
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it("prints failures in red on stderr with nothing on stdout in human mode", async () => {
+      scriptDocument([version(1, false)]);
+      await expectExit(run("resolve", "--document", DOC, "--library", LIB));
+      expect(logSpy).not.toHaveBeenCalled();
+      const [first, second] = errorSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+      expect(first).toContain("Error [no_published_revision]:");
+      expect(first).toBe(pc.red(stripAnsi(first)));
+      expect(second).toContain("Publish a revision in Dosu");
+    });
+
+    it("maps a FORBIDDEN response to access_denied", async () => {
+      scriptDocument([], {
+        "page.listVersions": () => {
+          throw trpcError("FORBIDDEN");
+        },
+      });
+      await expectExit(run("resolve", "--document", DOC, "--library", LIB, "--json"));
+      expect(singleJSON()).toMatchObject({ status: "error", reason: "access_denied" });
+    });
+
+    it("requires login", async () => {
+      mockLoadConfig.mockReturnValue({ schema_version: CONFIG_SCHEMA_VERSION });
+      await expectExit(run("resolve", "--document", DOC, "--library", LIB, "--json"));
+      expect(allErrors()).toContain("Not logged in. Run 'dosu login' first.");
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it("requires --document and --library as UUIDs", async () => {
+      await expect(run("resolve", "--library", LIB)).rejects.toMatchObject({
+        code: "commander.missingMandatoryOptionValue",
+      });
+      await expect(run("resolve", "--document", DOC)).rejects.toMatchObject({
+        code: "commander.missingMandatoryOptionValue",
+      });
+      await expect(run("resolve", "--document", "nope", "--library", LIB)).rejects.toMatchObject({
+        code: "commander.invalidArgument",
+      });
+    });
+  });
+
+  describe("skill links", () => {
+    it("reports when nothing is linked", async () => {
+      await run("links");
+      expect(plainOutput()).toContain("No linked skills found.");
+
+      logSpy.mockClear();
+      await run("links", "--json");
+      expect(singleJSON()).toEqual({ step: "skill_links", status: "ok", skills: [] });
+    });
+
+    it("lists bindings across user and project roots and ignores foreign skills", async () => {
+      vi.spyOn(process, "cwd").mockReturnValue(projectDir);
+      seed(skillFile("alpha"), expectedRender("alpha"));
+      seed(skillFile("mine"), FOREIGN_SKILL);
+      const projectFile = projectSkillFile("beta");
+      seed(
+        projectFile,
+        renderSkillMarkdown({
+          name: "beta",
+          description: "Pinned.",
+          marker: marker({ document_id: OTHER_DOC, library_id: OTHER_LIB, revision: 3 }),
+        }),
+      );
+
+      await run("links");
+      const output = plainOutput();
+      expect(output).toMatch(/^alpha\s+879cbca9\s+live\s+11111111\s+user\s+\S+alpha\/SKILL\.md/m);
+      expect(output).toMatch(/^beta\s+5b1f0c0e\s+pinned \(r3\)\s+22222222\s+project\s+/m);
+      expect(output).toContain(projectFile);
+      expect(output).not.toContain("mine");
+      expect(output).not.toContain("edited after");
+
+      logSpy.mockClear();
+      await run("links", "--json");
+      const out = singleJSON();
+      expect(out).toMatchObject({ step: "skill_links", status: "ok" });
+      expect(out.skills).toEqual([
+        expect.objectContaining({ name: "alpha", agent: "claude", scope: "user", edited: false }),
+        expect.objectContaining({
+          name: "beta",
+          scope: "project",
+          path: projectFile,
+          marker: expect.objectContaining({ document_id: OTHER_DOC, revision: 3 }),
+        }),
+      ]);
+    });
+
+    it("marks edited bindings with an asterisk and explains it", async () => {
+      seed(skillFile("alpha"), `${expectedRender("alpha")}\nLocal note.\n`);
+      await run("links");
+      const output = plainOutput();
+      expect(output).toMatch(/^alpha \*\s/m);
+      expect(output).toContain("* edited after it was generated");
+
+      logSpy.mockClear();
+      await run("links", "--json");
+      expect(singleJSON().skills).toEqual([
+        expect.objectContaining({ name: "alpha", edited: true }),
+      ]);
+    });
+
+    it("accepts --project when the project root does not exist yet", async () => {
+      vi.spyOn(process, "cwd").mockReturnValue(projectDir);
+      seed(skillFile("alpha"), expectedRender("alpha"));
+      await run("links", "--project", "--json");
+      expect(singleJSON().skills).toEqual([
+        expect.objectContaining({ name: "alpha", scope: "user" }),
+      ]);
+    });
+
+    it("does not require login", async () => {
+      mockLoadConfig.mockReturnValue({ schema_version: CONFIG_SCHEMA_VERSION });
+      await run("links", "--json");
+      expect(singleJSON()).toMatchObject({ status: "ok" });
+      expect(mockLoadConfig).not.toHaveBeenCalled();
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unsupported --agent", async () => {
+      await expect(run("links", "--agent", "cursor")).rejects.toMatchObject({
+        code: "commander.invalidArgument",
+      });
+    });
+  });
+
+  describe("skill unlink", () => {
+    it("removes an owned binding and its now-empty directory", async () => {
+      const file = skillFile("alpha");
+      seed(file, expectedRender("alpha"));
+      await run("unlink", "alpha", "--agent", "claude", "--json");
+      expect(singleJSON()).toEqual({
+        step: "skill_unlink",
+        status: "ok",
+        skill: { name: "alpha", agent: "claude", scope: "user", path: file },
+        directory_removed: true,
+        leftover: [],
+      });
+      expect(existsSync(dirname(file))).toBe(false);
+      expect(mockLoadConfig).not.toHaveBeenCalled();
+    });
+
+    it("keeps a directory that still holds other files and reports them", async () => {
+      const file = skillFile("alpha");
+      seed(file, expectedRender("alpha"));
+      writeFileSync(join(dirname(file), "notes.txt"), "keep me");
+
+      await run("unlink", "alpha", "--agent", "claude");
+      const output = plainOutput();
+      expect(output).toContain("✓ Unlinked skill 'alpha'");
+      expect(output).toContain(`Left in place: ${dirname(file)} (notes.txt)`);
+      expect(existsSync(file)).toBe(false);
+      expect(readFileSync(join(dirname(file), "notes.txt"), "utf-8")).toBe("keep me");
+    });
+
+    it("prints only the success line when the directory was removed", async () => {
+      seed(skillFile("alpha"), expectedRender("alpha"));
+      await run("unlink", "alpha", "--agent", "claude");
+      expect(plainOutput()).toBe("✓ Unlinked skill 'alpha'");
+    });
+
+    it("refuses to remove a skill Dosu does not own", async () => {
+      const file = skillFile("mine");
+      seed(file, FOREIGN_SKILL);
+      await expectExit(run("unlink", "mine", "--agent", "claude", "--json"));
+      expect(singleJSON()).toMatchObject({
+        step: "skill_unlink",
+        status: "error",
+        reason: "not_a_dosu_link",
+        agent_next_steps:
+          "This skill was not created by 'dosu skill link'; remove it manually if intended.",
+      });
+      expect(readFileSync(file, "utf-8")).toBe(FOREIGN_SKILL);
+    });
+
+    it("reports a missing skill as not_found", async () => {
+      await expectExit(run("unlink", "ghost", "--agent", "claude"));
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(allErrors()).toContain("Error [not_found]:");
+      expect(allErrors()).toContain("Run 'dosu skill links' to see linked skills.");
+    });
+
+    it("leaves a corrupt marker in place", async () => {
+      const file = skillFile("broken");
+      seed(file, CORRUPT_SKILL);
+      await expectExit(run("unlink", "broken", "--agent", "claude", "--json"));
+      expect(singleJSON()).toMatchObject({
+        reason: "corrupt",
+        agent_next_steps: "Inspect the file and remove it manually if intended.",
+      });
+      expect(readFileSync(file, "utf-8")).toBe(CORRUPT_SKILL);
+    });
+
+    it("rejects the reserved official skill name before touching the filesystem", async () => {
+      await expectExit(run("unlink", "dosu", "--agent", "claude", "--json"));
+      const out = singleJSON();
+      expect(out).toMatchObject({ step: "skill_unlink", status: "error", reason: "invalid_name" });
+      expect(String(out.message)).toContain("reserved");
+    });
+
+    it("targets <cwd>/.claude/skills with --project without a git check", async () => {
+      vi.spyOn(process, "cwd").mockReturnValue(projectDir);
+      const file = projectSkillFile("beta");
+      seed(file, expectedRender("beta"));
+      await run("unlink", "beta", "--agent", "claude", "--project", "--json");
+      expect(singleJSON()).toMatchObject({
+        skill: { scope: "project", path: file },
+        directory_removed: true,
+      });
+      expect(existsSync(file)).toBe(false);
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
+
+    it("requires --agent", async () => {
+      await expect(run("unlink", "alpha")).rejects.toMatchObject({
+        code: "commander.missingMandatoryOptionValue",
+      });
+    });
   });
 });

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,14 +1,46 @@
 /**
- * `dosu skill` — manage the Dosu agent skill.
+ * `dosu skill` — manage the Dosu agent skill, and link Dosu documents as live
+ * skills (`link|resolve|links|unlink`).
  */
 
 import { exec, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
+import { emitError } from "../agent/output";
+import { createTypedClient } from "../client/trpc";
 import { logger } from "../debug/logger";
+import { inGitWorkTree } from "../setup/agents-md-step";
+import {
+  defaultSkillDescription,
+  MAX_SKILL_DESCRIPTION_LENGTH,
+  renderSkillMarkdown,
+  skillNameError,
+} from "../skills/binding";
+import { resolveLinkedProcedure } from "../skills/resolve";
+import {
+  type ExistingBinding,
+  linkedSkillRoot,
+  listLinkedSkills,
+  readExistingBinding,
+  removeLinkedSkill,
+  type SkillRoot,
+  skillPathsFor,
+  writeSkillFile,
+} from "../skills/store";
+import {
+  type LinkedSkillEntry,
+  SKILL_LINK_TEMPLATE_VERSION,
+  type SkillAgent,
+  type SkillScope,
+} from "../skills/types";
 import { clearInstalledSha, fetchLatestSha, writeSkillCache } from "../version/skill-update-check";
+import { VERSION } from "../version/version";
+import { boundedText, positiveInteger, uuid } from "./arguments";
+import { requireLoginConfig } from "./auth";
+import { printInfo, printResult, printTable } from "./output";
 
 const SKILL_REPO = "dosu-ai/dosu-skill";
 const SKILL_NAME = "dosu";
@@ -181,8 +213,221 @@ function installedSkillNames(): string[] | null {
   return names;
 }
 
+// ─── Live knowledge skills (`skill link|resolve|links|unlink`) ───────────────
+
+/** Coding agents that can host a linked skill. Claude Code only in v1. */
+const LINK_AGENTS: readonly SkillAgent[] = ["claude"];
+
+const INVALID_NAME_NEXT_STEPS =
+  "Choose a name that starts with a letter or digit and uses only letters, digits, '.', '_' or '-'.";
+
+const UNLINK_NEXT_STEPS: Readonly<Record<"not_found" | "not_a_dosu_link" | "corrupt", string>> = {
+  not_found: "Run 'dosu skill links' to see linked skills.",
+  not_a_dosu_link:
+    "This skill was not created by 'dosu skill link'; remove it manually if intended.",
+  corrupt: "Inspect the file and remove it manually if intended.",
+};
+
+interface CommandFailure {
+  reason: string;
+  message: string;
+  agent_next_steps: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Report a classified failure and exit 1. In `--json` mode the error is one JSON
+ * object on stdout (the driving agent reads stdout); in human mode it is red
+ * text on stderr so stdout only ever carries data.
+ */
+function fail(step: string, json: boolean | undefined, failure: CommandFailure): never {
+  if (json) {
+    emitError({
+      step,
+      reason: failure.reason,
+      message: failure.message,
+      ...(failure.details ? { details: failure.details } : {}),
+      agent_next_steps: failure.agent_next_steps,
+    });
+  } else {
+    console.error(pc.red(`Error [${failure.reason}]: ${failure.message}`));
+    console.error(pc.dim(failure.agent_next_steps));
+  }
+  process.exit(1);
+}
+
+/** Logged in with a selected Library; same guard and messages as `dosu docs`. */
+function requireConfig() {
+  const cfg = requireLoginConfig();
+  const libraryId = cfg.active_account?.target?.space_id;
+  if (!libraryId) {
+    console.error(pc.red("Missing space config. Run 'dosu setup' to reconfigure."));
+    process.exit(1);
+  }
+  return { cfg, libraryId, orgId: cfg.active_account?.target?.org_id ?? null };
+}
+
+function agentOption(): Option {
+  return new Option("--agent <agent>", "Coding agent that hosts the skill").choices(LINK_AGENTS);
+}
+
+function scopeFor(project: boolean | undefined): SkillScope {
+  return project ? "project" : "user";
+}
+
+/** Validate the name, then resolve `<root>/<name>/SKILL.md` with the containment check. */
+function pathsFor(
+  agent: SkillAgent,
+  scope: SkillScope,
+  name: string,
+  step: string,
+  json: boolean | undefined,
+): { dir: string; file: string } {
+  const nameError = skillNameError(name);
+  if (nameError) {
+    fail(step, json, {
+      reason: "invalid_name",
+      message: nameError,
+      agent_next_steps: INVALID_NAME_NEXT_STEPS,
+    });
+  }
+  const root = linkedSkillRoot(agent, scope);
+  const paths = skillPathsFor(root, name);
+  // Defense in depth: skillNameError already rejects every shape skillPathsFor
+  // refuses, but the containment check is what actually guards the filesystem.
+  if (!paths) {
+    fail(step, json, {
+      reason: "invalid_name",
+      message: `Skill name "${name}" does not resolve to a directory inside ${root}.`,
+      agent_next_steps: INVALID_NAME_NEXT_STEPS,
+    });
+  }
+  return paths;
+}
+
+type LinkAction = "created" | "updated" | "unchanged";
+
+type LinkDecision =
+  | { kind: "write"; action: Exclude<LinkAction, "unchanged"> }
+  | { kind: "unchanged" }
+  | { kind: "fail"; failure: CommandFailure };
+
+/**
+ * Existing-target rules for `skill link`. Foreign skills are never overwritten,
+ * `--force` or not; owned bindings are rewritten freely unless the user edited
+ * the generated file or the binding points at another document.
+ */
+function decideLink(
+  existing: ExistingBinding,
+  input: { name: string; file: string; document_id: string; content: string; force: boolean },
+): LinkDecision {
+  const { name, file, document_id, content, force } = input;
+  switch (existing.kind) {
+    case "absent":
+      return { kind: "write", action: "created" };
+    case "foreign":
+      return {
+        kind: "fail",
+        failure: {
+          reason: "name_taken",
+          message: `A skill named '${name}' already exists at ${file} and was not created by Dosu.`,
+          agent_next_steps:
+            "Choose a different --name. --force does not overwrite skills Dosu does not own.",
+        },
+      };
+    case "corrupt":
+      if (force) return { kind: "write", action: "updated" };
+      return {
+        kind: "fail",
+        failure: {
+          reason: "binding_corrupt",
+          message: existing.message,
+          agent_next_steps: "Inspect the file, then re-run with --force to overwrite it.",
+        },
+      };
+    case "owned": {
+      const previous = existing.marker.document_id;
+      if (previous !== document_id && !force) {
+        return {
+          kind: "fail",
+          failure: {
+            reason: "binding_points_elsewhere",
+            message: `Skill '${name}' is linked to document ${previous}.`,
+            details: { previous_document_id: previous },
+            agent_next_steps: `Re-run with --force to point it at ${document_id}, or choose a different --name.`,
+          },
+        };
+      }
+      if (existing.content === content) return { kind: "unchanged" };
+      if (existing.edited && !force) {
+        return {
+          kind: "fail",
+          failure: {
+            reason: "binding_modified",
+            message: `The generated file at ${file} was edited after it was created.`,
+            agent_next_steps:
+              "Re-run with --force to overwrite your edits, or unlink and link again.",
+          },
+        };
+      }
+      return { kind: "write", action: "updated" };
+    }
+  }
+}
+
+function trackingLabel(revision: number | null): string {
+  return revision === null ? "live" : `pinned to revision ${revision}`;
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+function linkRow(entry: LinkedSkillEntry): string[] {
+  const { marker } = entry;
+  return [
+    entry.edited ? `${entry.name} *` : entry.name,
+    shortId(marker.document_id),
+    marker.revision === null ? "live" : `pinned (r${marker.revision})`,
+    shortId(marker.library_id),
+    entry.scope,
+    entry.path,
+  ];
+}
+
+interface LinkOptions {
+  name: string;
+  agent: SkillAgent;
+  revision?: number;
+  description?: string;
+  project?: boolean;
+  force?: boolean;
+  json?: boolean;
+}
+
+interface ResolveOptions {
+  document: string;
+  library: string;
+  revision?: number;
+  json?: boolean;
+}
+
+interface LinksOptions {
+  agent: SkillAgent;
+  project?: boolean;
+  json?: boolean;
+}
+
+interface UnlinkOptions {
+  agent: SkillAgent;
+  project?: boolean;
+  json?: boolean;
+}
+
 export function skillCommand(): Command {
-  const cmd = new Command("skill").description("Manage the Dosu agent skill");
+  const cmd = new Command("skill").description(
+    "Manage the Dosu agent skill and link Dosu documents as live skills",
+  );
 
   cmd
     .command("install")
@@ -240,6 +485,218 @@ export function skillCommand(): Command {
         process.exit(1);
       }
       console.log(pc.green(`\n✓ Skills updated.`));
+    });
+
+  cmd
+    .command("link")
+    .description("Link a Dosu document as a live skill for a coding agent")
+    .argument("<document-id>", "Dosu document ID", uuid)
+    .requiredOption("--name <skill-name>", "Skill name (invoked as /<skill-name>)")
+    .addOption(agentOption().makeOptionMandatory())
+    .option(
+      "--revision <n>",
+      "Pin the skill to this revision instead of following the highest published one",
+      positiveInteger,
+    )
+    .option(
+      "--description <text>",
+      "Override the generated skill description",
+      boundedText(MAX_SKILL_DESCRIPTION_LENGTH),
+    )
+    .option("--project", "Link in this repository's .claude/skills instead of user scope")
+    .option("--force", "Overwrite an edited binding or one linked to another document")
+    .option("--json", "Output as JSON")
+    .action(async (documentId: string, opts: LinkOptions) => {
+      const step = "skill_link";
+      const { cfg, libraryId, orgId } = requireConfig();
+      const scope = scopeFor(opts.project);
+      if (scope === "project" && !inGitWorkTree()) {
+        fail(step, opts.json, {
+          reason: "not_a_git_work_tree",
+          message: "--project requires a git work tree.",
+          agent_next_steps:
+            "Run this command inside a repository, or omit --project to link in user scope.",
+        });
+      }
+      const paths = pathsFor(opts.agent, scope, opts.name, step, opts.json);
+      const revision = opts.revision ?? null;
+
+      // Resolve exactly as `skill resolve` would; a source that cannot be
+      // resolved now is refused at link time and nothing is written.
+      const client = createTypedClient(cfg);
+      const result = await resolveLinkedProcedure(client, {
+        document_id: documentId,
+        library_id: libraryId,
+        active_library_id: libraryId,
+        revision,
+      });
+      if (!result.ok) fail(step, opts.json, result);
+
+      const description =
+        opts.description ?? defaultSkillDescription(result.source.title, opts.name, revision);
+      const content = renderSkillMarkdown({
+        name: opts.name,
+        description,
+        marker: {
+          document_id: documentId,
+          library_id: libraryId,
+          org_id: orgId,
+          revision,
+          template: SKILL_LINK_TEMPLATE_VERSION,
+          cli_version: VERSION,
+        },
+      });
+
+      const decision = decideLink(readExistingBinding(paths.file), {
+        name: opts.name,
+        file: paths.file,
+        document_id: documentId,
+        content,
+        force: opts.force === true,
+      });
+      if (decision.kind === "fail") fail(step, opts.json, decision.failure);
+      if (decision.kind === "write") writeSkillFile(paths.file, content);
+      const action: LinkAction = decision.kind === "write" ? decision.action : "unchanged";
+
+      const nextSteps = `Invoke /${opts.name} in Claude Code. If the skill does not appear, start a new session.`;
+      if (opts.json) {
+        printResult(
+          {
+            step,
+            status: "ok",
+            action,
+            skill: { name: opts.name, agent: opts.agent, scope, path: paths.file },
+            source: {
+              document_id: documentId,
+              title: result.source.title,
+              library_id: libraryId,
+              tracking: result.source.tracking,
+              resolved_revision: result.source.revision,
+            },
+            agent_next_steps: nextSteps,
+          },
+          { json: true },
+        );
+        return;
+      }
+      console.log(pc.green(`✓ Linked skill '${opts.name}' (${action})`));
+      printInfo([
+        ["Document", result.source.title],
+        ["ID", documentId],
+        ["Tracking", trackingLabel(revision)],
+        ["Resolved", `revision ${result.source.revision}`],
+        ["Path", paths.file],
+      ]);
+      console.log(pc.dim(nextSteps));
+    });
+
+  cmd
+    .command("resolve")
+    .description("Fetch the published revision of the document a linked skill points at")
+    .requiredOption("--document <document-id>", "Dosu document ID", uuid)
+    .requiredOption("--library <library-id>", "Library ID recorded in the skill", uuid)
+    .option("--revision <n>", "Pinned revision (omit for the highest published)", positiveInteger)
+    .option("--json", "Output as JSON")
+    .action(async (opts: ResolveOptions) => {
+      const step = "skill_resolve";
+      const { cfg, libraryId } = requireConfig();
+      const client = createTypedClient(cfg);
+      const result = await resolveLinkedProcedure(client, {
+        document_id: opts.document,
+        library_id: opts.library,
+        active_library_id: libraryId,
+        revision: opts.revision ?? null,
+      });
+      if (!result.ok) fail(step, opts.json, result);
+
+      if (opts.json) {
+        printResult(
+          { step, status: "ok", source: result.source, body: result.body },
+          { json: true },
+        );
+        return;
+      }
+      const { title, document_id, revision, tracking } = result.source;
+      console.log(
+        pc.bold(
+          `Source: "${title}" · document ${document_id} · revision ${revision} · ${tracking}`,
+        ),
+      );
+      console.log("");
+      // The body is data for the agent to follow; nothing in it is executed here.
+      console.log(result.body);
+    });
+
+  cmd
+    .command("links")
+    .description("List skills linked to Dosu documents")
+    .addOption(agentOption().default("claude"))
+    .option("--project", "Also scan this repository's .claude/skills")
+    .option("--json", "Output as JSON")
+    .action((opts: LinksOptions) => {
+      const roots: SkillRoot[] = [
+        { root: linkedSkillRoot(opts.agent, "user"), agent: opts.agent, scope: "user" },
+      ];
+      const projectRoot = linkedSkillRoot(opts.agent, "project");
+      if (opts.project || existsSync(projectRoot)) {
+        roots.push({ root: projectRoot, agent: opts.agent, scope: "project" });
+      }
+      const entries = listLinkedSkills(roots);
+
+      if (opts.json) {
+        printResult({ step: "skill_links", status: "ok", skills: entries }, { json: true });
+        return;
+      }
+      if (entries.length === 0) {
+        console.log(pc.dim("No linked skills found."));
+        return;
+      }
+      printTable(
+        ["Name", "Document", "Tracking", "Library", "Scope", "Path"],
+        entries.map(linkRow),
+      );
+      if (entries.some((entry) => entry.edited)) {
+        console.log(pc.dim("* edited after it was generated"));
+      }
+    });
+
+  cmd
+    .command("unlink")
+    .description("Remove a skill created by 'dosu skill link'")
+    .argument("<skill-name>", "Skill name")
+    .addOption(agentOption().makeOptionMandatory())
+    .option("--project", "Remove from this repository's .claude/skills instead of user scope")
+    .option("--json", "Output as JSON")
+    .action((name: string, opts: UnlinkOptions) => {
+      const step = "skill_unlink";
+      const scope = scopeFor(opts.project);
+      const paths = pathsFor(opts.agent, scope, name, step, opts.json);
+      const result = removeLinkedSkill(paths.file);
+      if (!result.removed) {
+        fail(step, opts.json, {
+          reason: result.reason,
+          message: result.message,
+          agent_next_steps: UNLINK_NEXT_STEPS[result.reason],
+        });
+      }
+
+      if (opts.json) {
+        printResult(
+          {
+            step,
+            status: "ok",
+            skill: { name, agent: opts.agent, scope, path: paths.file },
+            directory_removed: result.directory_removed,
+            leftover: result.leftover,
+          },
+          { json: true },
+        );
+        return;
+      }
+      console.log(pc.green(`✓ Unlinked skill '${name}'`));
+      if (result.leftover.length > 0) {
+        console.log(pc.dim(`Left in place: ${paths.dir} (${result.leftover.join(", ")})`));
+      }
     });
 
   return cmd;

--- a/src/skills/binding.test.ts
+++ b/src/skills/binding.test.ts
@@ -1,0 +1,422 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  defaultSkillDescription,
+  MAX_SKILL_DESCRIPTION_LENGTH,
+  MAX_SKILL_NAME_LENGTH,
+  parseMarker,
+  type RenderInput,
+  renderSkillMarkdown,
+  skillNameError,
+} from "./binding";
+import { type LinkMarker, SKILL_LINK_TEMPLATE_VERSION } from "./types";
+
+const DOCUMENT_ID = "879cbca9-2fbf-45be-9a3e-1b74303238be";
+const LIBRARY_ID = "11111111-2222-3333-4444-555555555555";
+const ORG_ID = "66666666-7777-8888-9999-000000000000";
+
+const baseMarker: Omit<LinkMarker, "content_sha256"> = {
+  document_id: DOCUMENT_ID,
+  library_id: LIBRARY_ID,
+  org_id: ORG_ID,
+  revision: null,
+  template: SKILL_LINK_TEMPLATE_VERSION,
+  cli_version: "0.53.0",
+};
+
+const liveInput: RenderInput = {
+  name: "migration-review",
+  description: defaultSkillDescription("DB Enum Widening Checklist", "migration-review", null),
+  marker: baseMarker,
+};
+
+const MARKER_LINE_RE = /^<!-- dosu:skill-link v(\d+) (\{.*\}) -->$/m;
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function markerLineOf(content: string): string {
+  const match = content.match(MARKER_LINE_RE);
+  if (!match) throw new Error("no marker line in content");
+  return match[0];
+}
+
+function markerJsonOf(content: string): Record<string, unknown> {
+  const match = content.match(MARKER_LINE_RE);
+  if (!match) throw new Error("no marker line in content");
+  return JSON.parse(match[2] as string) as Record<string, unknown>;
+}
+
+function withoutMarkerLine(content: string): string {
+  return content.replace(`${markerLineOf(content)}\n`, "");
+}
+
+/** Replace the marker JSON in a rendered file with the result of `mutate`. */
+function rewriteMarker(
+  content: string,
+  mutate: (marker: Record<string, unknown>) => unknown,
+): string {
+  const line = markerLineOf(content);
+  const json = markerJsonOf(content);
+  const replacement = `<!-- dosu:skill-link v${SKILL_LINK_TEMPLATE_VERSION} ${JSON.stringify(mutate(json))} -->`;
+  return content.replace(line, replacement);
+}
+
+describe("skillNameError", () => {
+  it.each([
+    "migration-review",
+    "a",
+    "Foo.bar_1",
+    "a".repeat(MAX_SKILL_NAME_LENGTH),
+  ])("accepts %j", (name) => {
+    expect(skillNameError(name)).toBeNull();
+  });
+
+  it.each([
+    ["", /empty/],
+    ["a".repeat(MAX_SKILL_NAME_LENGTH + 1), /at most 64 characters/],
+    ["../x", /start with a letter or digit/],
+    ["/abs", /start with a letter or digit/],
+    [".hidden", /start with a letter or digit/],
+    ["--all", /start with a letter or digit/],
+    ["-x", /start with a letter or digit/],
+    ["dosu", /reserved for the official Dosu skill/],
+    [".", /start with a letter or digit/],
+    ["..", /start with a letter or digit/],
+    ["has space", /only letters, digits/],
+    ["a/b", /only letters, digits/],
+    ["a\\b", /only letters, digits/],
+  ])("rejects %j", (name, message) => {
+    expect(skillNameError(name)).toMatch(message);
+  });
+
+  it("exposes the length limit used by the error message", () => {
+    expect(MAX_SKILL_NAME_LENGTH).toBe(64);
+  });
+});
+
+describe("defaultSkillDescription", () => {
+  it("renders the live variant", () => {
+    expect(defaultSkillDescription("DB Enum Widening Checklist", "migration-review", null)).toBe(
+      `Follow the team's "DB Enum Widening Checklist" procedure maintained in Dosu. Use when the user asks to run migration-review or mentions DB Enum Widening Checklist.`,
+    );
+  });
+
+  it("appends the pinned revision", () => {
+    expect(defaultSkillDescription("DB Enum Widening Checklist", "migration-review", 4)).toBe(
+      `Follow the team's "DB Enum Widening Checklist" procedure maintained in Dosu. Use when the user asks to run migration-review or mentions DB Enum Widening Checklist. (pinned to revision 4)`,
+    );
+  });
+
+  it("collapses whitespace runs in the title", () => {
+    expect(defaultSkillDescription("  DB   Enum\n Widening\t\tChecklist ", "x", null)).toBe(
+      `Follow the team's "DB Enum Widening Checklist" procedure maintained in Dosu. Use when the user asks to run x or mentions DB Enum Widening Checklist.`,
+    );
+  });
+
+  it("truncates over-long descriptions with an ellipsis", () => {
+    const description = defaultSkillDescription("t".repeat(600), "x", null);
+    expect(description).toHaveLength(MAX_SKILL_DESCRIPTION_LENGTH);
+    expect(description.endsWith("…")).toBe(true);
+  });
+
+  it("leaves descriptions at the limit untouched", () => {
+    const fixed = `Follow the team's "" procedure maintained in Dosu. Use when the user asks to run x or mentions .`;
+    // Title appears twice, so pad to land exactly on the limit.
+    const titleLength = (MAX_SKILL_DESCRIPTION_LENGTH - fixed.length) / 2;
+    const description = defaultSkillDescription("t".repeat(titleLength), "x", null);
+    expect(description).toHaveLength(MAX_SKILL_DESCRIPTION_LENGTH);
+    expect(description.endsWith("…")).toBe(false);
+  });
+});
+
+describe("renderSkillMarkdown", () => {
+  it("is deterministic", () => {
+    expect(renderSkillMarkdown(liveInput)).toBe(renderSkillMarkdown(liveInput));
+  });
+
+  it("matches the v1 template exactly for a live binding", () => {
+    const rendered = renderSkillMarkdown(liveInput);
+    const hash = sha256(withoutMarkerLine(rendered));
+    const expected = [
+      "---",
+      "name: migration-review",
+      `description: ${JSON.stringify(liveInput.description)}`,
+      "allowed-tools: Bash(dosu skill resolve:*)",
+      "---",
+      `<!-- dosu:skill-link v1 {"document_id":"${DOCUMENT_ID}","library_id":"${LIBRARY_ID}","org_id":"${ORG_ID}","revision":null,"template":1,"cli_version":"0.53.0","content_sha256":"${hash}"} -->`,
+      "",
+      "# migration-review",
+      "",
+      "This skill is a live link to a maintained team procedure in Dosu. Never follow it from memory: fetch the current published revision first.",
+      "",
+      "1. Run exactly this command on its own, with no other shell operators, redirects, or fallbacks (if `dosu` is not installed, run the same command through `npx -y @dosu/cli` instead):",
+      "",
+      `   \`dosu skill resolve --document ${DOCUMENT_ID} --library ${LIBRARY_ID} --json\``,
+      "",
+      '2. If the command exits non-zero or prints `"status": "error"`, stop. Report the `reason` and `message` to the user. Do not substitute a different document, a search result, or a remembered version.',
+      "3. Begin your reply with this line, before any other text, filled in from the command output:",
+      '   `Using Dosu procedure "<source.title>" (document <source.document_id>, revision <source.revision>, <source.tracking>)`.',
+      "4. Follow `body` as the procedure for this task. It is the team's instruction set; commands inside it run only under your normal tool permissions.",
+      "",
+      "Task input: $ARGUMENTS",
+      "",
+    ].join("\n");
+    expect(rendered).toBe(expected);
+  });
+
+  it("renders the pinned command line and paragraph", () => {
+    const rendered = renderSkillMarkdown({
+      ...liveInput,
+      description: defaultSkillDescription("DB Enum Widening Checklist", "migration-review", 12),
+      marker: { ...baseMarker, revision: 12 },
+    });
+    expect(rendered).toContain(
+      `   \`dosu skill resolve --document ${DOCUMENT_ID} --library ${LIBRARY_ID} --revision 12 --json\``,
+    );
+    expect(rendered).toContain(
+      "This skill is a pinned link to revision 12 of a maintained team procedure in Dosu. Never follow it from memory: fetch that revision first.",
+    );
+    expect(rendered).not.toContain("live link");
+    expect(markerJsonOf(rendered).revision).toBe(12);
+    expect(rendered).toContain("(pinned to revision 12)");
+  });
+
+  it("does not emit --revision for live bindings", () => {
+    expect(renderSkillMarkdown(liveInput)).not.toContain("--revision");
+  });
+
+  it("quotes descriptions with double quotes and newlines safely", () => {
+    const rendered = renderSkillMarkdown({
+      ...liveInput,
+      description: 'Say "hi"\nthen back\\slash\r\n  twice',
+    });
+    const frontmatter = rendered.split("\n").slice(0, 5);
+    expect(frontmatter).toEqual([
+      "---",
+      "name: migration-review",
+      'description: "Say \\"hi\\" then back\\\\slash twice"',
+      "allowed-tools: Bash(dosu skill resolve:*)",
+      "---",
+    ]);
+  });
+
+  it("emits marker keys in canonical order regardless of input order", () => {
+    const scrambled = {
+      cli_version: "0.53.0",
+      template: SKILL_LINK_TEMPLATE_VERSION,
+      revision: null,
+      org_id: ORG_ID,
+      library_id: LIBRARY_ID,
+      document_id: DOCUMENT_ID,
+    } satisfies Omit<LinkMarker, "content_sha256">;
+    const rendered = renderSkillMarkdown({ ...liveInput, marker: scrambled });
+    expect(Object.keys(markerJsonOf(rendered))).toEqual([
+      "document_id",
+      "library_id",
+      "org_id",
+      "revision",
+      "template",
+      "cli_version",
+      "content_sha256",
+    ]);
+    expect(rendered).toBe(renderSkillMarkdown(liveInput));
+  });
+
+  it("stamps the shared template version into the marker prefix", () => {
+    expect(markerLineOf(renderSkillMarkdown(liveInput))).toMatch(
+      new RegExp(`^<!-- dosu:skill-link v${SKILL_LINK_TEMPLATE_VERSION} `),
+    );
+  });
+
+  it("renders a null org_id", () => {
+    const rendered = renderSkillMarkdown({ ...liveInput, marker: { ...baseMarker, org_id: null } });
+    expect(markerJsonOf(rendered).org_id).toBeNull();
+  });
+
+  it("ends with exactly one newline", () => {
+    const rendered = renderSkillMarkdown(liveInput);
+    expect(rendered.endsWith("\n")).toBe(true);
+    expect(rendered.endsWith("\n\n")).toBe(false);
+  });
+
+  it("stores the hash of the file with the marker line removed", () => {
+    const rendered = renderSkillMarkdown(liveInput);
+    expect(markerJsonOf(rendered).content_sha256).toBe(sha256(withoutMarkerLine(rendered)));
+  });
+
+  it("never includes credential-like strings", () => {
+    const fakeConfig = {
+      access_token: "eyJhbGciOiJIUzI1NiJ9.fake-access-token",
+      refresh_token: "fake-refresh-token-value",
+      api_key: "sk_user_fake_api_key_value",
+    };
+    const rendered = renderSkillMarkdown({
+      name: "migration-review",
+      description: defaultSkillDescription("Checklist", "migration-review", null),
+      marker: { ...baseMarker, org_id: "org-for-config-owner" },
+    });
+    for (const [key, value] of Object.entries(fakeConfig)) {
+      expect(rendered).not.toContain(key);
+      expect(rendered).not.toContain(value);
+    }
+    expect(rendered).not.toContain("sk_user_");
+    expect(rendered).not.toContain("eyJ");
+  });
+});
+
+describe("parseMarker", () => {
+  it("round-trips a rendered file", () => {
+    const rendered = renderSkillMarkdown(liveInput);
+    const result = parseMarker(rendered);
+    expect(result).toEqual({
+      kind: "ok",
+      edited: false,
+      marker: { ...baseMarker, content_sha256: sha256(withoutMarkerLine(rendered)) },
+    });
+  });
+
+  it("round-trips a pinned file", () => {
+    const rendered = renderSkillMarkdown({ ...liveInput, marker: { ...baseMarker, revision: 7 } });
+    const result = parseMarker(rendered);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.marker.revision).toBe(7);
+    expect(result.edited).toBe(false);
+  });
+
+  it("flags an appended line as edited", () => {
+    const rendered = `${renderSkillMarkdown(liveInput)}\nAlways run the tests too.\n`;
+    const result = parseMarker(rendered);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.edited).toBe(true);
+    expect(result.marker.document_id).toBe(DOCUMENT_ID);
+  });
+
+  it("flags a changed byte in the body as edited", () => {
+    const rendered = renderSkillMarkdown(liveInput).replace("Never follow", "never follow");
+    const result = parseMarker(rendered);
+    expect(result).toMatchObject({ kind: "ok", edited: true });
+  });
+
+  it("flags a changed frontmatter description as edited", () => {
+    const rendered = renderSkillMarkdown(liveInput).replace("description: ", "description: X ");
+    expect(parseMarker(rendered)).toMatchObject({ kind: "ok", edited: true });
+  });
+
+  it("reports missing when there is no marker line", () => {
+    expect(parseMarker("---\nname: mine\n---\n\n# mine\n")).toEqual({ kind: "missing" });
+    expect(parseMarker("")).toEqual({ kind: "missing" });
+  });
+
+  it("does not treat an indented or inline mention as a marker", () => {
+    const content =
+      "# notes\n\n  <!-- dosu:skill-link v1 {} -->\nsee <!-- dosu:skill-link v1 {} --> here\n";
+    expect(parseMarker(content)).toEqual({ kind: "missing" });
+  });
+
+  it("reports corrupt for a malformed marker line", () => {
+    const content = "---\n---\n<!-- dosu:skill-link v1 not-json-at-all -->\n\n# x\n";
+    expect(parseMarker(content)).toMatchObject({ kind: "corrupt", message: /malformed/ });
+  });
+
+  it("reports corrupt for invalid JSON", () => {
+    const content = '---\n---\n<!-- dosu:skill-link v1 {"document_id": } -->\n\n# x\n';
+    expect(parseMarker(content)).toMatchObject({ kind: "corrupt", message: /not valid JSON/ });
+  });
+
+  it.each<[string, (marker: Record<string, unknown>) => unknown, RegExp]>([
+    [
+      "missing document_id",
+      ({ document_id: _drop, ...rest }) => rest,
+      /document_id.*must be a string/,
+    ],
+    ["numeric library_id", (m) => ({ ...m, library_id: 5 }), /library_id.*must be a string/],
+    ["numeric org_id", (m) => ({ ...m, org_id: 5 }), /org_id.*must be a string or null/],
+    ["string revision", (m) => ({ ...m, revision: "4" }), /revision.*null or a positive integer/],
+    ["zero revision", (m) => ({ ...m, revision: 0 }), /revision.*null or a positive integer/],
+    [
+      "fractional revision",
+      (m) => ({ ...m, revision: 1.5 }),
+      /revision.*null or a positive integer/,
+    ],
+    ["zero template", (m) => ({ ...m, template: 0 }), /template.*positive integer/],
+    ["string template", (m) => ({ ...m, template: "1" }), /template.*positive integer/],
+    ["numeric cli_version", (m) => ({ ...m, cli_version: 1 }), /cli_version.*must be a string/],
+    ["short content_sha256", (m) => ({ ...m, content_sha256: "abc123" }), /content_sha256.*64/],
+    [
+      "non-hex content_sha256",
+      (m) => ({ ...m, content_sha256: "z".repeat(64) }),
+      /content_sha256.*64/,
+    ],
+    ["numeric content_sha256", (m) => ({ ...m, content_sha256: 42 }), /content_sha256.*64/],
+  ])("reports corrupt for %s", (_label, mutate, message) => {
+    const content = rewriteMarker(renderSkillMarkdown(liveInput), mutate);
+    expect(parseMarker(content)).toMatchObject({ kind: "corrupt", message });
+  });
+
+  it("reports corrupt when two marker lines are present", () => {
+    const rendered = renderSkillMarkdown(liveInput);
+    const line = markerLineOf(rendered);
+    const content = rendered.replace(line, `${line}\n${line}`);
+    expect(parseMarker(content)).toMatchObject({ kind: "corrupt", message: /more than one/ });
+  });
+
+  it("accepts an uppercase hash and compares case-insensitively", () => {
+    const content = rewriteMarker(renderSkillMarkdown(liveInput), (m) => ({
+      ...m,
+      content_sha256: String(m.content_sha256).toUpperCase(),
+    }));
+    const result = parseMarker(content);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.edited).toBe(false);
+    expect(result.marker.content_sha256).toBe(
+      (markerJsonOf(renderSkillMarkdown(liveInput)).content_sha256 as string).toLowerCase(),
+    );
+  });
+
+  it("drops unknown marker fields from the parsed marker", () => {
+    const content = rewriteMarker(renderSkillMarkdown(liveInput), (m) => ({ ...m, extra: true }));
+    const result = parseMarker(content);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(Object.keys(result.marker)).toEqual([
+      "document_id",
+      "library_id",
+      "org_id",
+      "revision",
+      "template",
+      "cli_version",
+      "content_sha256",
+    ]);
+  });
+
+  it("parses a marker from a future template version", () => {
+    const rendered = renderSkillMarkdown(liveInput);
+    const content = rendered.replace("<!-- dosu:skill-link v1 ", "<!-- dosu:skill-link v9 ");
+    expect(parseMarker(content)).toMatchObject({ kind: "ok", edited: false });
+  });
+
+  it("still parses a file converted to CRLF line endings", () => {
+    const content = renderSkillMarkdown(liveInput).replace(/\n/g, "\r\n");
+    const result = parseMarker(content);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.marker).toMatchObject(baseMarker);
+    expect(result.marker.content_sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("parses a marker on the final line without a trailing newline", () => {
+    const rendered = renderSkillMarkdown(liveInput);
+    const line = markerLineOf(rendered);
+    const content = `${withoutMarkerLine(rendered)}${line}`;
+    const result = parseMarker(content);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    // Body is identical to the rendered one, so the hash still matches.
+    expect(result.edited).toBe(false);
+  });
+});

--- a/src/skills/binding.ts
+++ b/src/skills/binding.ts
@@ -1,0 +1,229 @@
+/**
+ * Pure helpers for live knowledge skill bindings: name validation, the
+ * deterministic `SKILL.md` template, and the ownership marker that lets the
+ * CLI recognise (and detect edits to) files it generated. No I/O here; the
+ * filesystem layer lives in `./store`.
+ */
+
+import { createHash } from "node:crypto";
+import { type LinkMarker, SKILL_LINK_TEMPLATE_VERSION } from "./types";
+
+export const MAX_SKILL_NAME_LENGTH = 64;
+export const MAX_SKILL_DESCRIPTION_LENGTH = 500;
+
+/**
+ * Same shape as `SAFE_SKILL_NAME` in `src/commands/skill.ts`: the name becomes
+ * a directory and is echoed into shell commands, so it must start with an
+ * alphanumeric (no `-x` option lookalikes, no dotfiles, no `..`) and cannot
+ * contain path separators.
+ */
+const SAFE_SKILL_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+/** The official Dosu skill installed by `dosu skill install`. */
+const RESERVED_SKILL_NAMES: ReadonlySet<string> = new Set(["dosu"]);
+
+const ELLIPSIS = "…";
+
+/** Returns null when valid, otherwise a one-sentence human error message. */
+export function skillNameError(name: string): string | null {
+  if (name.length === 0) return "Skill name must not be empty.";
+  if (name.length > MAX_SKILL_NAME_LENGTH) {
+    return `Skill name must be at most ${MAX_SKILL_NAME_LENGTH} characters.`;
+  }
+  if (!SAFE_SKILL_NAME.test(name)) {
+    return "Skill name must start with a letter or digit and contain only letters, digits, '.', '_' or '-'.";
+  }
+  if (RESERVED_SKILL_NAMES.has(name)) {
+    return `Skill name "${name}" is reserved for the official Dosu skill.`;
+  }
+  return null;
+}
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** Default frontmatter description, fixed at link time. */
+export function defaultSkillDescription(
+  title: string,
+  name: string,
+  revision: number | null,
+): string {
+  const cleanTitle = collapseWhitespace(title);
+  let description = `Follow the team's "${cleanTitle}" procedure maintained in Dosu. Use when the user asks to run ${name} or mentions ${cleanTitle}.`;
+  if (revision !== null) description += ` (pinned to revision ${revision})`;
+  if (description.length > MAX_SKILL_DESCRIPTION_LENGTH) {
+    description = `${description.slice(0, MAX_SKILL_DESCRIPTION_LENGTH - ELLIPSIS.length)}${ELLIPSIS}`;
+  }
+  return description;
+}
+
+export interface RenderInput {
+  name: string;
+  description: string;
+  marker: Omit<LinkMarker, "content_sha256">;
+}
+
+function sha256Hex(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/** Marker JSON with keys in canonical order, so the rendered line is stable. */
+function canonicalMarker(marker: LinkMarker): LinkMarker {
+  return {
+    document_id: marker.document_id,
+    library_id: marker.library_id,
+    org_id: marker.org_id,
+    revision: marker.revision,
+    template: marker.template,
+    cli_version: marker.cli_version,
+    content_sha256: marker.content_sha256,
+  };
+}
+
+function markerLine(marker: LinkMarker): string {
+  return `<!-- dosu:skill-link v${SKILL_LINK_TEMPLATE_VERSION} ${JSON.stringify(canonicalMarker(marker))} -->`;
+}
+
+function resolveCommand(marker: Omit<LinkMarker, "content_sha256">): string {
+  const revision = marker.revision === null ? "" : ` --revision ${marker.revision}`;
+  return `dosu skill resolve --document ${marker.document_id} --library ${marker.library_id}${revision} --json`;
+}
+
+function linkParagraph(revision: number | null): string {
+  if (revision === null) {
+    return "This skill is a live link to a maintained team procedure in Dosu. Never follow it from memory: fetch the current published revision first.";
+  }
+  return `This skill is a pinned link to revision ${revision} of a maintained team procedure in Dosu. Never follow it from memory: fetch that revision first.`;
+}
+
+/**
+ * Assemble the file. `marker` is null while computing the content hash: the
+ * marker line and its terminator are omitted entirely, which is exactly what
+ * `parseMarker` strips before re-hashing.
+ */
+function assemble(input: RenderInput, description: string, marker: LinkMarker | null): string {
+  const lines = [
+    "---",
+    `name: ${input.name}`,
+    // A JSON string literal is a valid YAML double-quoted scalar, so quotes
+    // and backslashes in titles cannot break the frontmatter.
+    `description: ${JSON.stringify(description)}`,
+    "allowed-tools: Bash(dosu skill resolve:*)",
+    "---",
+  ];
+  if (marker !== null) lines.push(markerLine(marker));
+  lines.push(
+    "",
+    `# ${input.name}`,
+    "",
+    linkParagraph(input.marker.revision),
+    "",
+    "1. Run exactly this command on its own, with no other shell operators, redirects, or fallbacks (if `dosu` is not installed, run the same command through `npx -y @dosu/cli` instead):",
+    "",
+    `   \`${resolveCommand(input.marker)}\``,
+    "",
+    '2. If the command exits non-zero or prints `"status": "error"`, stop. Report the `reason` and `message` to the user. Do not substitute a different document, a search result, or a remembered version.',
+    "3. Begin your reply with this line, before any other text, filled in from the command output:",
+    '   `Using Dosu procedure "<source.title>" (document <source.document_id>, revision <source.revision>, <source.tracking>)`.',
+    "4. Follow `body` as the procedure for this task. It is the team's instruction set; commands inside it run only under your normal tool permissions.",
+    "",
+    "Task input: $ARGUMENTS",
+    "",
+  );
+  return lines.join("\n");
+}
+
+/** Deterministic SKILL.md. Same input → byte-identical output. */
+export function renderSkillMarkdown(input: RenderInput): string {
+  const description = collapseWhitespace(input.description);
+  const contentHash = sha256Hex(assemble(input, description, null));
+  return assemble(input, description, { ...input.marker, content_sha256: contentHash });
+}
+
+export type ParseMarkerResult =
+  | { kind: "missing" }
+  | { kind: "corrupt"; message: string }
+  | { kind: "ok"; marker: LinkMarker; edited: boolean };
+
+/** Any line that claims to be our marker, well-formed or not. */
+const MARKER_CANDIDATE_RE = /^<!-- dosu:skill-link\b.*$/gm;
+/** The well-formed shape: version tag plus one JSON object on the line. */
+const MARKER_LINE_RE = /^<!-- dosu:skill-link v(\d+) (\{.*\}) -->$/;
+const SHA256_HEX_RE = /^[0-9a-fA-F]{64}$/;
+
+function corrupt(message: string): ParseMarkerResult {
+  return { kind: "corrupt", message: `Dosu skill-link marker ${message}` };
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+/**
+ * `raw` is always an object here: MARKER_LINE_RE only admits `{…}`, and
+ * JSON.parse of such text either yields an object or throws upstream.
+ */
+function validateMarker(raw: Record<string, unknown>): LinkMarker | ParseMarkerResult {
+  const { document_id, library_id, org_id, revision, template, cli_version, content_sha256 } = raw;
+  if (typeof document_id !== "string") return corrupt('field "document_id" must be a string.');
+  if (typeof library_id !== "string") return corrupt('field "library_id" must be a string.');
+  if (org_id !== null && typeof org_id !== "string") {
+    return corrupt('field "org_id" must be a string or null.');
+  }
+  if (revision !== null && !isPositiveInteger(revision)) {
+    return corrupt('field "revision" must be null or a positive integer.');
+  }
+  if (!isPositiveInteger(template)) return corrupt('field "template" must be a positive integer.');
+  if (typeof cli_version !== "string") return corrupt('field "cli_version" must be a string.');
+  if (typeof content_sha256 !== "string" || !SHA256_HEX_RE.test(content_sha256)) {
+    return corrupt('field "content_sha256" must be a 64-character hex string.');
+  }
+  return canonicalMarker({
+    document_id,
+    library_id,
+    org_id,
+    revision,
+    template,
+    cli_version,
+    content_sha256: content_sha256.toLowerCase(),
+  });
+}
+
+/**
+ * Locate the marker line, validate it, and compare the hash of everything
+ * else against `content_sha256` to detect user edits. The marker line is
+ * removed together with its own line terminator (`\n` or `\r\n`); nothing
+ * else is normalised, so a file converted to CRLF reports `edited: true`.
+ */
+export function parseMarker(content: string): ParseMarkerResult {
+  const candidates = [...content.matchAll(MARKER_CANDIDATE_RE)];
+  if (candidates.length === 0) return { kind: "missing" };
+  if (candidates.length > 1) return corrupt("appears more than once in the file.");
+
+  const candidate = candidates[0] as RegExpMatchArray;
+  const line = candidate[0];
+  const match = line.match(MARKER_LINE_RE);
+  if (!match) return corrupt("line is malformed.");
+
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(match[2] as string) as Record<string, unknown>;
+  } catch {
+    return corrupt("is not valid JSON.");
+  }
+  const validated = validateMarker(raw);
+  if ("kind" in validated) return validated;
+
+  const start = candidate.index as number;
+  let end = start + line.length;
+  if (content.startsWith("\r\n", end)) end += 2;
+  else if (content.startsWith("\n", end)) end += 1;
+  const remainder = content.slice(0, start) + content.slice(end);
+
+  return {
+    kind: "ok",
+    marker: validated,
+    edited: sha256Hex(remainder) !== validated.content_sha256,
+  };
+}

--- a/src/skills/resolve.test.ts
+++ b/src/skills/resolve.test.ts
@@ -1,0 +1,681 @@
+import { TRPCClientError } from "@trpc/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TypedClient } from "../client/trpc";
+import { MAX_PROCEDURE_CHARS, type ResolveInput, resolveLinkedProcedure } from "./resolve";
+import type { ResolveFailure, ResolveReason, ResolveResult, ResolveSuccess } from "./types";
+
+const mockQuery = vi.fn();
+const mockMutate = vi.fn();
+
+function createMockProxy(path: string[] = []): unknown {
+  return new Proxy(() => {}, {
+    get(_, prop: string) {
+      if (prop === "query") return (input: unknown) => mockQuery(path.join("."), input);
+      if (prop === "mutate") return (input: unknown) => mockMutate(path.join("."), input);
+      return createMockProxy([...path, prop]);
+    },
+  });
+}
+
+const client = createMockProxy() as unknown as TypedClient;
+
+const DOC = "879cbca9-2fbf-45be-9a3e-1b74303238be";
+const LIB = "11111111-1111-4111-8111-111111111111";
+const OTHER_LIB = "22222222-2222-4222-8222-222222222222";
+const STORE = "66e1c189-0000-4000-8000-000000000000";
+const OTHER_STORE = "77777777-0000-4000-8000-000000000000";
+const UPDATED_AT = "2026-09-10T01:08:02.487426+00:00";
+const FIXED_NOW = new Date("2026-09-11T12:00:00.000Z");
+const BODY = "# DB Enum Widening Checklist\n\n1. Confirm the enum is widened, never narrowed.\n";
+
+type Handler = (input: unknown) => unknown;
+
+/** Script return values (or thrown errors) per procedure path. Unscripted paths reject loudly. */
+function script(handlers: Record<string, Handler>): void {
+  mockQuery.mockImplementation(async (path: string, input: unknown) => {
+    const handler = handlers[path];
+    if (!handler) throw new Error(`unscripted procedure: ${path}`);
+    return handler(input);
+  });
+}
+
+function calledPaths(): string[] {
+  return mockQuery.mock.calls.map((call) => call[0] as string);
+}
+
+function inputOf(index: number): unknown {
+  return mockQuery.mock.calls[index]?.[1];
+}
+
+function version(v: number, published: boolean) {
+  return {
+    id: `pv-${v}`,
+    version: v,
+    published,
+    pending_status: published ? null : "PENDING_REVIEW",
+    created_at: `2026-09-0${v}T00:00:00.000Z`,
+    origin: "manual_update",
+    author: null,
+    agent_activity_artifact: [],
+    external_trigger_url: null,
+    page: null,
+  };
+}
+
+function page(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DOC,
+    title: "DB Enum Widening Checklist",
+    body: BODY,
+    version: 2,
+    page_version_id: "pv-2",
+    published: true,
+    archived: false,
+    knowledge_store_id: STORE,
+    updated_at: UPDATED_AT,
+    pending_status: null,
+    ...overrides,
+  };
+}
+
+const store = { id: STORE, space_id: LIB, org_id: "org-1", created_at: "", updated_at: "" };
+
+/**
+ * Happy-path scripting: store found, the given revision inventory, and `page.get`
+ * echoing back whichever version was requested (with optional overrides).
+ */
+function scriptDocument(
+  versions: unknown,
+  pageOverrides: Record<string, unknown> = {},
+  extra: Record<string, Handler> = {},
+): void {
+  script({
+    "knowledgeStore.getBySpaceId": () => store,
+    "page.listVersions": () => versions,
+    "page.get": (input) => {
+      const { version: v } = input as { version: number };
+      return page({ version: v, page_version_id: `pv-${v}`, ...pageOverrides });
+    },
+    ...extra,
+  });
+}
+
+/**
+ * Builds a `TRPCClientError` whose `err.data.code` is readable, matching what
+ * `httpLink` surfaces for a server error envelope. Omit `code` to mimic a wrapped
+ * transport failure (no envelope, optional `cause`).
+ */
+function trpcError(code?: string, cause?: Error) {
+  return new TRPCClientError("upstream failure", {
+    cause,
+    result:
+      code === undefined
+        ? undefined
+        : { error: { code: -32000, message: "upstream failure", data: { code } } },
+  });
+}
+
+function baseInput(overrides: Partial<ResolveInput> = {}): ResolveInput {
+  return {
+    document_id: DOC,
+    library_id: LIB,
+    active_library_id: LIB,
+    now: () => FIXED_NOW,
+    ...overrides,
+  };
+}
+
+function expectOk(result: ResolveResult): ResolveSuccess {
+  if (!result.ok) throw new Error(`expected ok, got ${result.reason}: ${result.message}`);
+  return result;
+}
+
+function expectFail(result: ResolveResult, reason: ResolveReason): ResolveFailure {
+  if (result.ok) throw new Error(`expected ${reason}, got ok (revision ${result.source.revision})`);
+  expect(result.reason).toBe(reason);
+  expect(result.message).toBeTypeOf("string");
+  expect(result.agent_next_steps).toBeTypeOf("string");
+  return result;
+}
+
+afterEach(() => {
+  // The resolver must never broaden: no tag listing, no search, no mutations.
+  const forbidden = calledPaths().filter(
+    (p) => p === "page.listWithTags" || p.startsWith("search."),
+  );
+  expect(forbidden).toEqual([]);
+  expect(mockMutate).not.toHaveBeenCalled();
+  mockQuery.mockReset();
+  mockMutate.mockReset();
+});
+
+describe("resolveLinkedProcedure", () => {
+  describe("live tracking", () => {
+    it("picks the highest published revision when the latest is a draft", async () => {
+      scriptDocument([version(1, true), version(2, true), version(3, false)]);
+
+      const result = expectOk(await resolveLinkedProcedure(client, baseInput()));
+
+      expect(calledPaths()).toEqual([
+        "knowledgeStore.getBySpaceId",
+        "page.listVersions",
+        "page.get",
+      ]);
+      expect(inputOf(0)).toEqual({ space_id: LIB });
+      expect(inputOf(1)).toEqual({ page_id: DOC });
+      expect(inputOf(2)).toEqual({ page_id: DOC, version: 2 });
+      expect(result.source).toEqual({
+        document_id: DOC,
+        title: "DB Enum Widening Checklist",
+        revision: 2,
+        page_version_id: "pv-2",
+        published: true,
+        tracking: "live",
+        library_id: LIB,
+        knowledge_store_id: STORE,
+        updated_at: UPDATED_AT,
+        fetched_at: FIXED_NOW.toISOString(),
+      });
+      expect(result.body).toBe(BODY);
+    });
+
+    it("reflects a later publish on the next call without reinstall", async () => {
+      let inventory = [version(1, true), version(2, true)];
+      script({
+        "knowledgeStore.getBySpaceId": () => store,
+        "page.listVersions": () => inventory,
+        "page.get": (input) => page({ version: (input as { version: number }).version }),
+      });
+
+      const first = expectOk(await resolveLinkedProcedure(client, baseInput()));
+      expect(first.source.revision).toBe(2);
+
+      inventory = [...inventory, version(3, true)];
+      const second = expectOk(await resolveLinkedProcedure(client, baseInput()));
+      expect(second.source.revision).toBe(3);
+      expect(second.source.tracking).toBe("live");
+
+      const getCalls = mockQuery.mock.calls.filter((c) => c[0] === "page.get").map((c) => c[1]);
+      expect(getCalls).toEqual([
+        { page_id: DOC, version: 2 },
+        { page_id: DOC, version: 3 },
+      ]);
+    });
+
+    it("treats revision: null as live", async () => {
+      scriptDocument([version(1, true)]);
+
+      const result = expectOk(await resolveLinkedProcedure(client, baseInput({ revision: null })));
+
+      expect(calledPaths()).toContain("page.listVersions");
+      expect(result.source.tracking).toBe("live");
+      expect(result.source.revision).toBe(1);
+    });
+
+    it("returns document_not_found when the revision inventory is empty", async () => {
+      scriptDocument([]);
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "document_not_found",
+      );
+
+      expect(failure.message).toBe(
+        `Document ${DOC} was not found or is not accessible in this Library.`,
+      );
+      expect(failure.agent_next_steps).toBe(
+        "Confirm the document id and that your account can access it. Do not substitute another document.",
+      );
+      expect(calledPaths()).toEqual(["knowledgeStore.getBySpaceId", "page.listVersions"]);
+    });
+
+    it("returns document_not_found when the revision inventory is not an array", async () => {
+      scriptDocument(null);
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "document_not_found");
+      expect(calledPaths()).not.toContain("page.get");
+    });
+
+    it("returns no_published_revision when only drafts exist", async () => {
+      scriptDocument([version(1, false), version(2, false), version(3, false)]);
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "no_published_revision",
+      );
+
+      expect(failure.message).toBe(`Document ${DOC} has 3 revisions but none is published.`);
+      expect(failure.agent_next_steps).toBe(
+        "Publish a revision in Dosu, then retry. Draft revisions are never used.",
+      );
+      expect(failure.details).toEqual({ total_revisions: 3 });
+      expect(calledPaths()).not.toContain("page.get");
+    });
+
+    it("uses the singular when a single draft exists", async () => {
+      scriptDocument([version(1, false)]);
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "no_published_revision",
+      );
+
+      expect(failure.message).toBe(`Document ${DOC} has 1 revision but none is published.`);
+      expect(failure.details).toEqual({ total_revisions: 1 });
+    });
+
+    it("returns document_not_found when page.get returns null for the chosen revision", async () => {
+      scriptDocument([version(1, true)], {}, { "page.get": () => null });
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "document_not_found",
+      );
+
+      expect(failure.details).toBeUndefined();
+      expect(calledPaths().filter((p) => p === "page.get")).toHaveLength(1);
+    });
+  });
+
+  describe("pinned tracking", () => {
+    it("fetches exactly the pinned revision and never lists versions", async () => {
+      scriptDocument([version(1, true), version(2, true), version(3, true)]);
+
+      const result = expectOk(await resolveLinkedProcedure(client, baseInput({ revision: 2 })));
+
+      expect(calledPaths()).toEqual(["knowledgeStore.getBySpaceId", "page.get"]);
+      expect(inputOf(1)).toEqual({ page_id: DOC, version: 2 });
+      expect(result.source.revision).toBe(2);
+      expect(result.source.tracking).toBe("pinned");
+      expect(result.source.page_version_id).toBe("pv-2");
+    });
+
+    it("fails with revision_unavailable and never falls back when the pinned revision is null", async () => {
+      script({
+        "knowledgeStore.getBySpaceId": () => store,
+        "page.get": () => null,
+      });
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput({ revision: 2 })),
+        "revision_unavailable",
+      );
+
+      expect(failure.message).toBe(`Revision 2 of document ${DOC} is not available.`);
+      expect(failure.agent_next_steps).toBe(
+        "Do not fall back to the current revision. Re-link with a valid --revision or without --revision for live tracking.",
+      );
+      expect(failure.details).toEqual({ revision: 2 });
+      expect(calledPaths()).toEqual(["knowledgeStore.getBySpaceId", "page.get"]);
+    });
+
+    it("refuses a pinned draft revision", async () => {
+      scriptDocument([version(1, true), version(2, false)], { published: false });
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput({ revision: 2 })),
+        "revision_not_published",
+      );
+
+      expect(failure.message).toBe(`Revision 2 of document ${DOC} is not published.`);
+      expect(failure.details).toEqual({ revision: 2 });
+    });
+  });
+
+  describe("library and knowledge store checks", () => {
+    it("fails with library_mismatch before any client call when the active Library differs", async () => {
+      script({});
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput({ active_library_id: OTHER_LIB })),
+        "library_mismatch",
+      );
+
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(failure.message).toBe(
+        `This skill is linked to Library ${LIB} but the active Library is ${OTHER_LIB}.`,
+      );
+      expect(failure.agent_next_steps).toBe(
+        "Select the Library this skill was linked in with 'dosu setup', or re-link with --force to bind it to the current Library.",
+      );
+      expect(failure.details).toEqual({ linked_library_id: LIB, active_library_id: OTHER_LIB });
+    });
+
+    it("fails with knowledge_store_missing when getBySpaceId returns null", async () => {
+      script({ "knowledgeStore.getBySpaceId": () => null });
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "knowledge_store_missing",
+      );
+
+      expect(failure.message).toBe(
+        "No knowledge store found for this Library. Run 'dosu setup' to reconfigure.",
+      );
+      expect(calledPaths()).toEqual(["knowledgeStore.getBySpaceId"]);
+    });
+
+    it("fails with library_mismatch when the page belongs to another knowledge store", async () => {
+      scriptDocument([version(1, true)], { knowledge_store_id: OTHER_STORE });
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "library_mismatch",
+      );
+
+      expect(failure.message).toBe(
+        `Document ${DOC} belongs to a different Library than the one this skill is linked to.`,
+      );
+      expect(failure.details).toEqual({
+        linked_library_id: LIB,
+        active_library_id: LIB,
+        expected_knowledge_store_id: STORE,
+        actual_knowledge_store_id: OTHER_STORE,
+      });
+    });
+  });
+
+  describe("page validation", () => {
+    it("refuses an archived document", async () => {
+      scriptDocument([version(1, true)], { archived: true });
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "document_archived",
+      );
+
+      expect(failure.message).toBe(`Document ${DOC} is archived.`);
+      expect(failure.details).toBeUndefined();
+    });
+
+    it("refuses a null body", async () => {
+      scriptDocument([version(1, true)], { body: null });
+
+      const failure = expectFail(await resolveLinkedProcedure(client, baseInput()), "empty_body");
+
+      expect(failure.message).toBe(`Revision 1 of document ${DOC} has an empty body.`);
+      expect(failure.details).toEqual({ revision: 1 });
+    });
+
+    it("refuses a whitespace-only body", async () => {
+      scriptDocument([version(1, true)], { body: "   \n\t " });
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "empty_body");
+    });
+
+    it("reports resolver_inconsistency when the returned version differs from the request", async () => {
+      script({
+        "knowledgeStore.getBySpaceId": () => store,
+        "page.listVersions": () => [version(1, true), version(2, true)],
+        "page.get": () => page({ version: 1, page_version_id: "pv-1" }),
+      });
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "resolver_inconsistency",
+      );
+
+      expect(failure.message).toBe(
+        `Requested revision 2 of document ${DOC} but received revision 1.`,
+      );
+      expect(failure.details).toEqual({ requested: 2, received: 1 });
+    });
+  });
+
+  describe("size limit", () => {
+    it("returns a body of exactly MAX_PROCEDURE_CHARS untouched", async () => {
+      // Leading/trailing whitespace proves nothing is trimmed on the way out.
+      const body = ` ${"x".repeat(MAX_PROCEDURE_CHARS - 2)} `;
+      expect(body.length).toBe(MAX_PROCEDURE_CHARS);
+      scriptDocument([version(1, true)], { body });
+
+      const result = expectOk(await resolveLinkedProcedure(client, baseInput()));
+
+      expect(result.body.length).toBe(MAX_PROCEDURE_CHARS);
+      expect(result.body).toBe(body);
+    });
+
+    it("fails closed with procedure_too_large at MAX_PROCEDURE_CHARS + 1", async () => {
+      const body = "x".repeat(MAX_PROCEDURE_CHARS + 1);
+      scriptDocument([version(1, true)], { body });
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "procedure_too_large",
+      );
+
+      expect(failure.message).toBe(
+        `The procedure is ${MAX_PROCEDURE_CHARS + 1} characters; the limit is ${MAX_PROCEDURE_CHARS}. Nothing was truncated.`,
+      );
+      expect(failure.agent_next_steps).toBe(
+        "Ask the document owner to split or shorten the procedure, or link a smaller document.",
+      );
+      expect(failure.details).toEqual({
+        actual: MAX_PROCEDURE_CHARS + 1,
+        limit: MAX_PROCEDURE_CHARS,
+      });
+    });
+  });
+
+  describe("error mapping", () => {
+    it("maps FORBIDDEN from page.get to access_denied", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw trpcError("FORBIDDEN");
+          },
+        },
+      );
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "access_denied",
+      );
+
+      expect(failure.message).toBe(`Access to document ${DOC} was denied for the current account.`);
+      expect(failure.agent_next_steps).toBe(
+        "Log in with an account that belongs to this Library ('dosu login'), then retry.",
+      );
+    });
+
+    it("maps UNAUTHORIZED from the knowledge store lookup to access_denied", async () => {
+      script({
+        "knowledgeStore.getBySpaceId": () => {
+          throw trpcError("UNAUTHORIZED");
+        },
+      });
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "access_denied");
+      expect(calledPaths()).toEqual(["knowledgeStore.getBySpaceId"]);
+    });
+
+    it("maps NOT_FOUND from listVersions to document_not_found", async () => {
+      scriptDocument(
+        [],
+        {},
+        {
+          "page.listVersions": () => {
+            throw trpcError("NOT_FOUND");
+          },
+        },
+      );
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "document_not_found");
+      expect(calledPaths()).not.toContain("page.get");
+    });
+
+    it("maps a TRPCClientError wrapping a fetch TypeError to network_error", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw trpcError(undefined, new TypeError("fetch failed"));
+          },
+        },
+      );
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "network_error",
+      );
+
+      expect(failure.message).toBe(
+        "The procedure could not be loaded; check your connection and retry.",
+      );
+      expect(failure.agent_next_steps).toBe(
+        "Retry once the network is available. Do not proceed from memory.",
+      );
+    });
+
+    it("maps a TRPCClientError with an unknown code to unexpected_error", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw trpcError("INTERNAL_SERVER_ERROR");
+          },
+        },
+      );
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "unexpected_error",
+      );
+
+      expect(failure.message).toBe(
+        `Unexpected error while resolving document ${DOC}: upstream failure`,
+      );
+      expect(failure.details).toEqual({ error: "upstream failure" });
+    });
+
+    it("maps a TRPCClientError with no envelope and no TypeError cause to unexpected_error", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw trpcError(undefined, new Error("socket hang up"));
+          },
+        },
+      );
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "unexpected_error");
+    });
+
+    it("ignores a non-string code in error data", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw Object.assign(trpcError(), { data: { code: 403, httpStatus: 403 } });
+          },
+        },
+      );
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "unexpected_error");
+    });
+
+    it("ignores null error data", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw Object.assign(trpcError(), { data: null });
+          },
+        },
+      );
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "unexpected_error");
+    });
+
+    it("maps a bare TypeError to network_error", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw new TypeError("fetch failed");
+          },
+        },
+      );
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "network_error");
+    });
+
+    it("maps an AbortError to network_error", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
+          },
+        },
+      );
+
+      expectFail(await resolveLinkedProcedure(client, baseInput()), "network_error");
+    });
+
+    it("maps a plain Error to unexpected_error with its message", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw new Error("disk on fire");
+          },
+        },
+      );
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "unexpected_error",
+      );
+
+      expect(failure.message).toBe(
+        `Unexpected error while resolving document ${DOC}: disk on fire`,
+      );
+      expect(failure.details).toEqual({ error: "disk on fire" });
+    });
+
+    it("maps a thrown non-Error value to unexpected_error", async () => {
+      scriptDocument(
+        [version(1, true)],
+        {},
+        {
+          "page.get": () => {
+            throw "boom";
+          },
+        },
+      );
+
+      const failure = expectFail(
+        await resolveLinkedProcedure(client, baseInput()),
+        "unexpected_error",
+      );
+
+      expect(failure.details).toEqual({ error: "boom" });
+    });
+  });
+
+  describe("clock", () => {
+    it("stamps fetched_at with the wall clock when no clock is injected", async () => {
+      scriptDocument([version(1, true)]);
+      const before = Date.now();
+
+      const result = expectOk(await resolveLinkedProcedure(client, baseInput({ now: undefined })));
+
+      const fetchedAt = Date.parse(result.source.fetched_at);
+      expect(fetchedAt).toBeGreaterThanOrEqual(before);
+      expect(fetchedAt).toBeLessThanOrEqual(Date.now());
+      expect(result.source.published).toBe(true);
+      expect(result.source.updated_at).toBe(UPDATED_AT);
+    });
+  });
+});

--- a/src/skills/resolve.ts
+++ b/src/skills/resolve.ts
@@ -1,0 +1,250 @@
+/**
+ * Resolver for live knowledge skills (`dosu skill resolve`).
+ *
+ * Fetches exactly one Dosu document revision through the typed CLI contract and
+ * enforces the binding contract: the active Library must match the linked one,
+ * only published revisions are used, drafts are never substituted, a pinned
+ * revision never falls back to the current one, and an oversized procedure
+ * fails closed instead of being truncated.
+ *
+ * The resolver never logs, prints, exits, or executes anything from the body.
+ * Every classified failure is returned as a `ResolveFailure`; nothing is thrown.
+ */
+
+import { isTRPCClientError } from "@trpc/client";
+import type { TypedClient } from "../client/trpc";
+import type {
+  ResolvedSource,
+  ResolveFailure,
+  ResolveReason,
+  ResolveResult,
+  SkillTracking,
+} from "./types";
+
+/** Hard ceiling on procedure body size. Roughly 8k tokens. Never truncate; fail closed. */
+export const MAX_PROCEDURE_CHARS = 32_000;
+
+export interface ResolveInput {
+  document_id: string;
+  /** The Library (space) id recorded in the binding. */
+  library_id: string;
+  /** `active_account.target.space_id` from the CLI config. */
+  active_library_id: string;
+  /** `undefined`/`null` = live (highest published revision); a number = pinned. */
+  revision?: number | null;
+  /** Injectable clock for `fetched_at`. Defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+const NO_SUBSTITUTE_NEXT_STEPS =
+  "Confirm the document id and that your account can access it. Do not substitute another document.";
+
+function fail(
+  reason: ResolveReason,
+  message: string,
+  agent_next_steps: string,
+  details?: Record<string, unknown>,
+): ResolveFailure {
+  const failure: ResolveFailure = { ok: false, reason, message, agent_next_steps };
+  if (details) failure.details = details;
+  return failure;
+}
+
+function documentNotFound(document_id: string): ResolveFailure {
+  return fail(
+    "document_not_found",
+    `Document ${document_id} was not found or is not accessible in this Library.`,
+    NO_SUBSTITUTE_NEXT_STEPS,
+  );
+}
+
+function accessDenied(document_id: string): ResolveFailure {
+  return fail(
+    "access_denied",
+    `Access to document ${document_id} was denied for the current account.`,
+    "Log in with an account that belongs to this Library ('dosu login'), then retry.",
+  );
+}
+
+function networkError(): ResolveFailure {
+  return fail(
+    "network_error",
+    "The procedure could not be loaded; check your connection and retry.",
+    "Retry once the network is available. Do not proceed from memory.",
+  );
+}
+
+function unexpectedError(document_id: string, error: string): ResolveFailure {
+  return fail(
+    "unexpected_error",
+    `Unexpected error while resolving document ${document_id}: ${error}`,
+    "Retry once. If the error persists, report it with the message above. Do not proceed from memory.",
+    { error },
+  );
+}
+
+/** `TRPCClientError.data` is untyped at this boundary; read `code` only when it is a string. */
+function readErrorCode(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) return undefined;
+  const code = (data as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function classifyError(err: unknown, document_id: string): ResolveFailure {
+  if (isTRPCClientError(err)) {
+    const code = readErrorCode(err.data);
+    if (code === "FORBIDDEN" || code === "UNAUTHORIZED") return accessDenied(document_id);
+    if (code === "NOT_FOUND") return documentNotFound(document_id);
+    // tRPC wraps fetch failures in a TRPCClientError with no error envelope.
+    if (code === undefined && err.cause instanceof TypeError) return networkError();
+    return unexpectedError(document_id, err.message);
+  }
+  if (err instanceof TypeError) return networkError();
+  if (err instanceof Error) {
+    if (err.name === "AbortError") return networkError();
+    return unexpectedError(document_id, err.message);
+  }
+  return unexpectedError(document_id, String(err));
+}
+
+/**
+ * Resolve the document revision a linked skill must follow.
+ *
+ * Live bindings select the highest revision flagged `published` from the
+ * revision inventory and then fetch exactly that revision. Pinned bindings
+ * fetch the pinned revision directly and never consult the inventory.
+ */
+export async function resolveLinkedProcedure(
+  client: TypedClient,
+  input: ResolveInput,
+): Promise<ResolveResult> {
+  const { document_id, library_id, active_library_id } = input;
+  const revision = input.revision ?? null;
+  const now = input.now ?? (() => new Date());
+  const pinned = revision !== null;
+
+  if (active_library_id !== library_id) {
+    return fail(
+      "library_mismatch",
+      `This skill is linked to Library ${library_id} but the active Library is ${active_library_id}.`,
+      "Select the Library this skill was linked in with 'dosu setup', or re-link with --force to bind it to the current Library.",
+      { linked_library_id: library_id, active_library_id },
+    );
+  }
+
+  try {
+    const store = await client.knowledgeStore.getBySpaceId.query({ space_id: library_id });
+    if (!store) {
+      return fail(
+        "knowledge_store_missing",
+        "No knowledge store found for this Library. Run 'dosu setup' to reconfigure.",
+        "Run 'dosu setup' to select a configured Library, then retry.",
+      );
+    }
+    const expectedStoreId = store.id;
+
+    let target: number;
+    if (pinned) {
+      target = revision;
+    } else {
+      const versions = await client.page.listVersions.query({ page_id: document_id });
+      if (!Array.isArray(versions) || versions.length === 0) {
+        return documentNotFound(document_id);
+      }
+      const published = versions.filter((v) => v.published === true);
+      if (published.length === 0) {
+        const total = versions.length;
+        return fail(
+          "no_published_revision",
+          `Document ${document_id} has ${total} revision${total === 1 ? "" : "s"} but none is published.`,
+          "Publish a revision in Dosu, then retry. Draft revisions are never used.",
+          { total_revisions: total },
+        );
+      }
+      target = Math.max(...published.map((v) => v.version));
+    }
+
+    const page = await client.page.get.query({ page_id: document_id, version: target });
+
+    if (page === null) {
+      if (pinned) {
+        return fail(
+          "revision_unavailable",
+          `Revision ${revision} of document ${document_id} is not available.`,
+          "Do not fall back to the current revision. Re-link with a valid --revision or without --revision for live tracking.",
+          { revision },
+        );
+      }
+      return documentNotFound(document_id);
+    }
+    if (page.published !== true) {
+      return fail(
+        "revision_not_published",
+        `Revision ${page.version} of document ${document_id} is not published.`,
+        "Only published revisions are used. Publish this revision in Dosu or link a published one.",
+        { revision: page.version },
+      );
+    }
+    if (page.archived === true) {
+      return fail(
+        "document_archived",
+        `Document ${document_id} is archived.`,
+        "Restore the document in Dosu or link a different document. Archived procedures are never used.",
+      );
+    }
+    if (page.knowledge_store_id !== expectedStoreId) {
+      return fail(
+        "library_mismatch",
+        `Document ${document_id} belongs to a different Library than the one this skill is linked to.`,
+        "Re-link the skill in the Library that owns this document, or select that Library with 'dosu setup'.",
+        {
+          linked_library_id: library_id,
+          active_library_id,
+          expected_knowledge_store_id: expectedStoreId,
+          actual_knowledge_store_id: page.knowledge_store_id,
+        },
+      );
+    }
+    if (page.body === null || page.body.trim() === "") {
+      return fail(
+        "empty_body",
+        `Revision ${page.version} of document ${document_id} has an empty body.`,
+        "Add content to the document and publish it, then retry.",
+        { revision: page.version },
+      );
+    }
+    if (page.version !== target) {
+      return fail(
+        "resolver_inconsistency",
+        `Requested revision ${target} of document ${document_id} but received revision ${page.version}.`,
+        "Retry once. If this persists, report it as a Dosu CLI bug. Nothing was used.",
+        { requested: target, received: page.version },
+      );
+    }
+    if (page.body.length > MAX_PROCEDURE_CHARS) {
+      return fail(
+        "procedure_too_large",
+        `The procedure is ${page.body.length} characters; the limit is ${MAX_PROCEDURE_CHARS}. Nothing was truncated.`,
+        "Ask the document owner to split or shorten the procedure, or link a smaller document.",
+        { actual: page.body.length, limit: MAX_PROCEDURE_CHARS },
+      );
+    }
+
+    const tracking: SkillTracking = pinned ? "pinned" : "live";
+    const source: ResolvedSource = {
+      document_id,
+      title: page.title,
+      revision: page.version,
+      page_version_id: page.page_version_id,
+      published: true,
+      tracking,
+      library_id,
+      knowledge_store_id: page.knowledge_store_id,
+      updated_at: page.updated_at,
+      fetched_at: now().toISOString(),
+    };
+    return { ok: true, source, body: page.body };
+  } catch (err) {
+    return classifyError(err, document_id);
+  }
+}

--- a/src/skills/store.test.ts
+++ b/src/skills/store.test.ts
@@ -1,0 +1,419 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, parse, resolve, sep } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defaultSkillDescription, renderSkillMarkdown } from "./binding";
+import {
+  linkedSkillRoot,
+  listLinkedSkills,
+  readExistingBinding,
+  removeLinkedSkill,
+  skillPathsFor,
+  writeSkillFile,
+} from "./store";
+import { type LinkMarker, SKILL_LINK_TEMPLATE_VERSION } from "./types";
+
+const DOCUMENT_ID = "879cbca9-2fbf-45be-9a3e-1b74303238be";
+const LIBRARY_ID = "11111111-2222-3333-4444-555555555555";
+
+const baseMarker: Omit<LinkMarker, "content_sha256"> = {
+  document_id: DOCUMENT_ID,
+  library_id: LIBRARY_ID,
+  org_id: null,
+  revision: null,
+  template: SKILL_LINK_TEMPLATE_VERSION,
+  cli_version: "0.53.0",
+};
+
+function rendered(name: string, revision: number | null = null): string {
+  return renderSkillMarkdown({
+    name,
+    description: defaultSkillDescription("DB Enum Widening Checklist", name, revision),
+    marker: { ...baseMarker, revision },
+  });
+}
+
+const FOREIGN_SKILL = "---\nname: mine\ndescription: hand written\n---\n\n# mine\n";
+const CORRUPT_SKILL =
+  "---\nname: broken\n---\n<!-- dosu:skill-link v1 {not json} -->\n\n# broken\n";
+
+/** Snapshot of every file under `dir`: relative path → content + mtime. */
+function snapshot(dir: string): Record<string, { content: string; mtimeMs: number }> {
+  const out: Record<string, { content: string; mtimeMs: number }> = {};
+  const walk = (current: string, prefix: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      const full = join(current, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(full, rel);
+      else out[rel] = { content: readFileSync(full, "utf-8"), mtimeMs: statSync(full).mtimeMs };
+    }
+  };
+  walk(dir, "");
+  return out;
+}
+
+let tempDir: string;
+let originalClaudeConfigDir: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dosu-skills-"));
+  originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = join(tempDir, "claude-config");
+});
+
+afterEach(() => {
+  if (originalClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("linkedSkillRoot", () => {
+  it("uses CLAUDE_CONFIG_DIR for user scope", () => {
+    expect(linkedSkillRoot("claude", "user")).toBe(join(tempDir, "claude-config", "skills"));
+  });
+
+  it("trims CLAUDE_CONFIG_DIR", () => {
+    process.env.CLAUDE_CONFIG_DIR = `  ${join(tempDir, "padded")}  `;
+    expect(linkedSkillRoot("claude", "user")).toBe(join(tempDir, "padded", "skills"));
+  });
+
+  it("falls back to ~/.claude/skills when CLAUDE_CONFIG_DIR is unset", () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    expect(linkedSkillRoot("claude", "user")).toBe(join(homedir(), ".claude", "skills"));
+  });
+
+  it("falls back to ~/.claude/skills when CLAUDE_CONFIG_DIR is whitespace", () => {
+    process.env.CLAUDE_CONFIG_DIR = "   ";
+    expect(linkedSkillRoot("claude", "user")).toBe(join(homedir(), ".claude", "skills"));
+  });
+
+  it("uses <cwd>/.claude/skills for project scope", () => {
+    expect(linkedSkillRoot("claude", "project", tempDir)).toBe(join(tempDir, ".claude", "skills"));
+  });
+
+  it("defaults project scope to process.cwd()", () => {
+    expect(linkedSkillRoot("claude", "project")).toBe(join(process.cwd(), ".claude", "skills"));
+  });
+});
+
+describe("skillPathsFor", () => {
+  it("returns the directory and SKILL.md under the root for a valid name", () => {
+    const root = join(tempDir, "skills");
+    expect(skillPathsFor(root, "migration-review")).toEqual({
+      dir: join(root, "migration-review"),
+      file: join(root, "migration-review", "SKILL.md"),
+    });
+  });
+
+  it("resolves a relative root against the working directory", () => {
+    const paths = skillPathsFor("relative-root", "x");
+    expect(paths?.dir).toBe(resolve("relative-root", "x"));
+  });
+
+  it.each([
+    "../x",
+    "..",
+    ".",
+    "",
+    "/abs",
+    "a/b",
+    "a/../..",
+    "x/",
+  ])("refuses %j and writes nothing outside the root", (name) => {
+    const root = join(tempDir, "skills");
+    mkdirSync(root, { recursive: true });
+    const before = snapshot(tempDir);
+    expect(skillPathsFor(root, name)).toBeNull();
+    expect(snapshot(tempDir)).toEqual(before);
+    expect(existsSync(join(tempDir, "x"))).toBe(false);
+  });
+
+  it("refuses an absolute path built from the root itself", () => {
+    const root = join(tempDir, "skills");
+    expect(skillPathsFor(root, root)).toBeNull();
+    expect(skillPathsFor(root, join(root, "x"))).toBeNull();
+  });
+
+  it("handles a root that already ends with the separator", () => {
+    const root = `${join(tempDir, "skills")}${sep}`;
+    expect(skillPathsFor(root, "x")).toEqual({
+      dir: join(tempDir, "skills", "x"),
+      file: join(tempDir, "skills", "x", "SKILL.md"),
+    });
+  });
+
+  it("handles the filesystem root, whose resolved form keeps its separator", () => {
+    const fsRoot = parse(process.cwd()).root;
+    expect(skillPathsFor(fsRoot, "x")).toEqual({
+      dir: join(fsRoot, "x"),
+      file: join(fsRoot, "x", "SKILL.md"),
+    });
+  });
+});
+
+describe("writeSkillFile", () => {
+  it("creates parent directories and writes byte-identical content", () => {
+    const file = join(tempDir, "skills", "migration-review", "SKILL.md");
+    const content = rendered("migration-review");
+    writeSkillFile(file, content);
+    expect(readFileSync(file, "utf-8")).toBe(content);
+    if (process.platform !== "win32") {
+      expect(statSync(file).mode & 0o777).toBe(0o644);
+    }
+  });
+
+  it("replaces an existing file without leaving temp files behind", () => {
+    const dir = join(tempDir, "skills", "migration-review");
+    const file = join(dir, "SKILL.md");
+    writeSkillFile(file, rendered("migration-review"));
+    writeSkillFile(file, rendered("migration-review", 4));
+    expect(readFileSync(file, "utf-8")).toBe(rendered("migration-review", 4));
+    expect(readdirSync(dir)).toEqual(["SKILL.md"]);
+  });
+
+  it("leaves sibling skill directories byte-identical", () => {
+    const root = join(tempDir, "skills");
+    mkdirSync(join(root, "other", "nested"), { recursive: true });
+    writeFileSync(join(root, "other", "SKILL.md"), FOREIGN_SKILL);
+    writeFileSync(join(root, "other", "nested", "notes.txt"), "keep me\n");
+    const before = snapshot(join(root, "other"));
+
+    writeSkillFile(join(root, "migration-review", "SKILL.md"), rendered("migration-review"));
+
+    expect(snapshot(join(root, "other"))).toEqual(before);
+    expect(readdirSync(root).sort()).toEqual(["migration-review", "other"]);
+  });
+
+  it("cleans up its temp file when the rename fails", () => {
+    const dir = join(tempDir, "skills", "blocked");
+    // A directory occupying the target path makes rename() fail.
+    mkdirSync(join(dir, "SKILL.md", "inner"), { recursive: true });
+    expect(() => writeSkillFile(join(dir, "SKILL.md"), "x")).toThrow();
+    expect(readdirSync(dir)).toEqual(["SKILL.md"]);
+    expect(readdirSync(join(dir, "SKILL.md"))).toEqual(["inner"]);
+  });
+});
+
+describe("readExistingBinding", () => {
+  it("reports absent when there is no file", () => {
+    expect(readExistingBinding(join(tempDir, "nope", "SKILL.md"))).toEqual({ kind: "absent" });
+  });
+
+  it("reports foreign for a SKILL.md without a marker and leaves it untouched", () => {
+    const file = join(tempDir, "mine", "SKILL.md");
+    mkdirSync(join(tempDir, "mine"));
+    writeFileSync(file, FOREIGN_SKILL);
+    expect(readExistingBinding(file)).toEqual({ kind: "foreign" });
+    expect(readFileSync(file, "utf-8")).toBe(FOREIGN_SKILL);
+  });
+
+  it("reports foreign when SKILL.md is a directory", () => {
+    const file = join(tempDir, "weird", "SKILL.md");
+    mkdirSync(file, { recursive: true });
+    expect(readExistingBinding(file)).toEqual({ kind: "foreign" });
+  });
+
+  it("reports corrupt for an unparseable marker", () => {
+    const file = join(tempDir, "broken", "SKILL.md");
+    mkdirSync(join(tempDir, "broken"));
+    writeFileSync(file, CORRUPT_SKILL);
+    expect(readExistingBinding(file)).toMatchObject({ kind: "corrupt", message: /marker/ });
+  });
+
+  it("reports owned with edited:false for a generated file", () => {
+    const file = join(tempDir, "owned", "SKILL.md");
+    const content = rendered("owned");
+    mkdirSync(join(tempDir, "owned"));
+    writeFileSync(file, content);
+    const result = readExistingBinding(file);
+    expect(result.kind).toBe("owned");
+    if (result.kind !== "owned") return;
+    expect(result.edited).toBe(false);
+    expect(result.content).toBe(content);
+    expect(result.marker).toMatchObject(baseMarker);
+  });
+
+  it("reports owned with edited:true after a user edit", () => {
+    const file = join(tempDir, "owned", "SKILL.md");
+    mkdirSync(join(tempDir, "owned"));
+    writeFileSync(file, `${rendered("owned")}\nAlso run the linter.\n`);
+    expect(readExistingBinding(file)).toMatchObject({ kind: "owned", edited: true });
+  });
+});
+
+describe("listLinkedSkills", () => {
+  it("returns only marker-bearing skills across roots, sorted by scope then name", () => {
+    const userRoot = join(tempDir, "claude-config", "skills");
+    const projectRoot = join(tempDir, "project", ".claude", "skills");
+
+    for (const [root, name, content] of [
+      [userRoot, "zeta-link", rendered("zeta-link")],
+      [userRoot, "alpha-link", rendered("frontmatter-name-differs", 3)],
+      [userRoot, "edited-link", `${rendered("edited-link")}\nextra\n`],
+      [userRoot, "foreign", FOREIGN_SKILL],
+      [userRoot, "corrupt", CORRUPT_SKILL],
+      [projectRoot, "proj-b", rendered("proj-b")],
+      [projectRoot, "proj-a", rendered("proj-a")],
+      [projectRoot, "proj-foreign", FOREIGN_SKILL],
+    ] as const) {
+      mkdirSync(join(root, name), { recursive: true });
+      writeFileSync(join(root, name, "SKILL.md"), content);
+    }
+    // Noise that must be ignored: a plain file in the root, a directory
+    // without SKILL.md, and a directory where SKILL.md is itself a directory.
+    writeFileSync(join(userRoot, "README.md"), "# not a skill\n");
+    mkdirSync(join(userRoot, "empty-dir"));
+    mkdirSync(join(userRoot, "dir-skill", "SKILL.md"), { recursive: true });
+
+    const entries = listLinkedSkills([
+      { root: projectRoot, agent: "claude", scope: "project" },
+      { root: userRoot, agent: "claude", scope: "user" },
+      { root: join(tempDir, "does-not-exist"), agent: "claude", scope: "user" },
+    ]);
+
+    expect(entries.map((e) => [e.scope, e.name, e.edited])).toEqual([
+      ["user", "alpha-link", false],
+      ["user", "edited-link", true],
+      ["user", "zeta-link", false],
+      ["project", "proj-a", false],
+      ["project", "proj-b", false],
+    ]);
+    const alpha = entries[0] as (typeof entries)[number];
+    expect(alpha.agent).toBe("claude");
+    expect(alpha.path).toBe(join(userRoot, "alpha-link", "SKILL.md"));
+    expect(alpha.marker.revision).toBe(3);
+    expect(alpha.marker.document_id).toBe(DOCUMENT_ID);
+  });
+
+  it("returns an empty list when no root exists", () => {
+    expect(
+      listLinkedSkills([{ root: join(tempDir, "missing"), agent: "claude", scope: "user" }]),
+    ).toEqual([]);
+  });
+
+  it("scans a root listed twice only once, under its first scope", () => {
+    const root = join(tempDir, "claude-config", "skills");
+    mkdirSync(join(root, "only-once"), { recursive: true });
+    writeFileSync(join(root, "only-once", "SKILL.md"), rendered("only-once"));
+
+    const entries = listLinkedSkills([
+      { root, agent: "claude", scope: "user" },
+      { root: `${root}${sep}`, agent: "claude", scope: "project" },
+    ]);
+    expect(entries.map((e) => [e.scope, e.name])).toEqual([["user", "only-once"]]);
+  });
+
+  it("orders names by code point, not by locale", () => {
+    const root = join(tempDir, "claude-config", "skills");
+    for (const name of ["c-skill", "a-skill", "B-skill"]) {
+      mkdirSync(join(root, name), { recursive: true });
+      writeFileSync(join(root, name, "SKILL.md"), rendered(name));
+    }
+    const entries = listLinkedSkills([{ root, agent: "claude", scope: "user" }]);
+    expect(entries.map((e) => e.name)).toEqual(["B-skill", "a-skill", "c-skill"]);
+  });
+
+  it("skips a root that is a plain file", () => {
+    const root = join(tempDir, "file-root");
+    writeFileSync(root, "not a directory\n");
+    expect(listLinkedSkills([{ root, agent: "claude", scope: "user" }])).toEqual([]);
+  });
+
+  it("follows symlinked skill directories and skips dangling ones", () => {
+    if (process.platform === "win32") return;
+    const root = join(tempDir, "skills");
+    const real = join(tempDir, "elsewhere", "real-skill");
+    mkdirSync(root, { recursive: true });
+    mkdirSync(real, { recursive: true });
+    writeFileSync(join(real, "SKILL.md"), rendered("real-skill"));
+    symlinkSync(real, join(root, "linked"));
+    symlinkSync(join(tempDir, "gone"), join(root, "dangling"));
+
+    const entries = listLinkedSkills([{ root, agent: "claude", scope: "user" }]);
+    expect(entries.map((e) => e.name)).toEqual(["linked"]);
+  });
+});
+
+describe("removeLinkedSkill", () => {
+  it("removes an owned file and its empty directory", () => {
+    const dir = join(tempDir, "skills", "owned");
+    const file = join(dir, "SKILL.md");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, rendered("owned"));
+
+    expect(removeLinkedSkill(file)).toEqual({
+      removed: true,
+      directory_removed: true,
+      leftover: [],
+    });
+    expect(existsSync(dir)).toBe(false);
+    expect(existsSync(join(tempDir, "skills"))).toBe(true);
+  });
+
+  it("removes an edited owned file too", () => {
+    const dir = join(tempDir, "skills", "owned");
+    const file = join(dir, "SKILL.md");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, `${rendered("owned")}\nedited\n`);
+    expect(removeLinkedSkill(file)).toMatchObject({ removed: true, directory_removed: true });
+  });
+
+  it("keeps a non-empty directory and reports the leftovers", () => {
+    const dir = join(tempDir, "skills", "owned");
+    const file = join(dir, "SKILL.md");
+    mkdirSync(join(dir, "assets"), { recursive: true });
+    writeFileSync(file, rendered("owned"));
+    writeFileSync(join(dir, "notes.txt"), "keep\n");
+
+    expect(removeLinkedSkill(file)).toEqual({
+      removed: true,
+      directory_removed: false,
+      leftover: ["assets", "notes.txt"],
+    });
+    expect(existsSync(file)).toBe(false);
+    expect(readFileSync(join(dir, "notes.txt"), "utf-8")).toBe("keep\n");
+  });
+
+  it("refuses a foreign SKILL.md and leaves it byte-identical", () => {
+    const dir = join(tempDir, "skills", "mine");
+    const file = join(dir, "SKILL.md");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, FOREIGN_SKILL);
+
+    expect(removeLinkedSkill(file)).toMatchObject({
+      removed: false,
+      reason: "not_a_dosu_link",
+      message: /not a Dosu skill link/,
+    });
+    expect(readFileSync(file, "utf-8")).toBe(FOREIGN_SKILL);
+  });
+
+  it("refuses a corrupt marker", () => {
+    const dir = join(tempDir, "skills", "broken");
+    const file = join(dir, "SKILL.md");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, CORRUPT_SKILL);
+
+    expect(removeLinkedSkill(file)).toMatchObject({ removed: false, reason: "corrupt" });
+    expect(readFileSync(file, "utf-8")).toBe(CORRUPT_SKILL);
+  });
+
+  it("reports not_found when the file is absent", () => {
+    expect(removeLinkedSkill(join(tempDir, "skills", "nope", "SKILL.md"))).toMatchObject({
+      removed: false,
+      reason: "not_found",
+    });
+  });
+});

--- a/src/skills/store.ts
+++ b/src/skills/store.ts
@@ -1,0 +1,181 @@
+/**
+ * Filesystem layer for live knowledge skill bindings: where `SKILL.md` files
+ * live for each agent and scope, containment-checked path resolution,
+ * ownership-aware reads, atomic writes, and listing/removal that only ever
+ * touch files carrying our marker.
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve, sep } from "node:path";
+import { parseMarker } from "./binding";
+import type { LinkedSkillEntry, LinkMarker, SkillAgent, SkillScope } from "./types";
+
+const SKILL_FILE = "SKILL.md";
+
+/** Per-agent user config dir. Mirrors `skillInstallTargetForProvider` for Claude Code. */
+const USER_CONFIG_DIR: Readonly<Record<SkillAgent, () => string>> = {
+  claude: () => process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude"),
+};
+
+/** Per-agent project-local skills directory, relative to the working directory. */
+const PROJECT_SKILLS_DIR: Readonly<Record<SkillAgent, readonly string[]>> = {
+  claude: [".claude", "skills"],
+};
+
+/** Root directory that holds `<name>/SKILL.md` directories for the agent+scope. */
+export function linkedSkillRoot(agent: SkillAgent, scope: SkillScope, cwd?: string): string {
+  if (scope === "project") return join(cwd ?? process.cwd(), ...PROJECT_SKILLS_DIR[agent]);
+  return join(USER_CONFIG_DIR[agent](), "skills");
+}
+
+/**
+ * Resolve `<root>/<name>` and `<root>/<name>/SKILL.md`. Returns null unless
+ * `name` is a single path segment and the resolved directory is strictly inside
+ * `root`, so `../x`, absolute paths, `.`, `x/` and nested `a/b` are all refused
+ * before any I/O.
+ */
+export function skillPathsFor(root: string, name: string): { dir: string; file: string } | null {
+  if (name !== basename(name)) return null;
+  const resolvedRoot = resolve(root);
+  const prefix = resolvedRoot.endsWith(sep) ? resolvedRoot : `${resolvedRoot}${sep}`;
+  const dir = resolve(resolvedRoot, name);
+  if (!dir.startsWith(prefix)) return null;
+  return { dir, file: join(dir, SKILL_FILE) };
+}
+
+export type ExistingBinding =
+  | { kind: "absent" }
+  | { kind: "foreign" }
+  | { kind: "corrupt"; message: string }
+  | { kind: "owned"; marker: LinkMarker; content: string; edited: boolean };
+
+/** Classify whatever currently sits at `file` without modifying it. */
+export function readExistingBinding(file: string): ExistingBinding {
+  if (!existsSync(file)) return { kind: "absent" };
+  // Anything that is not a regular file (a directory named SKILL.md, say) is
+  // someone else's; treat it like a foreign skill and never touch it.
+  if (!statSync(file).isFile()) return { kind: "foreign" };
+  const content = readFileSync(file, "utf-8");
+  const parsed = parseMarker(content);
+  if (parsed.kind === "missing") return { kind: "foreign" };
+  if (parsed.kind === "corrupt") return { kind: "corrupt", message: parsed.message };
+  return { kind: "owned", marker: parsed.marker, content, edited: parsed.edited };
+}
+
+/**
+ * mkdir -p the parent, write to a temp file in the same directory, then rename
+ * over `file` so readers never observe a partial SKILL.md. Mode 0o644 is set
+ * explicitly so the result does not depend on the umask.
+ */
+export function writeSkillFile(file: string, content: string): void {
+  const dir = dirname(file);
+  mkdirSync(dir, { recursive: true });
+  const temp = join(dir, `.${SKILL_FILE}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`);
+  try {
+    writeFileSync(temp, content, { encoding: "utf-8", mode: 0o644 });
+    chmodSync(temp, 0o644);
+    renameSync(temp, file);
+  } catch (error) {
+    rmSync(temp, { force: true });
+    throw error;
+  }
+}
+
+export interface SkillRoot {
+  root: string;
+  agent: SkillAgent;
+  scope: SkillScope;
+}
+
+const SCOPE_ORDER: Readonly<Record<SkillScope, number>> = { user: 0, project: 1 };
+
+/** Code-point order, independent of the process locale. */
+function compareNames(a: string, b: string): number {
+  return Number(a > b) - Number(a < b);
+}
+
+function compareEntries(a: LinkedSkillEntry, b: LinkedSkillEntry): number {
+  return SCOPE_ORDER[a.scope] - SCOPE_ORDER[b.scope] || compareNames(a.name, b.name);
+}
+
+function isDirectory(path: string): boolean {
+  return statSync(path, { throwIfNoEntry: false })?.isDirectory() === true;
+}
+
+/**
+ * Scan every `<root>/<dir>/SKILL.md` for each root and return only files carrying a
+ * parseable marker. Missing roots are skipped silently; foreign skills, plain
+ * files in the root, and corrupt markers are ignored. A root that appears more
+ * than once (e.g. `CLAUDE_CONFIG_DIR` pointing at `<cwd>/.claude`) is scanned
+ * once, under the scope it was first listed with. Sorted by scope then name.
+ * `name` is the directory name, not the frontmatter name.
+ */
+export function listLinkedSkills(roots: readonly SkillRoot[]): LinkedSkillEntry[] {
+  const entries: LinkedSkillEntry[] = [];
+  const seen = new Set<string>();
+  for (const { root, agent, scope } of roots) {
+    const resolvedRoot = resolve(root);
+    if (seen.has(resolvedRoot) || !isDirectory(resolvedRoot)) continue;
+    seen.add(resolvedRoot);
+    for (const name of readdirSync(root)) {
+      const file = join(root, name, SKILL_FILE);
+      // statSync follows symlinks, so a symlinked skill directory (the shape
+      // `dosu skill install` produces) is included; a dangling one is not.
+      if (statSync(file, { throwIfNoEntry: false })?.isFile() !== true) continue;
+      const parsed = parseMarker(readFileSync(file, "utf-8"));
+      if (parsed.kind !== "ok") continue;
+      entries.push({
+        name,
+        agent,
+        scope,
+        path: file,
+        marker: parsed.marker,
+        edited: parsed.edited,
+      });
+    }
+  }
+  return entries.sort(compareEntries);
+}
+
+export type RemoveResult =
+  | { removed: true; directory_removed: boolean; leftover: string[] }
+  | { removed: false; reason: "not_found" | "not_a_dosu_link" | "corrupt"; message: string };
+
+/** Remove SKILL.md only when it carries a valid marker; then rmdir the directory only if empty. */
+export function removeLinkedSkill(file: string): RemoveResult {
+  const existing = readExistingBinding(file);
+  if (existing.kind === "absent") {
+    return { removed: false, reason: "not_found", message: `No skill file at ${file}.` };
+  }
+  if (existing.kind === "foreign") {
+    return {
+      removed: false,
+      reason: "not_a_dosu_link",
+      message: `${file} is not a Dosu skill link; leaving it untouched.`,
+    };
+  }
+  if (existing.kind === "corrupt") {
+    return { removed: false, reason: "corrupt", message: existing.message };
+  }
+
+  unlinkSync(file);
+  const dir = dirname(file);
+  const leftover = readdirSync(dir).sort();
+  if (leftover.length > 0) return { removed: true, directory_removed: false, leftover };
+  rmdirSync(dir);
+  return { removed: true, directory_removed: true, leftover: [] };
+}

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared types for live knowledge skills (`dosu skill link|resolve|links|unlink`).
+ *
+ * A "binding" is a generated `SKILL.md` that points a coding agent at one Dosu
+ * document. The resolver fetches that document's highest published revision
+ * (or a pinned revision) at invocation time, so editing the document in Dosu
+ * changes what every agent using the skill does.
+ */
+
+/** Coding agents that can host a linked skill. Claude Code only in v1. */
+export type SkillAgent = "claude";
+
+/** Where the skill directory lives: the agent's user config dir or `<cwd>/.claude/skills`. */
+export type SkillScope = "user" | "project";
+
+/** `live` follows the highest published revision; `pinned` is fixed to one revision. */
+export type SkillTracking = "live" | "pinned";
+
+/** Current generated-file template version. Bump when the rendered SKILL.md changes shape. */
+export const SKILL_LINK_TEMPLATE_VERSION = 1;
+
+/**
+ * Ownership + provenance marker embedded in the generated SKILL.md as an HTML
+ * comment. `content_sha256` is the SHA-256 (hex) of the file with the marker
+ * line removed, so user edits to the generated file can be detected.
+ */
+export interface LinkMarker {
+  document_id: string;
+  library_id: string;
+  org_id: string | null;
+  /** `null` = live tracking; a number = pinned to that revision. */
+  revision: number | null;
+  template: number;
+  cli_version: string;
+  content_sha256: string;
+}
+
+/** Everything the resolver learned about the document revision it returned. */
+export interface ResolvedSource {
+  document_id: string;
+  title: string;
+  revision: number;
+  page_version_id: string;
+  published: true;
+  tracking: SkillTracking;
+  library_id: string;
+  knowledge_store_id: string;
+  updated_at: string;
+  fetched_at: string;
+}
+
+/** Machine-readable failure classes. Every failure exits 1. */
+export type ResolveReason =
+  | "library_mismatch"
+  | "knowledge_store_missing"
+  | "document_not_found"
+  | "no_published_revision"
+  | "revision_unavailable"
+  | "revision_not_published"
+  | "document_archived"
+  | "empty_body"
+  | "resolver_inconsistency"
+  | "procedure_too_large"
+  | "access_denied"
+  | "network_error"
+  | "unexpected_error";
+
+export interface ResolveFailure {
+  ok: false;
+  reason: ResolveReason;
+  /** Human-readable, one sentence, safe to print. */
+  message: string;
+  /** What the calling agent should tell the user / do next. */
+  agent_next_steps: string;
+  /** Optional structured details (ids, sizes) for programmatic consumers. */
+  details?: Record<string, unknown>;
+}
+
+export interface ResolveSuccess {
+  ok: true;
+  source: ResolvedSource;
+  body: string;
+}
+
+export type ResolveResult = ResolveSuccess | ResolveFailure;
+
+/** One binding found on disk by `dosu skill links`. */
+export interface LinkedSkillEntry {
+  name: string;
+  agent: SkillAgent;
+  scope: SkillScope;
+  path: string;
+  marker: LinkMarker;
+  /** True when the file's content hash no longer matches the marker (user edited it). */
+  edited: boolean;
+}


### PR DESCRIPTION
Linked skill instructions can change in Dosu without redistributing a new local skill file. This adds `dosu skill link`, `resolve`, `links`, and `unlink` for Claude Code. Each invocation fetches the highest published revision of its linked Library document, or the exact revision selected with `--revision`.

Bindings carry document and Library provenance, protect foreign and edited skill files, and fail explicitly when their source cannot be used. The related document-update fix preserves omitted fields, so a body-only instruction update does not clear the document title. Includes implementation tests and usage documentation.

## Validation

- 1,866 tests across 74 files passed with coverage thresholds met.
- Coverage: 96.56% statements, 91.46% branches, 97.37% functions, 97.15% lines.
- Biome checks, TypeScript, and dead-code checks passed.
- npm bundle and standalone binary built; compiled `skill link --help` verified.

## Try it

Check out this PR, then build from source:

```sh
bun install --frozen-lockfile
bun run build
export PATH="$PWD/bin:$PATH"
```

With the CLI authenticated to the document's Library:

```sh
dosu skill link <published-document-id> --name team-review --agent claude
```

Start a new Claude Code session and invoke `/team-review <task>`. Publish an instruction update in Dosu and invoke it again. Use `--revision <n>` when linking to keep the instructions fixed to a published version. See `docs/live-skills.md` for scope, commands, and failure behavior.
