### PR TITLE
feat: add 'sources connect' and 'sources create' commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Once authenticated against a deployment, you can drive the Dosu platform without
 | `dosu docs` | Manage documents (list, create, update, import, publish, AI-generate) |
 | `dosu threads` | List and manage conversation threads |
 | `dosu review` | Document review workflow |
-| `dosu sources` | Manage connected data sources (list, sync, update) |
+| `dosu sources` | Manage connected data sources (list, connect, create, sync, update) |
 | `dosu integrations` | List and inspect platform integrations (Slack, GitHub, …) |
 | `dosu topics` | List knowledge base topics and their pages |
 | `dosu members` | Invite organization members |


### PR DESCRIPTION
Cherry-picked from `feat/knowledge-sync-hooks` (adc3f34) — the only commit on that branch that never made it into `beta`. Everything else from #199 already shipped through the beta channel.

Adds `dosu sources connect` and `dosu sources create` to the sources command group.

Closes out the remaining work from #199.