### PR TITLE
fix(mcp): write Zed config to ~/.config/zed with Zed's remote-server shape

### DIFF
--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -8,9 +8,11 @@ import {
   loadJSONConfig,
   mcpHeaders,
   mcpURL,
+  readJSONConfig,
   removeJSONServer,
   saveJSONConfig,
   stripJSONComments,
+  stripTrailingCommas,
   writeSecureFile,
 } from "./config-helpers";
 
@@ -90,6 +92,27 @@ describe("stripJSONComments", () => {
   });
 });
 
+describe("stripTrailingCommas", () => {
+  it("drops trailing commas before } and ] across whitespace", () => {
+    const input = '{\n  "a": [1, 2,\n  ],\n  "b": {"c": 1,},\n}';
+    expect(JSON.parse(stripTrailingCommas(input))).toEqual({ a: [1, 2], b: { c: 1 } });
+  });
+
+  it("leaves commas inside strings alone", () => {
+    const input = '{"a": ",}", "b": ",]", "c": "x\\",}"}';
+    expect(stripTrailingCommas(input)).toBe(input);
+  });
+
+  it("does not touch separating commas", () => {
+    const input = '{"a": 1, "b": [1, 2]}';
+    expect(stripTrailingCommas(input)).toBe(input);
+  });
+
+  it("handles empty input", () => {
+    expect(stripTrailingCommas("")).toBe("");
+  });
+});
+
 describe("JSON config file operations", () => {
   let tempDir: string;
 
@@ -117,6 +140,36 @@ describe("JSON config file operations", () => {
       const path = join(tempDir, "test.jsonc");
       writeFileSync(path, '{\n// comment\n"foo": "bar"\n}');
       expect(loadJSONConfig(path)).toEqual({ foo: "bar" });
+    });
+
+    it("tolerates comments and trailing commas in a .json file (Zed/VS Code style)", () => {
+      const path = join(tempDir, "settings.json");
+      writeFileSync(
+        path,
+        '// Zed settings\n// documentation: https://zed.dev/docs/configuring-zed\n{\n  "ui_font_size": 16, /* px */\n  "theme": { "mode": "system", },\n}',
+      );
+      expect(loadJSONConfig(path)).toEqual({ ui_font_size: 16, theme: { mode: "system" } });
+    });
+
+    it("returns empty object for an unparseable file", () => {
+      const path = join(tempDir, "broken.json");
+      writeFileSync(path, "{ not json");
+      expect(loadJSONConfig(path)).toEqual({});
+    });
+  });
+
+  describe("readJSONConfig", () => {
+    it("returns empty object for a missing or blank file", () => {
+      expect(readJSONConfig(join(tempDir, "missing.json"))).toEqual({});
+      const blank = join(tempDir, "blank.json");
+      writeFileSync(blank, "  \n");
+      expect(readJSONConfig(blank)).toEqual({});
+    });
+
+    it("throws a descriptive error for an unparseable file", () => {
+      const path = join(tempDir, "broken.json");
+      writeFileSync(path, "{ not json");
+      expect(() => readJSONConfig(path)).toThrow(/Could not parse .*broken\.json as JSON/);
     });
   });
 
@@ -200,6 +253,27 @@ describe("JSON config file operations", () => {
       const result = loadJSONConfig(path);
       expect(result.mcpServers.dosu).toEqual({ url: "new" });
     });
+
+    it("preserves the rest of a commented settings file (Zed's default template)", () => {
+      const path = join(tempDir, "settings.json");
+      writeFileSync(
+        path,
+        '// Zed settings\n{\n  "ui_font_size": 16,\n  "theme": { "mode": "system", "light": "One Light", "dark": "One Dark" },\n}',
+      );
+      installJSONServer(path, "context_servers", { url: "http://dosu" });
+      const result = loadJSONConfig(path);
+      expect(result.ui_font_size).toBe(16);
+      expect(result.theme).toEqual({ mode: "system", light: "One Light", dark: "One Dark" });
+      expect(result.context_servers.dosu).toEqual({ url: "http://dosu" });
+    });
+
+    it("refuses to overwrite a file it cannot parse", () => {
+      const path = join(tempDir, "broken.json");
+      const original = '{"mcpServers": { "other": ';
+      writeFileSync(path, original);
+      expect(() => installJSONServer(path, "mcpServers", { url: "x" })).toThrow(/Could not parse/);
+      expect(readFileSync(path, "utf-8")).toBe(original);
+    });
   });
 
   describe("removeJSONServer", () => {
@@ -215,6 +289,28 @@ describe("JSON config file operations", () => {
       const result = loadJSONConfig(path);
       expect(result.mcpServers.dosu).toBeUndefined();
       expect(result.mcpServers.other).toEqual({ url: "y" });
+    });
+
+    it("does not create the file when it is missing", () => {
+      const path = join(tempDir, "nope.json");
+      removeJSONServer(path, "mcpServers");
+      expect(existsSync(path)).toBe(false);
+    });
+
+    it("leaves an unparseable file untouched", () => {
+      const path = join(tempDir, "broken.json");
+      const original = "{ definitely not json";
+      writeFileSync(path, original);
+      removeJSONServer(path, "mcpServers");
+      expect(readFileSync(path, "utf-8")).toBe(original);
+    });
+
+    it("does not rewrite a file that has no dosu entry", () => {
+      const path = join(tempDir, "untouched.json");
+      const original = '// keep my comment\n{"mcpServers": {"other": {"url": "y"}}}';
+      writeFileSync(path, original);
+      removeJSONServer(path, "mcpServers");
+      expect(readFileSync(path, "utf-8")).toBe(original);
     });
   });
 });

--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -87,6 +87,10 @@ describe("stripJSONComments", () => {
     expect(JSON.parse(result)).toEqual({ key: "value" });
   });
 
+  it("drops an unterminated block comment to end of input", () => {
+    expect(stripJSONComments('{"a": 1} /* open')).toBe('{"a": 1} ');
+  });
+
   it("handles empty input", () => {
     expect(stripJSONComments("")).toBe("");
   });

--- a/src/mcp/config-helpers.test.ts
+++ b/src/mcp/config-helpers.test.ts
@@ -108,6 +108,11 @@ describe("stripTrailingCommas", () => {
     expect(stripTrailingCommas(input)).toBe(input);
   });
 
+  it("passes through an unterminated string ending in a backslash", () => {
+    const input = '{"a": "abc\\';
+    expect(stripTrailingCommas(input)).toBe(input);
+  });
+
   it("handles empty input", () => {
     expect(stripTrailingCommas("")).toBe("");
   });

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -97,16 +97,31 @@ export function mcpRemoteServer(url: string, apiKey: string | undefined): McpRem
  * For .jsonc files, comments are stripped before parsing.
  */
 export function loadJSONConfig(path: string): JsonConfig {
-  if (!existsSync(path)) return {};
-  let data = readFileSync(path, "utf-8").trim();
-  if (!data) return {};
-  if (path.endsWith(".jsonc")) {
-    data = stripJSONComments(data);
-  }
   try {
-    return JSON.parse(data);
+    return readJSONConfig(path);
   } catch {
     return {};
+  }
+}
+
+/**
+ * Reads a JSON/JSONC config file. Returns `{}` for a missing or empty file and
+ * THROWS when a non-empty file cannot be parsed, so writers never mistake an
+ * unreadable file for an empty one and overwrite it.
+ *
+ * Comments and trailing commas are tolerated regardless of extension: several
+ * hosts (Zed's `settings.json`, VS Code's `mcp.json`) are JSONC-by-default and
+ * Zed's shipped template opens with `//` header lines.
+ */
+export function readJSONConfig(path: string): JsonConfig {
+  if (!existsSync(path)) return {};
+  const raw = readFileSync(path, "utf-8").trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(stripTrailingCommas(stripJSONComments(raw)));
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Could not parse ${path} as JSON (${detail}). Fix the file and retry.`);
   }
 }
 
@@ -165,6 +180,41 @@ export function stripJSONComments(data: string): string {
 }
 
 /**
+ * Removes trailing commas before `}` / `]` outside of string literals
+ * (JSONC-lenient parsers such as Zed's accept them; `JSON.parse` does not).
+ * Run AFTER stripJSONComments so only whitespace can sit between the comma
+ * and the closing bracket.
+ */
+export function stripTrailingCommas(data: string): string {
+  const result: string[] = [];
+  let inString = false;
+  for (let i = 0; i < data.length; i++) {
+    const ch = data[i];
+    if (inString) {
+      result.push(ch);
+      if (ch === "\\" && i + 1 < data.length) {
+        result.push(data[++i]);
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      result.push(ch);
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < data.length && /\s/.test(data[j])) j++;
+      if (data[j] === "}" || data[j] === "]") continue; // drop the comma
+    }
+    result.push(ch);
+  }
+  return result.join("");
+}
+
+/**
  * Writes a JSON config file, creating parent directories as needed.
  */
 export function saveJSONConfig(path: string, cfg: JsonConfig): void {
@@ -194,7 +244,8 @@ export function isJSONKeyConfigured(configPath: string, topLevelKey: string): bo
  * Writes the dosu MCP server entry into a JSON config file.
  */
 export function installJSONServer(configPath: string, topKey: string, server: JsonConfig): void {
-  const jsonCfg = loadJSONConfig(configPath);
+  // Strict read: an unparseable settings file must abort, never be replaced.
+  const jsonCfg = readJSONConfig(configPath);
   let section = jsonCfg[topKey];
   if (typeof section !== "object" || section === null) {
     section = {};
@@ -208,15 +259,15 @@ export function installJSONServer(configPath: string, topKey: string, server: Js
  * Removes the dosu entry from a JSON config file.
  */
 export function removeJSONServer(configPath: string, topKey: string): void {
+  if (!existsSync(configPath)) return; // nothing to remove, and don't create the file
   let jsonCfg: JsonConfig;
   try {
-    jsonCfg = loadJSONConfig(configPath);
+    jsonCfg = readJSONConfig(configPath);
   } catch {
-    return; // file doesn't exist or can't be read = nothing to remove
+    return; // unparseable: leave the user's file untouched rather than clobber it
   }
   const section = jsonCfg[topKey];
-  if (typeof section === "object" && section !== null) {
-    delete section.dosu;
-  }
+  if (typeof section !== "object" || section === null || !("dosu" in section)) return;
+  delete section.dosu;
   saveJSONConfig(configPath, jsonCfg);
 }

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -104,10 +104,7 @@ export function mcpRemoteServer(url: string, apiKey: string | undefined): McpRem
   };
 }
 
-/**
- * Reads and unmarshals a JSON config file. Returns an empty object if the file doesn't exist.
- * For .jsonc files, comments are stripped before parsing.
- */
+/** Non-throwing wrapper around readJSONConfig: `{}` on any failure. */
 export function loadJSONConfig(path: string): JsonConfig {
   try {
     return readJSONConfig(path);
@@ -142,27 +139,8 @@ export function stripJSONComments(data: string): string {
   let i = 0;
 
   while (i < data.length) {
-    // String literal — copy verbatim, handling escapes
     if (data[i] === '"') {
-      result.push(data[i]);
-      i++;
-      while (i < data.length && data[i] !== '"') {
-        if (data[i] === "\\") {
-          result.push(data[i]);
-          i++;
-          if (i < data.length) {
-            result.push(data[i]);
-            i++;
-          }
-          continue;
-        }
-        result.push(data[i]);
-        i++;
-      }
-      if (i < data.length) {
-        result.push(data[i]);
-        i++;
-      }
+      i = copyStringLiteral(data, i, result);
       continue;
     }
 
@@ -177,7 +155,7 @@ export function stripJSONComments(data: string): string {
     if (i + 1 < data.length && data[i] === "/" && data[i + 1] === "*") {
       i += 2;
       while (i + 1 < data.length && !(data[i] === "*" && data[i + 1] === "/")) i++;
-      if (i + 1 < data.length) i += 2;
+      i = i + 1 < data.length ? i + 2 : data.length; // unterminated: swallow to EOF
       continue;
     }
 
@@ -189,34 +167,47 @@ export function stripJSONComments(data: string): string {
 }
 
 /**
+ * Copies the string literal that opens at `data[start]` into `out`, honoring
+ * backslash escapes, and returns the index just past its closing quote (or
+ * `data.length` for an unterminated literal).
+ */
+function copyStringLiteral(data: string, start: number, out: string[]): number {
+  let i = start + 1;
+  out.push('"');
+  while (i < data.length && data[i] !== '"') {
+    out.push(data[i]);
+    if (data[i] === "\\" && i + 1 < data.length) out.push(data[++i]);
+    i++;
+  }
+  if (i < data.length) {
+    out.push('"');
+    i++;
+  }
+  return i;
+}
+
+/**
  * Removes trailing commas before `}` / `]` outside string literals. Run after
  * stripJSONComments so only whitespace can separate the comma and the bracket.
  */
 export function stripTrailingCommas(data: string): string {
   const result: string[] = [];
-  let inString = false;
-  for (let i = 0; i < data.length; i++) {
-    const ch = data[i];
-    if (inString) {
-      result.push(ch);
-      if (ch === "\\" && i + 1 < data.length) {
-        result.push(data[++i]);
-      } else if (ch === '"') {
-        inString = false;
-      }
+  let i = 0;
+  while (i < data.length) {
+    if (data[i] === '"') {
+      i = copyStringLiteral(data, i, result);
       continue;
     }
-    if (ch === '"') {
-      inString = true;
-      result.push(ch);
-      continue;
-    }
-    if (ch === ",") {
+    if (data[i] === ",") {
       let j = i + 1;
       while (j < data.length && /\s/.test(data[j])) j++;
-      if (data[j] === "}" || data[j] === "]") continue;
+      if (data[j] === "}" || data[j] === "]") {
+        i++;
+        continue;
+      }
     }
-    result.push(ch);
+    result.push(data[i]);
+    i++;
   }
   return result.join("");
 }

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -35,7 +35,7 @@ export function mcpURL(deploymentID: string): string {
 /**
  * Returns the base MCP endpoint URL without a deployment ID (for OSS mode).
  */
-export function mcpBaseURL(): string {
+function mcpBaseURL(): string {
   return `${getBackendURL()}/v1/mcp`;
 }
 

--- a/src/mcp/config-helpers.ts
+++ b/src/mcp/config-helpers.ts
@@ -10,6 +10,7 @@ import { dirname } from "node:path";
 // caller's CWD `node_modules` at runtime and fails outside this repo.
 // @ts-expect-error — write-file-atomic ships no types; shape is documented inline.
 import writeFileAtomicRaw from "write-file-atomic";
+import { type Config, MODE_OSS } from "../config/config";
 import { getBackendURL } from "../config/constants";
 
 type WriteFileAtomicOptions = {
@@ -36,6 +37,17 @@ export function mcpURL(deploymentID: string): string {
  */
 export function mcpBaseURL(): string {
   return `${getBackendURL()}/v1/mcp`;
+}
+
+/**
+ * Returns the MCP endpoint for the active mode: the bare base URL in OSS mode,
+ * the deployment-scoped URL otherwise.
+ */
+export function mcpEndpoint(cfg: Config): string {
+  if (cfg.mode === MODE_OSS) return mcpBaseURL();
+  const deploymentID = cfg.active_account?.target?.deployment_id;
+  if (!deploymentID) throw new Error("deployment ID is required");
+  return mcpURL(deploymentID);
 }
 
 /**
@@ -105,13 +117,10 @@ export function loadJSONConfig(path: string): JsonConfig {
 }
 
 /**
- * Reads a JSON/JSONC config file. Returns `{}` for a missing or empty file and
- * THROWS when a non-empty file cannot be parsed, so writers never mistake an
- * unreadable file for an empty one and overwrite it.
- *
- * Comments and trailing commas are tolerated regardless of extension: several
- * hosts (Zed's `settings.json`, VS Code's `mcp.json`) are JSONC-by-default and
- * Zed's shipped template opens with `//` header lines.
+ * Reads a JSON/JSONC config file: `{}` when missing or empty, throws when a
+ * non-empty file cannot be parsed so callers never overwrite an unreadable file.
+ * Comments and trailing commas are tolerated for every extension (Zed's and
+ * VS Code's settings files are JSONC by default).
  */
 export function readJSONConfig(path: string): JsonConfig {
   if (!existsSync(path)) return {};
@@ -120,7 +129,7 @@ export function readJSONConfig(path: string): JsonConfig {
   try {
     return JSON.parse(stripTrailingCommas(stripJSONComments(raw)));
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = (err as Error).message;
     throw new Error(`Could not parse ${path} as JSON (${detail}). Fix the file and retry.`);
   }
 }
@@ -180,10 +189,8 @@ export function stripJSONComments(data: string): string {
 }
 
 /**
- * Removes trailing commas before `}` / `]` outside of string literals
- * (JSONC-lenient parsers such as Zed's accept them; `JSON.parse` does not).
- * Run AFTER stripJSONComments so only whitespace can sit between the comma
- * and the closing bracket.
+ * Removes trailing commas before `}` / `]` outside string literals. Run after
+ * stripJSONComments so only whitespace can separate the comma and the bracket.
  */
 export function stripTrailingCommas(data: string): string {
   const result: string[] = [];
@@ -207,7 +214,7 @@ export function stripTrailingCommas(data: string): string {
     if (ch === ",") {
       let j = i + 1;
       while (j < data.length && /\s/.test(data[j])) j++;
-      if (data[j] === "}" || data[j] === "]") continue; // drop the comma
+      if (data[j] === "}" || data[j] === "]") continue;
     }
     result.push(ch);
   }
@@ -244,7 +251,6 @@ export function isJSONKeyConfigured(configPath: string, topLevelKey: string): bo
  * Writes the dosu MCP server entry into a JSON config file.
  */
 export function installJSONServer(configPath: string, topKey: string, server: JsonConfig): void {
-  // Strict read: an unparseable settings file must abort, never be replaced.
   const jsonCfg = readJSONConfig(configPath);
   let section = jsonCfg[topKey];
   if (typeof section !== "object" || section === null) {
@@ -259,12 +265,11 @@ export function installJSONServer(configPath: string, topKey: string, server: Js
  * Removes the dosu entry from a JSON config file.
  */
 export function removeJSONServer(configPath: string, topKey: string): void {
-  if (!existsSync(configPath)) return; // nothing to remove, and don't create the file
   let jsonCfg: JsonConfig;
   try {
     jsonCfg = readJSONConfig(configPath);
   } catch {
-    return; // unparseable: leave the user's file untouched rather than clobber it
+    return; // never rewrite a file we could not parse
   }
   const section = jsonCfg[topKey];
   if (typeof section !== "object" || section === null || !("dosu" in section)) return;

--- a/src/mcp/providers/antigravity.ts
+++ b/src/mcp/providers/antigravity.ts
@@ -1,4 +1,3 @@
-import { mcpHeaders, mcpURL } from "../config-helpers";
 import { createJSONProvider } from "./base";
 
 export const AntigravityProvider = () =>
@@ -10,10 +9,8 @@ export const AntigravityProvider = () =>
     paths: ["~/.gemini"],
     globalPath: "~/.gemini/antigravity/mcp_config.json",
     topKey: "mcpServers",
-    buildServer: (cfg) => ({
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      serverUrl: mcpURL(cfg.active_account!.target!.deployment_id!),
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+    buildServer: ({ url, headers }) => ({
+      serverUrl: url,
+      headers,
     }),
   });

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -3,17 +3,22 @@
  * Most providers follow the same install/remove pattern — only the config path and top-level key differ.
  */
 
-import { type Config, MODE_OSS } from "../../config/config";
+import type { Config } from "../../config/config";
 import {
   installJSONServer,
   isJSONKeyConfigured,
-  mcpBaseURL,
+  mcpEndpoint,
   mcpHeaders,
-  mcpURL,
   removeJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
 import type { SetupProvider } from "../providers";
+
+/** The resolved Dosu MCP endpoint a provider writes into its config file. */
+export interface McpEndpoint {
+  url: string;
+  headers: Record<string, string>;
+}
 
 export interface BaseProviderConfig {
   providerName: string;
@@ -23,38 +28,26 @@ export interface BaseProviderConfig {
   paths: string[];
   globalPath: string;
   topKey: string;
-  /** Override the server entry shape if needed */
-  // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
-  buildServer?: (cfg: Config) => Record<string, any>;
   /**
-   * Override the OSS-mode server entry shape. Defaults to the same
-   * `{ type: "http", url, headers }` shape as the cloud default; providers
-   * whose config schema differs (e.g. Zed) must override both.
+   * Shapes the server entry for this tool's schema. Receives the endpoint
+   * already resolved for the active mode (OSS vs cloud), so overrides never
+   * need to know which mode they are in. Defaults to `{ type: "http", url, headers }`.
    */
   // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
-  buildOSSServer?: (cfg: Config) => Record<string, any>;
+  buildServer?: (endpoint: McpEndpoint, cfg: Config) => Record<string, any>;
   /** For providers that use a different local config path pattern */
   localConfigPath?: (cwd: string) => string;
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
+const defaultBuildServer = ({ url, headers }: McpEndpoint): Record<string, any> => ({
+  type: "http",
+  url,
+  headers,
+});
+
 export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
-  // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
-  const defaultBuildServer = (cfg: Config): Record<string, any> => ({
-    type: "http",
-    // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-    url: mcpURL(cfg.active_account!.target!.deployment_id!),
-    headers: mcpHeaders(cfg.active_account?.target?.api_key),
-  });
-
-  // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
-  const defaultBuildOSSServer = (cfg: Config): Record<string, any> => ({
-    type: "http",
-    url: mcpBaseURL(),
-    headers: mcpHeaders(cfg.active_account?.target?.api_key),
-  });
-
   const buildServer = opts.buildServer ?? defaultBuildServer;
-  const buildOSSServer = opts.buildOSSServer ?? defaultBuildOSSServer;
 
   return {
     name: () => opts.providerName,
@@ -67,8 +60,10 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
     isConfigured: () => isJSONKeyConfigured(expandHome(opts.globalPath), opts.topKey),
 
     install(cfg: Config, global: boolean): void {
-      if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
-        throw new Error("deployment ID is required");
+      const endpoint: McpEndpoint = {
+        url: mcpEndpoint(cfg),
+        headers: mcpHeaders(cfg.active_account?.target?.api_key),
+      };
       let configPath: string;
       if (global) {
         configPath = expandHome(opts.globalPath);
@@ -77,8 +72,7 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
       } else {
         throw new Error(`${opts.providerName} does not support local installation`);
       }
-      const serverBuilder = cfg.mode === MODE_OSS ? buildOSSServer : buildServer;
-      installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
+      installJSONServer(configPath, opts.topKey, buildServer(endpoint, cfg));
     },
 
     remove(global: boolean): void {

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -26,6 +26,13 @@ export interface BaseProviderConfig {
   /** Override the server entry shape if needed */
   // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
   buildServer?: (cfg: Config) => Record<string, any>;
+  /**
+   * Override the OSS-mode server entry shape. Defaults to the same
+   * `{ type: "http", url, headers }` shape as the cloud default; providers
+   * whose config schema differs (e.g. Zed) must override both.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: server entries are arbitrary JSON
+  buildOSSServer?: (cfg: Config) => Record<string, any>;
   /** For providers that use a different local config path pattern */
   localConfigPath?: (cwd: string) => string;
 }
@@ -47,6 +54,7 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
   });
 
   const buildServer = opts.buildServer ?? defaultBuildServer;
+  const buildOSSServer = opts.buildOSSServer ?? defaultBuildOSSServer;
 
   return {
     name: () => opts.providerName,
@@ -69,7 +77,7 @@ export function createJSONProvider(opts: BaseProviderConfig): SetupProvider {
       } else {
         throw new Error(`${opts.providerName} does not support local installation`);
       }
-      const serverBuilder = cfg.mode === MODE_OSS ? defaultBuildOSSServer : buildServer;
+      const serverBuilder = cfg.mode === MODE_OSS ? buildOSSServer : buildServer;
       installJSONServer(configPath, opts.topKey, serverBuilder(cfg));
     },
 

--- a/src/mcp/providers/base.ts
+++ b/src/mcp/providers/base.ts
@@ -15,7 +15,7 @@ import { expandHome, isInstalled } from "../detect";
 import type { SetupProvider } from "../providers";
 
 /** The resolved Dosu MCP endpoint a provider writes into its config file. */
-export interface McpEndpoint {
+interface McpEndpoint {
   url: string;
   headers: Record<string, string>;
 }

--- a/src/mcp/providers/claude-desktop.ts
+++ b/src/mcp/providers/claude-desktop.ts
@@ -1,11 +1,10 @@
 import { join } from "node:path";
-import { type Config, MODE_OSS } from "../../config/config";
+import type { Config } from "../../config/config";
 import {
   installJSONServer,
   isJSONKeyConfigured,
-  mcpBaseURL,
+  mcpEndpoint,
   mcpRemoteServer,
-  mcpURL,
   removeJSONServer,
 } from "../config-helpers";
 import { appSupportDir, findNpx, isInstalled, npxPathEnv } from "../detect";
@@ -27,13 +26,7 @@ export const ClaudeDesktopProvider = (): SetupProvider => ({
 
   install(cfg: Config, global: boolean): void {
     if (!global) throw new Error("Claude Desktop does not support local installation");
-    if (cfg.mode !== MODE_OSS && !cfg.active_account?.target?.deployment_id)
-      throw new Error("deployment ID is required");
-    const url =
-      cfg.mode === MODE_OSS
-        ? mcpBaseURL()
-        : // biome-ignore lint/style/noNonNullAssertion: guaranteed by the guard above
-          mcpURL(cfg.active_account!.target!.deployment_id!);
+    const url = mcpEndpoint(cfg);
     // Claude Desktop's chat surface launches only stdio servers from this
     // config file (and only renders MCP Apps from them); remote HTTP goes
     // through the Connectors UI, which cannot be automated. Proxy the remote

--- a/src/mcp/providers/cline-cli.ts
+++ b/src/mcp/providers/cline-cli.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { mcpHeaders, mcpURL } from "../config-helpers";
 import { expandHome } from "../detect";
 import { createJSONProvider } from "./base";
 
@@ -16,12 +15,10 @@ export const ClineCliProvider = () =>
     paths: [clineDir()],
     globalPath: join(clineDir(), "data", "settings", "cline_mcp_settings.json"),
     topKey: "mcpServers",
-    buildServer: (cfg) => ({
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.active_account!.target!.deployment_id!),
+    buildServer: ({ url, headers }) => ({
+      url,
       type: "streamableHttp",
       disabled: false,
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+      headers,
     }),
   });

--- a/src/mcp/providers/cline.ts
+++ b/src/mcp/providers/cline.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { mcpHeaders, mcpURL } from "../config-helpers";
 import { appSupportDir } from "../detect";
 import { createJSONProvider } from "./base";
 
@@ -15,12 +14,10 @@ export const ClineProvider = () =>
     paths: [extensionDir()],
     globalPath: join(extensionDir(), "settings", "cline_mcp_settings.json"),
     topKey: "mcpServers",
-    buildServer: (cfg) => ({
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.active_account!.target!.deployment_id!),
+    buildServer: ({ url, headers }) => ({
+      url,
       type: "streamableHttp",
       disabled: false,
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+      headers,
     }),
   });

--- a/src/mcp/providers/codex.ts
+++ b/src/mcp/providers/codex.ts
@@ -7,7 +7,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, MODE_OSS } from "../../config/config";
-import { mcpBaseURL, mcpRemoteServer, mcpURL, writeSecureFile } from "../config-helpers";
+import { mcpEndpoint, mcpRemoteServer, writeSecureFile } from "../config-helpers";
 import { expandHome, findNpx, isInstalled, npxPathEnv } from "../detect";
 import type { SetupProvider } from "../providers";
 
@@ -31,12 +31,6 @@ function readTOML(path: string): string {
 
 function writeTOML(path: string, content: string): void {
   writeSecureFile(path, content);
-}
-
-function mcpEndpoint(cfg: Config): string {
-  if (cfg.mode === MODE_OSS) return mcpBaseURL();
-  if (!cfg.active_account?.target?.deployment_id) throw new Error("deployment ID is required");
-  return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
 function tomlString(value: string): string {

--- a/src/mcp/providers/copilot.ts
+++ b/src/mcp/providers/copilot.ts
@@ -1,11 +1,10 @@
 import { join } from "node:path";
-import { type Config, MODE_OSS } from "../../config/config";
+import type { Config } from "../../config/config";
 import {
   installJSONServer,
   isJSONKeyConfigured,
-  mcpBaseURL,
+  mcpEndpoint,
   mcpHeaders,
-  mcpURL,
   removeJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
@@ -16,12 +15,6 @@ function globalPath(): string {
     return join(process.env.XDG_CONFIG_HOME, "mcp-config.json");
   }
   return expandHome("~/.copilot/mcp-config.json");
-}
-
-function mcpEndpoint(cfg: Config): string {
-  if (cfg.mode === MODE_OSS) return mcpBaseURL();
-  if (!cfg.active_account?.target?.deployment_id) throw new Error("deployment ID is required");
-  return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
 export const CopilotProvider = (): SetupProvider => ({

--- a/src/mcp/providers/cursor.ts
+++ b/src/mcp/providers/cursor.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { mcpHeaders, mcpURL } from "../config-helpers";
 import { createJSONProvider } from "./base";
 
 export const CursorProvider = () =>
@@ -11,11 +10,9 @@ export const CursorProvider = () =>
     paths: ["~/.cursor"],
     globalPath: "~/.cursor/mcp.json",
     topKey: "mcpServers",
-    buildServer: (cfg) => ({
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.active_account!.target!.deployment_id!),
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+    buildServer: ({ url, headers }) => ({
+      url,
+      headers,
     }),
     localConfigPath: (cwd) => join(cwd, ".cursor", "mcp.json"),
   });

--- a/src/mcp/providers/manual.ts
+++ b/src/mcp/providers/manual.ts
@@ -1,12 +1,6 @@
-import { type Config, MODE_OSS } from "../../config/config";
-import { mcpBaseURL, mcpHeaders, mcpURL } from "../config-helpers";
+import type { Config } from "../../config/config";
+import { mcpEndpoint, mcpHeaders } from "../config-helpers";
 import type { Provider, ProviderInstallOptions } from "../providers";
-
-function mcpEndpoint(cfg: Config): string {
-  if (cfg.mode === MODE_OSS) return mcpBaseURL();
-  if (!cfg.active_account?.target?.deployment_id) throw new Error("deployment ID is required");
-  return mcpURL(cfg.active_account?.target?.deployment_id);
-}
 
 function maskSecret(secret: string): string {
   if (secret.length <= 8) return "[hidden]";

--- a/src/mcp/providers/mcporter.ts
+++ b/src/mcp/providers/mcporter.ts
@@ -1,12 +1,11 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { type Config, MODE_OSS } from "../../config/config";
+import type { Config } from "../../config/config";
 import {
   installJSONServer,
   isJSONKeyConfigured,
-  mcpBaseURL,
+  mcpEndpoint,
   mcpHeaders,
-  mcpURL,
   removeJSONServer,
 } from "../config-helpers";
 import { expandHome, isInstalled } from "../detect";
@@ -18,12 +17,6 @@ function resolveGlobalConfigPath(): string {
   const jsoncPath = expandHome("~/.mcporter/mcporter.jsonc");
   if (existsSync(jsoncPath)) return jsoncPath;
   return jsonPath;
-}
-
-function mcpEndpoint(cfg: Config): string {
-  if (cfg.mode === MODE_OSS) return mcpBaseURL();
-  if (!cfg.active_account?.target?.deployment_id) throw new Error("deployment ID is required");
-  return mcpURL(cfg.active_account?.target?.deployment_id);
 }
 
 export const MCPorterProvider = (): SetupProvider => ({

--- a/src/mcp/providers/opencode.ts
+++ b/src/mcp/providers/opencode.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { mcpHeaders, mcpURL } from "../config-helpers";
 import { createJSONProvider } from "./base";
 
 export const OpenCodeProvider = () =>
@@ -11,13 +10,11 @@ export const OpenCodeProvider = () =>
     paths: ["~/.config/opencode"],
     globalPath: "~/.config/opencode/opencode.json",
     topKey: "mcp",
-    buildServer: (cfg) => ({
+    buildServer: ({ url, headers }) => ({
       type: "remote",
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.active_account!.target!.deployment_id!),
+      url,
       enabled: true,
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+      headers,
     }),
     localConfigPath: (cwd) => join(cwd, "opencode.json"),
   });

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -95,6 +95,28 @@ describe("createJSONProvider (base)", () => {
     expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
+  it("OSS install uses buildOSSServer override when provided", async () => {
+    const { createJSONProvider } = await import("./base");
+    const globalPath = join(tempDir, "oss-override.json");
+    const provider = createJSONProvider({
+      providerName: "TestProvider",
+      providerID: "test",
+      local: false,
+      priorityValue: 1,
+      paths: [],
+      globalPath,
+      topKey: "mcpServers",
+      buildServer: () => ({ shape: "cloud" }),
+      buildOSSServer: () => ({ shape: "oss" }),
+    });
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+    expect(loadJSONConfig(globalPath).mcpServers.dosu).toEqual({ shape: "oss" });
+
+    provider.install(makeCfg(), true);
+    expect(loadJSONConfig(globalPath).mcpServers.dosu).toEqual({ shape: "cloud" });
+  });
+
   it("install throws when deployment_id is missing", async () => {
     const { createJSONProvider } = await import("./base");
     const provider = createJSONProvider({
@@ -1199,12 +1221,17 @@ describe("AntigravityProvider", () => {
 describe("ZedProvider", () => {
   let tempDir: string;
   let origHome: string | undefined;
+  let origXdg: string | undefined;
   let origCwd: string;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), "dosu-zed-test-"));
     origHome = process.env.HOME;
     process.env.HOME = tempDir;
+    // Pin the Linux branch to ~/.config so the path assertion below holds on
+    // any POSIX runner regardless of the host's XDG_CONFIG_HOME.
+    origXdg = process.env.XDG_CONFIG_HOME;
+    delete process.env.XDG_CONFIG_HOME;
     origCwd = process.cwd();
     process.chdir(tempDir);
   });
@@ -1212,7 +1239,26 @@ describe("ZedProvider", () => {
   afterEach(() => {
     process.chdir(origCwd);
     process.env.HOME = origHome;
+    if (origXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = origXdg;
     rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global config lives in Zed's config dir, not its Application Support data dir", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+
+    const globalCfgPath = provider.globalConfigPath();
+    // Zed only reads settings.json from its config dir (~/.config/zed on
+    // macOS + Linux, %APPDATA%\Zed on Windows). Application Support is Zed's
+    // data dir and holds no settings file.
+    expect(globalCfgPath).not.toContain("Application Support");
+    /* v8 ignore next 3 -- win32 arm not exercised on POSIX CI */
+    if (process.platform === "win32") {
+      expect(globalCfgPath).toBe(join(process.env.APPDATA ?? "", "Zed", "settings.json"));
+    } else {
+      expect(globalCfgPath).toBe(join(tempDir, ".config", "zed", "settings.json"));
+    }
   });
 
   it("global install writes to settings.json with context_servers key", async () => {
@@ -1225,8 +1271,55 @@ describe("ZedProvider", () => {
     expect(existsSync(globalCfgPath)).toBe(true);
     const cfg = loadJSONConfig(globalCfgPath);
     expect(cfg.context_servers.dosu).toBeDefined();
-    expect(cfg.context_servers.dosu.source).toBe("custom");
-    expect(cfg.context_servers.dosu.type).toBe("http");
+    expect(cfg.context_servers.dosu.url).toContain("dep-123");
+    expect(cfg.context_servers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("writes Zed's remote-server shape: url + headers only, no source/type discriminator", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    // Zed's ContextServerSettingsContent::Http variant is { enabled?, url,
+    // headers?, timeout?, oauth? } — `source`/`type` are not in the schema.
+    expect(Object.keys(cfg.context_servers.dosu).sort()).toEqual(["headers", "url"]);
+    expect(cfg.context_servers.dosu.source).toBeUndefined();
+    expect(cfg.context_servers.dosu.type).toBeUndefined();
+  });
+
+  it("OSS mode also writes Zed's remote-server shape against the base MCP URL", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    expect(Object.keys(cfg.context_servers.dosu).sort()).toEqual(["headers", "url"]);
+    expect(cfg.context_servers.dosu.url).toContain("/v1/mcp");
+    expect(cfg.context_servers.dosu.url).not.toContain("/deployments/");
+    expect(cfg.context_servers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("preserves sibling context_servers entries when installing", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+    const globalCfgPath = provider.globalConfigPath();
+    mkdirSync(dirname(globalCfgPath), { recursive: true });
+    writeFileSync(
+      globalCfgPath,
+      JSON.stringify({
+        theme: "One Dark",
+        context_servers: { other: { command: "npx", args: ["-y", "some-mcp"] } },
+      }),
+    );
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(globalCfgPath);
+    expect(cfg.theme).toBe("One Dark");
+    expect(cfg.context_servers.other.command).toBe("npx");
     expect(cfg.context_servers.dosu.url).toContain("dep-123");
   });
 

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -1302,6 +1302,35 @@ describe("ZedProvider", () => {
     expect(cfg.context_servers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
+  it("preserves a settings.json that starts with Zed's default comment header", async () => {
+    const { ZedProvider } = await import("./zed");
+    const provider = ZedProvider();
+    const globalCfgPath = provider.globalConfigPath();
+    mkdirSync(dirname(globalCfgPath), { recursive: true });
+    writeFileSync(
+      globalCfgPath,
+      [
+        "// Zed settings",
+        "//",
+        "// For information on how to configure Zed, see the Zed",
+        "// documentation: https://zed.dev/docs/configuring-zed",
+        "{",
+        '  "ui_font_size": 16,',
+        '  "buffer_font_size": 16,',
+        '  "theme": { "mode": "system", "light": "One Light", "dark": "One Dark" },',
+        "}",
+      ].join("\n"),
+    );
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(globalCfgPath);
+    expect(cfg.ui_font_size).toBe(16);
+    expect(cfg.buffer_font_size).toBe(16);
+    expect(cfg.theme.dark).toBe("One Dark");
+    expect(cfg.context_servers.dosu.url).toContain("dep-123");
+  });
+
   it("preserves sibling context_servers entries when installing", async () => {
     const { ZedProvider } = await import("./zed");
     const provider = ZedProvider();

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -95,9 +95,9 @@ describe("createJSONProvider (base)", () => {
     expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
   });
 
-  it("OSS install uses buildOSSServer override when provided", async () => {
+  it("resolves the endpoint for the active mode before calling a custom buildServer", async () => {
     const { createJSONProvider } = await import("./base");
-    const globalPath = join(tempDir, "oss-override.json");
+    const globalPath = join(tempDir, "endpoint.json");
     const provider = createJSONProvider({
       providerName: "TestProvider",
       providerID: "test",
@@ -106,15 +106,18 @@ describe("createJSONProvider (base)", () => {
       paths: [],
       globalPath,
       topKey: "mcpServers",
-      buildServer: () => ({ shape: "cloud" }),
-      buildOSSServer: () => ({ shape: "oss" }),
+      buildServer: ({ url, headers }) => ({ endpoint: url, auth: headers["X-Dosu-API-Key"] }),
     });
 
     provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
-    expect(loadJSONConfig(globalPath).mcpServers.dosu).toEqual({ shape: "oss" });
+    const oss = loadJSONConfig(globalPath).mcpServers.dosu;
+    expect(oss.endpoint).toMatch(/\/v1\/mcp$/);
+    expect(oss.auth).toBe("key-abc");
 
     provider.install(makeCfg(), true);
-    expect(loadJSONConfig(globalPath).mcpServers.dosu).toEqual({ shape: "cloud" });
+    const cloud = loadJSONConfig(globalPath).mcpServers.dosu;
+    expect(cloud.endpoint).toContain("/v1/mcp/deployments/dep-123");
+    expect(cloud.auth).toBe("key-abc");
   });
 
   it("install throws when deployment_id is missing", async () => {
@@ -247,7 +250,7 @@ describe("createJSONProvider (base)", () => {
       paths: [],
       globalPath,
       topKey: "servers",
-      buildServer: (cfg) => ({
+      buildServer: (_endpoint, cfg) => ({
         myUrl: `custom-${cfg.active_account?.target?.deployment_id}`,
       }),
     });
@@ -1044,6 +1047,17 @@ describe("CursorProvider", () => {
     const cfg = loadJSONConfig(configPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
   });
+
+  it("OSS mode writes the same shape against the base MCP URL", async () => {
+    const { CursorProvider } = await import("./cursor");
+    const provider = CursorProvider();
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+
+    const cfg = loadJSONConfig(join(tempDir, ".cursor", "mcp.json"));
+    expect(Object.keys(cfg.mcpServers.dosu).sort()).toEqual(["headers", "url"]);
+    expect(cfg.mcpServers.dosu.url).toMatch(/\/v1\/mcp$/);
+  });
 });
 
 describe("OpenCodeProvider", () => {
@@ -1102,6 +1116,59 @@ describe("OpenCodeProvider", () => {
     const configPath = join(tempDir, ".config", "opencode", "opencode.json");
     const cfg = loadJSONConfig(configPath);
     expect(cfg.mcp.dosu).toBeUndefined();
+  });
+
+  it("OSS mode keeps OpenCode's remote shape against the base MCP URL", async () => {
+    const { OpenCodeProvider } = await import("./opencode");
+    const provider = OpenCodeProvider();
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    expect(cfg.mcp.dosu.type).toBe("remote");
+    expect(cfg.mcp.dosu.enabled).toBe(true);
+    expect(cfg.mcp.dosu.url).toMatch(/\/v1\/mcp$/);
+  });
+});
+
+describe("ClineProvider", () => {
+  let tempDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "dosu-cline-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("global install writes Cline's streamableHttp shape", async () => {
+    const { ClineProvider } = await import("./cline");
+    const provider = ClineProvider();
+
+    provider.install(makeCfg(), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    expect(provider.globalConfigPath()).toMatch(/cline_mcp_settings\.json$/);
+    expect(cfg.mcpServers.dosu.type).toBe("streamableHttp");
+    expect(cfg.mcpServers.dosu.disabled).toBe(false);
+    expect(cfg.mcpServers.dosu.url).toContain("dep-123");
+    expect(cfg.mcpServers.dosu.headers["X-Dosu-API-Key"]).toBe("key-abc");
+  });
+
+  it("OSS mode keeps the same shape against the base MCP URL", async () => {
+    const { ClineProvider } = await import("./cline");
+    const provider = ClineProvider();
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    expect(cfg.mcpServers.dosu.type).toBe("streamableHttp");
+    expect(cfg.mcpServers.dosu.url).toMatch(/\/v1\/mcp$/);
   });
 });
 
@@ -1166,6 +1233,18 @@ describe("ClineCliProvider", () => {
 
     expect(() => provider.install(makeCfg(), false)).toThrow("does not support local installation");
   });
+
+  it("OSS mode keeps Cline's streamableHttp shape against the base MCP URL", async () => {
+    const { ClineCliProvider } = await import("./cline-cli");
+    const provider = ClineCliProvider();
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+
+    const cfg = loadJSONConfig(provider.globalConfigPath());
+    expect(cfg.mcpServers.dosu.type).toBe("streamableHttp");
+    expect(cfg.mcpServers.dosu.disabled).toBe(false);
+    expect(cfg.mcpServers.dosu.url).toMatch(/\/v1\/mcp$/);
+  });
 });
 
 describe("AntigravityProvider", () => {
@@ -1216,6 +1295,17 @@ describe("AntigravityProvider", () => {
     const cfg = loadJSONConfig(configPath);
     expect(cfg.mcpServers.dosu).toBeUndefined();
   });
+
+  it("OSS mode keeps Antigravity's serverUrl key against the base MCP URL", async () => {
+    const { AntigravityProvider } = await import("./antigravity");
+    const provider = AntigravityProvider();
+
+    provider.install(makeCfg({ mode: "oss", deployment_id: undefined }), true);
+
+    const cfg = loadJSONConfig(join(tempDir, ".gemini", "antigravity", "mcp_config.json"));
+    expect(Object.keys(cfg.mcpServers.dosu).sort()).toEqual(["headers", "serverUrl"]);
+    expect(cfg.mcpServers.dosu.serverUrl).toMatch(/\/v1\/mcp$/);
+  });
 });
 
 describe("ZedProvider", () => {
@@ -1228,8 +1318,6 @@ describe("ZedProvider", () => {
     tempDir = mkdtempSync(join(tmpdir(), "dosu-zed-test-"));
     origHome = process.env.HOME;
     process.env.HOME = tempDir;
-    // Pin the Linux branch to ~/.config so the path assertion below holds on
-    // any POSIX runner regardless of the host's XDG_CONFIG_HOME.
     origXdg = process.env.XDG_CONFIG_HOME;
     delete process.env.XDG_CONFIG_HOME;
     origCwd = process.cwd();
@@ -1249,9 +1337,6 @@ describe("ZedProvider", () => {
     const provider = ZedProvider();
 
     const globalCfgPath = provider.globalConfigPath();
-    // Zed only reads settings.json from its config dir (~/.config/zed on
-    // macOS + Linux, %APPDATA%\Zed on Windows). Application Support is Zed's
-    // data dir and holds no settings file.
     expect(globalCfgPath).not.toContain("Application Support");
     /* v8 ignore next 3 -- win32 arm not exercised on POSIX CI */
     if (process.platform === "win32") {
@@ -1282,8 +1367,6 @@ describe("ZedProvider", () => {
     provider.install(makeCfg(), true);
 
     const cfg = loadJSONConfig(provider.globalConfigPath());
-    // Zed's ContextServerSettingsContent::Http variant is { enabled?, url,
-    // headers?, timeout?, oauth? } — `source`/`type` are not in the schema.
     expect(Object.keys(cfg.context_servers.dosu).sort()).toEqual(["headers", "url"]);
     expect(cfg.context_servers.dosu.source).toBeUndefined();
     expect(cfg.context_servers.dosu.type).toBeUndefined();
@@ -1386,5 +1469,58 @@ describe("ZedProvider", () => {
     const configPath = join(tempDir, ".zed", "settings.json");
     const cfg = loadJSONConfig(configPath);
     expect(cfg.context_servers.dosu).toBeUndefined();
+  });
+
+  it("strips the dosu entry from the legacy macOS data-dir file on global install and remove", async () => {
+    const { ZedProvider } = await import("./zed");
+    const legacyPath = join(tempDir, "Library", "Application Support", "Zed", "settings.json");
+    mkdirSync(dirname(legacyPath), { recursive: true });
+    writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        context_servers: { dosu: { url: "old", headers: { "X-Dosu-API-Key": "k" } } },
+      }),
+    );
+    const provider = ZedProvider(legacyPath);
+
+    provider.install(makeCfg(), true);
+    expect(existsSync(legacyPath)).toBe(false);
+    expect(loadJSONConfig(provider.globalConfigPath()).context_servers.dosu.url).toContain(
+      "dep-123",
+    );
+
+    writeFileSync(
+      legacyPath,
+      JSON.stringify({ theme: "One Dark", context_servers: { dosu: { url: "old" }, other: {} } }),
+    );
+    provider.remove(true);
+    const legacy = loadJSONConfig(legacyPath);
+    expect(legacy.theme).toBe("One Dark");
+    expect(legacy.context_servers.other).toEqual({});
+    expect(legacy.context_servers.dosu).toBeUndefined();
+    expect(loadJSONConfig(provider.globalConfigPath()).context_servers.dosu).toBeUndefined();
+  });
+
+  it("local install/remove and a null legacy path leave legacy handling alone", async () => {
+    const { ZedProvider, removeLegacyDosuEntry } = await import("./zed");
+    const legacyPath = join(tempDir, "legacy.json");
+    writeFileSync(legacyPath, JSON.stringify({ context_servers: { dosu: { url: "old" } } }));
+
+    const provider = ZedProvider(legacyPath);
+    provider.install(makeCfg(), false);
+    provider.remove(false);
+    expect(existsSync(legacyPath)).toBe(true);
+
+    ZedProvider(null).install(makeCfg(), true);
+    expect(existsSync(legacyPath)).toBe(true);
+
+    // Missing, unparseable, and dosu-less files are all no-ops.
+    removeLegacyDosuEntry(join(tempDir, "missing.json"));
+    writeFileSync(legacyPath, "{ not json");
+    removeLegacyDosuEntry(legacyPath);
+    expect(readFileSync(legacyPath, "utf-8")).toBe("{ not json");
+    writeFileSync(legacyPath, JSON.stringify({ context_servers: { other: {} } }));
+    removeLegacyDosuEntry(legacyPath);
+    expect(loadJSONConfig(legacyPath).context_servers.other).toEqual({});
   });
 });

--- a/src/mcp/providers/providers-install.test.ts
+++ b/src/mcp/providers/providers-install.test.ts
@@ -1337,7 +1337,6 @@ describe("ZedProvider", () => {
     const provider = ZedProvider();
 
     const globalCfgPath = provider.globalConfigPath();
-    expect(globalCfgPath).not.toContain("Application Support");
     /* v8 ignore next 3 -- win32 arm not exercised on POSIX CI */
     if (process.platform === "win32") {
       expect(globalCfgPath).toBe(join(process.env.APPDATA ?? "", "Zed", "settings.json"));
@@ -1368,8 +1367,6 @@ describe("ZedProvider", () => {
 
     const cfg = loadJSONConfig(provider.globalConfigPath());
     expect(Object.keys(cfg.context_servers.dosu).sort()).toEqual(["headers", "url"]);
-    expect(cfg.context_servers.dosu.source).toBeUndefined();
-    expect(cfg.context_servers.dosu.type).toBeUndefined();
   });
 
   it("OSS mode also writes Zed's remote-server shape against the base MCP URL", async () => {
@@ -1411,27 +1408,6 @@ describe("ZedProvider", () => {
     expect(cfg.ui_font_size).toBe(16);
     expect(cfg.buffer_font_size).toBe(16);
     expect(cfg.theme.dark).toBe("One Dark");
-    expect(cfg.context_servers.dosu.url).toContain("dep-123");
-  });
-
-  it("preserves sibling context_servers entries when installing", async () => {
-    const { ZedProvider } = await import("./zed");
-    const provider = ZedProvider();
-    const globalCfgPath = provider.globalConfigPath();
-    mkdirSync(dirname(globalCfgPath), { recursive: true });
-    writeFileSync(
-      globalCfgPath,
-      JSON.stringify({
-        theme: "One Dark",
-        context_servers: { other: { command: "npx", args: ["-y", "some-mcp"] } },
-      }),
-    );
-
-    provider.install(makeCfg(), true);
-
-    const cfg = loadJSONConfig(globalCfgPath);
-    expect(cfg.theme).toBe("One Dark");
-    expect(cfg.context_servers.other.command).toBe("npx");
     expect(cfg.context_servers.dosu.url).toContain("dep-123");
   });
 

--- a/src/mcp/providers/zed.ts
+++ b/src/mcp/providers/zed.ts
@@ -1,33 +1,61 @@
-import { platform } from "node:os";
+import { homedir, platform } from "node:os";
 import { join } from "node:path";
-import { mcpHeaders, mcpURL } from "../config-helpers";
+import { mcpBaseURL, mcpHeaders, mcpURL } from "../config-helpers";
 import { appSupportDir } from "../detect";
 import { createJSONProvider } from "./base";
 
+/**
+ * Zed keeps `settings.json` in its *config* dir, which is NOT the same as its
+ * data dir (`~/Library/Application Support/Zed` on macOS — that one only holds
+ * db/, extensions/, languages/, etc.). Per `crates/paths` in zed-industries/zed:
+ *
+ *   macOS   ~/.config/zed
+ *   Linux   $XDG_CONFIG_HOME/zed  (fallback ~/.config/zed)
+ *   Windows %APPDATA%\Zed
+ *
+ * Writing to the Application Support dir on macOS produced a file Zed never
+ * reads, so `dosu setup` appeared to succeed while Zed showed no Dosu server.
+ */
 /* v8 ignore start -- platform dispatch: only one branch runs per CI runner */
-function zedConfigDir(): string {
+export function zedConfigDir(): string {
+  const os = platform();
+  if (os === "win32") return join(appSupportDir(), "Zed");
+  if (os === "darwin") return join(homedir(), ".config", "zed");
+  return join(appSupportDir(), "zed"); // Linux: appSupportDir() already honors XDG_CONFIG_HOME
+}
+
+/** Zed's data dir; used only for install detection alongside the config dir. */
+function zedDataDir(): string {
   const os = platform();
   if (os === "darwin" || os === "win32") return join(appSupportDir(), "Zed");
-  return join(appSupportDir(), "zed"); // Linux uses lowercase
+  return join(appSupportDir(), "zed");
 }
 /* v8 ignore stop */
 
+/**
+ * Zed's remote (HTTP) context-server entry is `{ url, headers? }` — there is
+ * no `source`/`type` discriminator (see `ContextServerSettingsContent::Http`
+ * in zed-industries/zed `crates/settings_content/src/project.rs`). The extra
+ * keys the CLI used to emit are not part of Zed's settings schema.
+ */
 export const ZedProvider = () =>
   createJSONProvider({
     providerName: "Zed",
     providerID: "zed",
     local: true,
     priorityValue: 10,
-    paths: [zedConfigDir()],
+    paths: [zedConfigDir(), zedDataDir()],
     globalPath: join(zedConfigDir(), "settings.json"),
     topKey: "context_servers",
     buildServer: (cfg) => ({
-      source: "custom",
-      type: "http",
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       url: mcpURL(cfg.active_account!.target!.deployment_id!),
       // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
       headers: mcpHeaders(cfg.active_account!.target!.api_key!),
+    }),
+    buildOSSServer: (cfg) => ({
+      url: mcpBaseURL(),
+      headers: mcpHeaders(cfg.active_account?.target?.api_key),
     }),
     localConfigPath: (cwd) => join(cwd, ".zed", "settings.json"),
   });

--- a/src/mcp/providers/zed.ts
+++ b/src/mcp/providers/zed.ts
@@ -17,18 +17,26 @@ import { createJSONProvider } from "./base";
  * reads, so `dosu setup` appeared to succeed while Zed showed no Dosu server.
  */
 /* v8 ignore start -- platform dispatch: only one branch runs per CI runner */
-export function zedConfigDir(): string {
+function zedConfigDir(): string {
   const os = platform();
   if (os === "win32") return join(appSupportDir(), "Zed");
   if (os === "darwin") return join(homedir(), ".config", "zed");
   return join(appSupportDir(), "zed"); // Linux: appSupportDir() already honors XDG_CONFIG_HOME
 }
 
-/** Zed's data dir; used only for install detection alongside the config dir. */
+/**
+ * Zed's data dir (db/, extensions/, languages/); used only for install
+ * detection so a Zed that has never written settings.json is still found.
+ *
+ *   macOS   ~/Library/Application Support/Zed
+ *   Linux   $XDG_DATA_HOME/zed  (fallback ~/.local/share/zed)
+ *   Windows %LOCALAPPDATA%\Zed
+ */
 function zedDataDir(): string {
   const os = platform();
-  if (os === "darwin" || os === "win32") return join(appSupportDir(), "Zed");
-  return join(appSupportDir(), "zed");
+  if (os === "darwin") return join(appSupportDir(), "Zed");
+  if (os === "win32") return join(process.env.LOCALAPPDATA ?? "", "Zed");
+  return join(process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share"), "zed");
 }
 /* v8 ignore stop */
 

--- a/src/mcp/providers/zed.ts
+++ b/src/mcp/providers/zed.ts
@@ -1,20 +1,15 @@
+import { rmSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
-import { mcpBaseURL, mcpHeaders, mcpURL } from "../config-helpers";
+import { readJSONConfig, saveJSONConfig } from "../config-helpers";
 import { appSupportDir } from "../detect";
+import type { SetupProvider } from "../providers";
 import { createJSONProvider } from "./base";
 
 /**
- * Zed keeps `settings.json` in its *config* dir, which is NOT the same as its
- * data dir (`~/Library/Application Support/Zed` on macOS — that one only holds
- * db/, extensions/, languages/, etc.). Per `crates/paths` in zed-industries/zed:
- *
- *   macOS   ~/.config/zed
- *   Linux   $XDG_CONFIG_HOME/zed  (fallback ~/.config/zed)
+ * Zed reads settings.json from its config dir, not its data dir:
+ *   macOS   ~/.config/zed          Linux  $XDG_CONFIG_HOME/zed (~/.config/zed)
  *   Windows %APPDATA%\Zed
- *
- * Writing to the Application Support dir on macOS produced a file Zed never
- * reads, so `dosu setup` appeared to succeed while Zed showed no Dosu server.
  */
 /* v8 ignore start -- platform dispatch: only one branch runs per CI runner */
 function zedConfigDir(): string {
@@ -25,11 +20,8 @@ function zedConfigDir(): string {
 }
 
 /**
- * Zed's data dir (db/, extensions/, languages/); used only for install
- * detection so a Zed that has never written settings.json is still found.
- *
- *   macOS   ~/Library/Application Support/Zed
- *   Linux   $XDG_DATA_HOME/zed  (fallback ~/.local/share/zed)
+ * Data dir (db/, extensions/), used only for install detection:
+ *   macOS   ~/Library/Application Support/Zed   Linux  $XDG_DATA_HOME/zed (~/.local/share/zed)
  *   Windows %LOCALAPPDATA%\Zed
  */
 function zedDataDir(): string {
@@ -38,16 +30,36 @@ function zedDataDir(): string {
   if (os === "win32") return join(process.env.LOCALAPPDATA ?? "", "Zed");
   return join(process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share"), "zed");
 }
+
+/** Where CLI <= 0.52.2 wrote the entry on macOS (Zed's data dir, never read by Zed). */
+function legacyDarwinSettingsPath(): string | null {
+  return platform() === "darwin" ? join(appSupportDir(), "Zed", "settings.json") : null;
+}
 /* v8 ignore stop */
 
 /**
- * Zed's remote (HTTP) context-server entry is `{ url, headers? }` — there is
- * no `source`/`type` discriminator (see `ContextServerSettingsContent::Http`
- * in zed-industries/zed `crates/settings_content/src/project.rs`). The extra
- * keys the CLI used to emit are not part of Zed's settings schema.
+ * Strips the stale dosu entry (and its API key) from a legacy settings file,
+ * deleting the file outright when nothing else is left in it.
  */
-export const ZedProvider = () =>
-  createJSONProvider({
+export function removeLegacyDosuEntry(path: string): void {
+  let cfg: ReturnType<typeof readJSONConfig>;
+  try {
+    cfg = readJSONConfig(path);
+  } catch {
+    return;
+  }
+  const servers = cfg.context_servers;
+  if (typeof servers !== "object" || servers === null || !("dosu" in servers)) return;
+  delete servers.dosu;
+  const nothingElse = Object.keys(cfg).length === 1 && Object.keys(servers).length === 0;
+  if (nothingElse) rmSync(path, { force: true });
+  else saveJSONConfig(path, cfg);
+}
+
+// Zed's HTTP context_servers entry is `{ url, headers? }`; there is no
+// `source`/`type` discriminator (ContextServerSettingsContent::Http).
+export const ZedProvider = (legacyPath = legacyDarwinSettingsPath()): SetupProvider => {
+  const provider = createJSONProvider({
     providerName: "Zed",
     providerID: "zed",
     local: true,
@@ -55,15 +67,19 @@ export const ZedProvider = () =>
     paths: [zedConfigDir(), zedDataDir()],
     globalPath: join(zedConfigDir(), "settings.json"),
     topKey: "context_servers",
-    buildServer: (cfg) => ({
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      url: mcpURL(cfg.active_account!.target!.deployment_id!),
-      // biome-ignore lint/style/noNonNullAssertion: guaranteed by install() guard
-      headers: mcpHeaders(cfg.active_account!.target!.api_key!),
-    }),
-    buildOSSServer: (cfg) => ({
-      url: mcpBaseURL(),
-      headers: mcpHeaders(cfg.active_account?.target?.api_key),
-    }),
+    buildServer: ({ url, headers }) => ({ url, headers }),
     localConfigPath: (cwd) => join(cwd, ".zed", "settings.json"),
   });
+  if (!legacyPath) return provider;
+  return {
+    ...provider,
+    install(cfg, global) {
+      provider.install(cfg, global);
+      if (global) removeLegacyDosuEntry(legacyPath);
+    },
+    remove(global) {
+      provider.remove(global);
+      if (global) removeLegacyDosuEntry(legacyPath);
+    },
+  };
+};


### PR DESCRIPTION
## Summary

`dosu setup` / `dosu mcp add zed` reported success on macOS but Zed never saw the Dosu server. Fixing it surfaced two more problems in the shared provider layer: commented settings files were wiped on install, and OSS mode wrote schema-invalid entries for four other tools.

## What was wrong

**1. Wrong file on macOS.** The Zed provider wrote to `~/Library/Application Support/Zed/settings.json`. That is Zed's *data* dir and holds no settings file. Zed reads user settings from its *config* dir:

| Platform | Config dir (settings.json) | Data dir |
|---|---|---|
| macOS | `~/.config/zed` | `~/Library/Application Support/Zed` |
| Linux | `$XDG_CONFIG_HOME/zed` → `~/.config/zed` | `$XDG_DATA_HOME/zed` → `~/.local/share/zed` |
| Windows | `%APPDATA%\Zed` | `%LOCALAPPDATA%\Zed` |

**2. Wrong entry shape.** The provider emitted `source: "custom"` and `type: "http"`. Zed's `ContextServerSettingsContent` is an untagged enum whose HTTP variant is `{ url, headers?, timeout?, oauth? }`, discriminated by the presence of `url`. The entry is now `{ url, headers }`.

**3. Commented settings files were wiped.** Zed's bundled `settings.json` template opens with `//` comment lines, and Zed parses settings as lenient JSONC. `loadJSONConfig` only stripped comments for `.jsonc` paths and returned `{}` on any parse failure, so `installJSONServer` read a fresh user's settings as empty and wrote back a file containing only the Dosu entry.

**4. OSS mode ignored every provider's `buildServer`.** `createJSONProvider` had separate cloud and OSS builders, and only the cloud one was overridable. In OSS mode Cline and Cline CLI got `type: "http"` (their schema allows `stdio|sse|streamableHttp`), OpenCode got `type: "http"` (allows `local|remote`), and Antigravity got `url` instead of the required `serverUrl`. Each of those tools rejects or ignores the entry.

## Changes

**Provider factory** (`base.ts`, `config-helpers.ts`)
- New shared `mcpEndpoint(cfg)` returns the base URL in OSS mode and the deployment URL otherwise. It replaces four identical local copies (manual, copilot, mcporter, codex) and Claude Desktop's inline ternary.
- `createJSONProvider` resolves `{ url, headers }` once and passes it to a single `buildServer(endpoint, cfg)`. Overriding providers no longer need non-null assertions or mode awareness. Fixes item 4 for every provider at once.

**JSON helpers** (`config-helpers.ts`)
- Comments and trailing commas are tolerated for every JSON config file, not just `.jsonc`.
- New `readJSONConfig` reads strictly and throws a descriptive error; `installJSONServer` uses it so an unparseable file is never overwritten.
- `removeJSONServer` never rewrites an unparseable file and leaves files with no `dosu` entry untouched.

**Zed** (`zed.ts`)
- Per-platform config dir, `{ url, headers }` shape, detection via config *or* data dir.
- Global install and remove strip the `dosu` entry from the legacy macOS file the old provider wrote, and delete that file when nothing else is in it, so the stale API key does not linger on upgraded machines.

**Tests**
- Zed: path assertion, exact key set, OSS shape, sibling-entry preservation, Zed's comment header, legacy-file cleanup.
- Helpers: JSONC in `.json`, trailing commas, refuse-to-clobber, remove no-ops.
- OSS-shape tests for Cline, Cline CLI, Cursor, OpenCode, Antigravity. Cline previously had no provider tests.

Known trade-off: a re-serialized settings file loses the user's comments. Data is preserved. This matches how the CLI already treated `.jsonc` configs.

## Verification

- `bun run check`, `bun run typecheck` clean. `bunx vitest run --coverage`: 1708 tests, 71 files, thresholds met. No uncovered lines remain in the changed provider code.
- Built the npm bundle and ran `dosu mcp add zed -g` against a live macOS Zed config with six existing `context_servers` entries. Wrote to `~/.config/zed/settings.json`; every top-level key and all sibling servers preserved.
- Relaunched Zed with `ZED_LOG=context_server=trace`. Log shows `starting context server dosu`, `context server dosu initialized` (server info `Dosu MCP 3.3.1`), and a populated `tools/list` response.

## Reviewer notes

- Zed builds older than the November 2025 settings migration required a `source` tag on every entry. Dropping it targets current Zed (1.x auto-updates); flagging in case anyone supports pinned pre-migration builds.
- `appSupportDir()` in `detect.ts` is really the Electron user-data dir. Its name is what led the original Zed provider astray. Renaming it and adding `xdgConfigHome()` / `xdgDataHome()` helpers (which would also fix OpenCode ignoring `XDG_CONFIG_HOME`) is a sensible follow-up, left out to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
